### PR TITLE
Add VibeVoice 7B support and decoder LoRA merging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,6 +219,7 @@ add_library(engine_runtime STATIC
     src/models/vibevoice/diffusion_sampler.cpp
     src/models/vibevoice/generator.cpp
     src/models/vibevoice/loader.cpp
+    src/models/vibevoice/lora.cpp
     src/models/vibevoice/scheduler.cpp
     src/models/vibevoice/session.cpp
     src/models/vibevoice/tokenizer_audio.cpp

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Highlights:
 ## News
 
 > [!IMPORTANT]
+> **2026-07-01:** VibeVoice 7B joins the 1.5B model, and decoder LoRA adapters can now be merged at load time through `--load-option vibevoice.lora`.
+
+> [!IMPORTANT]
 > **2026-06-30:** VibeVoice 1.5B is now released in the framework, bringing long-form, multi-speaker dialogue TTS into the normal audio.cpp model surface.
 
 > [!TIP]
@@ -55,7 +58,7 @@ Current model status in the framework:
 | **silero_vad** | VAD | lang agnostic | Silero VAD | **released** |
 | **sortformer_diar** | diarization | en | Sortformer-4spk-v1 | **released** |
 | **vevo2** | TTS, singing generation, voice conversion, singing conversion, editing | en, zh | Vevo2 with Qwen2.5-0.5B AR model | **released** |
-| **vibevoice** | TTS, multi-speaker dialogue TTS | en, zh | VibeVoice-1.5B | **released** |
+| **vibevoice** | TTS, multi-speaker dialogue TTS | en, zh | VibeVoice-1.5B, VibeVoice-7B | **released** |
 | **voxcpm2** | TTS, voice cloning, voice design | ar, da, de, el, en, es, fi, fr, he, hi, id, it, ja, km, ko, lo, ms, my, nl, no, pl, pt, ru, sv, sw, th, tl, tr, vi, zh | VoxCPM2-2B, 48 kHz | **released** |
 | ace_step | music generation | 50+ langs | ACE-Step 1.5 with acestep-5Hz-lm-1.7B | integration |
 | audio_flamingo_next | audio understanding, ASR, audio captioning, audio QA | en, multilingual audio understanding | Audio Flamingo Next Instruct, Qwen2-7B based | optimization |
@@ -425,6 +428,7 @@ Recommended top-level install packages:
 | `supertonic_3` | Supertonic 3 | **Yes** |
 | `vevo2` | Vevo2 | No |
 | `vibevoice_1_5b` | VibeVoice 1.5B | No |
+| `vibevoice_7b` | VibeVoice 7B | No |
 | `voxcpm2` | VoxCPM2 | No |
 
 > [!WARNING]

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -358,18 +358,21 @@ audiocpp_cli --task tts --family supertonic --model models/supertonic-3 --backen
 
 ## VibeVoice
 
-VibeVoice 1.5B is a long-form multi-speaker TTS model. Prompts use speaker-labeled lines, and speaker reference WAVs are provided in the same order as the speaker ids.
+VibeVoice is a long-form multi-speaker TTS model, available in 1.5B and 7B sizes. Prompts use speaker-labeled lines, and speaker reference WAVs are provided in the same order as the speaker ids.
 
 | Field | Value |
 |---|---|
 | Family | `vibevoice` |
-| Model directory | `models/VibeVoice-1.5B` |
+| Model directory | `models/VibeVoice-1.5B` (or `models/VibeVoice-7B`) |
 | Task | `tts` |
 | Modes | `offline` |
 | Languages | Model auto-handles supported languages |
 | Voice input | Up to four speaker reference WAVs through `voice_samples` |
 | Text format | Lines like `Speaker 1: ... Speaker 2: ...`; ids are normalized internally |
 | Long-form | No text chunking; generation uses the model long-form path |
+| LoRA | Optional PEFT decoder adapter through `--load-option vibevoice.lora` |
+
+Both sizes share the same CLI surface and the same Qwen2.5 tokenizer; the 7B is simply larger (hidden size 3584 vs 1536) and needs a matching 7B LoRA if one is used.
 
 ```bash
 audiocpp_cli --task tts --family vibevoice --model models/VibeVoice-1.5B --backend cuda --text "Speaker 1: Hello. Speaker 2: Nice to meet you." --request-option voice_samples=assets/resources/a.wav,assets/resources/b.wav --out out.wav
@@ -386,5 +389,9 @@ audiocpp_cli --task tts --family vibevoice --model models/VibeVoice-1.5B --backe
 | `--temperature` | float | `1.0` | Decoder sampling temperature. |
 | `--top-k` | integer | `50` | Decoder top-k sampling limit. |
 | `--top-p` | float | `1.0` | Decoder nucleus sampling limit. |
+| `--load-option vibevoice.lora=<path>` | PEFT adapter dir or `.safetensors` | not set | Merge a LoRA adapter into the decoder linears at load time. Adapter dims must match the base model size. |
+| `--load-option vibevoice.lora_scale=<float>` | float | `lora_alpha / r` | Override the LoRA merge scale from `adapter_config.json`. |
+
+A LoRA is merged into the base weights at load time, so it composes with the `vibevoice.*_weight_type` quantization options and adds no per-step cost. Use a 1.5B adapter with `VibeVoice-1.5B` and a 7B adapter with `VibeVoice-7B`; a size mismatch is rejected with a descriptive error.
 
 For backend weight-type controls, use `audiocpp_cli --inspect --model <model-dir> --family <family>`.

--- a/include/engine/models/vibevoice/decoder.h
+++ b/include/engine/models/vibevoice/decoder.h
@@ -92,6 +92,7 @@ struct VibeVoiceDecoderLayerWeights {
 struct VibeVoiceDecoderWeights {
     std::shared_ptr<core::BackendWeightStore> store;
     core::TensorValue token_embedding;
+    core::TensorValue lm_head;
     std::vector<VibeVoiceDecoderLayerWeights> layers;
     assets::TensorDataF32 norm;
 };

--- a/include/engine/models/vibevoice/lora.h
+++ b/include/engine/models/vibevoice/lora.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "engine/framework/assets/tensor_source.h"
+
+#include <filesystem>
+#include <memory>
+
+namespace engine::models::vibevoice {
+
+std::shared_ptr<const assets::TensorSource> make_lora_merged_tensor_source(
+    std::shared_ptr<const assets::TensorSource> base,
+    const std::filesystem::path & adapter_path,
+    float scale_override);
+
+}  // namespace engine::models::vibevoice

--- a/src/models/vibevoice/assets.cpp
+++ b/src/models/vibevoice/assets.cpp
@@ -173,17 +173,30 @@ VibeVoiceDiffusionHeadConfig parse_diffusion_head_config(const engine::io::json:
     return config;
 }
 
+int64_t require_acoustic_vae_dim(const engine::io::json::Value & root) {
+    // VibeVoice-7B's config.json spells this key "acostic_vae_dim".
+    for (const char * key : {"acoustic_vae_dim", "acostic_vae_dim"}) {
+        if (const auto * value = root.find(key); value != nullptr) {
+            return value->as_i64();
+        }
+    }
+    throw std::runtime_error("VibeVoice config is missing acoustic_vae_dim");
+}
+
 VibeVoiceConfig parse_config(const assets::ResourceBundle & resources) {
     const auto root = resources.parse_json("config");
     VibeVoiceConfig config;
     config.model_type = json::optional_string(root, "model_type", "");
     require_string_value(config.model_type, "vibevoice", "model_type");
     config.torch_dtype = json::optional_string(root, "torch_dtype", config.torch_dtype);
-    config.acoustic_vae_dim = json::require_i64(root, "acoustic_vae_dim");
+    config.acoustic_vae_dim = require_acoustic_vae_dim(root);
     config.semantic_vae_dim = json::require_i64(root, "semantic_vae_dim");
     config.acoustic_tokenizer = parse_tokenizer_config(root.require("acoustic_tokenizer_config"), "acoustic tokenizer");
     config.semantic_tokenizer = parse_tokenizer_config(root.require("semantic_tokenizer_config"), "semantic tokenizer");
     config.decoder = parse_decoder_config(root.require("decoder_config"));
+    // VibeVoice-7B carries tie_word_embeddings at the top level, unlike the 1.5B decoder config.
+    config.decoder.tie_word_embeddings =
+        json::optional_bool(root, "tie_word_embeddings", config.decoder.tie_word_embeddings);
     config.diffusion_head = parse_diffusion_head_config(root.require("diffusion_head_config"));
     require_positive(config.acoustic_vae_dim, "acoustic_vae_dim");
     require_positive(config.semantic_vae_dim, "semantic_vae_dim");
@@ -416,6 +429,10 @@ void validate_weight_anchors(const VibeVoiceAssets & assets) {
     const auto & weights = *assets.model_weights;
     const auto & decoder = config.decoder;
     require_tensor_metadata(weights, "model.language_model.embed_tokens.weight", {decoder.vocab_size, decoder.hidden_size});
+    if (!decoder.tie_word_embeddings) {
+        const auto lm_head_name = weights.require_tensor_name({"lm_head.weight", "model.lm_head.weight"});
+        require_tensor_metadata(weights, lm_head_name, {decoder.vocab_size, decoder.hidden_size});
+    }
     require_tensor_metadata(weights, "model.language_model.norm.weight", {decoder.hidden_size});
     require_tensor_metadata(weights, "model.language_model.layers.0.self_attn.q_proj.weight", {decoder.hidden_size, decoder.hidden_size});
     require_tensor_metadata(

--- a/src/models/vibevoice/decoder.cpp
+++ b/src/models/vibevoice/decoder.cpp
@@ -338,6 +338,15 @@ VibeVoiceDecoderWeights load_vibevoice_decoder_weights(
         "model.language_model.embed_tokens.weight",
         weight_storage_type,
         {config.vocab_size, config.hidden_size});
+    if (config.tie_word_embeddings) {
+        weights.lm_head = weights.token_embedding;
+    } else {
+        weights.lm_head = weights.store->load_tensor(
+            *assets.model_weights,
+            assets.model_weights->require_tensor_name({"lm_head.weight", "model.lm_head.weight"}),
+            weight_storage_type,
+            {config.vocab_size, config.hidden_size});
+    }
     weights.layers.reserve(static_cast<size_t>(config.num_hidden_layers));
     for (int64_t layer = 0; layer < config.num_hidden_layers; ++layer) {
         weights.layers.push_back(load_layer_weights(
@@ -498,7 +507,7 @@ public:
         hidden_output_ = x.tensor;
         auto logits = modules::LinearModule(
                           binding::linear_config(config.hidden_size, config.vocab_size, false))
-                          .build(ctx, x, binding::linear_data(constants, runtime_->weights().token_embedding));
+                          .build(ctx, x, binding::linear_data(constants, runtime_->weights().lm_head));
         logits_output_ = logits.tensor;
         ggml_set_output(logits_output_);
         graph_ = ggml_new_graph_custom(ctx_.get(), 65536, false);
@@ -761,7 +770,7 @@ private:
             hidden_output_ = x.tensor;
             auto logits = modules::LinearModule(
                               binding::linear_config(config.hidden_size, config.vocab_size, false))
-                              .build(ctx, x, binding::linear_data(constants_, runtime_->weights().token_embedding));
+                              .build(ctx, x, binding::linear_data(constants_, runtime_->weights().lm_head));
             logits_output_ = logits.tensor;
             graph_ = ggml_new_graph_custom(ctx_.get(), 8192, false);
             ggml_set_output(logits_output_);
@@ -1006,7 +1015,7 @@ public:
         hidden_output_ = x.tensor;
         auto logits = modules::LinearModule(
                           binding::linear_config(config.hidden_size, config.vocab_size, false))
-                          .build(ctx, x, binding::linear_data(constants, runtime_->weights().token_embedding));
+                          .build(ctx, x, binding::linear_data(constants, runtime_->weights().lm_head));
         logits_output_ = logits.tensor;
         ggml_set_output(logits_output_);
         ggml_build_forward_expand(graph_, logits_output_);
@@ -1202,7 +1211,7 @@ public:
         hidden_output_ = x.tensor;
         auto logits = modules::LinearModule(
                           binding::linear_config(config.hidden_size, config.vocab_size, false))
-                          .build(ctx, x, binding::linear_data(constants, runtime_->weights().token_embedding));
+                          .build(ctx, x, binding::linear_data(constants, runtime_->weights().lm_head));
         logits_output_ = logits.tensor;
         ggml_set_output(logits_output_);
         ggml_build_forward_expand(graph_, logits_output_);

--- a/src/models/vibevoice/loader.cpp
+++ b/src/models/vibevoice/loader.cpp
@@ -111,6 +111,8 @@ public:
             {"vibevoice.connector_weight_type", "native|f32|f16|bf16|q8_0", "Acoustic and semantic connector weight storage type."},
             {"vibevoice.decoder_weight_type", "native|f32|f16|bf16|q8_0", "Language decoder weight storage type."},
             {"vibevoice.diffusion_head_weight_type", "native|f32|f16|bf16|q8_0", "Diffusion prediction head weight storage type."},
+            {"vibevoice.lora", "path", "PEFT LoRA adapter directory or safetensors merged into the decoder weights."},
+            {"vibevoice.lora_scale", "float", "LoRA merge scale override; defaults to lora_alpha / r."},
         };
         inspection.discovered_configs = discover_config_assets(request);
         inspection.discovered_weights = discover_weight_assets(request);

--- a/src/models/vibevoice/lora.cpp
+++ b/src/models/vibevoice/lora.cpp
@@ -1,0 +1,277 @@
+#include "engine/models/vibevoice/lora.h"
+
+#include "engine/framework/io/filesystem.h"
+#include "engine/framework/io/json.h"
+
+#include <cmath>
+#include <cstring>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace engine::models::vibevoice {
+namespace json = engine::io::json;
+namespace {
+
+constexpr std::string_view kLoraWeightsFile = "adapter_model.safetensors";
+constexpr std::string_view kLoraConfigFile = "adapter_config.json";
+constexpr std::string_view kPeftPrefix = "base_model.model.";
+constexpr std::string_view kLanguageModelPrefix = "model.language_model.";
+constexpr std::string_view kLoraASuffix = ".lora_A.weight";
+constexpr std::string_view kLoraBSuffix = ".lora_B.weight";
+
+struct LoraAdapterPaths {
+    std::filesystem::path weights;
+    std::optional<std::filesystem::path> config;
+};
+
+struct LoraTensorDelta {
+    std::vector<float> a;
+    std::vector<float> b;
+    int64_t r = 0;
+    int64_t in = 0;
+    int64_t out = 0;
+    float scale = 1.0F;
+};
+
+struct LoraTensorNames {
+    std::optional<std::string> a_name;
+    std::optional<std::string> b_name;
+};
+
+bool has_suffix(const std::string & name, std::string_view suffix) {
+    return name.size() >= suffix.size() &&
+        name.compare(name.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+
+std::string strip_prefix(const std::string & name, std::string_view prefix) {
+    if (name.rfind(prefix, 0) == 0) {
+        return name.substr(prefix.size());
+    }
+    return name;
+}
+
+LoraAdapterPaths resolve_adapter_paths(const std::filesystem::path & adapter_path) {
+    LoraAdapterPaths paths;
+    if (engine::io::is_existing_directory(adapter_path)) {
+        paths.weights = adapter_path / kLoraWeightsFile;
+        const auto config = adapter_path / kLoraConfigFile;
+        if (engine::io::is_existing_file(config)) {
+            paths.config = config;
+        }
+    } else if (engine::io::is_existing_file(adapter_path)) {
+        paths.weights = adapter_path;
+        const auto config = adapter_path.parent_path() / kLoraConfigFile;
+        if (engine::io::is_existing_file(config)) {
+            paths.config = config;
+        }
+    } else {
+        throw std::runtime_error("VibeVoice LoRA path does not exist: " + adapter_path.string());
+    }
+    if (!engine::io::is_existing_file(paths.weights)) {
+        throw std::runtime_error("VibeVoice LoRA adapter weights not found: " + paths.weights.string());
+    }
+    return paths;
+}
+
+float resolve_adapter_scale(const std::optional<std::filesystem::path> & config_path, float scale_override) {
+    if (scale_override > 0.0F) {
+        return scale_override;
+    }
+    if (!config_path.has_value()) {
+        throw std::runtime_error(
+            "VibeVoice LoRA has no adapter_config.json; pass vibevoice.lora_scale to set the merge scale");
+    }
+    const auto root = json::parse_file(*config_path);
+    const auto rank = json::require_i64(root, "r");
+    if (rank <= 0) {
+        throw std::runtime_error("VibeVoice LoRA adapter_config.json has non-positive r");
+    }
+    const float alpha = json::optional_f32(root, "lora_alpha", static_cast<float>(rank));
+    const bool use_rslora = json::optional_bool(root, "use_rslora", false);
+    const float denom = use_rslora ? std::sqrt(static_cast<float>(rank)) : static_cast<float>(rank);
+    return alpha / denom;
+}
+
+std::string resolve_base_weight_name(const assets::TensorSource & base, const std::string & module_path) {
+    const std::string prefixed = std::string(kLanguageModelPrefix) + module_path + ".weight";
+    if (base.has_tensor(prefixed)) {
+        return prefixed;
+    }
+    const std::string bare = module_path + ".weight";
+    if (base.has_tensor(bare)) {
+        return bare;
+    }
+    throw std::runtime_error("VibeVoice LoRA targets a module with no matching base weight: " + module_path);
+}
+
+std::vector<float> merged_f32_values(
+    const assets::TensorSource & base,
+    const std::string & name,
+    const LoraTensorDelta & delta) {
+    auto values = base.require_f32(name, std::optional<std::vector<int64_t>>({delta.out, delta.in}));
+    // values[o, i] += scale * sum_k B[o, k] * A[k, i]
+    for (int64_t o = 0; o < delta.out; ++o) {
+        const int64_t row = o * delta.in;
+        for (int64_t k = 0; k < delta.r; ++k) {
+            const float b = delta.scale * delta.b[static_cast<size_t>(o * delta.r + k)];
+            if (b == 0.0F) {
+                continue;
+            }
+            const float * a_row = delta.a.data() + static_cast<size_t>(k * delta.in);
+            for (int64_t i = 0; i < delta.in; ++i) {
+                values[static_cast<size_t>(row + i)] += b * a_row[i];
+            }
+        }
+    }
+    return values;
+}
+
+class LoraMergedTensorSource final : public assets::TensorSource {
+public:
+    LoraMergedTensorSource(
+        std::shared_ptr<const assets::TensorSource> base,
+        std::unordered_map<std::string, LoraTensorDelta> deltas)
+        : base_(std::move(base)),
+          deltas_(std::move(deltas)) {}
+
+    const std::filesystem::path & source_path() const noexcept override {
+        return base_->source_path();
+    }
+
+    bool has_tensor(std::string_view name) const noexcept override {
+        return base_->has_tensor(name);
+    }
+
+    assets::TensorMetadata require_metadata(std::string_view name) const override {
+        return base_->require_metadata(name);
+    }
+
+    std::vector<assets::TensorMetadata> tensors() const override {
+        return base_->tensors();
+    }
+
+    void release_storage() const override {
+        base_->release_storage();
+    }
+
+    assets::RawTensorData require_tensor_data(std::string_view name) const override {
+        const auto delta = deltas_.find(std::string(name));
+        if (delta == deltas_.end()) {
+            return base_->require_tensor_data(name);
+        }
+        const std::string key(name);
+        const auto values = merged_f32_values(*base_, key, delta->second);
+        assets::RawTensorData raw;
+        raw.metadata = assets::TensorMetadata{key, "F32", {delta->second.out, delta->second.in}};
+        raw.bytes.resize(values.size() * sizeof(float));
+        std::memcpy(raw.bytes.data(), values.data(), raw.bytes.size());
+        return raw;
+    }
+
+    std::vector<float> require_f32(
+        std::string_view name,
+        const std::optional<std::vector<int64_t>> & expected_shape) const override {
+        const auto delta = deltas_.find(std::string(name));
+        if (delta == deltas_.end()) {
+            return base_->require_f32(name, expected_shape);
+        }
+        return merged_f32_values(*base_, std::string(name), delta->second);
+    }
+
+    std::optional<std::vector<float>> optional_f32(
+        std::string_view name,
+        const std::optional<std::vector<int64_t>> & expected_shape) const override {
+        if (!has_tensor(name)) {
+            return std::nullopt;
+        }
+        return require_f32(name, expected_shape);
+    }
+
+    int64_t require_i64_scalar(std::string_view name) const override {
+        return base_->require_i64_scalar(name);
+    }
+
+private:
+    std::shared_ptr<const assets::TensorSource> base_;
+    std::unordered_map<std::string, LoraTensorDelta> deltas_;
+};
+
+std::unordered_map<std::string, LoraTensorNames> collect_lora_tensor_names(const assets::TensorSource & adapter) {
+    std::unordered_map<std::string, LoraTensorNames> names;
+    for (const auto & metadata : adapter.tensors()) {
+        const std::string stripped = strip_prefix(metadata.name, kPeftPrefix);
+        if (has_suffix(stripped, kLoraASuffix)) {
+            names[stripped.substr(0, stripped.size() - kLoraASuffix.size())].a_name = metadata.name;
+        } else if (has_suffix(stripped, kLoraBSuffix)) {
+            names[stripped.substr(0, stripped.size() - kLoraBSuffix.size())].b_name = metadata.name;
+        }
+    }
+    return names;
+}
+
+LoraTensorDelta load_lora_delta(
+    const assets::TensorSource & base,
+    const assets::TensorSource & adapter,
+    const std::string & module_path,
+    const LoraTensorNames & names,
+    const std::string & base_name,
+    float scale) {
+    if (!names.a_name.has_value() || !names.b_name.has_value()) {
+        throw std::runtime_error("VibeVoice LoRA module is missing an A/B pair: " + module_path);
+    }
+    const auto a_meta = adapter.require_metadata(*names.a_name);
+    const auto b_meta = adapter.require_metadata(*names.b_name);
+    if (a_meta.shape.size() != 2 || b_meta.shape.size() != 2) {
+        throw std::runtime_error("VibeVoice LoRA A/B tensors must be rank-2: " + module_path);
+    }
+    LoraTensorDelta delta;
+    delta.r = a_meta.shape[0];
+    delta.in = a_meta.shape[1];
+    delta.out = b_meta.shape[0];
+    delta.scale = scale;
+    if (b_meta.shape[1] != delta.r) {
+        throw std::runtime_error("VibeVoice LoRA A/B rank mismatch for " + module_path);
+    }
+    if (base.require_metadata(base_name).shape != std::vector<int64_t>({delta.out, delta.in})) {
+        throw std::runtime_error(
+            "VibeVoice LoRA shape mismatch for " + base_name + " (adapter is trained for a different model size)");
+    }
+    delta.a = adapter.require_f32(*names.a_name, std::optional<std::vector<int64_t>>({delta.r, delta.in}));
+    delta.b = adapter.require_f32(*names.b_name, std::optional<std::vector<int64_t>>({delta.out, delta.r}));
+    return delta;
+}
+
+}  // namespace
+
+std::shared_ptr<const assets::TensorSource> make_lora_merged_tensor_source(
+    std::shared_ptr<const assets::TensorSource> base,
+    const std::filesystem::path & adapter_path,
+    float scale_override) {
+    if (base == nullptr) {
+        throw std::runtime_error("VibeVoice LoRA merge requires a base tensor source");
+    }
+    const auto paths = resolve_adapter_paths(adapter_path);
+    const float scale = resolve_adapter_scale(paths.config, scale_override);
+    const auto adapter = assets::open_tensor_source(paths.weights);
+
+    const auto tensor_names = collect_lora_tensor_names(*adapter);
+    if (tensor_names.empty()) {
+        throw std::runtime_error("VibeVoice LoRA adapter contains no lora_A/lora_B tensors: " + paths.weights.string());
+    }
+
+    std::unordered_map<std::string, LoraTensorDelta> deltas;
+    deltas.reserve(tensor_names.size());
+    for (const auto & [module_path, names] : tensor_names) {
+        const std::string base_name = resolve_base_weight_name(*base, module_path);
+        deltas.emplace(base_name, load_lora_delta(*base, *adapter, module_path, names, base_name, scale));
+    }
+
+    return std::make_shared<LoraMergedTensorSource>(std::move(base), std::move(deltas));
+}
+
+}  // namespace engine::models::vibevoice

--- a/src/models/vibevoice/session.cpp
+++ b/src/models/vibevoice/session.cpp
@@ -4,6 +4,7 @@
 #include "engine/framework/assets/tensor_source.h"
 #include "engine/framework/debug/trace.h"
 #include "engine/framework/runtime/options.h"
+#include "engine/models/vibevoice/lora.h"
 
 #include <algorithm>
 #include <cctype>
@@ -25,6 +26,25 @@ std::shared_ptr<const VibeVoiceAssets> require_assets(std::shared_ptr<const Vibe
         throw std::runtime_error("VibeVoice session requires assets");
     }
     return assets;
+}
+
+std::shared_ptr<const VibeVoiceAssets> apply_lora_option(
+    std::shared_ptr<const VibeVoiceAssets> assets,
+    const runtime::SessionOptions & options) {
+    const auto lora_path = runtime::find_option(options.options, {"vibevoice.lora"});
+    if (!lora_path.has_value() || lora_path->empty()) {
+        return assets;
+    }
+    float scale_override = -1.0F;
+    if (const auto value = runtime::parse_finite_float_option(options.options, {"vibevoice.lora_scale"})) {
+        if (*value <= 0.0F) {
+            throw std::runtime_error("VibeVoice vibevoice.lora_scale must be positive");
+        }
+        scale_override = *value;
+    }
+    auto updated = std::make_shared<VibeVoiceAssets>(*assets);
+    updated->model_weights = make_lora_merged_tensor_source(assets->model_weights, *lora_path, scale_override);
+    return updated;
 }
 
 void validate_weight_storage(engine::assets::TensorStorageType storage_type, const char * option_name) {
@@ -52,6 +72,8 @@ const runtime::SessionOptions & require_supported_backend_options(const runtime:
             key == "vibevoice.decoder_weight_type" ||
             key == "vibevoice.diffusion_head_weight_type") {
             validate_weight_storage(engine::assets::parse_tensor_storage_type(value), key.c_str());
+        } else if (key == "vibevoice.lora" || key == "vibevoice.lora_scale") {
+            // Validated where the adapter is loaded.
         } else if (key.rfind("vibevoice.", 0) == 0) {
             throw std::runtime_error("unknown VibeVoice session option: " + key);
         }
@@ -195,7 +217,7 @@ VibeVoiceSession::VibeVoiceSession(
     std::shared_ptr<const VibeVoiceAssets> assets)
     : runtime::RuntimeSessionBase(require_supported_backend_options(options)),
       task_(task),
-      assets_(require_assets(std::move(assets))),
+      assets_(apply_lora_option(require_assets(std::move(assets)), options)),
       text_tokenizer_(assets_),
       audio_tokenizer_(
           assets_,

--- a/tools/model_manager.py
+++ b/tools/model_manager.py
@@ -512,6 +512,52 @@ CATALOG: tuple[ModelPackage, ...] = (
         ),
     ),
     ModelPackage(
+        id="vibevoice_7b",
+        display_name="VibeVoice 7B",
+        target_directory="VibeVoice-7B",
+        source=CompositeSnapshotSource(
+            placements=(
+                SnapshotPlacement(
+                    source=SnapshotSource(repo_id="vibevoice/VibeVoice-7B"),
+                    required_files=(
+                        "config.json",
+                        "model.safetensors.index.json",
+                        "model-00001-of-00010.safetensors",
+                        "model-00002-of-00010.safetensors",
+                        "model-00003-of-00010.safetensors",
+                        "model-00004-of-00010.safetensors",
+                        "model-00005-of-00010.safetensors",
+                        "model-00006-of-00010.safetensors",
+                        "model-00007-of-00010.safetensors",
+                        "model-00008-of-00010.safetensors",
+                        "model-00009-of-00010.safetensors",
+                        "model-00010-of-00010.safetensors",
+                        "preprocessor_config.json",
+                    ),
+                ),
+            ),
+        ),
+        required_files=(
+            "config.json",
+            "model.safetensors.index.json",
+            "model-00001-of-00010.safetensors",
+            "model-00002-of-00010.safetensors",
+            "model-00003-of-00010.safetensors",
+            "model-00004-of-00010.safetensors",
+            "model-00005-of-00010.safetensors",
+            "model-00006-of-00010.safetensors",
+            "model-00007-of-00010.safetensors",
+            "model-00008-of-00010.safetensors",
+            "model-00009-of-00010.safetensors",
+            "model-00010-of-00010.safetensors",
+            "preprocessor_config.json",
+            "tokenizer.json",
+            "tokenizer_config.json",
+            "vocab.json",
+            "merges.txt",
+        ),
+    ),
+    ModelPackage(
         id="higgs_audio_v3_tts_4b",
         display_name="Higgs Audio v3 TTS 4B",
         target_directory="higgs-audio-v3-tts-4b",
@@ -1305,7 +1351,9 @@ def install_composite_snapshot(
             convert_moss_tts_weights(staged_package_root)
         elif package.id in {"irodori_tts_500m_v3", "irodori_tts_600m_v3_voice_design"}:
             convert_irodori_dacvae_weights(staged_package_root.parent / "Semantic-DACVAE-Japanese-32dim")
-        elif package.id == "vibevoice_1_5b":
+        elif package.id in {"vibevoice_1_5b", "vibevoice_7b"}:
+            # VibeVoice 1.5B and 7B share the same Qwen2.5 tokenizer, and neither
+            # upstream repo ships the tokenizer files, so both reuse one bundle.
             copy_bundled_model_manager_assets(
                 "vibevoice_1_5b",
                 staged_package_root,


### PR DESCRIPTION
Support the VibeVoice 7B model alongside the 1.5B:
- Add the vibevoice_7b model-manager package, reusing the shared Qwen2.5 tokenizer bundle.
- Handle the 7B config.json, tolerating its upstream "acostic_vae_dim" key and reading top-level tie_word_embeddings.
- Load a separate lm_head.weight when word embeddings are untied and bind the decoder logits head to it.

Add optional PEFT LoRA merging for the decoder:
- Merge lora_A/lora_B into the targeted linear weights at load time via a tensor-source decorator, so it composes with the weight-type quantization options at no per-step cost.
- Expose it through the vibevoice.lora / vibevoice.lora_scale load options and document it in the README and docs/tts.md.