### PR TITLE
Improve Chatterbox memory usage

### DIFF
--- a/app/server/main.cpp
+++ b/app/server/main.cpp
@@ -2,6 +2,8 @@
 #include "http.h"
 #include "runtime.h"
 
+#include "engine/framework/debug/trace.h"
+
 #include <filesystem>
 #include <iostream>
 #include <optional>
@@ -31,6 +33,7 @@ bool has_arg(int argc, char ** argv, const std::string & name) {
 void print_help() {
     std::cout
         << "audiocpp_server --config <server.json> [--host <ip>] [--port <port>] [--device <id>] [--threads <n>]\n"
+        << "                [--log] [--log-file <path>]\n"
         << "\n"
         << "Endpoints:\n"
         << "  GET  /health\n"
@@ -52,6 +55,11 @@ int main(int argc, char ** argv) {
         if (!config_path.has_value()) {
             throw std::runtime_error("missing required --config argument");
         }
+        const auto log_file = arg_value(argc, argv, "--log-file");
+        engine::debug::configure_logging(engine::debug::LoggingConfig{
+            has_arg(argc, argv, "--log") || log_file.has_value(),
+            log_file,
+        });
 
         auto config = minitts::server::load_server_config(*config_path);
         if (const auto host = arg_value(argc, argv, "--host")) {

--- a/app/server/runtime.cpp
+++ b/app/server/runtime.cpp
@@ -6,16 +6,20 @@
 #include "engine/framework/runtime/registry.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <cstdint>
 #include <sstream>
 #include <stdexcept>
+#include <unordered_map>
 #include <utility>
 
 namespace minitts::server {
 namespace {
 
 using engine::io::json::Value;
+
+using Clock = std::chrono::steady_clock;
 
 std::string json_quote(std::string_view value) {
     return engine::io::json::stringify_string(value);
@@ -108,7 +112,49 @@ std::string base64_encode(const std::vector<uint8_t> & bytes) {
     return base64_encode(bytes.data(), bytes.size());
 }
 
-std::string task_result_json(const engine::runtime::TaskResult & result) {
+double elapsed_ms(Clock::time_point started) {
+    return std::chrono::duration<double, std::milli>(Clock::now() - started).count();
+}
+
+double audio_duration_ms(const engine::runtime::AudioBuffer & audio) {
+    if (audio.sample_rate <= 0 || audio.channels <= 0) {
+        return 0.0;
+    }
+    return 1000.0 * static_cast<double>(audio.samples.size()) /
+        static_cast<double>(audio.sample_rate * audio.channels);
+}
+
+double audio_rtf(double wall_ms, double duration_ms) {
+    return duration_ms > 0.0 ? wall_ms / duration_ms : 0.0;
+}
+
+std::string timing_json(double wall_ms) {
+    std::ostringstream out;
+    out << "{\"wall_ms\":" << wall_ms << "}";
+    return out.str();
+}
+
+std::string timing_json(double wall_ms, const engine::runtime::AudioBuffer & audio) {
+    const double duration_ms = audio_duration_ms(audio);
+    std::ostringstream out;
+    out << "{\"wall_ms\":" << wall_ms
+        << ",\"audio_duration_ms\":" << duration_ms
+        << ",\"rtf\":" << audio_rtf(wall_ms, duration_ms) << "}";
+    return out.str();
+}
+
+std::unordered_map<std::string, std::string> timing_headers(
+    double wall_ms,
+    const engine::runtime::AudioBuffer & audio) {
+    const double duration_ms = audio_duration_ms(audio);
+    return {
+        {"X-AudioCPP-Wall-Ms", std::to_string(wall_ms)},
+        {"X-AudioCPP-Audio-Duration-Ms", std::to_string(duration_ms)},
+        {"X-AudioCPP-RTF", std::to_string(audio_rtf(wall_ms, duration_ms))},
+    };
+}
+
+std::string task_result_json(const engine::runtime::TaskResult & result, double wall_ms) {
     std::ostringstream out;
     out << "{";
     bool first = true;
@@ -196,6 +242,14 @@ std::string task_result_json(const engine::runtime::TaskResult & result) {
                 << ",\"confidence\":" << word.confidence << "}";
         }
         out << "]";
+    }
+    field("timing");
+    if (result.audio_output.has_value()) {
+        out << timing_json(wall_ms, *result.audio_output);
+    } else if (result.named_audio_outputs.size() == 1) {
+        out << timing_json(wall_ms, result.named_audio_outputs.front().audio);
+    } else {
+        out << timing_json(wall_ms);
     }
     out << "}";
     return out.str();
@@ -364,37 +418,55 @@ ServerState::LoadedModel & ServerState::require_model(const Value & body) {
     return *models_.at(it->second);
 }
 
-engine::runtime::TaskResult ServerState::run_model(
+struct ServerState::TimedTaskResult {
+    engine::runtime::TaskResult result;
+    double wall_ms = 0.0;
+};
+
+ServerState::TimedTaskResult ServerState::run_model(
     LoadedModel & model,
     const engine::runtime::TaskRequest & request) {
     std::lock_guard<std::mutex> lock(model.mutex);
     ensure_model_loaded_locked(model);
+    const auto started = Clock::now();
     model.session->prepare(engine::runtime::build_preparation_request(request));
-    return model.offline->run(request);
+    auto result = model.offline->run(request);
+    return TimedTaskResult{std::move(result), elapsed_ms(started)};
 }
 
 HttpResponse ServerState::handle_speech(const std::string & body_text) {
     const auto body = engine::io::json::parse(body_text);
     auto & model = require_model(body);
     const auto request = build_openai_speech_request(body, request_base_);
-    const auto result = run_model(model, request);
-    const auto wav = encode_pcm16_wav(select_audio_output(result));
+    const auto timed_result = run_model(model, request);
+    const auto & audio = select_audio_output(timed_result.result);
+    const auto wav = encode_pcm16_wav(audio);
     const auto response_format = engine::io::json::optional_string(body, "response_format", "wav");
     if (response_format == "json" || response_format == "b64_json") {
-        return json_response("{\"audio\":" + json_quote(base64_encode(wav)) + ",\"format\":\"wav\"}");
+        return json_response(
+            "{\"audio\":" + json_quote(base64_encode(wav)) +
+            ",\"format\":\"wav\",\"timing\":" + timing_json(timed_result.wall_ms, audio) + "}");
     }
-    return HttpResponse{200, "audio/wav", std::string(reinterpret_cast<const char *>(wav.data()), wav.size()), {}};
+    return HttpResponse{
+        200,
+        "audio/wav",
+        std::string(reinterpret_cast<const char *>(wav.data()), wav.size()),
+        timing_headers(timed_result.wall_ms, audio),
+    };
 }
 
 HttpResponse ServerState::handle_transcription(const std::string & body_text) {
     const auto body = engine::io::json::parse(body_text);
     auto & model = require_model(body);
     const auto request = build_openai_transcription_request(body, request_base_);
-    const auto result = run_model(model, request);
+    const auto timed_result = run_model(model, request);
+    const auto & result = timed_result.result;
     if (!result.text_output.has_value()) {
         throw std::runtime_error("model result did not contain transcript text");
     }
-    return json_response("{\"text\":" + json_quote(result.text_output->text) + "}");
+    return json_response(
+        "{\"text\":" + json_quote(result.text_output->text) +
+        ",\"timing\":" + timing_json(timed_result.wall_ms) + "}");
 }
 
 HttpResponse ServerState::handle_generic_run(const std::string & body_text) {
@@ -404,7 +476,8 @@ HttpResponse ServerState::handle_generic_run(const std::string & body_text) {
     const auto request = minitts::cli::build_request_from_json(
         request_json != nullptr ? *request_json : body,
         request_base_);
-    return json_response(task_result_json(run_model(model, request)));
+    const auto timed_result = run_model(model, request);
+    return json_response(task_result_json(timed_result.result, timed_result.wall_ms));
 }
 
 std::string ServerState::models_json() const {

--- a/app/server/runtime.h
+++ b/app/server/runtime.h
@@ -34,7 +34,8 @@ private:
     void load_models();
     void ensure_model_loaded_locked(LoadedModel & model);
     LoadedModel & require_model(const engine::io::json::Value & body);
-    engine::runtime::TaskResult run_model(LoadedModel & model, const engine::runtime::TaskRequest & request);
+    struct TimedTaskResult;
+    TimedTaskResult run_model(LoadedModel & model, const engine::runtime::TaskRequest & request);
     HttpResponse handle_speech(const std::string & body_text);
     HttpResponse handle_transcription(const std::string & body_text);
     HttpResponse handle_generic_run(const std::string & body_text);

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -42,7 +42,7 @@ audiocpp_cli --task clon --family chatterbox --model models/chatterbox --backend
 |---|---|---:|---|
 | `--voice-ref` | WAV path | required | Reference speaker audio. |
 | `--language` | language code | `en` | Text language. |
-| `--text-chunk-size` | integer chars | `256` | Long-form chunk size. |
+| `--text-chunk-size` | integer chars | `128` | Long-form chunk size. |
 | `--guidance-scale` | float | `0.5` | CFG strength. |
 | `--temperature` | float | `0.8` | T3 sampling temperature. |
 | `--top-p` | float | `0.8` | T3 nucleus sampling limit. |

--- a/include/engine/framework/modules/hift_vocoder.h
+++ b/include/engine/framework/modules/hift_vocoder.h
@@ -144,6 +144,7 @@ public:
         uint64_t prior_noise_values = 0,
         const std::vector<float> * source_random_values = nullptr) const;
     std::vector<float> predict_f0(const std::vector<float> & mel, int64_t frames) const;
+    void release_runtime_cache() const;
 
 private:
     struct State;

--- a/include/engine/framework/runtime/cache_slots.h
+++ b/include/engine/framework/runtime/cache_slots.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <utility>
+#include <vector>
+
+namespace engine::runtime {
+
+template <typename Key, typename Value, typename Equal = std::equal_to<Key>>
+class CacheSlots {
+public:
+    explicit CacheSlots(std::size_t capacity = 1)
+        : capacity_(capacity) {}
+
+    std::size_t capacity() const noexcept {
+        return capacity_;
+    }
+
+    std::size_t size() const noexcept {
+        return entries_.size();
+    }
+
+    void set_capacity(std::size_t capacity) {
+        capacity_ = capacity;
+        evict_to_capacity();
+    }
+
+    Value * find(const Key & key) {
+        for (auto & entry : entries_) {
+            if (equal_(entry.key, key)) {
+                entry.last_used = next_tick();
+                return &entry.value;
+            }
+        }
+        return nullptr;
+    }
+
+    const Value * find(const Key & key) const {
+        for (const auto & entry : entries_) {
+            if (equal_(entry.key, key)) {
+                return &entry.value;
+            }
+        }
+        return nullptr;
+    }
+
+    void put(Key key, Value value) {
+        if (capacity_ == 0) {
+            entries_.clear();
+            return;
+        }
+        for (auto & entry : entries_) {
+            if (equal_(entry.key, key)) {
+                entry.key = std::move(key);
+                entry.value = std::move(value);
+                entry.last_used = next_tick();
+                return;
+            }
+        }
+        if (entries_.size() >= capacity_) {
+            erase_lru();
+        }
+        entries_.push_back(Entry{
+            std::move(key),
+            std::move(value),
+            next_tick(),
+        });
+    }
+
+    void clear() {
+        entries_.clear();
+    }
+
+private:
+    struct Entry {
+        Key key;
+        Value value;
+        std::uint64_t last_used = 0;
+    };
+
+    std::uint64_t next_tick() noexcept {
+        return ++tick_;
+    }
+
+    void evict_to_capacity() {
+        while (entries_.size() > capacity_) {
+            erase_lru();
+        }
+    }
+
+    void erase_lru() {
+        if (entries_.empty()) {
+            return;
+        }
+        std::size_t oldest = 0;
+        for (std::size_t i = 1; i < entries_.size(); ++i) {
+            if (entries_[i].last_used < entries_[oldest].last_used) {
+                oldest = i;
+            }
+        }
+        entries_.erase(entries_.begin() + static_cast<std::ptrdiff_t>(oldest));
+    }
+
+    std::size_t capacity_ = 1;
+    std::uint64_t tick_ = 0;
+    std::vector<Entry> entries_;
+    Equal equal_;
+};
+
+}  // namespace engine::runtime

--- a/include/engine/models/chatterbox/components.h
+++ b/include/engine/models/chatterbox/components.h
@@ -199,6 +199,7 @@ public:
         uint64_t seed,
         uint64_t prior_noise_values,
         const std::vector<float> & cache_source) const;
+    void release_runtime_cache() const;
 
 private:
     struct State;

--- a/include/engine/models/chatterbox/s3gen_inference.h
+++ b/include/engine/models/chatterbox/s3gen_inference.h
@@ -22,6 +22,8 @@ public:
     S3GenSessionCache(const S3GenSessionCache &) = delete;
     S3GenSessionCache & operator=(const S3GenSessionCache &) = delete;
 
+    void release_runtime_graphs();
+
 private:
     struct State;
     std::unique_ptr<State> state_;

--- a/include/engine/models/chatterbox/session.h
+++ b/include/engine/models/chatterbox/session.h
@@ -2,15 +2,30 @@
 
 #include "engine/framework/runtime/session_base.h"
 #include "engine/framework/assets/tensor_source.h"
+#include "engine/framework/runtime/cache_slots.h"
 #include "engine/models/chatterbox/assets.h"
 #include "engine/models/chatterbox/conditionals.h"
 #include "engine/models/chatterbox/tts.h"
 
+#include <cstddef>
 #include <filesystem>
 #include <memory>
 #include <optional>
+#include <string>
 
 namespace engine::models::chatterbox {
+
+struct ChatterboxConditionalsCacheKey {
+    runtime::AudioBuffer reference_audio;
+    float exaggeration = 0.0f;
+    std::string language;
+};
+
+struct ChatterboxConditionalsCacheKeyEqual {
+    bool operator()(
+        const ChatterboxConditionalsCacheKey & lhs,
+        const ChatterboxConditionalsCacheKey & rhs) const;
+};
 
 class ChatterboxSession final
     : public runtime::RuntimeSessionBase
@@ -35,8 +50,14 @@ private:
     std::shared_ptr<const ChatterboxAssetPaths> assets_;
     engine::assets::TensorStorageType t3_weight_storage_type_ = engine::assets::TensorStorageType::Native;
     engine::assets::TensorStorageType component_weight_storage_type_ = engine::assets::TensorStorageType::Native;
+    bool mem_saver_ = false;
     std::unique_ptr<ChatterboxTtsComponent> component_;
+    std::optional<std::string> component_language_;
     std::optional<ChatterboxVoiceCloneConfig> voice_clone_config_;
+    runtime::CacheSlots<
+        ChatterboxConditionalsCacheKey,
+        ChatterboxConditionalsOutputs,
+        ChatterboxConditionalsCacheKeyEqual> conditionals_cache_;
     std::optional<ChatterboxConditionalsOutputs> cached_conditionals_;
     double cached_prompt_prep_ms_ = 0.0;
 };

--- a/include/engine/models/chatterbox/t3_component.h
+++ b/include/engine/models/chatterbox/t3_component.h
@@ -22,6 +22,7 @@ public:
         const engine::core::ExecutionContext & execution_context);
 
     T3GenerateOutputs generate_speech_tokens(const T3GenerateRequest & request) const;
+    void release_runtime_graphs() const;
     void release_runtime_cache() const;
 
 private:

--- a/include/engine/models/chatterbox/tts.h
+++ b/include/engine/models/chatterbox/tts.h
@@ -94,7 +94,8 @@ public:
         std::shared_ptr<const S3FlowDecoderWeights> flow_decoder_weights,
         engine::models::chatterbox::HiFTVocoderComponent vocoder,
         ChatterboxPromptPrepConfig prompt_prep_config,
-        const engine::core::ExecutionContext & execution_context);
+        const engine::core::ExecutionContext & execution_context,
+        bool mem_saver = false);
 
     ChatterboxVoiceCloneOutputs synthesize_voice_clone(
         const std::string & text,
@@ -125,6 +126,7 @@ private:
     std::shared_ptr<const S3FlowDecoderWeights> flow_decoder_weights_;
     engine::models::chatterbox::HiFTVocoderComponent vocoder_;
     const engine::core::ExecutionContext * execution_context_ = nullptr;
+    bool mem_saver_ = false;
     std::shared_ptr<State> state_;
 };
 

--- a/src/framework/modules/hift_vocoder.cpp
+++ b/src/framework/modules/hift_vocoder.cpp
@@ -566,6 +566,9 @@ public:
     }
 
     ~F0Runner() {
+        if (weights_ != nullptr && graph_ != nullptr) {
+            engine::core::release_backend_graph_resources(weights_->execution_context->backend(), graph_);
+        }
         if (buffer_ != nullptr) {
             ggml_backend_buffer_free(buffer_);
         }
@@ -635,6 +638,9 @@ public:
     }
 
     ~BackendRunner() {
+        if (weights_ != nullptr && graph_ != nullptr) {
+            engine::core::release_backend_graph_resources(weights_->execution_context->backend(), graph_);
+        }
         if (buffer_ != nullptr) {
             ggml_backend_buffer_free(buffer_);
         }
@@ -712,6 +718,12 @@ public:
         out.samples = static_cast<int64_t>(out.waveform.size());
         out.sample_rate = weights_->config.sampling_rate;
         return out;
+    }
+
+    void release_runtime_cache() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        f0_runner_.reset();
+        backend_runner_.reset();
     }
 
 private:
@@ -954,6 +966,13 @@ std::vector<float> HiftVocoderComponent::predict_f0(const std::vector<float> & m
         throw std::runtime_error("HiFT component is not initialized");
     }
     return state_->runner->predict_f0(mel, frames);
+}
+
+void HiftVocoderComponent::release_runtime_cache() const {
+    if (state_ == nullptr || state_->runner == nullptr) {
+        throw std::runtime_error("HiFT component is not initialized");
+    }
+    state_->runner->release_runtime_cache();
 }
 
 }  // namespace engine::modules

--- a/src/models/chatterbox/components/t3_runtime.h
+++ b/src/models/chatterbox/components/t3_runtime.h
@@ -850,6 +850,9 @@ public:
     }
 
     ~T3DecodeBackendRunner() {
+        if (owner_ != nullptr && graph_ != nullptr) {
+            engine::core::release_backend_graph_resources(owner_->backend(), graph_);
+        }
         if (buffer_ != nullptr) {
             ggml_backend_buffer_free(buffer_);
             buffer_ = nullptr;
@@ -1167,6 +1170,9 @@ public:
     }
 
     ~T3PrefillBackendRunner() {
+        if (owner_ != nullptr && graph_ != nullptr) {
+            engine::core::release_backend_graph_resources(owner_->backend(), graph_);
+        }
         if (buffer_ != nullptr) {
             ggml_backend_buffer_free(buffer_);
             buffer_ = nullptr;

--- a/src/models/chatterbox/hift_vocoder_impl.cpp
+++ b/src/models/chatterbox/hift_vocoder_impl.cpp
@@ -454,4 +454,11 @@ HiFTVocoderOutputs HiFTVocoderComponent::infer(
     return outputs;
 }
 
+void HiFTVocoderComponent::release_runtime_cache() const {
+    if (state_ == nullptr) {
+        throw std::runtime_error("Chatterbox framework HiFT wrapper is not initialized");
+    }
+    state_->component.release_runtime_cache();
+}
+
 }  // namespace engine::models::chatterbox

--- a/src/models/chatterbox/loader.cpp
+++ b/src/models/chatterbox/loader.cpp
@@ -81,6 +81,18 @@ public:
         inspection.capabilities.languages = supported_chatterbox_language_codes();
         inspection.capabilities.supports_speaker_reference = true;
         inspection.capabilities.supports_style_condition = true;
+        inspection.cli.session_options = {
+            {
+                "--session-option chatterbox.conditionals_cache_slots",
+                "n",
+                "Prepared voice-condition cache slots; default 1, set 0 to disable.",
+            },
+            {
+                "--session-option chatterbox.mem_saver=true",
+                "",
+                "Free non-conditional runtime graphs after each request chunk; default false.",
+            },
+        };
         inspection.discovered_configs = discover_config_assets(request);
         inspection.discovered_weights = discover_weight_assets(request);
         return inspection;

--- a/src/models/chatterbox/s3gen_flow.cpp
+++ b/src/models/chatterbox/s3gen_flow.cpp
@@ -194,7 +194,15 @@ void copy_backend_tensor(
     ggml_backend_tensor_copy(src.tensor, dst.tensor);
 }
 
-void release_graph_resources(ggml_context *& ggml, ggml_backend_buffer_t & buffer) {
+void release_graph_resources(
+    const engine::core::ExecutionContext * execution_context,
+    ggml_cgraph *& graph,
+    ggml_context *& ggml,
+    ggml_backend_buffer_t & buffer) {
+    if (execution_context != nullptr && graph != nullptr) {
+        engine::core::release_backend_graph_resources(execution_context->backend(), graph);
+        graph = nullptr;
+    }
     if (buffer != nullptr) {
         ggml_backend_buffer_free(buffer);
         buffer = nullptr;
@@ -1011,7 +1019,7 @@ private:
         }
 
         ~FlowEncoderEmbedPrelookBackendRunner() {
-            release_graph_resources(ggml_, buffer_);
+            release_graph_resources(execution_context_, graph_, ggml_, buffer_);
         }
 
         void write_input(const std::vector<float> & input) {
@@ -1126,7 +1134,7 @@ private:
             }
 
             ~FlowEncoderAttentionBackendRunner() {
-                release_graph_resources(ggml_, buffer_);
+                release_graph_resources(execution_context_, graph_, ggml_, buffer_);
             }
 
             engine::core::TensorValue & input_tensor() {
@@ -1201,7 +1209,7 @@ private:
             }
 
             ~FlowEncoderFeedForwardBackendRunner() {
-                release_graph_resources(ggml_, buffer_);
+                release_graph_resources(execution_context_, graph_, ggml_, buffer_);
             }
 
             engine::core::TensorValue & input_tensor() {
@@ -1283,7 +1291,7 @@ private:
         }
 
         ~FlowEncoderUpsampleBackendRunner() {
-            release_graph_resources(ggml_, buffer_);
+            release_graph_resources(execution_context_, graph_, ggml_, buffer_);
         }
 
         engine::core::TensorValue & input_tensor() {
@@ -1349,7 +1357,7 @@ private:
         }
 
         ~FlowEncoderAfterNormBackendRunner() {
-            release_graph_resources(ggml_, buffer_);
+            release_graph_resources(execution_context_, graph_, ggml_, buffer_);
         }
 
         engine::core::TensorValue & input_tensor() {
@@ -1403,9 +1411,9 @@ public:
     }
 
     ~FlowDecoderBackendRunner() {
-        if (buffer_ != nullptr) {
-            ggml_backend_buffer_free(buffer_);
-            buffer_ = nullptr;
+        if (graph_ != nullptr) {
+            engine::core::release_backend_graph_resources(backend_, graph_);
+            graph_ = nullptr;
         }
         if (graph_ggml_ != nullptr) {
             ggml_free(graph_ggml_);
@@ -1429,9 +1437,9 @@ public:
         if (graph_ != nullptr && active_frames_ == frames) {
             return;
         }
-        if (buffer_ != nullptr) {
-            ggml_backend_buffer_free(buffer_);
-            buffer_ = nullptr;
+        if (graph_ != nullptr) {
+            engine::core::release_backend_graph_resources(backend_, graph_);
+            graph_ = nullptr;
         }
         if (gallocr_ != nullptr) {
             ggml_gallocr_free(gallocr_);
@@ -1441,7 +1449,6 @@ public:
             ggml_free(graph_ggml_);
             graph_ggml_ = nullptr;
         }
-        graph_ = nullptr;
         output_tensor_ = {};
         attention_mask_ = {};
         skip_tensor_ = {};
@@ -1480,12 +1487,12 @@ public:
         attention_mask_ =
             engine::core::make_tensor(ctx, GGML_TYPE_F16, engine::core::TensorShape::from_dims({batch_, 8, frames, frames}));
         ggml_set_input(attention_mask_.tensor);
-        if (execution_context_->uses_host_graph_plan()) {
-            ggml_set_output(mu_in_.tensor);
-            ggml_set_output(spks_in_.tensor);
-            ggml_set_output(cond_in_.tensor);
-            ggml_set_output(attention_mask_.tensor);
-        }
+        ggml_set_output(x_in_.tensor);
+        ggml_set_output(mu_in_.tensor);
+        ggml_set_output(time_in_.tensor);
+        ggml_set_output(spks_in_.tensor);
+        ggml_set_output(cond_in_.tensor);
+        ggml_set_output(attention_mask_.tensor);
         auto time_hidden = linear_lastdim(ctx, time_in_, weights.time_mlp_1, writer);
         time_hidden = engine::core::wrap_tensor(ggml_silu(ctx.ggml, time_hidden.tensor), time_hidden.shape, GGML_TYPE_F32);
         time_hidden = linear_lastdim(ctx, time_hidden, weights.time_mlp_2, writer);
@@ -1525,21 +1532,14 @@ public:
 
         graph_ = ggml_new_graph_custom(graph_ggml_, 262144, false);
         ggml_build_forward_expand(graph_, output_tensor_.tensor);
+        gallocr_ = ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend_));
+        if (gallocr_ == nullptr ||
+            !ggml_gallocr_reserve(gallocr_, graph_) ||
+            !ggml_gallocr_alloc_graph(gallocr_, graph_)) {
+            throw std::runtime_error("failed to allocate backend graph tensors for S3 flow decoder");
+        }
         if (execution_context_->uses_host_graph_plan()) {
-            gallocr_ = ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend_));
-            if (gallocr_ == nullptr) {
-                throw std::runtime_error("failed to initialize graph allocator for S3 flow decoder");
-            }
-            ggml_gallocr_reserve(gallocr_, graph_);
-            if (!ggml_gallocr_alloc_graph(gallocr_, graph_)) {
-                throw std::runtime_error("failed to allocate backend graph tensors for S3 flow decoder");
-            }
             engine::core::prepare_host_graph_plan(*execution_context_, graph_, cpu_plan_);
-        } else {
-            buffer_ = ggml_backend_alloc_ctx_tensors(graph_ggml_, backend_);
-            if (buffer_ == nullptr) {
-                throw std::runtime_error("failed to allocate S3 flow decoder backend tensors");
-            }
         }
         writer.flush();
     }
@@ -1625,7 +1625,6 @@ private:
     const engine::core::ExecutionContext * execution_context_ = nullptr;
     ggml_backend_t backend_ = nullptr;
     ggml_context * graph_ggml_ = nullptr;
-    ggml_backend_buffer_t buffer_ = nullptr;
     ggml_gallocr_t gallocr_ = nullptr;
     ggml_cgraph * graph_ = nullptr;
     engine::core::TensorValue x_in_;

--- a/src/models/chatterbox/s3gen_inference.cpp
+++ b/src/models/chatterbox/s3gen_inference.cpp
@@ -180,6 +180,9 @@ public:
     }
 
     ~S3TokenEmbeddingGraph() {
+        if (execution_context_ != nullptr && graph_ != nullptr) {
+            engine::core::release_backend_graph_resources(execution_context_->backend(), graph_);
+        }
         if (buffer_ != nullptr) {
             ggml_backend_buffer_free(buffer_);
         }
@@ -274,6 +277,9 @@ public:
     }
 
     ~S3Token2MelPrepareGraph() {
+        if (execution_context_ != nullptr && graph_ != nullptr) {
+            engine::core::release_backend_graph_resources(execution_context_->backend(), graph_);
+        }
         if (buffer_ != nullptr) {
             ggml_backend_buffer_free(buffer_);
         }
@@ -427,6 +433,11 @@ S3GenSessionCache::S3GenSessionCache(engine::core::BackendConfig backend)
 S3GenSessionCache::~S3GenSessionCache() = default;
 S3GenSessionCache::S3GenSessionCache(S3GenSessionCache &&) noexcept = default;
 S3GenSessionCache & S3GenSessionCache::operator=(S3GenSessionCache &&) noexcept = default;
+
+void S3GenSessionCache::release_runtime_graphs() {
+    state_->release_pre_cfm_graphs();
+    state_->release_cfm_decoder_graphs();
+}
 
 S3Token2MelOutputs compute_s3_token2mel_inference(
     S3GenSessionCache & cache,

--- a/src/models/chatterbox/session.cpp
+++ b/src/models/chatterbox/session.cpp
@@ -9,6 +9,9 @@
 
 #include <chrono>
 #include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
 #include <memory>
 #include <stdexcept>
 
@@ -16,7 +19,7 @@ namespace engine::models::chatterbox {
 
 namespace {
 
-constexpr int64_t kDefaultTextChunkSize = 256;
+constexpr int64_t kDefaultTextChunkSize = 128;
 
 ChatterboxVoiceCloneConfig make_voice_clone_config(
     const std::unordered_map<std::string, std::string> & options) {
@@ -75,6 +78,12 @@ bool float_equal(float lhs, float rhs) {
     return std::fabs(lhs - rhs) <= 1.0e-6f;
 }
 
+bool same_audio_buffer(const runtime::AudioBuffer & lhs, const runtime::AudioBuffer & rhs) {
+    return lhs.sample_rate == rhs.sample_rate &&
+        lhs.channels == rhs.channels &&
+        lhs.samples == rhs.samples;
+}
+
 bool same_voice_clone_config(const ChatterboxVoiceCloneConfig & lhs, const ChatterboxVoiceCloneConfig & rhs) {
     return float_equal(lhs.exaggeration, rhs.exaggeration) &&
         float_equal(lhs.guidance_scale, rhs.guidance_scale) &&
@@ -113,6 +122,7 @@ std::unique_ptr<ChatterboxTtsComponent> make_chatterbox_component_for_language(
     const engine::core::ExecutionContext & execution_context,
     engine::assets::TensorStorageType t3_weight_storage_type,
     engine::assets::TensorStorageType component_weight_storage_type,
+    bool mem_saver,
     const std::string & language) {
     const bool use_multilingual = chatterbox_language_uses_multilingual_t3(language);
     return std::make_unique<ChatterboxTtsComponent>(
@@ -145,7 +155,8 @@ std::unique_ptr<ChatterboxTtsComponent> make_chatterbox_component_for_language(
             execution_context,
             component_weight_storage_type),
         make_prompt_prep_config(options),
-        execution_context);
+        execution_context,
+        mem_saver);
 }
 
 std::shared_ptr<const ChatterboxAssetPaths> require_assets(std::shared_ptr<const ChatterboxAssetPaths> assets) {
@@ -182,6 +193,8 @@ void validate_chatterbox_options(const runtime::SessionOptions & options) {
         if (key.rfind("chatterbox.", 0) == 0 &&
             key != "chatterbox.weight_type" &&
             key != "chatterbox.t3_weight_type" &&
+            key != "chatterbox.conditionals_cache_slots" &&
+            key != "chatterbox.mem_saver" &&
             key != "chatterbox.encoder_condition_samples" &&
             key != "chatterbox.decoder_condition_samples" &&
             key != "chatterbox.t3_speech_cond_prompt_len") {
@@ -209,7 +222,37 @@ engine::assets::TensorStorageType resolve_component_weight_storage_type(const ru
     return storage_type;
 }
 
+std::size_t resolve_conditionals_cache_slots(const runtime::SessionOptions & options) {
+    constexpr int64_t kDefaultConditionalsCacheSlots = 1;
+    const int64_t slots = runtime::parse_i64_option(
+        options.options,
+        {"chatterbox.conditionals_cache_slots", "conditionals_cache_slots"})
+        .value_or(kDefaultConditionalsCacheSlots);
+    if (slots < 0) {
+        throw std::runtime_error("chatterbox.conditionals_cache_slots must be non-negative");
+    }
+    if (static_cast<std::uint64_t>(slots) > static_cast<std::uint64_t>(std::numeric_limits<std::size_t>::max())) {
+        throw std::runtime_error("chatterbox.conditionals_cache_slots is too large");
+    }
+    return static_cast<std::size_t>(slots);
+}
+
+bool resolve_mem_saver(const runtime::SessionOptions & options) {
+    if (const auto value = runtime::find_option(options.options, {"chatterbox.mem_saver", "mem_saver"})) {
+        return runtime::parse_bool_option(*value, "chatterbox.mem_saver");
+    }
+    return false;
+}
+
 }  // namespace
+
+bool ChatterboxConditionalsCacheKeyEqual::operator()(
+    const ChatterboxConditionalsCacheKey & lhs,
+    const ChatterboxConditionalsCacheKey & rhs) const {
+    return lhs.language == rhs.language &&
+        float_equal(lhs.exaggeration, rhs.exaggeration) &&
+        same_audio_buffer(lhs.reference_audio, rhs.reference_audio);
+}
 
 ChatterboxSession::ChatterboxSession(
     runtime::TaskSpec task,
@@ -219,7 +262,9 @@ ChatterboxSession::ChatterboxSession(
       task_(std::move(task)),
       assets_(require_assets(std::move(assets))),
       t3_weight_storage_type_(resolve_t3_weight_storage_type(this->options())),
-      component_weight_storage_type_(resolve_component_weight_storage_type(this->options())) {
+      component_weight_storage_type_(resolve_component_weight_storage_type(this->options())),
+      mem_saver_(resolve_mem_saver(this->options())),
+      conditionals_cache_(resolve_conditionals_cache_slots(this->options())) {
     if (task_.task != runtime::VoiceTaskKind::VoiceCloning) {
         throw std::runtime_error("Chatterbox session only supports --task clon");
     }
@@ -251,19 +296,47 @@ void ChatterboxSession::prepare(const runtime::SessionPreparationRequest & reque
     }
     const auto session_config = make_voice_clone_config(request.options, request.text->language);
     voice_clone_config_ = session_config;
-    component_ = make_chatterbox_component_for_language(
-        *assets_,
-        this->options(),
-        execution_context(),
-        t3_weight_storage_type_,
-        component_weight_storage_type_,
-        session_config.language);
-    const auto prompt_prep_started = std::chrono::steady_clock::now();
-    cached_conditionals_ = component_->prepare_voice_clone_conditionals(
-        *request.voice->speaker->audio,
-        session_config);
-    cached_prompt_prep_ms_ =
-        std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - prompt_prep_started).count();
+    if (!component_ || !component_language_.has_value() || *component_language_ != session_config.language) {
+        component_.reset();
+        component_language_.reset();
+        component_ = make_chatterbox_component_for_language(
+            *assets_,
+            this->options(),
+            execution_context(),
+            t3_weight_storage_type_,
+            component_weight_storage_type_,
+            mem_saver_,
+            session_config.language);
+        component_language_ = session_config.language;
+        cached_conditionals_.reset();
+        conditionals_cache_.clear();
+    }
+    const auto & reference_audio = *request.voice->speaker->audio;
+    ChatterboxConditionalsCacheKey conditionals_key{
+        reference_audio,
+        session_config.exaggeration,
+        session_config.language,
+    };
+    const auto * conditionals_cache_entry = conditionals_cache_.find(conditionals_key);
+    const bool conditionals_cache_hit =
+        conditionals_cache_entry != nullptr;
+    engine::debug::trace_log_scalar("chatterbox.conditionals.cache_hit", conditionals_cache_hit ? 1 : 0);
+    engine::debug::trace_log_scalar(
+        "chatterbox.conditionals.cache_slots",
+        static_cast<int64_t>(conditionals_cache_.capacity()));
+    if (conditionals_cache_hit) {
+        cached_conditionals_ = *conditionals_cache_entry;
+        cached_prompt_prep_ms_ = 0.0;
+    } else {
+        const auto prompt_prep_started = std::chrono::steady_clock::now();
+        auto prepared_conditionals = component_->prepare_voice_clone_conditionals(
+            reference_audio,
+            session_config);
+        cached_conditionals_ = prepared_conditionals;
+        conditionals_cache_.put(std::move(conditionals_key), std::move(prepared_conditionals));
+        cached_prompt_prep_ms_ =
+            std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - prompt_prep_started).count();
+    }
     mark_prepared();
 }
 

--- a/src/models/chatterbox/t3_component.cpp
+++ b/src/models/chatterbox/t3_component.cpp
@@ -78,6 +78,12 @@ std::vector<float> build_positioned_token_embeddings(
 
 namespace engine::models::chatterbox {
 struct T3InferenceComponent::State {
+    void release_runtime_graphs() {
+        std::lock_guard<std::mutex> lock(mutex);
+        runner.reset();
+        prefill_runner.reset();
+    }
+
     void release_runtime_cache() {
         std::lock_guard<std::mutex> lock(mutex);
         owner.reset();
@@ -667,6 +673,10 @@ T3GenerateOutputs T3InferenceComponent::generate_speech_tokens(const T3GenerateR
     outputs.token_count = static_cast<int64_t>(outputs.predicted_tokens.size());
     outputs.prefix_cache_build_ms = prefix_cache_build_ms;
     return outputs;
+}
+
+void T3InferenceComponent::release_runtime_graphs() const {
+    state_->release_runtime_graphs();
 }
 
 void T3InferenceComponent::release_runtime_cache() const {

--- a/src/models/chatterbox/tts.cpp
+++ b/src/models/chatterbox/tts.cpp
@@ -80,7 +80,8 @@ ChatterboxTtsComponent::ChatterboxTtsComponent(
     std::shared_ptr<const S3FlowDecoderWeights> flow_decoder_weights,
     engine::models::chatterbox::HiFTVocoderComponent vocoder,
     ChatterboxPromptPrepConfig prompt_prep_config,
-    const engine::core::ExecutionContext & execution_context)
+    const engine::core::ExecutionContext & execution_context,
+    bool mem_saver)
     : t3_(
           std::move(t3_weights),
           execution_context),
@@ -94,6 +95,7 @@ ChatterboxTtsComponent::ChatterboxTtsComponent(
       flow_decoder_weights_(std::move(flow_decoder_weights)),
       vocoder_(std::move(vocoder)),
       execution_context_(&execution_context),
+      mem_saver_(mem_saver),
       state_(std::make_shared<State>(execution_context.config())) {
     if (!tokenizer_) {
         throw std::runtime_error("ChatterboxTtsComponent requires text tokenizer");
@@ -204,7 +206,9 @@ ChatterboxVoiceCloneOutputs ChatterboxTtsComponent::synthesize_voice_clone_impl(
     engine::debug::timing_log_scalar("chatterbox.voice_clone.t3.next_embed_ms", outputs.t3_next_embed_ms);
     outputs.generated_speech_tokens = t3_outputs.predicted_tokens;
     outputs.cleaned_speech_tokens = clean_generated_speech_tokens_like_python(outputs.generated_speech_tokens);
-    if (execution_context_ != nullptr && execution_context_->uses_host_graph_plan()) {
+    if (mem_saver_) {
+        t3_.release_runtime_graphs();
+    } else if (execution_context_ != nullptr && execution_context_->uses_host_graph_plan()) {
         t3_.release_runtime_cache();
     }
 
@@ -230,6 +234,9 @@ ChatterboxVoiceCloneOutputs ChatterboxTtsComponent::synthesize_voice_clone_impl(
     s3gen_timing.token2mel_ms =
         engine::debug::elapsed_ms(token2mel_started);
     const auto token2mel_memory_after = capture_backend_memory_snapshot(execution_context_);
+    if (mem_saver_) {
+        state_->s3_cache.release_runtime_graphs();
+    }
     const uint64_t prior_noise_values =
         static_cast<uint64_t>(mel.channels * (conds.gen.prompt_feat_frames + mel.frames));
     const auto vocoder_memory_before = capture_backend_memory_snapshot(execution_context_);
@@ -243,6 +250,9 @@ ChatterboxVoiceCloneOutputs ChatterboxTtsComponent::synthesize_voice_clone_impl(
         {});
     s3gen_timing.vocoder_ms =
         engine::debug::elapsed_ms(vocoder_started);
+    if (mem_saver_) {
+        vocoder_.release_runtime_cache();
+    }
     const auto vocoder_memory_after = capture_backend_memory_snapshot(execution_context_);
     outputs.s3gen_ms =
         engine::debug::elapsed_ms(s3gen_started);


### PR DESCRIPTION
## What This Addresses

This PR improves Chatterbox session reuse and memory behavior for server and CLI workloads.

- Adds a real Chatterbox voice-conditionals cache with configurable cache slots via `chatterbox.conditionals_cache_slots`.
- Reuses the Chatterbox component across requests when the language stays compatible, instead of rebuilding it unnecessarily.
- Adds `chatterbox.mem_saver=true`, which frees non-conditional runtime graphs after each chunk/request while preserving conditionals and reusable prompt/cache state.
- Releases backend graph resources when T3, S3, and HiFT runtime graphs are destroyed or rebuilt, reducing retained CUDA graph/resource pressure.
- Updates S3 flow decoder graph allocation/lifetime handling through the graph allocator path.
- Changes the Chatterbox default text chunk size from `256` to `128` to reduce long-form peak VRAM.
- Adds server-side wall timing in responses/headers through `timing.wall_ms`, plus audio duration and RTF where audio is returned.
- Adds server `--log` / `--log-file` support.
- Documents the new Chatterbox default chunk size and exposes the new Chatterbox session options in CLI inspection/help.

## Text Chunk Size Impact on VRAM and RTF

Measured with `chatterbox.mem_saver=true`. Lower RTF is better.

### 256 (old default)

| req | lang | chars | chunks | wall_s | audio_s | RTF | peak VRAM | resident VRAM | peak RSS |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|
| r1 | en | 1024 | 5 | 20.65 | 66.52 | 0.310 | 19424 MiB | 3072 MiB | 1374 MiB |
| r2 | de | 1253 | 6 | 22.75 | 82.12 | 0.277 | 19426 MiB | 3074 MiB | 1415 MiB |
| r3 | fr | 1483 | 7 | 25.27 | 96.28 | 0.262 | 19426 MiB | 3074 MiB | 1423 MiB |
| r4 | es | 1827 | 8 | 29.89 | 120.44 | 0.248 | 19426 MiB | 3074 MiB | 1432 MiB |
| r5 | it | 2056 | 9 | 32.79 | 135.36 | 0.242 | 19426 MiB | 3074 MiB | 1414 MiB |

### 128 (new default)

| req | lang | chars | chunks | wall_s | audio_s | RTF | peak VRAM | resident VRAM | peak RSS |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|
| r1 | en | 1024 | 11 | 21.56 | 71.84 | 0.300 | 7776 MiB | 3048 MiB | 1014 MiB |
| r2 | de | 1253 | 14 | 27.08 | 96.40 | 0.281 | 13186 MiB | 3050 MiB | 1312 MiB |
| r3 | fr | 1483 | 17 | 28.43 | 109.36 | 0.260 | 13440 MiB | 3050 MiB | 1300 MiB |
| r4 | es | 1827 | 21 | 34.69 | 141.44 | 0.245 | 14000 MiB | 3056 MiB | 1590 MiB |
| r5 | it | 2056 | 23 | 36.27 | 149.60 | 0.242 | 11062 MiB | 3056 MiB | 1330 MiB |

### 64

| req | lang | chars | chunks | wall_s | audio_s | RTF | peak VRAM | resident VRAM | peak RSS |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|
| r1 | en | 1024 | 22 | 25.74 | 79.24 | 0.325 | 8716 MiB | 3052 MiB | 992 MiB |
| r2 | de | 1253 | 26 | 32.12 | 110.24 | 0.291 | 9528 MiB | 3054 MiB | 1270 MiB |
| r3 | fr | 1483 | 31 | 35.57 | 127.84 | 0.278 | 8762 MiB | 3054 MiB | 1295 MiB |
| r4 | es | 1827 | 38 | 43.65 | 167.64 | 0.260 | 9996 MiB | 3054 MiB | 1290 MiB |
| r5 | it | 2056 | 43 | 46.91 | 188.76 | 0.248 | 9230 MiB | 3054 MiB | 1352 MiB |

The new `128` default is a middle ground: it substantially lowers peak VRAM versus `256`, while avoiding the heavier chunking overhead of `64`.

## Validation

- Built debug targets:
  - `audiocpp_cli`
  - `audiocpp_server`
- Ran Chatterbox CUDA path test with the new default chunk size.
- Existing `256` baseline remains useful for regression comparison, but exact output parity is not expected for long text that now splits into more chunks.

## Notes

This does not claim to fully eliminate Chatterbox peak VRAM spikes. The largest remaining peak is still likely from S3/HiFT graph workspace sizing during long chunks. The new default chunk size and `mem_saver` mode reduce practical peak/resident pressure, but deeper S3 graph sizing remains separate work.