### PR TITLE
Fix empty PocketTTS output after switching voices

### DIFF
--- a/src/models/pocket_tts/acoustic_model.cpp
+++ b/src/models/pocket_tts/acoustic_model.cpp
@@ -84,7 +84,12 @@ AcousticPreparedRuntime AcousticModel::prepare_runtime(
         && runtime_cache_.threads == threads
         && runtime_cache_.manifest == &manifest
         && runtime_cache_.prompt_capacity >= prompt_capacity
-        && runtime_cache_.initial_cache_capacity >= initial_cache_capacity
+        // The step runtime bakes the voice-prefix slot layout at creation: prompt KV
+        // destinations start at initial_cache_capacity and the prefix attention view
+        // spans exactly that many slots. Reusing a runtime built for a different prefix
+        // length misaligns the KV slots against the cache validity accounting, so the
+        // prefix capacity must match exactly (not merely fit).
+        && runtime_cache_.initial_cache_capacity == initial_cache_capacity
         && runtime_cache_.max_steps_capacity >= max_steps_capacity
         && runtime_cache_.flow_weights_view_context_bytes == flow_weights_view_context_bytes
         && runtime_cache_.flow_step_graph_context_bytes == flow_step_graph_context_bytes;


### PR DESCRIPTION
## Problem

With the OpenAI-compatible server (and any long-lived `PocketTTSSession`), only the first voice works. After switching to a different voice and back, generations for the earlier voice return a near-empty WAV (only a fraction of a second, no speech). Only restarting the server recovers. The failure is deterministic and independent of the seed.

Repro against `audiocpp_server` (CUDA, single `pocket-tts` model, lazy):

```
voice=bill_boerst  -> 169004 bytes (ok)
voice=bill_boerst  -> 172844 bytes (ok)
voice=azelma       -> 192044 bytes (ok, longer prefix forces runtime rebuild)
voice=bill_boerst  ->  15404 bytes (EMPTY — shorter prefix hits the stale cache)
```

## Root cause

`FlowLMStepRuntime` bakes the voice-prefix KV layout at construction: the prompt KV destination views start at slot `initial_cache_capacity` and the prefix attention view spans exactly that many slots. But the runtime cache-hit check in `AcousticModel::prepare_runtime` accepted any cached runtime with `initial_cache_capacity >= requested`.

When a request switches to a voice whose prepared state has a *shorter* prefix than the voice the runtime was built for, the reused runtime writes prompt KV entries at the old baked offsets (`old_prefix + step`), while `apply_prompt_from_state` advances the step cache from the new voice's `current_end`. The resulting validity mask marks stale KV slots from the previous voice as valid and excludes the actual prompt, so the model hits EOS immediately and only the prompt-length sliver of audio is decoded. A voice with a *longer* prefix fails the `>=` check and rebuilds — which is why the first switch works and only the switch back breaks.

## Fix

Require an exact `initial_cache_capacity` match for a runtime cache hit. Switching to a voice with a different prefix length now rebuilds the step runtime (the weights runtime is still reused via the existing `weights_hit` path); repeated requests with the same voice keep hitting the cache exactly as before.

## Verification

Built `windows-cuda-release` and re-ran the repro (RTX 5090): six alternating generations `bill_boerst ×2 → azelma → bill_boerst → azelma → bill_boerst` all produce full audio (3.5–4.4 s, peak amplitude 0.29–0.67); before the fix, every switch back to the shorter-prefix voice produced a ~0.3 s silent file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
