### PR TITLE
add OMTD core library

### DIFF
--- a/docs/omtd.md
+++ b/docs/omtd.md
@@ -1,0 +1,117 @@
+﻿# Output Multimodal Transfer/Decoder
+
+OMTD is a proposed output-side companion library for llama.cpp.
+
+It mirrors MTMD conceptually, but runs in the opposite direction:
+
+```text
+MTMD: media input -> embeddings/tokens -> language model
+OMTD: language model output -> output companion -> generated media
+```
+
+This framework patch adds only the library boundary. Model-specific output
+implementations, such as audio, image, or video generators, should be layered on
+top in separate patches.
+
+## Intended Frontend Support
+
+The intended frontend path is:
+
+```text
+llama-cli
+llama-server
+llama-tts
+    |
+    v
+  libomtd
+    |
+    v
+concrete output backend
+```
+
+Planned frontend responsibilities:
+
+- `llama-cli`: accept `--omtd FILE` for local output generation from a prompt.
+- `llama-server`: accept `--omtd FILE` and expose output-generation endpoints.
+- `llama-tts`: use OMTD as the shared TTS/audio-output backend path.
+
+This OMTD-only patch does not wire those flags yet. It creates the stable shared
+library and API first. The frontend wiring should be a separate patch, followed
+by model-specific backend patches.
+
+## Review Path
+
+Recommended patch order:
+
+```text
+1. OMTD core library and docs
+2. Frontend wiring for llama-cli, llama-server, and llama-tts
+3. First concrete OMTD backend
+```
+
+This keeps the generic output-runtime boundary reviewable without tying it to a
+specific model implementation.
+
+## Responsibilities
+
+OMTD owns:
+
+- A public C API for output companion detection.
+- A public C API for structured output generation requests.
+- Common status/error reporting for output generation backends.
+- Placeholder modality and model-type enums for future backends.
+
+OMTD does not own:
+
+- Input media processing. That remains MTMD.
+- `--mmproj` handling.
+- A concrete output model in this framework-only patch.
+- Application-specific file or HTTP response handling.
+
+## Current API
+
+Detection:
+
+```text
+omtd_is_output_companion_gguf(path)
+omtd_get_model_type(path)
+omtd_get_model_modality(path)
+```
+
+Audio generation boundary:
+
+```text
+omtd_audio_generate_file(params, error, error_size)
+```
+
+The audio generation entry point validates required fields and returns
+`OMTD_STATUS_UNSUPPORTED` until a concrete audio backend is added.
+
+## Diagram
+
+```text
+llama.cpp frontend
+        |
+        v
+  OMTD public API
+        |
+        +--> companion detection
+        |
+        +--> structured output request
+        |
+        v
+ model-specific output backend
+   added by later patches
+        |
+        v
+generated media output
+```
+
+## Relationship To MTMD
+
+| Area | MTMD | OMTD |
+| --- | --- | --- |
+| Direction | input -> model | model -> output |
+| Media role | user-provided input media | generated output media |
+| File role | input projector | output companion |
+| API style | tokenize/encode input | generate/decode output |

--- a/tests/test-omtd.cpp
+++ b/tests/test-omtd.cpp
@@ -1,0 +1,26 @@
+﻿#include "omtd.h"
+
+#include <cassert>
+#include <cstring>
+
+int main() {
+    char error[128] = {};
+
+    assert(!omtd_is_output_companion_gguf(nullptr));
+    assert(omtd_get_model_type(nullptr) == OMTD_MODEL_TYPE_UNKNOWN);
+    assert(omtd_get_model_modality(nullptr) == OMTD_MODALITY_UNKNOWN);
+
+    assert(omtd_audio_generate_file(nullptr, error, sizeof(error)) == OMTD_STATUS_INVALID_PARAM);
+    assert(std::strlen(error) > 0);
+
+    omtd_audio_generation_params params = {};
+    assert(omtd_audio_generate_file(&params, error, sizeof(error)) == OMTD_STATUS_INVALID_PARAM);
+
+    params.model_path = "model.gguf";
+    params.companion_path = "companion.gguf";
+    params.prompt = "hello";
+    params.output_path = "out.wav";
+    assert(omtd_audio_generate_file(&params, error, sizeof(error)) == OMTD_STATUS_UNSUPPORTED);
+
+    return 0;
+}

