### PR TITLE
Add VibeVoice 7B support and decoder LoRA merging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ add_compile_options(
 add_library(engine_runtime STATIC
     src/framework/assets/resource_bundle.cpp
     src/framework/assets/tensor_source.cpp
+    src/framework/assets/torch_bin.cpp
     src/framework/core/module.cpp
     src/framework/core/backend.cpp
     src/framework/core/deferred_tensor_writer.cpp
@@ -413,6 +414,24 @@ add_executable(miocodec_wavlm_parity
 )
 
 target_link_libraries(miocodec_wavlm_parity PRIVATE engine_runtime ggml)
+
+add_executable(torch_bin_parity
+    tests/vibevoice/torch_bin_parity.cpp
+)
+
+target_link_libraries(torch_bin_parity PRIVATE engine_runtime ggml)
+if (ENGINE_ENABLE_OPENMP)
+    target_link_libraries(torch_bin_parity PRIVATE OpenMP::OpenMP_CXX)
+endif()
+
+add_executable(vibevoice_finetune_overlay_check
+    tests/vibevoice/finetune_overlay_check.cpp
+)
+
+target_link_libraries(vibevoice_finetune_overlay_check PRIVATE engine_runtime ggml)
+if (ENGINE_ENABLE_OPENMP)
+    target_link_libraries(vibevoice_finetune_overlay_check PRIVATE OpenMP::OpenMP_CXX)
+endif()
 
 if (ENGINE_BUILD_WARMBENCH)
     function(add_engine_warmbench target_name source_file)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,6 +219,7 @@ add_library(engine_runtime STATIC
     src/models/vibevoice/diffusion_sampler.cpp
     src/models/vibevoice/generator.cpp
     src/models/vibevoice/loader.cpp
+    src/models/vibevoice/lora.cpp
     src/models/vibevoice/scheduler.cpp
     src/models/vibevoice/session.cpp
     src/models/vibevoice/tokenizer_audio.cpp

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Highlights:
 ## News
 
 > [!IMPORTANT]
-> **2026-07-01:** VibeVoice 7B joins the 1.5B model, and decoder LoRA adapters can now be merged at load time through `--load-option vibevoice.lora`.
+> **2026-07-01:** VibeVoice 7B joins the 1.5B model, and full fine-tune adapters — language-model LoRA plus fine-tuned diffusion head and acoustic/semantic connectors — can now be merged at load time through `--load-option vibevoice.lora`.
 
 > [!IMPORTANT]
 > **2026-06-30:** VibeVoice 1.5B is now released in the framework, bringing long-form, multi-speaker dialogue TTS into the normal audio.cpp model surface.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Highlights:
 ## News
 
 > [!IMPORTANT]
+> **2026-07-01:** VibeVoice 7B joins the 1.5B model, and decoder LoRA adapters can now be merged at load time through `--load-option vibevoice.lora`.
+
+> [!IMPORTANT]
 > **2026-06-30:** VibeVoice 1.5B is now released in the framework, bringing long-form, multi-speaker dialogue TTS into the normal audio.cpp model surface.
 
 > [!TIP]
@@ -55,7 +58,7 @@ Current model status in the framework:
 | **silero_vad** | VAD | lang agnostic | Silero VAD | **released** |
 | **sortformer_diar** | diarization | en | Sortformer-4spk-v1 | **released** |
 | **vevo2** | TTS, singing generation, voice conversion, singing conversion, editing | en, zh | Vevo2 with Qwen2.5-0.5B AR model | **released** |
-| **vibevoice** | TTS, multi-speaker dialogue TTS | en, zh | VibeVoice-1.5B | **released** |
+| **vibevoice** | TTS, multi-speaker dialogue TTS | en, zh | VibeVoice-1.5B, VibeVoice-7B | **released** |
 | **voxcpm2** | TTS, voice cloning, voice design | ar, da, de, el, en, es, fi, fr, he, hi, id, it, ja, km, ko, lo, ms, my, nl, no, pl, pt, ru, sv, sw, th, tl, tr, vi, zh | VoxCPM2-2B, 48 kHz | **released** |
 | ace_step | music generation | 50+ langs | ACE-Step 1.5 with acestep-5Hz-lm-1.7B | integration |
 | audio_flamingo_next | audio understanding, ASR, audio captioning, audio QA | en, multilingual audio understanding | Audio Flamingo Next Instruct, Qwen2-7B based | optimization |
@@ -425,6 +428,7 @@ Recommended top-level install packages:
 | `supertonic_3` | Supertonic 3 | **Yes** |
 | `vevo2` | Vevo2 | No |
 | `vibevoice_1_5b` | VibeVoice 1.5B | No |
+| `vibevoice_7b` | VibeVoice 7B | No |
 | `voxcpm2` | VoxCPM2 | No |
 
 > [!WARNING]

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -358,18 +358,21 @@ audiocpp_cli --task tts --family supertonic --model models/supertonic-3 --backen
 
 ## VibeVoice
 
-VibeVoice 1.5B is a long-form multi-speaker TTS model. Prompts use speaker-labeled lines, and speaker reference WAVs are provided in the same order as the speaker ids.
+VibeVoice is a long-form multi-speaker TTS model, available in 1.5B and 7B sizes. Prompts use speaker-labeled lines, and speaker reference WAVs are provided in the same order as the speaker ids.
 
 | Field | Value |
 |---|---|
 | Family | `vibevoice` |
-| Model directory | `models/VibeVoice-1.5B` |
+| Model directory | `models/VibeVoice-1.5B` (or `models/VibeVoice-7B`) |
 | Task | `tts` |
 | Modes | `offline` |
 | Languages | Model auto-handles supported languages |
 | Voice input | Up to four speaker reference WAVs through `voice_samples` |
 | Text format | Lines like `Speaker 1: ... Speaker 2: ...`; ids are normalized internally |
 | Long-form | No text chunking; generation uses the model long-form path |
+| LoRA | Optional PEFT decoder adapter through `--load-option vibevoice.lora` |
+
+Both sizes share the same CLI surface and the same Qwen2.5 tokenizer; the 7B is simply larger (hidden size 3584 vs 1536) and needs a matching 7B LoRA if one is used.
 
 ```bash
 audiocpp_cli --task tts --family vibevoice --model models/VibeVoice-1.5B --backend cuda --text "Speaker 1: Hello. Speaker 2: Nice to meet you." --request-option voice_samples=assets/resources/a.wav,assets/resources/b.wav --out out.wav
@@ -386,5 +389,9 @@ audiocpp_cli --task tts --family vibevoice --model models/VibeVoice-1.5B --backe
 | `--temperature` | float | `1.0` | Decoder sampling temperature. |
 | `--top-k` | integer | `50` | Decoder top-k sampling limit. |
 | `--top-p` | float | `1.0` | Decoder nucleus sampling limit. |
+| `--load-option vibevoice.lora=<path>` | PEFT adapter dir or `.safetensors` | not set | Merge a LoRA adapter into the decoder linears at load time. Adapter dims must match the base model size. |
+| `--load-option vibevoice.lora_scale=<float>` | float | `lora_alpha / r` | Override the LoRA merge scale from `adapter_config.json`. |
+
+A LoRA is merged into the base weights at load time, so it composes with the `vibevoice.*_weight_type` quantization options and adds no per-step cost. Use a 1.5B adapter with `VibeVoice-1.5B` and a 7B adapter with `VibeVoice-7B`; a size mismatch is rejected with a descriptive error.
 
 For backend weight-type controls, use `audiocpp_cli --inspect --model <model-dir> --family <family>`.

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -389,9 +389,9 @@ audiocpp_cli --task tts --family vibevoice --model models/VibeVoice-1.5B --backe
 | `--temperature` | float | `1.0` | Decoder sampling temperature. |
 | `--top-k` | integer | `50` | Decoder top-k sampling limit. |
 | `--top-p` | float | `1.0` | Decoder nucleus sampling limit. |
-| `--load-option vibevoice.lora=<path>` | PEFT adapter dir or `.safetensors` | not set | Merge a LoRA adapter into the decoder linears at load time. Adapter dims must match the base model size. |
+| `--load-option vibevoice.lora=<path>` | fine-tune adapter dir | not set | Overlay a fine-tune at load time: the language-model LoRA is delta-merged into the decoder linears, and the diffusion head and acoustic/semantic connectors (when present in the adapter dir) replace their base tensors. Dims must match the base model size. |
 | `--load-option vibevoice.lora_scale=<float>` | float | `lora_alpha / r` | Override the LoRA merge scale from `adapter_config.json`. |
 
-A LoRA is merged into the base weights at load time, so it composes with the `vibevoice.*_weight_type` quantization options and adds no per-step cost. Use a 1.5B adapter with `VibeVoice-1.5B` and a 7B adapter with `VibeVoice-7B`; a size mismatch is rejected with a descriptive error.
+The adapter follows the PEFT training layout: `adapter_model.safetensors` + `adapter_config.json` for the language-model LoRA, plus optional `diffusion_head/model.safetensors` (or `diffusion_head_full.bin`), `acoustic_connector/pytorch_model.bin`, and `semantic_connector/pytorch_model.bin` for the fully fine-tuned components. Everything is applied at load time, so it composes with the `vibevoice.*_weight_type` quantization options and adds no per-step cost; the overlay is logged with `--log`. Use a 1.5B adapter with `VibeVoice-1.5B` and a 7B adapter with `VibeVoice-7B`; a size mismatch is rejected with a descriptive error. The same option may instead be passed as `--session-option vibevoice.lora` (but not via both at once).
 
 For backend weight-type controls, use `audiocpp_cli --inspect --model <model-dir> --family <family>`.

--- a/include/engine/framework/assets/torch_bin.h
+++ b/include/engine/framework/assets/torch_bin.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "engine/framework/assets/tensor_source.h"
+
+#include <filesystem>
+#include <memory>
+
+namespace engine::assets {
+
+// Opens a PyTorch `.bin` checkpoint (a ZIP archive wrapping a pickled state dict) as a
+// tensor source. Only the restricted subset produced by torch.save of a flat
+// OrderedDict[str, Tensor] is supported, and the pickle is walked with a whitelist of
+// globals so no adapter code is ever executed. Tensor storages must be uncompressed.
+std::shared_ptr<const TensorSource> open_torch_bin_tensor_source(const std::filesystem::path & path);
+
+}  // namespace engine::assets

--- a/include/engine/models/vibevoice/assets.h
+++ b/include/engine/models/vibevoice/assets.h
@@ -111,6 +111,9 @@ struct VibeVoiceAssets {
     std::shared_ptr<const assets::TensorSource> model_weights;
     float speech_scaling_factor = 1.0F;
     float speech_bias_factor = 0.0F;
+    // Set once a fine-tune adapter has been overlaid onto model_weights, so the same adapter is
+    // not applied twice (e.g. via both --load-option and --session-option).
+    bool fine_tune_applied = false;
 };
 
 VibeVoiceAssetPaths resolve_vibevoice_assets(const std::filesystem::path & model_path);

--- a/include/engine/models/vibevoice/decoder.h
+++ b/include/engine/models/vibevoice/decoder.h
@@ -92,6 +92,7 @@ struct VibeVoiceDecoderLayerWeights {
 struct VibeVoiceDecoderWeights {
     std::shared_ptr<core::BackendWeightStore> store;
     core::TensorValue token_embedding;
+    core::TensorValue lm_head;
     std::vector<VibeVoiceDecoderLayerWeights> layers;
     assets::TensorDataF32 norm;
 };

--- a/include/engine/models/vibevoice/lora.h
+++ b/include/engine/models/vibevoice/lora.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "engine/framework/assets/tensor_source.h"
+
+#include <filesystem>
+#include <memory>
+
+namespace engine::models::vibevoice {
+
+std::shared_ptr<const assets::TensorSource> make_lora_merged_tensor_source(
+    std::shared_ptr<const assets::TensorSource> base,
+    const std::filesystem::path & adapter_path,
+    float scale_override);
+
+}  // namespace engine::models::vibevoice

--- a/include/engine/models/vibevoice/lora.h
+++ b/include/engine/models/vibevoice/lora.h
@@ -1,15 +1,29 @@
 #pragma once
 
 #include "engine/framework/assets/tensor_source.h"
+#include "engine/models/vibevoice/assets.h"
 
 #include <filesystem>
 #include <memory>
+#include <string>
+#include <unordered_map>
 
 namespace engine::models::vibevoice {
 
-std::shared_ptr<const assets::TensorSource> make_lora_merged_tensor_source(
+// Overlays a fine-tune adapter directory onto a base weight source: the language-model LoRA is
+// delta-merged into the decoder linears, and the diffusion head and acoustic/semantic connectors
+// (when present) fully replace their base tensors. Mirrors infer.py's apply_lora.
+std::shared_ptr<const assets::TensorSource> make_vibevoice_finetune_source(
     std::shared_ptr<const assets::TensorSource> base,
     const std::filesystem::path & adapter_path,
     float scale_override);
+
+// Applies the fine-tune adapter selected by the vibevoice.lora / vibevoice.lora_scale options,
+// returning assets whose model_weights carry the overlay (and fine_tune_applied set). Returns the
+// input unchanged when no vibevoice.lora option is present; throws if an adapter was already
+// applied (guards against passing it via both --load-option and --session-option).
+std::shared_ptr<const VibeVoiceAssets> apply_vibevoice_finetune_options(
+    std::shared_ptr<const VibeVoiceAssets> assets,
+    const std::unordered_map<std::string, std::string> & options);
 
 }  // namespace engine::models::vibevoice

--- a/src/framework/assets/torch_bin.cpp
+++ b/src/framework/assets/torch_bin.cpp
@@ -1,0 +1,582 @@
+#include "engine/framework/assets/torch_bin.h"
+
+#include <ggml.h>
+
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <map>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace engine::assets {
+namespace {
+
+// ---- Byte helpers -------------------------------------------------------------------
+
+uint16_t read_u16le(const uint8_t * data) {
+    return static_cast<uint16_t>(data[0]) | static_cast<uint16_t>(static_cast<uint16_t>(data[1]) << 8);
+}
+
+uint32_t read_u32le(const uint8_t * data) {
+    return static_cast<uint32_t>(data[0]) | (static_cast<uint32_t>(data[1]) << 8) |
+        (static_cast<uint32_t>(data[2]) << 16) | (static_cast<uint32_t>(data[3]) << 24);
+}
+
+std::vector<uint8_t> read_file(const std::filesystem::path & path) {
+    std::ifstream stream(path, std::ios::binary | std::ios::ate);
+    if (!stream) {
+        throw std::runtime_error("torch .bin cannot be opened: " + path.string());
+    }
+    const std::streamsize size = stream.tellg();
+    if (size < 0) {
+        throw std::runtime_error("torch .bin has an invalid size: " + path.string());
+    }
+    stream.seekg(0);
+    std::vector<uint8_t> bytes(static_cast<size_t>(size));
+    if (size > 0 && !stream.read(reinterpret_cast<char *>(bytes.data()), size)) {
+        throw std::runtime_error("torch .bin could not be read: " + path.string());
+    }
+    return bytes;
+}
+
+// ---- Minimal STORED-only ZIP reader -------------------------------------------------
+
+constexpr uint32_t kEocdSignature = 0x06054b50;
+constexpr uint32_t kCentralSignature = 0x02014b50;
+constexpr uint32_t kLocalSignature = 0x04034b50;
+constexpr uint32_t kZip64Sentinel = 0xffffffff;
+
+struct ZipEntry {
+    size_t offset = 0;  // byte offset of the entry payload inside the archive
+    size_t size = 0;    // payload size in bytes
+};
+
+std::map<std::string, ZipEntry> read_zip_entries(const std::vector<uint8_t> & bytes) {
+    if (bytes.size() < 22) {
+        throw std::runtime_error("torch .bin is too small to be a zip archive");
+    }
+    // Scan backwards for the end-of-central-directory record (no archive comment in torch files).
+    size_t eocd = bytes.size();
+    const size_t scan_limit = bytes.size() >= (22 + 0xffff) ? bytes.size() - (22 + 0xffff) : 0;
+    for (size_t pos = bytes.size() - 22 + 1; pos-- > scan_limit;) {
+        if (read_u32le(bytes.data() + pos) == kEocdSignature) {
+            eocd = pos;
+            break;
+        }
+    }
+    if (eocd == bytes.size()) {
+        throw std::runtime_error("torch .bin end-of-central-directory record not found");
+    }
+    const uint16_t entry_count = read_u16le(bytes.data() + eocd + 10);
+    const uint32_t central_offset = read_u32le(bytes.data() + eocd + 16);
+    if (central_offset == kZip64Sentinel) {
+        throw std::runtime_error("torch .bin uses zip64, which is not supported");
+    }
+
+    std::map<std::string, ZipEntry> entries;
+    size_t cursor = central_offset;
+    for (uint16_t index = 0; index < entry_count; ++index) {
+        if (cursor + 46 > bytes.size() || read_u32le(bytes.data() + cursor) != kCentralSignature) {
+            throw std::runtime_error("torch .bin central directory is malformed");
+        }
+        const uint16_t method = read_u16le(bytes.data() + cursor + 10);
+        const uint32_t compressed = read_u32le(bytes.data() + cursor + 20);
+        const uint32_t uncompressed = read_u32le(bytes.data() + cursor + 24);
+        const uint16_t name_len = read_u16le(bytes.data() + cursor + 28);
+        const uint16_t extra_len = read_u16le(bytes.data() + cursor + 30);
+        const uint16_t comment_len = read_u16le(bytes.data() + cursor + 32);
+        const uint32_t local_offset = read_u32le(bytes.data() + cursor + 42);
+        if (cursor + 46 + name_len > bytes.size()) {
+            throw std::runtime_error("torch .bin central directory entry is truncated");
+        }
+        std::string name(reinterpret_cast<const char *>(bytes.data() + cursor + 46), name_len);
+
+        if (local_offset == kZip64Sentinel || compressed != uncompressed) {
+            throw std::runtime_error("torch .bin entry is compressed or zip64, which is not supported: " + name);
+        }
+        if (method != 0) {
+            throw std::runtime_error("torch .bin entry is not stored uncompressed: " + name);
+        }
+        if (local_offset + 30 > bytes.size() || read_u32le(bytes.data() + local_offset) != kLocalSignature) {
+            throw std::runtime_error("torch .bin local header is malformed: " + name);
+        }
+        const uint16_t local_name_len = read_u16le(bytes.data() + local_offset + 26);
+        const uint16_t local_extra_len = read_u16le(bytes.data() + local_offset + 28);
+        const size_t data_offset = local_offset + 30 + local_name_len + local_extra_len;
+        if (data_offset + uncompressed > bytes.size()) {
+            throw std::runtime_error("torch .bin entry data is out of bounds: " + name);
+        }
+        entries.emplace(std::move(name), ZipEntry{data_offset, uncompressed});
+        cursor += 46 + name_len + extra_len + comment_len;
+    }
+    return entries;
+}
+
+// ---- Restricted pickle interpreter --------------------------------------------------
+
+enum class GlobalKind { None, OrderedDict, RebuildTensor, StorageF32, StorageF16, StorageBF16 };
+
+struct PickleValue {
+    enum class Kind { None, Int, Bool, Str, Tuple, Global, Storage, Tensor, Dict } kind = Kind::None;
+    int64_t integer = 0;
+    bool boolean = false;
+    std::string text;                 // Str value, or a Storage/Tensor storage key
+    std::vector<PickleValue> items;   // Tuple items, or a Dict as flat [k0, v0, k1, v1, ...]
+    GlobalKind global = GlobalKind::None;  // Global callable, or a Storage/Tensor dtype
+    std::vector<int64_t> shape;       // Tensor shape
+    int64_t numel = 0;                // Storage/Tensor element count
+};
+
+GlobalKind classify_global(const std::string & module, const std::string & name) {
+    if (module == "collections" && name == "OrderedDict") {
+        return GlobalKind::OrderedDict;
+    }
+    if (module == "torch._utils" && name == "_rebuild_tensor_v2") {
+        return GlobalKind::RebuildTensor;
+    }
+    if (module == "torch" && name == "FloatStorage") {
+        return GlobalKind::StorageF32;
+    }
+    if (module == "torch" && name == "HalfStorage") {
+        return GlobalKind::StorageF16;
+    }
+    if (module == "torch" && name == "BFloat16Storage") {
+        return GlobalKind::StorageBF16;
+    }
+    throw std::runtime_error("torch .bin pickle references an unsupported global: " + module + "." + name);
+}
+
+class PickleReader {
+public:
+    explicit PickleReader(const uint8_t * data, size_t size) : data_(data), size_(size) {}
+
+    // Returns the state dict as a flat [key, value, key, value, ...] tuple of the final OrderedDict.
+    std::vector<PickleValue> parse() {
+        while (cursor_ < size_) {
+            const uint8_t op = data_[cursor_++];
+            switch (op) {
+                case 0x80: expect(1); cursor_ += 1; break;                       // PROTO
+                case 0x95: expect(8); cursor_ += 8; break;                       // FRAME
+                case '(': marks_.push_back(stack_.size()); break;                // MARK
+                case '0': pop(); break;                                          // POP
+                case 'N': push(none_value()); break;                            // NONE
+                case 0x88: push(bool_value(true)); break;                       // NEWTRUE
+                case 0x89: push(bool_value(false)); break;                      // NEWFALSE
+                case 'K': push(int_value(read_byte())); break;                  // BININT1
+                case 'M': push(int_value(read_u16())); break;                   // BININT2
+                case 'J': push(int_value(read_i32())); break;                   // BININT
+                case 0x8a: push(int_value(read_long1())); break;                // LONG1
+                case 'X': push(str_value(read_bytes(read_u32()))); break;       // BINUNICODE
+                case 0x8c: push(str_value(read_bytes(read_byte()))); break;     // SHORT_BINUNICODE
+                case 'c': op_global(); break;                                   // GLOBAL
+                case 0x93: op_stack_global(); break;                            // STACK_GLOBAL
+                case ')': push(tuple_value({})); break;                         // EMPTY_TUPLE
+                case '}': push(dict_value()); break;                            // EMPTY_DICT
+                case 0x85: op_tuple(1); break;                                  // TUPLE1
+                case 0x86: op_tuple(2); break;                                  // TUPLE2
+                case 0x87: op_tuple(3); break;                                  // TUPLE3
+                case 't': op_tuple_mark(); break;                               // TUPLE
+                case 'q': op_put(read_byte()); break;                           // BINPUT
+                case 'r': op_put(read_u32()); break;                            // LONG_BINPUT
+                case 'h': op_get(read_byte()); break;                           // BINGET
+                case 'j': op_get(read_u32()); break;                            // LONG_BINGET
+                case 'Q': op_persid(); break;                                   // BINPERSID
+                case 'R': op_reduce(); break;                                   // REDUCE
+                case 's': op_setitem(); break;                                  // SETITEM
+                case 'u': op_setitems(); break;                                 // SETITEMS
+                case 'b': pop(); break;                                          // BUILD (drop __setstate__ payload, e.g. _metadata)
+                case '.': return finish();                                       // STOP
+                default:
+                    throw std::runtime_error(
+                        "torch .bin pickle uses an unsupported opcode: " + std::to_string(op));
+            }
+        }
+        throw std::runtime_error("torch .bin pickle ended without a STOP opcode");
+    }
+
+private:
+    static PickleValue none_value() { return PickleValue{}; }
+    static PickleValue int_value(int64_t v) {
+        PickleValue value;
+        value.kind = PickleValue::Kind::Int;
+        value.integer = v;
+        return value;
+    }
+    static PickleValue bool_value(bool v) {
+        PickleValue value;
+        value.kind = PickleValue::Kind::Bool;
+        value.boolean = v;
+        return value;
+    }
+    static PickleValue str_value(std::string v) {
+        PickleValue value;
+        value.kind = PickleValue::Kind::Str;
+        value.text = std::move(v);
+        return value;
+    }
+    static PickleValue tuple_value(std::vector<PickleValue> v) {
+        PickleValue value;
+        value.kind = PickleValue::Kind::Tuple;
+        value.items = std::move(v);
+        return value;
+    }
+    static PickleValue dict_value() {
+        PickleValue value;
+        value.kind = PickleValue::Kind::Dict;
+        return value;
+    }
+
+    void expect(size_t count) const {
+        if (cursor_ + count > size_) {
+            throw std::runtime_error("torch .bin pickle is truncated");
+        }
+    }
+    uint8_t read_byte() { expect(1); return data_[cursor_++]; }
+    uint16_t read_u16() { expect(2); const uint16_t v = read_u16le(data_ + cursor_); cursor_ += 2; return v; }
+    uint32_t read_u32() { expect(4); const uint32_t v = read_u32le(data_ + cursor_); cursor_ += 4; return v; }
+    int32_t read_i32() { return static_cast<int32_t>(read_u32()); }
+    int64_t read_long1() {
+        const uint8_t length = read_byte();
+        expect(length);
+        int64_t value = 0;
+        for (uint8_t i = 0; i < length; ++i) {
+            value |= static_cast<int64_t>(data_[cursor_ + i]) << (8 * i);
+        }
+        if (length > 0 && length < 8 && (data_[cursor_ + length - 1] & 0x80) != 0) {
+            value |= -(static_cast<int64_t>(1) << (8 * length));  // sign extend
+        }
+        cursor_ += length;
+        return value;
+    }
+    std::string read_bytes(size_t length) {
+        expect(length);
+        std::string out(reinterpret_cast<const char *>(data_ + cursor_), length);
+        cursor_ += length;
+        return out;
+    }
+    std::string read_line() {
+        std::string out;
+        while (cursor_ < size_ && data_[cursor_] != '\n') {
+            out.push_back(static_cast<char>(data_[cursor_++]));
+        }
+        expect(1);  // consume the '\n'
+        ++cursor_;
+        return out;
+    }
+
+    void push(PickleValue value) { stack_.push_back(std::move(value)); }
+    PickleValue pop() {
+        if (stack_.empty()) {
+            throw std::runtime_error("torch .bin pickle stack underflow");
+        }
+        PickleValue value = std::move(stack_.back());
+        stack_.pop_back();
+        return value;
+    }
+    size_t pop_mark() {
+        if (marks_.empty()) {
+            throw std::runtime_error("torch .bin pickle mark underflow");
+        }
+        const size_t mark = marks_.back();
+        marks_.pop_back();
+        return mark;
+    }
+
+    void op_global() {
+        const std::string module = read_line();
+        const std::string name = read_line();
+        PickleValue value;
+        value.kind = PickleValue::Kind::Global;
+        value.global = classify_global(module, name);
+        push(std::move(value));
+    }
+    void op_stack_global() {
+        const PickleValue name = pop();
+        const PickleValue module = pop();
+        PickleValue value;
+        value.kind = PickleValue::Kind::Global;
+        value.global = classify_global(module.text, name.text);
+        push(std::move(value));
+    }
+    void op_tuple(size_t count) {
+        std::vector<PickleValue> items(count);
+        for (size_t i = 0; i < count; ++i) {
+            items[count - 1 - i] = pop();
+        }
+        push(tuple_value(std::move(items)));
+    }
+    void op_tuple_mark() {
+        const size_t mark = pop_mark();
+        std::vector<PickleValue> items(stack_.begin() + static_cast<std::ptrdiff_t>(mark), stack_.end());
+        stack_.erase(stack_.begin() + static_cast<std::ptrdiff_t>(mark), stack_.end());
+        push(tuple_value(std::move(items)));
+    }
+    void op_put(size_t id) {
+        if (stack_.empty()) {
+            throw std::runtime_error("torch .bin pickle put on an empty stack");
+        }
+        if (memo_.size() <= id) {
+            memo_.resize(id + 1);
+        }
+        memo_[id] = stack_.back();
+    }
+    void op_get(size_t id) {
+        if (id >= memo_.size()) {
+            throw std::runtime_error("torch .bin pickle get references an unknown memo id");
+        }
+        push(memo_[id]);
+    }
+    void op_persid() {
+        const PickleValue spec = pop();  // ('storage', StorageType, key, device, numel)
+        if (spec.kind != PickleValue::Kind::Tuple || spec.items.size() < 5 ||
+            spec.items[1].kind != PickleValue::Kind::Global ||
+            spec.items[2].kind != PickleValue::Kind::Str ||
+            spec.items[4].kind != PickleValue::Kind::Int) {
+            throw std::runtime_error("torch .bin pickle has an unexpected storage descriptor");
+        }
+        PickleValue storage;
+        storage.kind = PickleValue::Kind::Storage;
+        storage.global = spec.items[1].global;
+        storage.text = spec.items[2].text;
+        storage.numel = spec.items[4].integer;
+        push(std::move(storage));
+    }
+    void op_reduce() {
+        const PickleValue args = pop();
+        const PickleValue func = pop();
+        if (func.kind != PickleValue::Kind::Global) {
+            throw std::runtime_error("torch .bin pickle reduce on a non-global callable");
+        }
+        if (func.global == GlobalKind::OrderedDict) {
+            push(dict_value());
+            return;
+        }
+        if (func.global == GlobalKind::RebuildTensor) {
+            if (args.kind != PickleValue::Kind::Tuple || args.items.size() < 3 ||
+                args.items[0].kind != PickleValue::Kind::Storage ||
+                args.items[2].kind != PickleValue::Kind::Tuple) {
+                throw std::runtime_error("torch .bin pickle has an unexpected tensor descriptor");
+            }
+            PickleValue tensor;
+            tensor.kind = PickleValue::Kind::Tensor;
+            tensor.global = args.items[0].global;
+            tensor.text = args.items[0].text;
+            tensor.numel = args.items[0].numel;
+            for (const auto & dim : args.items[2].items) {
+                if (dim.kind != PickleValue::Kind::Int) {
+                    throw std::runtime_error("torch .bin pickle tensor shape is not integral");
+                }
+                tensor.shape.push_back(dim.integer);
+            }
+            push(std::move(tensor));
+            return;
+        }
+        throw std::runtime_error("torch .bin pickle reduce on an unsupported callable");
+    }
+    void op_setitem() {
+        PickleValue value = pop();
+        PickleValue key = pop();
+        if (stack_.empty() || stack_.back().kind != PickleValue::Kind::Dict) {
+            throw std::runtime_error("torch .bin pickle setitem without a dict");
+        }
+        stack_.back().items.push_back(std::move(key));
+        stack_.back().items.push_back(std::move(value));
+    }
+    void op_setitems() {
+        const size_t mark = pop_mark();
+        std::vector<PickleValue> items(stack_.begin() + static_cast<std::ptrdiff_t>(mark), stack_.end());
+        stack_.erase(stack_.begin() + static_cast<std::ptrdiff_t>(mark), stack_.end());
+        if (stack_.empty() || stack_.back().kind != PickleValue::Kind::Dict) {
+            throw std::runtime_error("torch .bin pickle setitems without a dict");
+        }
+        for (auto & item : items) {
+            stack_.back().items.push_back(std::move(item));
+        }
+    }
+    std::vector<PickleValue> finish() {
+        const PickleValue result = pop();
+        if (result.kind != PickleValue::Kind::Dict) {
+            throw std::runtime_error("torch .bin pickle did not produce a state dict");
+        }
+        return result.items;
+    }
+
+    const uint8_t * data_;
+    size_t size_;
+    size_t cursor_ = 0;
+    std::vector<PickleValue> stack_;
+    std::vector<PickleValue> memo_;
+    std::vector<size_t> marks_;
+};
+
+// ---- Tensor source ------------------------------------------------------------------
+
+struct TensorRecord {
+    std::string dtype;  // "F32", "F16", or "BF16"
+    std::vector<int64_t> shape;
+    size_t byte_offset = 0;
+    size_t byte_size = 0;
+};
+
+const char * storage_dtype_name(GlobalKind kind) {
+    switch (kind) {
+        case GlobalKind::StorageF32: return "F32";
+        case GlobalKind::StorageF16: return "F16";
+        case GlobalKind::StorageBF16: return "BF16";
+        default:
+            throw std::runtime_error("torch .bin tensor has an unsupported storage dtype");
+    }
+}
+
+size_t dtype_byte_size(const std::string & dtype) {
+    if (dtype == "F32") {
+        return 4;
+    }
+    return 2;  // F16 / BF16
+}
+
+std::vector<float> decode_f32(const std::string & dtype, const uint8_t * data, size_t elements) {
+    std::vector<float> values(elements);
+    if (dtype == "F32") {
+        std::memcpy(values.data(), data, elements * sizeof(float));
+    } else if (dtype == "F16") {
+        ggml_fp16_to_fp32_row(
+            reinterpret_cast<const ggml_fp16_t *>(data), values.data(), static_cast<int64_t>(elements));
+    } else {
+        ggml_bf16_to_fp32_row(
+            reinterpret_cast<const ggml_bf16_t *>(data), values.data(), static_cast<int64_t>(elements));
+    }
+    return values;
+}
+
+int64_t shape_elements(const std::vector<int64_t> & shape) {
+    int64_t total = 1;
+    for (const int64_t dim : shape) {
+        total *= dim;
+    }
+    return total;
+}
+
+class TorchBinTensorSource final : public TensorSource {
+public:
+    explicit TorchBinTensorSource(std::filesystem::path path)
+        : path_(std::move(path)), bytes_(read_file(path_)) {
+        const auto entries = read_zip_entries(bytes_);
+        std::string prefix;
+        const ZipEntry * pickle = nullptr;
+        for (const auto & [name, entry] : entries) {
+            if (name == "data.pkl" || (name.size() >= 9 && name.compare(name.size() - 9, 9, "/data.pkl") == 0)) {
+                prefix = name.substr(0, name.size() - std::string("data.pkl").size());  // keeps trailing '/'
+                pickle = &entry;
+                break;
+            }
+        }
+        if (pickle == nullptr) {
+            throw std::runtime_error("torch .bin does not contain a data.pkl: " + path_.string());
+        }
+        PickleReader reader(bytes_.data() + pickle->offset, pickle->size);
+        const std::vector<PickleValue> entries_flat = reader.parse();
+        for (size_t i = 0; i + 1 < entries_flat.size(); i += 2) {
+            const PickleValue & key = entries_flat[i];
+            const PickleValue & value = entries_flat[i + 1];
+            if (key.kind != PickleValue::Kind::Str || value.kind != PickleValue::Kind::Tensor) {
+                throw std::runtime_error("torch .bin state dict has a non-tensor entry: " + key.text);
+            }
+            const auto storage = entries.find(prefix + "data/" + value.text);
+            if (storage == entries.end()) {
+                throw std::runtime_error("torch .bin is missing storage for tensor: " + key.text);
+            }
+            TensorRecord record;
+            record.dtype = storage_dtype_name(value.global);
+            record.shape = value.shape;
+            const size_t element_bytes = dtype_byte_size(record.dtype);
+            record.byte_size = static_cast<size_t>(shape_elements(value.shape)) * element_bytes;
+            record.byte_offset = storage->second.offset;
+            if (record.byte_size > storage->second.size) {
+                throw std::runtime_error("torch .bin tensor is larger than its storage: " + key.text);
+            }
+            records_.emplace(key.text, std::move(record));
+        }
+    }
+
+    const std::filesystem::path & source_path() const noexcept override {
+        return path_;
+    }
+
+    bool has_tensor(std::string_view name) const noexcept override {
+        return records_.find(std::string(name)) != records_.end();
+    }
+
+    TensorMetadata require_metadata(std::string_view name) const override {
+        const auto & record = require_record(name);
+        return TensorMetadata{std::string(name), record.dtype, record.shape};
+    }
+
+    std::vector<TensorMetadata> tensors() const override {
+        std::vector<TensorMetadata> out;
+        out.reserve(records_.size());
+        for (const auto & [name, record] : records_) {
+            out.push_back({name, record.dtype, record.shape});
+        }
+        return out;
+    }
+
+    RawTensorData require_tensor_data(std::string_view name) const override {
+        const auto & record = require_record(name);
+        RawTensorData tensor;
+        tensor.metadata = TensorMetadata{std::string(name), record.dtype, record.shape};
+        tensor.bytes.resize(record.byte_size);
+        std::memcpy(tensor.bytes.data(), bytes_.data() + record.byte_offset, record.byte_size);
+        return tensor;
+    }
+
+    std::vector<float> require_f32(
+        std::string_view name,
+        const std::optional<std::vector<int64_t>> & expected_shape) const override {
+        const auto & record = require_record(name);
+        if (expected_shape.has_value() && *expected_shape != record.shape) {
+            throw std::runtime_error("torch .bin tensor shape mismatch for " + std::string(name));
+        }
+        return decode_f32(
+            record.dtype,
+            bytes_.data() + record.byte_offset,
+            static_cast<size_t>(shape_elements(record.shape)));
+    }
+
+    std::optional<std::vector<float>> optional_f32(
+        std::string_view name,
+        const std::optional<std::vector<int64_t>> & expected_shape) const override {
+        if (!has_tensor(name)) {
+            return std::nullopt;
+        }
+        return require_f32(name, expected_shape);
+    }
+
+    int64_t require_i64_scalar(std::string_view name) const override {
+        throw std::runtime_error("torch .bin does not support i64 scalars: " + std::string(name));
+    }
+
+private:
+    const TensorRecord & require_record(std::string_view name) const {
+        const auto it = records_.find(std::string(name));
+        if (it == records_.end()) {
+            throw std::runtime_error("missing tensor: " + std::string(name));
+        }
+        return it->second;
+    }
+
+    std::filesystem::path path_;
+    std::vector<uint8_t> bytes_;
+    std::map<std::string, TensorRecord> records_;
+};
+
+}  // namespace
+
+std::shared_ptr<const TensorSource> open_torch_bin_tensor_source(const std::filesystem::path & path) {
+    return std::make_shared<TorchBinTensorSource>(path);
+}
+
+}  // namespace engine::assets

--- a/src/models/vibevoice/assets.cpp
+++ b/src/models/vibevoice/assets.cpp
@@ -173,17 +173,30 @@ VibeVoiceDiffusionHeadConfig parse_diffusion_head_config(const engine::io::json:
     return config;
 }
 
+int64_t require_acoustic_vae_dim(const engine::io::json::Value & root) {
+    // VibeVoice-7B's config.json spells this key "acostic_vae_dim".
+    for (const char * key : {"acoustic_vae_dim", "acostic_vae_dim"}) {
+        if (const auto * value = root.find(key); value != nullptr) {
+            return value->as_i64();
+        }
+    }
+    throw std::runtime_error("VibeVoice config is missing acoustic_vae_dim");
+}
+
 VibeVoiceConfig parse_config(const assets::ResourceBundle & resources) {
     const auto root = resources.parse_json("config");
     VibeVoiceConfig config;
     config.model_type = json::optional_string(root, "model_type", "");
     require_string_value(config.model_type, "vibevoice", "model_type");
     config.torch_dtype = json::optional_string(root, "torch_dtype", config.torch_dtype);
-    config.acoustic_vae_dim = json::require_i64(root, "acoustic_vae_dim");
+    config.acoustic_vae_dim = require_acoustic_vae_dim(root);
     config.semantic_vae_dim = json::require_i64(root, "semantic_vae_dim");
     config.acoustic_tokenizer = parse_tokenizer_config(root.require("acoustic_tokenizer_config"), "acoustic tokenizer");
     config.semantic_tokenizer = parse_tokenizer_config(root.require("semantic_tokenizer_config"), "semantic tokenizer");
     config.decoder = parse_decoder_config(root.require("decoder_config"));
+    // VibeVoice-7B carries tie_word_embeddings at the top level, unlike the 1.5B decoder config.
+    config.decoder.tie_word_embeddings =
+        json::optional_bool(root, "tie_word_embeddings", config.decoder.tie_word_embeddings);
     config.diffusion_head = parse_diffusion_head_config(root.require("diffusion_head_config"));
     require_positive(config.acoustic_vae_dim, "acoustic_vae_dim");
     require_positive(config.semantic_vae_dim, "semantic_vae_dim");
@@ -416,6 +429,10 @@ void validate_weight_anchors(const VibeVoiceAssets & assets) {
     const auto & weights = *assets.model_weights;
     const auto & decoder = config.decoder;
     require_tensor_metadata(weights, "model.language_model.embed_tokens.weight", {decoder.vocab_size, decoder.hidden_size});
+    if (!decoder.tie_word_embeddings) {
+        const auto lm_head_name = weights.require_tensor_name({"lm_head.weight", "model.lm_head.weight"});
+        require_tensor_metadata(weights, lm_head_name, {decoder.vocab_size, decoder.hidden_size});
+    }
     require_tensor_metadata(weights, "model.language_model.norm.weight", {decoder.hidden_size});
     require_tensor_metadata(weights, "model.language_model.layers.0.self_attn.q_proj.weight", {decoder.hidden_size, decoder.hidden_size});
     require_tensor_metadata(

--- a/src/models/vibevoice/decoder.cpp
+++ b/src/models/vibevoice/decoder.cpp
@@ -338,6 +338,15 @@ VibeVoiceDecoderWeights load_vibevoice_decoder_weights(
         "model.language_model.embed_tokens.weight",
         weight_storage_type,
         {config.vocab_size, config.hidden_size});
+    if (config.tie_word_embeddings) {
+        weights.lm_head = weights.token_embedding;
+    } else {
+        weights.lm_head = weights.store->load_tensor(
+            *assets.model_weights,
+            assets.model_weights->require_tensor_name({"lm_head.weight", "model.lm_head.weight"}),
+            weight_storage_type,
+            {config.vocab_size, config.hidden_size});
+    }
     weights.layers.reserve(static_cast<size_t>(config.num_hidden_layers));
     for (int64_t layer = 0; layer < config.num_hidden_layers; ++layer) {
         weights.layers.push_back(load_layer_weights(
@@ -498,7 +507,7 @@ public:
         hidden_output_ = x.tensor;
         auto logits = modules::LinearModule(
                           binding::linear_config(config.hidden_size, config.vocab_size, false))
-                          .build(ctx, x, binding::linear_data(constants, runtime_->weights().token_embedding));
+                          .build(ctx, x, binding::linear_data(constants, runtime_->weights().lm_head));
         logits_output_ = logits.tensor;
         ggml_set_output(logits_output_);
         graph_ = ggml_new_graph_custom(ctx_.get(), 65536, false);
@@ -761,7 +770,7 @@ private:
             hidden_output_ = x.tensor;
             auto logits = modules::LinearModule(
                               binding::linear_config(config.hidden_size, config.vocab_size, false))
-                              .build(ctx, x, binding::linear_data(constants_, runtime_->weights().token_embedding));
+                              .build(ctx, x, binding::linear_data(constants_, runtime_->weights().lm_head));
             logits_output_ = logits.tensor;
             graph_ = ggml_new_graph_custom(ctx_.get(), 8192, false);
             ggml_set_output(logits_output_);
@@ -1006,7 +1015,7 @@ public:
         hidden_output_ = x.tensor;
         auto logits = modules::LinearModule(
                           binding::linear_config(config.hidden_size, config.vocab_size, false))
-                          .build(ctx, x, binding::linear_data(constants, runtime_->weights().token_embedding));
+                          .build(ctx, x, binding::linear_data(constants, runtime_->weights().lm_head));
         logits_output_ = logits.tensor;
         ggml_set_output(logits_output_);
         ggml_build_forward_expand(graph_, logits_output_);
@@ -1202,7 +1211,7 @@ public:
         hidden_output_ = x.tensor;
         auto logits = modules::LinearModule(
                           binding::linear_config(config.hidden_size, config.vocab_size, false))
-                          .build(ctx, x, binding::linear_data(constants, runtime_->weights().token_embedding));
+                          .build(ctx, x, binding::linear_data(constants, runtime_->weights().lm_head));
         logits_output_ = logits.tensor;
         ggml_set_output(logits_output_);
         ggml_build_forward_expand(graph_, logits_output_);

--- a/src/models/vibevoice/loader.cpp
+++ b/src/models/vibevoice/loader.cpp
@@ -1,6 +1,7 @@
 #include "engine/models/vibevoice/loader.h"
 
 #include "engine/framework/io/filesystem.h"
+#include "engine/models/vibevoice/lora.h"
 #include "engine/models/vibevoice/session.h"
 
 #include <stdexcept>
@@ -111,7 +112,9 @@ public:
             {"vibevoice.connector_weight_type", "native|f32|f16|bf16|q8_0", "Acoustic and semantic connector weight storage type."},
             {"vibevoice.decoder_weight_type", "native|f32|f16|bf16|q8_0", "Language decoder weight storage type."},
             {"vibevoice.diffusion_head_weight_type", "native|f32|f16|bf16|q8_0", "Diffusion prediction head weight storage type."},
-            {"vibevoice.lora", "path", "PEFT LoRA adapter directory or safetensors merged into the decoder weights."},
+        };
+        inspection.cli.load_options = {
+            {"vibevoice.lora", "path", "Fine-tune adapter dir (LM LoRA + diffusion head + acoustic/semantic connectors) merged at load time."},
             {"vibevoice.lora_scale", "float", "LoRA merge scale override; defaults to lora_alpha / r."},
         };
         inspection.discovered_configs = discover_config_assets(request);
@@ -120,7 +123,10 @@ public:
     }
 
     std::unique_ptr<runtime::ILoadedVoiceModel> load(const runtime::ModelLoadRequest & request) const override {
-        return load_vibevoice_model(resolve_model_root(request.model_path));
+        auto assets = apply_vibevoice_finetune_options(
+            load_vibevoice_assets(resolve_model_root(request.model_path)), request.options);
+        return std::make_unique<VibeVoiceLoadedModel>(
+            vibevoice_metadata(*assets), vibevoice_capabilities(), std::move(assets));
     }
 };
 

--- a/src/models/vibevoice/loader.cpp
+++ b/src/models/vibevoice/loader.cpp
@@ -111,6 +111,8 @@ public:
             {"vibevoice.connector_weight_type", "native|f32|f16|bf16|q8_0", "Acoustic and semantic connector weight storage type."},
             {"vibevoice.decoder_weight_type", "native|f32|f16|bf16|q8_0", "Language decoder weight storage type."},
             {"vibevoice.diffusion_head_weight_type", "native|f32|f16|bf16|q8_0", "Diffusion prediction head weight storage type."},
+            {"vibevoice.lora", "path", "PEFT LoRA adapter directory or safetensors merged into the decoder weights."},
+            {"vibevoice.lora_scale", "float", "LoRA merge scale override; defaults to lora_alpha / r."},
         };
         inspection.discovered_configs = discover_config_assets(request);
         inspection.discovered_weights = discover_weight_assets(request);

--- a/src/models/vibevoice/lora.cpp
+++ b/src/models/vibevoice/lora.cpp
@@ -1,0 +1,277 @@
+#include "engine/models/vibevoice/lora.h"
+
+#include "engine/framework/io/filesystem.h"
+#include "engine/framework/io/json.h"
+
+#include <cmath>
+#include <cstring>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace engine::models::vibevoice {
+namespace json = engine::io::json;
+namespace {
+
+constexpr std::string_view kLoraWeightsFile = "adapter_model.safetensors";
+constexpr std::string_view kLoraConfigFile = "adapter_config.json";
+constexpr std::string_view kPeftPrefix = "base_model.model.";
+constexpr std::string_view kLanguageModelPrefix = "model.language_model.";
+constexpr std::string_view kLoraASuffix = ".lora_A.weight";
+constexpr std::string_view kLoraBSuffix = ".lora_B.weight";
+
+struct LoraAdapterPaths {
+    std::filesystem::path weights;
+    std::optional<std::filesystem::path> config;
+};
+
+struct LoraTensorDelta {
+    std::vector<float> a;
+    std::vector<float> b;
+    int64_t r = 0;
+    int64_t in = 0;
+    int64_t out = 0;
+    float scale = 1.0F;
+};
+
+struct LoraTensorNames {
+    std::optional<std::string> a_name;
+    std::optional<std::string> b_name;
+};
+
+bool has_suffix(const std::string & name, std::string_view suffix) {
+    return name.size() >= suffix.size() &&
+        name.compare(name.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+
+std::string strip_prefix(const std::string & name, std::string_view prefix) {
+    if (name.rfind(prefix, 0) == 0) {
+        return name.substr(prefix.size());
+    }
+    return name;
+}
+
+LoraAdapterPaths resolve_adapter_paths(const std::filesystem::path & adapter_path) {
+    LoraAdapterPaths paths;
+    if (engine::io::is_existing_directory(adapter_path)) {
+        paths.weights = adapter_path / kLoraWeightsFile;
+        const auto config = adapter_path / kLoraConfigFile;
+        if (engine::io::is_existing_file(config)) {
+            paths.config = config;
+        }
+    } else if (engine::io::is_existing_file(adapter_path)) {
+        paths.weights = adapter_path;
+        const auto config = adapter_path.parent_path() / kLoraConfigFile;
+        if (engine::io::is_existing_file(config)) {
+            paths.config = config;
+        }
+    } else {
+        throw std::runtime_error("VibeVoice LoRA path does not exist: " + adapter_path.string());
+    }
+    if (!engine::io::is_existing_file(paths.weights)) {
+        throw std::runtime_error("VibeVoice LoRA adapter weights not found: " + paths.weights.string());
+    }
+    return paths;
+}
+
+float resolve_adapter_scale(const std::optional<std::filesystem::path> & config_path, float scale_override) {
+    if (scale_override > 0.0F) {
+        return scale_override;
+    }
+    if (!config_path.has_value()) {
+        throw std::runtime_error(
+            "VibeVoice LoRA has no adapter_config.json; pass vibevoice.lora_scale to set the merge scale");
+    }
+    const auto root = json::parse_file(*config_path);
+    const auto rank = json::require_i64(root, "r");
+    if (rank <= 0) {
+        throw std::runtime_error("VibeVoice LoRA adapter_config.json has non-positive r");
+    }
+    const float alpha = json::optional_f32(root, "lora_alpha", static_cast<float>(rank));
+    const bool use_rslora = json::optional_bool(root, "use_rslora", false);
+    const float denom = use_rslora ? std::sqrt(static_cast<float>(rank)) : static_cast<float>(rank);
+    return alpha / denom;
+}
+
+std::string resolve_base_weight_name(const assets::TensorSource & base, const std::string & module_path) {
+    const std::string prefixed = std::string(kLanguageModelPrefix) + module_path + ".weight";
+    if (base.has_tensor(prefixed)) {
+        return prefixed;
+    }
+    const std::string bare = module_path + ".weight";
+    if (base.has_tensor(bare)) {
+        return bare;
+    }
+    throw std::runtime_error("VibeVoice LoRA targets a module with no matching base weight: " + module_path);
+}
+
+std::vector<float> merged_f32_values(
+    const assets::TensorSource & base,
+    const std::string & name,
+    const LoraTensorDelta & delta) {
+    auto values = base.require_f32(name, std::optional<std::vector<int64_t>>({delta.out, delta.in}));
+    // values[o, i] += scale * sum_k B[o, k] * A[k, i]
+    for (int64_t o = 0; o < delta.out; ++o) {
+        const int64_t row = o * delta.in;
+        for (int64_t k = 0; k < delta.r; ++k) {
+            const float b = delta.scale * delta.b[static_cast<size_t>(o * delta.r + k)];
+            if (b == 0.0F) {
+                continue;
+            }
+            const float * a_row = delta.a.data() + static_cast<size_t>(k * delta.in);
+            for (int64_t i = 0; i < delta.in; ++i) {
+                values[static_cast<size_t>(row + i)] += b * a_row[i];
+            }
+        }
+    }
+    return values;
+}
+
+class LoraMergedTensorSource final : public assets::TensorSource {
+public:
+    LoraMergedTensorSource(
+        std::shared_ptr<const assets::TensorSource> base,
+        std::unordered_map<std::string, LoraTensorDelta> deltas)
+        : base_(std::move(base)),
+          deltas_(std::move(deltas)) {}
+
+    const std::filesystem::path & source_path() const noexcept override {
+        return base_->source_path();
+    }
+
+    bool has_tensor(std::string_view name) const noexcept override {
+        return base_->has_tensor(name);
+    }
+
+    assets::TensorMetadata require_metadata(std::string_view name) const override {
+        return base_->require_metadata(name);
+    }
+
+    std::vector<assets::TensorMetadata> tensors() const override {
+        return base_->tensors();
+    }
+
+    void release_storage() const override {
+        base_->release_storage();
+    }
+
+    assets::RawTensorData require_tensor_data(std::string_view name) const override {
+        const auto delta = deltas_.find(std::string(name));
+        if (delta == deltas_.end()) {
+            return base_->require_tensor_data(name);
+        }
+        const std::string key(name);
+        const auto values = merged_f32_values(*base_, key, delta->second);
+        assets::RawTensorData raw;
+        raw.metadata = assets::TensorMetadata{key, "F32", {delta->second.out, delta->second.in}};
+        raw.bytes.resize(values.size() * sizeof(float));
+        std::memcpy(raw.bytes.data(), values.data(), raw.bytes.size());
+        return raw;
+    }
+
+    std::vector<float> require_f32(
+        std::string_view name,
+        const std::optional<std::vector<int64_t>> & expected_shape) const override {
+        const auto delta = deltas_.find(std::string(name));
+        if (delta == deltas_.end()) {
+            return base_->require_f32(name, expected_shape);
+        }
+        return merged_f32_values(*base_, std::string(name), delta->second);
+    }
+
+    std::optional<std::vector<float>> optional_f32(
+        std::string_view name,
+        const std::optional<std::vector<int64_t>> & expected_shape) const override {
+        if (!has_tensor(name)) {
+            return std::nullopt;
+        }
+        return require_f32(name, expected_shape);
+    }
+
+    int64_t require_i64_scalar(std::string_view name) const override {
+        return base_->require_i64_scalar(name);
+    }
+
+private:
+    std::shared_ptr<const assets::TensorSource> base_;
+    std::unordered_map<std::string, LoraTensorDelta> deltas_;
+};
+
+std::unordered_map<std::string, LoraTensorNames> collect_lora_tensor_names(const assets::TensorSource & adapter) {
+    std::unordered_map<std::string, LoraTensorNames> names;
+    for (const auto & metadata : adapter.tensors()) {
+        const std::string stripped = strip_prefix(metadata.name, kPeftPrefix);
+        if (has_suffix(stripped, kLoraASuffix)) {
+            names[stripped.substr(0, stripped.size() - kLoraASuffix.size())].a_name = metadata.name;
+        } else if (has_suffix(stripped, kLoraBSuffix)) {
+            names[stripped.substr(0, stripped.size() - kLoraBSuffix.size())].b_name = metadata.name;
+        }
+    }
+    return names;
+}
+
+LoraTensorDelta load_lora_delta(
+    const assets::TensorSource & base,
+    const assets::TensorSource & adapter,
+    const std::string & module_path,
+    const LoraTensorNames & names,
+    const std::string & base_name,
+    float scale) {
+    if (!names.a_name.has_value() || !names.b_name.has_value()) {
+        throw std::runtime_error("VibeVoice LoRA module is missing an A/B pair: " + module_path);
+    }
+    const auto a_meta = adapter.require_metadata(*names.a_name);
+    const auto b_meta = adapter.require_metadata(*names.b_name);
+    if (a_meta.shape.size() != 2 || b_meta.shape.size() != 2) {
+        throw std::runtime_error("VibeVoice LoRA A/B tensors must be rank-2: " + module_path);
+    }
+    LoraTensorDelta delta;
+    delta.r = a_meta.shape[0];
+    delta.in = a_meta.shape[1];
+    delta.out = b_meta.shape[0];
+    delta.scale = scale;
+    if (b_meta.shape[1] != delta.r) {
+        throw std::runtime_error("VibeVoice LoRA A/B rank mismatch for " + module_path);
+    }
+    if (base.require_metadata(base_name).shape != std::vector<int64_t>({delta.out, delta.in})) {
+        throw std::runtime_error(
+            "VibeVoice LoRA shape mismatch for " + base_name + " (adapter is trained for a different model size)");
+    }
+    delta.a = adapter.require_f32(*names.a_name, std::optional<std::vector<int64_t>>({delta.r, delta.in}));
+    delta.b = adapter.require_f32(*names.b_name, std::optional<std::vector<int64_t>>({delta.out, delta.r}));
+    return delta;
+}
+
+}  // namespace
+
+std::shared_ptr<const assets::TensorSource> make_lora_merged_tensor_source(
+    std::shared_ptr<const assets::TensorSource> base,
+    const std::filesystem::path & adapter_path,
+    float scale_override) {
+    if (base == nullptr) {
+        throw std::runtime_error("VibeVoice LoRA merge requires a base tensor source");
+    }
+    const auto paths = resolve_adapter_paths(adapter_path);
+    const float scale = resolve_adapter_scale(paths.config, scale_override);
+    const auto adapter = assets::open_tensor_source(paths.weights);
+
+    const auto tensor_names = collect_lora_tensor_names(*adapter);
+    if (tensor_names.empty()) {
+        throw std::runtime_error("VibeVoice LoRA adapter contains no lora_A/lora_B tensors: " + paths.weights.string());
+    }
+
+    std::unordered_map<std::string, LoraTensorDelta> deltas;
+    deltas.reserve(tensor_names.size());
+    for (const auto & [module_path, names] : tensor_names) {
+        const std::string base_name = resolve_base_weight_name(*base, module_path);
+        deltas.emplace(base_name, load_lora_delta(*base, *adapter, module_path, names, base_name, scale));
+    }
+
+    return std::make_shared<LoraMergedTensorSource>(std::move(base), std::move(deltas));
+}
+
+}  // namespace engine::models::vibevoice

--- a/src/models/vibevoice/lora.cpp
+++ b/src/models/vibevoice/lora.cpp
@@ -1,7 +1,10 @@
 #include "engine/models/vibevoice/lora.h"
 
+#include "engine/framework/assets/torch_bin.h"
+#include "engine/framework/debug/trace.h"
 #include "engine/framework/io/filesystem.h"
 #include "engine/framework/io/json.h"
+#include "engine/framework/runtime/options.h"
 
 #include <cmath>
 #include <cstring>
@@ -23,6 +26,13 @@ constexpr std::string_view kPeftPrefix = "base_model.model.";
 constexpr std::string_view kLanguageModelPrefix = "model.language_model.";
 constexpr std::string_view kLoraASuffix = ".lora_A.weight";
 constexpr std::string_view kLoraBSuffix = ".lora_B.weight";
+constexpr std::string_view kPredictionHeadPrefix = "model.prediction_head.";
+constexpr std::string_view kAcousticConnectorPrefix = "model.acoustic_connector.";
+constexpr std::string_view kSemanticConnectorPrefix = "model.semantic_connector.";
+
+void log_line(const std::string & message, engine::debug::LogLevel level = engine::debug::LogLevel::Info) {
+    engine::debug::log_message(level, "vibevoice", message);
+}
 
 struct LoraAdapterPaths {
     std::filesystem::path weights;
@@ -36,6 +46,11 @@ struct LoraTensorDelta {
     int64_t in = 0;
     int64_t out = 0;
     float scale = 1.0F;
+};
+
+struct OverrideTensor {
+    std::vector<int64_t> shape;
+    std::vector<float> values;
 };
 
 struct LoraTensorNames {
@@ -76,6 +91,13 @@ LoraAdapterPaths resolve_adapter_paths(const std::filesystem::path & adapter_pat
         throw std::runtime_error("VibeVoice LoRA adapter weights not found: " + paths.weights.string());
     }
     return paths;
+}
+
+std::filesystem::path resolve_adapter_dir(const std::filesystem::path & adapter_path) {
+    if (engine::io::is_existing_directory(adapter_path)) {
+        return adapter_path;
+    }
+    return adapter_path.parent_path();
 }
 
 float resolve_adapter_scale(const std::optional<std::filesystem::path> & config_path, float scale_override) {
@@ -131,13 +153,17 @@ std::vector<float> merged_f32_values(
     return values;
 }
 
-class LoraMergedTensorSource final : public assets::TensorSource {
+// A weight source that overlays a fine-tune adapter onto a base source: full overrides replace a
+// base tensor outright, LoRA deltas add B*A to it, everything else falls through to the base.
+class VibeVoiceFineTuneSource final : public assets::TensorSource {
 public:
-    LoraMergedTensorSource(
+    VibeVoiceFineTuneSource(
         std::shared_ptr<const assets::TensorSource> base,
-        std::unordered_map<std::string, LoraTensorDelta> deltas)
+        std::unordered_map<std::string, LoraTensorDelta> deltas,
+        std::unordered_map<std::string, OverrideTensor> overrides)
         : base_(std::move(base)),
-          deltas_(std::move(deltas)) {}
+          deltas_(std::move(deltas)),
+          overrides_(std::move(overrides)) {}
 
     const std::filesystem::path & source_path() const noexcept override {
         return base_->source_path();
@@ -160,27 +186,30 @@ public:
     }
 
     assets::RawTensorData require_tensor_data(std::string_view name) const override {
-        const auto delta = deltas_.find(std::string(name));
+        const std::string key(name);
+        if (const auto override_it = overrides_.find(key); override_it != overrides_.end()) {
+            return raw_from_f32(key, override_it->second.shape, override_it->second.values);
+        }
+        const auto delta = deltas_.find(key);
         if (delta == deltas_.end()) {
             return base_->require_tensor_data(name);
         }
-        const std::string key(name);
         const auto values = merged_f32_values(*base_, key, delta->second);
-        assets::RawTensorData raw;
-        raw.metadata = assets::TensorMetadata{key, "F32", {delta->second.out, delta->second.in}};
-        raw.bytes.resize(values.size() * sizeof(float));
-        std::memcpy(raw.bytes.data(), values.data(), raw.bytes.size());
-        return raw;
+        return raw_from_f32(key, {delta->second.out, delta->second.in}, values);
     }
 
     std::vector<float> require_f32(
         std::string_view name,
         const std::optional<std::vector<int64_t>> & expected_shape) const override {
-        const auto delta = deltas_.find(std::string(name));
+        const std::string key(name);
+        if (const auto override_it = overrides_.find(key); override_it != overrides_.end()) {
+            return override_it->second.values;
+        }
+        const auto delta = deltas_.find(key);
         if (delta == deltas_.end()) {
             return base_->require_f32(name, expected_shape);
         }
-        return merged_f32_values(*base_, std::string(name), delta->second);
+        return merged_f32_values(*base_, key, delta->second);
     }
 
     std::optional<std::vector<float>> optional_f32(
@@ -197,8 +226,20 @@ public:
     }
 
 private:
+    static assets::RawTensorData raw_from_f32(
+        const std::string & name,
+        const std::vector<int64_t> & shape,
+        const std::vector<float> & values) {
+        assets::RawTensorData raw;
+        raw.metadata = assets::TensorMetadata{name, "F32", shape};
+        raw.bytes.resize(values.size() * sizeof(float));
+        std::memcpy(raw.bytes.data(), values.data(), raw.bytes.size());
+        return raw;
+    }
+
     std::shared_ptr<const assets::TensorSource> base_;
     std::unordered_map<std::string, LoraTensorDelta> deltas_;
+    std::unordered_map<std::string, OverrideTensor> overrides_;
 };
 
 std::unordered_map<std::string, LoraTensorNames> collect_lora_tensor_names(const assets::TensorSource & adapter) {
@@ -246,9 +287,71 @@ LoraTensorDelta load_lora_delta(
     return delta;
 }
 
+// Opens the diffusion-head fine-tune weights, preferring safetensors over the pickled variants.
+std::shared_ptr<const assets::TensorSource> open_diffusion_head_source(const std::filesystem::path & adapter_dir) {
+    const auto safetensors = adapter_dir / "diffusion_head" / "model.safetensors";
+    if (engine::io::is_existing_file(safetensors)) {
+        return assets::open_tensor_source(safetensors);
+    }
+    const auto bin = adapter_dir / "diffusion_head_full.bin";
+    if (engine::io::is_existing_file(bin)) {
+        return assets::open_torch_bin_tensor_source(bin);
+    }
+    const auto nested_bin = adapter_dir / "diffusion_head" / "diffusion_head_full.bin";
+    if (engine::io::is_existing_file(nested_bin)) {
+        return assets::open_torch_bin_tensor_source(nested_bin);
+    }
+    return nullptr;
+}
+
+// Registers full-weight overrides for every adapter tensor that has a matching base tensor. A shape
+// mismatch is a hard error (wrong model size); a missing base tensor is skipped like strict=False.
+int add_full_overrides(
+    const assets::TensorSource & base,
+    const assets::TensorSource & source,
+    std::string_view base_prefix,
+    std::unordered_map<std::string, OverrideTensor> & overrides) {
+    int count = 0;
+    for (const auto & metadata : source.tensors()) {
+        const std::string base_name = std::string(base_prefix) + metadata.name;
+        if (!base.has_tensor(base_name)) {
+            log_line("skip " + base_name + " (no matching base tensor)", engine::debug::LogLevel::Warning);
+            continue;
+        }
+        if (base.require_metadata(base_name).shape != metadata.shape) {
+            throw std::runtime_error(
+                "VibeVoice fine-tune shape mismatch for " + base_name +
+                " (adapter is trained for a different model size)");
+        }
+        OverrideTensor override_tensor;
+        override_tensor.shape = metadata.shape;
+        override_tensor.values = source.require_f32(metadata.name);
+        overrides[base_name] = std::move(override_tensor);
+        ++count;
+    }
+    return count;
+}
+
+void add_connector_overrides(
+    const assets::TensorSource & base,
+    const std::filesystem::path & adapter_dir,
+    const char * subdir,
+    std::string_view base_prefix,
+    const char * label,
+    std::unordered_map<std::string, OverrideTensor> & overrides) {
+    const auto path = adapter_dir / subdir / "pytorch_model.bin";
+    if (!engine::io::is_existing_file(path)) {
+        log_line(std::string(label) + ": not present, skipped");
+        return;
+    }
+    const auto source = assets::open_torch_bin_tensor_source(path);
+    const int count = add_full_overrides(base, *source, base_prefix, overrides);
+    log_line(std::string(label) + ": overrode " + std::to_string(count) + " tensors");
+}
+
 }  // namespace
 
-std::shared_ptr<const assets::TensorSource> make_lora_merged_tensor_source(
+std::shared_ptr<const assets::TensorSource> make_vibevoice_finetune_source(
     std::shared_ptr<const assets::TensorSource> base,
     const std::filesystem::path & adapter_path,
     float scale_override) {
@@ -271,7 +374,51 @@ std::shared_ptr<const assets::TensorSource> make_lora_merged_tensor_source(
         deltas.emplace(base_name, load_lora_delta(*base, *adapter, module_path, names, base_name, scale));
     }
 
-    return std::make_shared<LoraMergedTensorSource>(std::move(base), std::move(deltas));
+    log_line("applying fine-tune adapter: " + adapter_path.string());
+    log_line("LM LoRA: merged " + std::to_string(deltas.size()) + " decoder modules (scale " +
+        std::to_string(scale) + ")");
+
+    const auto adapter_dir = resolve_adapter_dir(adapter_path);
+    std::unordered_map<std::string, OverrideTensor> overrides;
+    if (const auto head = open_diffusion_head_source(adapter_dir)) {
+        const int count = add_full_overrides(*base, *head, kPredictionHeadPrefix, overrides);
+        log_line("diffusion head: overrode " + std::to_string(count) + " tensors");
+    } else {
+        log_line("diffusion head: not present, skipped");
+    }
+    add_connector_overrides(*base, adapter_dir, "acoustic_connector", kAcousticConnectorPrefix,
+        "acoustic connector", overrides);
+    add_connector_overrides(*base, adapter_dir, "semantic_connector", kSemanticConnectorPrefix,
+        "semantic connector", overrides);
+
+    return std::make_shared<VibeVoiceFineTuneSource>(std::move(base), std::move(deltas), std::move(overrides));
+}
+
+std::shared_ptr<const VibeVoiceAssets> apply_vibevoice_finetune_options(
+    std::shared_ptr<const VibeVoiceAssets> assets,
+    const std::unordered_map<std::string, std::string> & options) {
+    const auto lora_path = runtime::find_option(options, {"vibevoice.lora"});
+    if (!lora_path.has_value() || lora_path->empty()) {
+        return assets;
+    }
+    if (assets == nullptr) {
+        throw std::runtime_error("VibeVoice fine-tune requires assets");
+    }
+    if (assets->fine_tune_applied) {
+        throw std::runtime_error(
+            "VibeVoice LoRA already applied via --load-option; do not also pass it via --session-option");
+    }
+    float scale_override = -1.0F;
+    if (const auto value = runtime::parse_finite_float_option(options, {"vibevoice.lora_scale"})) {
+        if (*value <= 0.0F) {
+            throw std::runtime_error("VibeVoice vibevoice.lora_scale must be positive");
+        }
+        scale_override = *value;
+    }
+    auto updated = std::make_shared<VibeVoiceAssets>(*assets);
+    updated->model_weights = make_vibevoice_finetune_source(assets->model_weights, *lora_path, scale_override);
+    updated->fine_tune_applied = true;
+    return updated;
 }
 
 }  // namespace engine::models::vibevoice

--- a/src/models/vibevoice/session.cpp
+++ b/src/models/vibevoice/session.cpp
@@ -28,25 +28,6 @@ std::shared_ptr<const VibeVoiceAssets> require_assets(std::shared_ptr<const Vibe
     return assets;
 }
 
-std::shared_ptr<const VibeVoiceAssets> apply_lora_option(
-    std::shared_ptr<const VibeVoiceAssets> assets,
-    const runtime::SessionOptions & options) {
-    const auto lora_path = runtime::find_option(options.options, {"vibevoice.lora"});
-    if (!lora_path.has_value() || lora_path->empty()) {
-        return assets;
-    }
-    float scale_override = -1.0F;
-    if (const auto value = runtime::parse_finite_float_option(options.options, {"vibevoice.lora_scale"})) {
-        if (*value <= 0.0F) {
-            throw std::runtime_error("VibeVoice vibevoice.lora_scale must be positive");
-        }
-        scale_override = *value;
-    }
-    auto updated = std::make_shared<VibeVoiceAssets>(*assets);
-    updated->model_weights = make_lora_merged_tensor_source(assets->model_weights, *lora_path, scale_override);
-    return updated;
-}
-
 void validate_weight_storage(engine::assets::TensorStorageType storage_type, const char * option_name) {
     if (storage_type == engine::assets::TensorStorageType::Native ||
         storage_type == engine::assets::TensorStorageType::F32 ||
@@ -217,7 +198,7 @@ VibeVoiceSession::VibeVoiceSession(
     std::shared_ptr<const VibeVoiceAssets> assets)
     : runtime::RuntimeSessionBase(require_supported_backend_options(options)),
       task_(task),
-      assets_(apply_lora_option(require_assets(std::move(assets)), options)),
+      assets_(apply_vibevoice_finetune_options(require_assets(std::move(assets)), options.options)),
       text_tokenizer_(assets_),
       audio_tokenizer_(
           assets_,

--- a/src/models/vibevoice/session.cpp
+++ b/src/models/vibevoice/session.cpp
@@ -4,6 +4,7 @@
 #include "engine/framework/assets/tensor_source.h"
 #include "engine/framework/debug/trace.h"
 #include "engine/framework/runtime/options.h"
+#include "engine/models/vibevoice/lora.h"
 
 #include <algorithm>
 #include <cctype>
@@ -25,6 +26,25 @@ std::shared_ptr<const VibeVoiceAssets> require_assets(std::shared_ptr<const Vibe
         throw std::runtime_error("VibeVoice session requires assets");
     }
     return assets;
+}
+
+std::shared_ptr<const VibeVoiceAssets> apply_lora_option(
+    std::shared_ptr<const VibeVoiceAssets> assets,
+    const runtime::SessionOptions & options) {
+    const auto lora_path = runtime::find_option(options.options, {"vibevoice.lora"});
+    if (!lora_path.has_value() || lora_path->empty()) {
+        return assets;
+    }
+    float scale_override = -1.0F;
+    if (const auto value = runtime::parse_finite_float_option(options.options, {"vibevoice.lora_scale"})) {
+        if (*value <= 0.0F) {
+            throw std::runtime_error("VibeVoice vibevoice.lora_scale must be positive");
+        }
+        scale_override = *value;
+    }
+    auto updated = std::make_shared<VibeVoiceAssets>(*assets);
+    updated->model_weights = make_lora_merged_tensor_source(assets->model_weights, *lora_path, scale_override);
+    return updated;
 }
 
 void validate_weight_storage(engine::assets::TensorStorageType storage_type, const char * option_name) {
@@ -52,6 +72,8 @@ const runtime::SessionOptions & require_supported_backend_options(const runtime:
             key == "vibevoice.decoder_weight_type" ||
             key == "vibevoice.diffusion_head_weight_type") {
             validate_weight_storage(engine::assets::parse_tensor_storage_type(value), key.c_str());
+        } else if (key == "vibevoice.lora" || key == "vibevoice.lora_scale") {
+            // Validated where the adapter is loaded.
         } else if (key.rfind("vibevoice.", 0) == 0) {
             throw std::runtime_error("unknown VibeVoice session option: " + key);
         }
@@ -195,7 +217,7 @@ VibeVoiceSession::VibeVoiceSession(
     std::shared_ptr<const VibeVoiceAssets> assets)
     : runtime::RuntimeSessionBase(require_supported_backend_options(options)),
       task_(task),
-      assets_(require_assets(std::move(assets))),
+      assets_(apply_lora_option(require_assets(std::move(assets)), options)),
       text_tokenizer_(assets_),
       audio_tokenizer_(
           assets_,

--- a/tests/vibevoice/finetune_overlay_check.cpp
+++ b/tests/vibevoice/finetune_overlay_check.cpp
@@ -1,0 +1,89 @@
+// Verifies the VibeVoice fine-tune overlay: the diffusion head + connectors fully replace their
+// base tensors and the LM LoRA changes the decoder linears. Run with the base 7B model and the
+// mp1 adapter (defaults below), or pass <model_dir> <adapter_dir>.
+#include "engine/framework/assets/tensor_source.h"
+#include "engine/framework/assets/torch_bin.h"
+#include "engine/framework/debug/trace.h"
+#include "engine/models/vibevoice/assets.h"
+#include "engine/models/vibevoice/lora.h"
+
+#include <cmath>
+#include <cstdio>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace {
+
+void print8(const char * label, const std::vector<float> & values) {
+    std::printf("%-26s", label);
+    for (int i = 0; i < 8 && i < static_cast<int>(values.size()); ++i) {
+        std::printf(" % .6f", values[i]);
+    }
+    std::printf("\n");
+}
+
+bool equal8(const std::vector<float> & a, const std::vector<float> & b) {
+    for (int i = 0; i < 8; ++i) {
+        if (std::fabs(a[i] - b[i]) > 1.0e-6F * (1.0F + std::fabs(b[i]))) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool differ8(const std::vector<float> & a, const std::vector<float> & b) {
+    for (int i = 0; i < 8; ++i) {
+        if (std::fabs(a[i] - b[i]) > 1.0e-7F) {
+            return true;
+        }
+    }
+    return false;
+}
+
+}  // namespace
+
+int main(int argc, char ** argv) {
+    engine::debug::configure_logging(engine::debug::LoggingConfig{true, std::nullopt});
+
+    const std::filesystem::path model = argc > 1 ? argv[1] : "models/VibeVoice-7B";
+    const std::filesystem::path adapter =
+        argc > 2 ? argv[2] : "E:/REPOS/VIBEVOICE-MAIN/VibeVoice/loras/mp1";
+
+    const auto assets = engine::models::vibevoice::load_vibevoice_assets(model);
+    const auto base = assets->model_weights;
+    const auto overlay = engine::models::vibevoice::make_vibevoice_finetune_source(base, adapter, -1.0F);
+
+    bool ok = true;
+
+    const auto acoustic = engine::assets::open_torch_bin_tensor_source(
+        adapter / "acoustic_connector" / "pytorch_model.bin");
+    const auto acoustic_ref = acoustic->require_f32("fc1.weight");
+    const auto acoustic_overlay = overlay->require_f32("model.acoustic_connector.fc1.weight");
+    print8("acoustic.fc1 adapter", acoustic_ref);
+    print8("acoustic.fc1 overlay", acoustic_overlay);
+    const bool a_ok = equal8(acoustic_ref, acoustic_overlay);
+    std::printf("(a) acoustic connector override: %s\n\n", a_ok ? "PASS" : "FAIL");
+    ok = ok && a_ok;
+
+    const auto head = engine::assets::open_tensor_source(adapter / "diffusion_head" / "model.safetensors");
+    const auto head_ref = head->require_f32("cond_proj.weight");
+    const auto head_overlay = overlay->require_f32("model.prediction_head.cond_proj.weight");
+    print8("dhead.cond_proj adapter", head_ref);
+    print8("dhead.cond_proj overlay", head_overlay);
+    const bool b_ok = equal8(head_ref, head_overlay);
+    std::printf("(b) diffusion head override: %s\n\n", b_ok ? "PASS" : "FAIL");
+    ok = ok && b_ok;
+
+    const std::string lora_weight = "model.language_model.layers.0.mlp.gate_proj.weight";
+    const auto lora_base = base->require_f32(lora_weight);
+    const auto lora_overlay = overlay->require_f32(lora_weight);
+    print8("gate_proj base", lora_base);
+    print8("gate_proj overlay", lora_overlay);
+    const bool c_ok = differ8(lora_base, lora_overlay);
+    std::printf("(c) LM LoRA merge changed weights: %s\n\n", c_ok ? "PASS" : "FAIL");
+    ok = ok && c_ok;
+
+    std::printf("=== OVERLAY CHECK %s ===\n", ok ? "PASS" : "FAIL");
+    return ok ? 0 : 1;
+}

--- a/tests/vibevoice/torch_bin_parity.cpp
+++ b/tests/vibevoice/torch_bin_parity.cpp
@@ -1,0 +1,35 @@
+#include "engine/framework/assets/torch_bin.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+int main(int argc, char ** argv) {
+    const std::string path = argc > 1
+        ? argv[1]
+        : "E:/REPOS/VIBEVOICE-MAIN/VibeVoice/loras/mp1/semantic_connector/pytorch_model.bin";
+    try {
+        const auto source = engine::assets::open_torch_bin_tensor_source(path);
+        std::printf("torch .bin: %s\n", path.c_str());
+        for (const auto & meta : source->tensors()) {
+            const auto values = source->require_f32(meta.name);
+            double sum = 0.0;
+            for (const float value : values) {
+                sum += value;
+            }
+            std::printf("%-16s dtype=%-4s shape=[", meta.name.c_str(), meta.dtype.c_str());
+            for (size_t i = 0; i < meta.shape.size(); ++i) {
+                std::printf("%s%lld", i == 0 ? "" : ",", static_cast<long long>(meta.shape[i]));
+            }
+            std::printf("] mean=%.8f first8=", sum / static_cast<double>(values.size()));
+            for (size_t i = 0; i < values.size() && i < 8; ++i) {
+                std::printf("%s%.6f", i == 0 ? "" : ",", values[i]);
+            }
+            std::printf("\n");
+        }
+    } catch (const std::exception & error) {
+        std::fprintf(stderr, "torch_bin_parity failed: %s\n", error.what());
+        return 1;
+    }
+    return 0;
+}

--- a/tools/model_manager.py
+++ b/tools/model_manager.py
@@ -512,6 +512,52 @@ CATALOG: tuple[ModelPackage, ...] = (
         ),
     ),
     ModelPackage(
+        id="vibevoice_7b",
+        display_name="VibeVoice 7B",
+        target_directory="VibeVoice-7B",
+        source=CompositeSnapshotSource(
+            placements=(
+                SnapshotPlacement(
+                    source=SnapshotSource(repo_id="vibevoice/VibeVoice-7B"),
+                    required_files=(
+                        "config.json",
+                        "model.safetensors.index.json",
+                        "model-00001-of-00010.safetensors",
+                        "model-00002-of-00010.safetensors",
+                        "model-00003-of-00010.safetensors",
+                        "model-00004-of-00010.safetensors",
+                        "model-00005-of-00010.safetensors",
+                        "model-00006-of-00010.safetensors",
+                        "model-00007-of-00010.safetensors",
+                        "model-00008-of-00010.safetensors",
+                        "model-00009-of-00010.safetensors",
+                        "model-00010-of-00010.safetensors",
+                        "preprocessor_config.json",
+                    ),
+                ),
+            ),
+        ),
+        required_files=(
+            "config.json",
+            "model.safetensors.index.json",
+            "model-00001-of-00010.safetensors",
+            "model-00002-of-00010.safetensors",
+            "model-00003-of-00010.safetensors",
+            "model-00004-of-00010.safetensors",
+            "model-00005-of-00010.safetensors",
+            "model-00006-of-00010.safetensors",
+            "model-00007-of-00010.safetensors",
+            "model-00008-of-00010.safetensors",
+            "model-00009-of-00010.safetensors",
+            "model-00010-of-00010.safetensors",
+            "preprocessor_config.json",
+            "tokenizer.json",
+            "tokenizer_config.json",
+            "vocab.json",
+            "merges.txt",
+        ),
+    ),
+    ModelPackage(
         id="higgs_audio_v3_tts_4b",
         display_name="Higgs Audio v3 TTS 4B",
         target_directory="higgs-audio-v3-tts-4b",
@@ -1305,7 +1351,9 @@ def install_composite_snapshot(
             convert_moss_tts_weights(staged_package_root)
         elif package.id in {"irodori_tts_500m_v3", "irodori_tts_600m_v3_voice_design"}:
             convert_irodori_dacvae_weights(staged_package_root.parent / "Semantic-DACVAE-Japanese-32dim")
-        elif package.id == "vibevoice_1_5b":
+        elif package.id in {"vibevoice_1_5b", "vibevoice_7b"}:
+            # VibeVoice 1.5B and 7B share the same Qwen2.5 tokenizer, and neither
+            # upstream repo ships the tokenizer files, so both reuse one bundle.
             copy_bundled_model_manager_assets(
                 "vibevoice_1_5b",
                 staged_package_root,


### PR DESCRIPTION
Support the VibeVoice 7B model alongside the 1.5B:
- Add the vibevoice_7b model-manager package, reusing the shared Qwen2.5 tokenizer bundle.
- Handle the 7B config.json, tolerating its upstream "acostic_vae_dim" key and reading top-level tie_word_embeddings.
- Load a separate lm_head.weight when word embeddings are untied and bind the decoder logits head to it.

Add optional PEFT LoRA merging for the decoder:
- Merge lora_A/lora_B into the targeted linear weights at load time via a tensor-source decorator, so it composes with the weight-type quantization options at no per-step cost.
- Expose it through the vibevoice.lora / vibevoice.lora_scale load options and document it in the README and docs/tts.md.