--- a/tools/omtd/CMakeLists.txt
+++ b/tools/omtd/CMakeLists.txt
@@ -1,0 +1,19 @@
+﻿set(TARGET omtd)
+
+add_library(${TARGET} omtd.cpp)
+
+install(TARGETS ${TARGET}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+target_include_directories(${TARGET} PUBLIC .)
+target_link_libraries(${TARGET} PRIVATE ${CMAKE_THREAD_LIBS_INIT})
+
+target_compile_features(${TARGET} PUBLIC cxx_std_17)
+
+set_target_properties(${TARGET} PROPERTIES PUBLIC_HEADER omtd.h)
+
+if (BUILD_SHARED_LIBS)
+    set_target_properties(${TARGET} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()

--- a/tools/omtd/README.md
+++ b/tools/omtd/README.md
@@ -1,0 +1,77 @@
+﻿# Output Multimodal Transfer/Decoder
+
+`libomtd` defines the output-side companion boundary for llama.cpp tools.
+
+- `libmtmd`: input media -> model-readable embeddings/tokens
+- `libomtd`: model output -> generated media
+
+This patch only adds the OMTD framework and public API. Concrete output models
+and frontend wiring are added by follow-up patches.
+
+## Intended Frontend Path
+
+OMTD is intended to be used from the same user-facing tools that already host
+model interaction:
+
+```text
+llama-cli     --omtd FILE -> generated output file
+llama-server  --omtd FILE -> generated output endpoint or stream
+llama-tts     --omtd FILE -> generated speech/audio file
+```
+
+The framework-only patch does not add those flags yet. It adds the common
+library target and API first, so the later frontend patch can route all three
+frontends through the same OMTD boundary without introducing a model-specific
+backend at the same time.
+
+## Patch Path
+
+A clean review sequence is:
+
+```text
+1. OMTD core library and API
+2. llama-cli / llama-server / llama-tts frontend wiring
+3. First concrete OMTD backend
+```
+
+This keeps the generic OMTD design separate from any one output model.
+
+## Scope
+
+OMTD is for generated outputs. It does not replace MTMD and it does not load
+`--mmproj` files.
+
+Use:
+
+- `--mmproj FILE` for MTMD input-media projectors
+- `--omtd FILE` for OMTD output-media companions, once a frontend/backend patch
+  wires a concrete output model to this API
+
+## API
+
+The public C API is declared in `omtd.h`.
+
+Detection helpers:
+
+- `omtd_is_output_companion_gguf(path)`
+- `omtd_get_model_type(path)`
+- `omtd_get_model_modality(path)`
+
+Generation entry point:
+
+- `omtd_audio_generate_file(params, error, error_size)`
+
+The framework patch returns `OMTD_STATUS_UNSUPPORTED` for audio generation until
+an audio backend is registered by a model-specific patch.
+
+## OMTD vs MTMD
+
+| Area | MTMD | OMTD |
+| --- | --- | --- |
+| Direction | Media input to text model | Text model to generated media output |
+| Main flag | `--mmproj` | `--omtd` |
+| File role | Input projector/encoder GGUF | Output companion/decoder GGUF |
+| Current API shape | tokenize/encode helpers | output generation helpers |
+
+MTMD prepares input media so a language model can consume it. OMTD provides the
+library boundary for media generated from model output.

--- a/tools/omtd/omtd.cpp
+++ b/tools/omtd/omtd.cpp
@@ -1,0 +1,66 @@
+﻿#include "omtd.h"
+
+#include <cstring>
+
+static void omtd_set_error(char * error, const size_t error_size, const char * msg) {
+    if (!error || error_size == 0) {
+        return;
+    }
+    const char * text = msg ? msg : "";
+    std::strncpy(error, text, error_size - 1);
+    error[error_size - 1] = '\0';
+}
+
+static bool omtd_has_text(const char * value) {
+    return value && value[0] != '\0';
+}
+
+extern "C" bool omtd_is_output_companion_gguf(const char * path) {
+    return omtd_get_model_type(path) != OMTD_MODEL_TYPE_UNKNOWN;
+}
+
+extern "C" omtd_model_type omtd_get_model_type(const char * path) {
+    if (!omtd_has_text(path)) {
+        return OMTD_MODEL_TYPE_UNKNOWN;
+    }
+
+    // Model-specific OMTD patches add companion GGUF metadata recognizers here.
+    return OMTD_MODEL_TYPE_UNKNOWN;
+}
+
+extern "C" omtd_modality omtd_get_model_modality(const char * path) {
+    switch (omtd_get_model_type(path)) {
+        case OMTD_MODEL_TYPE_UNKNOWN:
+        default:
+            return OMTD_MODALITY_UNKNOWN;
+    }
+}
+
+extern "C" omtd_status omtd_audio_generate_file(
+        const omtd_audio_generation_params * params,
+        char * error,
+        const size_t error_size) {
+    if (!params) {
+        omtd_set_error(error, error_size, "missing OMTD audio generation params");
+        return OMTD_STATUS_INVALID_PARAM;
+    }
+    if (!omtd_has_text(params->model_path)) {
+        omtd_set_error(error, error_size, "missing backbone model path");
+        return OMTD_STATUS_INVALID_PARAM;
+    }
+    if (!omtd_has_text(params->companion_path)) {
+        omtd_set_error(error, error_size, "missing OMTD companion path");
+        return OMTD_STATUS_INVALID_PARAM;
+    }
+    if (!omtd_has_text(params->prompt)) {
+        omtd_set_error(error, error_size, "missing audio generation prompt");
+        return OMTD_STATUS_INVALID_PARAM;
+    }
+    if (!omtd_has_text(params->output_path)) {
+        omtd_set_error(error, error_size, "missing output path");
+        return OMTD_STATUS_INVALID_PARAM;
+    }
+
+    omtd_set_error(error, error_size, "no OMTD audio backend is available");
+    return OMTD_STATUS_UNSUPPORTED;
+}

--- a/tools/omtd/omtd.h
+++ b/tools/omtd/omtd.h
@@ -1,0 +1,91 @@
+﻿#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef LLAMA_SHARED
+#    if defined(_WIN32) && !defined(__MINGW32__)
+#        ifdef LLAMA_BUILD
+#            define OMTD_API __declspec(dllexport)
+#        else
+#            define OMTD_API __declspec(dllimport)
+#        endif
+#    else
+#        define OMTD_API __attribute__ ((visibility ("default")))
+#    endif
+#else
+#    define OMTD_API
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum omtd_modality {
+    OMTD_MODALITY_UNKNOWN = 0,
+    OMTD_MODALITY_AUDIO   = 1,
+    OMTD_MODALITY_IMAGE   = 2,
+    OMTD_MODALITY_VIDEO   = 3,
+} omtd_modality;
+
+typedef enum omtd_model_type {
+    OMTD_MODEL_TYPE_UNKNOWN = 0,
+} omtd_model_type;
+
+typedef enum omtd_status {
+    OMTD_STATUS_SUCCESS       = 0,
+    OMTD_STATUS_INVALID_PARAM = 1,
+    OMTD_STATUS_UNSUPPORTED   = 2,
+    OMTD_STATUS_RUNTIME_ERROR = 3,
+} omtd_status;
+
+typedef struct omtd_audio_generation_params {
+    const char * model_path;
+    const char * companion_path;
+    const char * prompt;
+    const char * output_path;
+
+    const char * device;
+    const char * omtd_backend;
+    const char * rvq_backend;
+    const char * vocoder_backend;
+
+    const char * ref_voice_path;
+    const char * ref_text_path;
+
+    int32_t n_gpu_layers;
+    int32_t n_ctx;
+
+    float duration_seconds;
+    float max_duration_seconds;
+    float temperature;
+    int32_t top_k;
+    int32_t seed;
+    int32_t stream_stride;
+    int32_t stream_holdback;
+
+    bool seed_is_set;
+    bool stream_wav;
+    bool raw_prompt;
+    bool verbose;
+    bool flash_attn;
+} omtd_audio_generation_params;
+
+// Detects output-modality companion GGUF files. The OMTD framework patch only
+// defines the boundary; model-specific recognizers are added by backend patches.
+OMTD_API bool omtd_is_output_companion_gguf(const char * path);
+
+OMTD_API omtd_model_type omtd_get_model_type(const char * path);
+OMTD_API omtd_modality   omtd_get_model_modality(const char * path);
+
+// Generate an audio file through an output-modality companion. The framework
+// returns OMTD_STATUS_UNSUPPORTED until a concrete audio backend is registered.
+OMTD_API omtd_status omtd_audio_generate_file(
+        const omtd_audio_generation_params * params,
+        char * error,
+        size_t error_size);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
## Summary

Adds the OMTD core library as a standalone output-modality boundary for future generated-media backends.

OMTD is the output-modality counterpart to MTMD: it keeps generated-media output routing behind a separate companion path instead of overloading input-media projector semantics.

## Notes

- Scope is OMTD core only.
- Model-specific backends are intentionally left for follow-up patches.
- This branch was prepared from `mirek190/llama.cpp` OMTD core commit `06c714efbfc5cc544a3dbee134c1e3368adabc05`, adapted onto `audio.cpp:release-0.1` by omitting llama.cpp aggregate CMake files that do not exist in audio.cpp.

## Validation

- Confirmed final branch diff contains only OMTD docs/source/test files.
- No audio.cpp CI has been run locally for this branch.