### PR TITLE
Feature/server multipart transcriptions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -610,6 +610,17 @@ if (ENGINE_BUILD_TESTS)
         NAME encoder_module_test
         COMMAND encoder_module_test
     )
+
+    add_executable(server_multipart_test
+        tests/unittests/test_server_multipart.cpp
+        app/server/multipart.cpp
+    )
+    target_include_directories(server_multipart_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/app/server)
+
+    add_test(
+        NAME server_multipart_test
+        COMMAND server_multipart_test
+    )
 endif()
 
 if (ENGINE_BUILD_EXAMPLES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -440,6 +440,7 @@ add_executable(audiocpp_server
     app/server/main.cpp
     app/server/config.cpp
     app/server/http.cpp
+    app/server/multipart.cpp
     app/server/runtime.cpp
     app/cli/args.cpp
     app/cli/request.cpp

--- a/app/server/README.md
+++ b/app/server/README.md
@@ -111,6 +111,29 @@ curl http://127.0.0.1:8080/v1/audio/transcriptions \
   }'
 ```
 
+Also accepts a `multipart/form-data` upload, matching the OpenAI Whisper API convention used by real clients (e.g. Open WebUI). The request is routed to the multipart path based on the `Content-Type` header; the JSON path above still works unchanged.
+
+```bash
+curl http://127.0.0.1:8080/v1/audio/transcriptions \
+  -F model=qwen3-asr \
+  -F language=en \
+  -F file=@/path/to/input.wav
+```
+
+`file` and `model` are required; `language` is optional. The uploaded bytes are spooled to a temporary file for the duration of the request and removed afterward.
+
+### `GET /v1/audio/voices?model=<id>`
+
+Lists the cached voice ids available for a TTS model, so a client can populate a voice picker instead of guessing generic names. For families that keep voice presets under `model_root/embeddings/*.safetensors` (`pocket_tts` today), this returns those ids; for other families, or an unknown/missing `model` parameter, it returns an empty list.
+
+```bash
+curl 'http://127.0.0.1:8080/v1/audio/voices?model=pocket-tts'
+```
+
+```json
+{"voices": ["alba", "cosette", "marius"]}
+```
+
 ### `POST /v1/tasks/run`
 
 Generic framework request route. The `request` object uses the same JSON fields as the `audiocpp_cli` request sequence format.

--- a/app/server/http.cpp
+++ b/app/server/http.cpp
@@ -180,6 +180,7 @@ HttpRequest read_http_request(SocketHandle socket) {
     }
     const auto query = request.path.find('?');
     if (query != std::string::npos) {
+        request.query = request.path.substr(query + 1);
         request.path = request.path.substr(0, query);
     }
 

--- a/app/server/http.h
+++ b/app/server/http.h
@@ -8,6 +8,7 @@ namespace minitts::server {
 struct HttpRequest {
     std::string method;
     std::string path;
+    std::string query;  // raw query string, e.g. "model=pocket-tts" (no leading '?')
     std::unordered_map<std::string, std::string> headers;
     std::string body;
 };

--- a/app/server/main.cpp
+++ b/app/server/main.cpp
@@ -40,6 +40,7 @@ void print_help() {
         << "Endpoints:\n"
         << "  GET  /health\n"
         << "  GET  /v1/models\n"
+        << "  GET  /v1/audio/voices?model=<id>\n"
         << "  POST /v1/audio/speech\n"
         << "  POST /v1/audio/transcriptions\n"
         << "  POST /v1/tasks/run\n";

--- a/app/server/multipart.cpp
+++ b/app/server/multipart.cpp
@@ -1,0 +1,159 @@
+#include "multipart.h"
+
+#include <algorithm>
+#include <cctype>
+#include <sstream>
+
+namespace minitts::server {
+namespace {
+
+std::string lower_ascii(std::string value) {
+    for (char & ch : value) {
+        ch = static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
+    }
+    return value;
+}
+
+std::string trim(std::string value) {
+    auto is_space = [](unsigned char ch) { return std::isspace(ch) != 0; };
+    value.erase(value.begin(), std::find_if(value.begin(), value.end(), [&](char ch) { return !is_space(ch); }));
+    value.erase(std::find_if(value.rbegin(), value.rend(), [&](char ch) { return !is_space(ch); }).base(), value.end());
+    return value;
+}
+
+// Extracts a `key="value"` or `key=value` parameter from a header value such as
+// `form-data; name="file"; filename="clip.wav"`.
+std::string extract_header_param(const std::string & header_value, const std::string & key) {
+    const std::string needle = key + "=";
+    const std::string lowered = lower_ascii(header_value);
+    size_t pos = 0;
+    while (true) {
+        pos = lowered.find(needle, pos);
+        if (pos == std::string::npos) {
+            return {};
+        }
+        // Make sure we matched a whole parameter name, not a suffix (e.g. "filename" vs "name").
+        if (pos == 0 || header_value[pos - 1] == ' ' || header_value[pos - 1] == ';') {
+            break;
+        }
+        pos += needle.size();
+    }
+    size_t start = pos + needle.size();
+    if (start < header_value.size() && header_value[start] == '"') {
+        const size_t end = header_value.find('"', start + 1);
+        if (end == std::string::npos) {
+            return header_value.substr(start + 1);
+        }
+        return header_value.substr(start + 1, end - start - 1);
+    }
+    size_t end = header_value.find(';', start);
+    if (end == std::string::npos) {
+        end = header_value.size();
+    }
+    return trim(header_value.substr(start, end - start));
+}
+
+std::string strip_trailing_newline(std::string value) {
+    if (value.size() >= 2 && value.compare(value.size() - 2, 2, "\r\n") == 0) {
+        value.resize(value.size() - 2);
+    } else if (!value.empty() && value.back() == '\n') {
+        value.resize(value.size() - 1);
+    }
+    return value;
+}
+
+MultipartPart parse_part(const std::string & segment) {
+    MultipartPart part;
+    size_t header_end = segment.find("\r\n\r\n");
+    size_t separator_len = 4;
+    if (header_end == std::string::npos) {
+        header_end = segment.find("\n\n");
+        separator_len = 2;
+    }
+    if (header_end == std::string::npos) {
+        return part;
+    }
+
+    part.data = segment.substr(header_end + separator_len);
+
+    std::istringstream header_stream(segment.substr(0, header_end));
+    std::string line;
+    while (std::getline(header_stream, line)) {
+        if (!line.empty() && line.back() == '\r') {
+            line.pop_back();
+        }
+        const auto colon = line.find(':');
+        if (colon == std::string::npos) {
+            continue;
+        }
+        const std::string key = lower_ascii(trim(line.substr(0, colon)));
+        const std::string value = trim(line.substr(colon + 1));
+        if (key == "content-disposition") {
+            part.name = extract_header_param(value, "name");
+            part.filename = extract_header_param(value, "filename");
+        }
+    }
+    return part;
+}
+
+}  // namespace
+
+std::optional<std::string> extract_multipart_boundary(const std::string & content_type) {
+    const std::string lowered = lower_ascii(content_type);
+    if (lowered.rfind("multipart/", 0) != 0) {
+        return std::nullopt;
+    }
+    const std::string key = "boundary=";
+    const auto pos = lowered.find(key);
+    if (pos == std::string::npos) {
+        return std::nullopt;
+    }
+    std::string value = content_type.substr(pos + key.size());
+    const auto semicolon = value.find(';');
+    if (semicolon != std::string::npos) {
+        value = value.substr(0, semicolon);
+    }
+    value = trim(value);
+    if (value.size() >= 2 && value.front() == '"' && value.back() == '"') {
+        value = value.substr(1, value.size() - 2);
+    }
+    if (value.empty()) {
+        return std::nullopt;
+    }
+    return value;
+}
+
+std::vector<MultipartPart> parse_multipart_body(const std::string & body, const std::string & boundary) {
+    std::vector<MultipartPart> parts;
+    const std::string delimiter = "--" + boundary;
+
+    size_t pos = body.find(delimiter);
+    if (pos == std::string::npos) {
+        return parts;
+    }
+    pos += delimiter.size();
+
+    while (true) {
+        if (body.compare(pos, 2, "--") == 0) {
+            break;
+        }
+        if (body.compare(pos, 2, "\r\n") == 0) {
+            pos += 2;
+        } else if (pos < body.size() && body[pos] == '\n') {
+            pos += 1;
+        }
+
+        const size_t next_delim = body.find(delimiter, pos);
+        if (next_delim == std::string::npos) {
+            break;
+        }
+
+        const std::string segment = strip_trailing_newline(body.substr(pos, next_delim - pos));
+        parts.push_back(parse_part(segment));
+        pos = next_delim + delimiter.size();
+    }
+
+    return parts;
+}
+
+}  // namespace minitts::server

--- a/app/server/multipart.h
+++ b/app/server/multipart.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace minitts::server {
+
+// One part of a multipart/form-data body, e.g. a form field or an uploaded file.
+struct MultipartPart {
+    std::string name;      // Content-Disposition "name" parameter.
+    std::string filename;  // Content-Disposition "filename" parameter; empty for plain fields.
+    std::string data;      // Raw part payload.
+};
+
+// Returns the boundary token from a "Content-Type: multipart/form-data; boundary=..." header,
+// or std::nullopt if the header does not describe a multipart body.
+std::optional<std::string> extract_multipart_boundary(const std::string & content_type);
+
+// Splits a multipart/form-data body into its constituent parts using the given boundary.
+std::vector<MultipartPart> parse_multipart_body(const std::string & body, const std::string & boundary);
+
+}  // namespace minitts::server

--- a/app/server/runtime.cpp
+++ b/app/server/runtime.cpp
@@ -34,6 +34,26 @@ std::filesystem::path resolve_path(const std::filesystem::path & base, const std
     return path.is_absolute() ? path : base / path;
 }
 
+// Minimal application/x-www-form-urlencoded query string lookup, e.g.
+// query_param("model=pocket-tts&foo=bar", "model") -> "pocket-tts".
+std::string query_param(const std::string & query, const std::string & key) {
+    size_t pos = 0;
+    while (pos < query.size()) {
+        const size_t amp = query.find('&', pos);
+        const std::string pair = query.substr(pos, amp == std::string::npos ? std::string::npos : amp - pos);
+        const auto eq = pair.find('=');
+        const std::string name = pair.substr(0, eq);
+        if (name == key) {
+            return eq == std::string::npos ? "" : pair.substr(eq + 1);
+        }
+        if (amp == std::string::npos) {
+            break;
+        }
+        pos = amp + 1;
+    }
+    return {};
+}
+
 const char * backend_name(engine::core::BackendType type) {
     switch (type) {
         case engine::core::BackendType::Cpu:
@@ -409,6 +429,9 @@ HttpResponse ServerState::handle(const HttpRequest & request) {
     if (request.method == "GET" && request.path == "/v1/models") {
         return json_response(models_json());
     }
+    if (request.method == "GET" && request.path == "/v1/audio/voices") {
+        return handle_voices(request);
+    }
     if (request.method == "POST" && request.path == "/v1/audio/speech") {
         return handle_speech(request.body);
     }
@@ -597,6 +620,42 @@ HttpResponse ServerState::handle_generic_run(const std::string & body_text) {
         request_base_);
     const auto timed_result = run_model(model, request);
     return json_response(task_result_json(timed_result.result, timed_result.wall_ms));
+}
+
+// Cached-voice discovery for the "voice"/cached_voice_id request field. Families that
+// support voice presets (e.g. pocket_tts, see assets.cpp: model_root/embeddings/<id>.safetensors)
+// keep them under an "embeddings" directory next to the model weights; other families simply
+// have no such directory and report no voices. Used by clients (llama-swap's playground, and
+// potentially Open WebUI) that call GET /v1/audio/voices?model=<id> to populate a voice picker
+// instead of guessing generic names like "alloy"/"nova".
+HttpResponse ServerState::handle_voices(const HttpRequest & request) const {
+    const std::string model_id = query_param(request.query, "model");
+    std::vector<std::string> voices;
+
+    const auto it = model_index_.find(model_id);
+    if (it != model_index_.end()) {
+        const auto embeddings_dir = models_.at(it->second)->config.path / "embeddings";
+        std::error_code ec;
+        if (std::filesystem::is_directory(embeddings_dir, ec)) {
+            for (const auto & entry : std::filesystem::directory_iterator(embeddings_dir, ec)) {
+                if (entry.is_regular_file() && entry.path().extension() == ".safetensors") {
+                    voices.push_back(entry.path().stem().string());
+                }
+            }
+        }
+    }
+    std::sort(voices.begin(), voices.end());
+
+    std::ostringstream out;
+    out << "{\"voices\":[";
+    for (size_t i = 0; i < voices.size(); ++i) {
+        if (i != 0) {
+            out << ",";
+        }
+        out << json_quote(voices[i]);
+    }
+    out << "]}";
+    return json_response(out.str());
 }
 
 std::string ServerState::models_json() const {

--- a/app/server/runtime.cpp
+++ b/app/server/runtime.cpp
@@ -1,14 +1,18 @@
 #include "runtime.h"
 
+#include "multipart.h"
+
 #include "../cli/request.h"
 
 #include "engine/framework/io/json.h"
 #include "engine/framework/runtime/registry.h"
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <cmath>
 #include <cstdint>
+#include <fstream>
 #include <iostream>
 #include <sstream>
 #include <stdexcept>
@@ -128,6 +132,37 @@ std::string base64_encode(const uint8_t * data, size_t size) {
 std::string base64_encode(const std::vector<uint8_t> & bytes) {
     return base64_encode(bytes.data(), bytes.size());
 }
+
+// Multipart file uploads arrive as in-memory bytes, but the WAV decoder only reads from disk,
+// so uploaded audio is spooled to a uniquely named temp file before decoding.
+std::filesystem::path write_temp_upload(const std::string & filename, const std::string & data) {
+    std::filesystem::path ext = std::filesystem::path(filename).extension();
+    if (ext.empty()) {
+        ext = ".wav";
+    }
+    static std::atomic<uint64_t> counter{0};
+    std::ostringstream name;
+    name << "audiocpp_upload_" << Clock::now().time_since_epoch().count() << "_" << counter.fetch_add(1)
+         << ext.string();
+    const auto path = std::filesystem::temp_directory_path() / name.str();
+    std::ofstream out(path, std::ios::binary);
+    if (!out) {
+        throw std::runtime_error("failed to create temp file for upload: " + path.string());
+    }
+    out.write(data.data(), static_cast<std::streamsize>(data.size()));
+    if (!out) {
+        throw std::runtime_error("failed to write temp file for upload: " + path.string());
+    }
+    return path;
+}
+
+struct TempFileGuard {
+    std::filesystem::path path;
+    ~TempFileGuard() {
+        std::error_code ec;
+        std::filesystem::remove(path, ec);
+    }
+};
 
 double elapsed_ms(Clock::time_point started) {
     return std::chrono::duration<double, std::milli>(Clock::now() - started).count();
@@ -378,7 +413,7 @@ HttpResponse ServerState::handle(const HttpRequest & request) {
         return handle_speech(request.body);
     }
     if (request.method == "POST" && request.path == "/v1/audio/transcriptions") {
-        return handle_transcription(request.body);
+        return handle_transcription(request);
     }
     if (request.method == "POST" && request.path == "/v1/tasks/run") {
         return handle_generic_run(request.body);
@@ -483,10 +518,66 @@ HttpResponse ServerState::handle_speech(const std::string & body_text) {
     };
 }
 
-HttpResponse ServerState::handle_transcription(const std::string & body_text) {
+HttpResponse ServerState::handle_transcription(const HttpRequest & request) {
+    std::string content_type;
+    if (const auto it = request.headers.find("content-type"); it != request.headers.end()) {
+        content_type = it->second;
+    }
+    if (const auto boundary = extract_multipart_boundary(content_type)) {
+        return handle_transcription_multipart(request.body, *boundary);
+    }
+    return handle_transcription_json(request.body);
+}
+
+HttpResponse ServerState::handle_transcription_json(const std::string & body_text) {
     const auto body = engine::io::json::parse(body_text);
     auto & model = require_model(body);
     const auto request = build_openai_transcription_request(body, request_base_);
+    return run_transcription(model, request);
+}
+
+// Accepts the same multipart/form-data shape OpenAI's Whisper API (and clients built against it,
+// e.g. Open WebUI) send: a "file" part with the audio bytes, plus "model" and optional "language"
+// fields. audio.cpp's native JSON request only takes a server-local path, so the uploaded bytes are
+// spooled to a temp file and routed through the existing JSON request builder.
+HttpResponse ServerState::handle_transcription_multipart(const std::string & body_text, const std::string & boundary) {
+    const auto parts = parse_multipart_body(body_text, boundary);
+
+    const MultipartPart * file_part = nullptr;
+    std::string model_id;
+    std::string language;
+    for (const auto & part : parts) {
+        if (part.name == "file") {
+            file_part = &part;
+        } else if (part.name == "model") {
+            model_id = part.data;
+        } else if (part.name == "language") {
+            language = part.data;
+        }
+    }
+    if (file_part == nullptr || file_part->data.empty()) {
+        throw std::runtime_error("multipart transcription request requires a non-empty 'file' field");
+    }
+    if (model_id.empty()) {
+        throw std::runtime_error("multipart transcription request requires a 'model' field");
+    }
+
+    const TempFileGuard guard{write_temp_upload(file_part->filename, file_part->data)};
+
+    engine::io::json::Value::Object fields;
+    fields.emplace("model", engine::io::json::Value::make_string(model_id));
+    fields.emplace("audio", engine::io::json::Value::make_string(guard.path.string()));
+    if (!language.empty()) {
+        fields.emplace("language", engine::io::json::Value::make_string(language));
+    }
+    const auto body = engine::io::json::Value::make_object(std::move(fields));
+
+    auto & model = require_model(body);
+    const auto request = build_openai_transcription_request(body, request_base_);
+    return run_transcription(model, request);
+}
+
+HttpResponse ServerState::run_transcription(LoadedModel & model, const engine::runtime::TaskRequest & request) {
     const auto timed_result = run_model(model, request);
     const auto & result = timed_result.result;
     if (!result.text_output.has_value()) {

--- a/app/server/runtime.h
+++ b/app/server/runtime.h
@@ -42,6 +42,7 @@ private:
     HttpResponse handle_transcription_multipart(const std::string & body_text, const std::string & boundary);
     HttpResponse run_transcription(LoadedModel & model, const engine::runtime::TaskRequest & request);
     HttpResponse handle_generic_run(const std::string & body_text);
+    HttpResponse handle_voices(const HttpRequest & request) const;
     std::string models_json() const;
 
     ServerConfig config_;

--- a/app/server/runtime.h
+++ b/app/server/runtime.h
@@ -37,7 +37,10 @@ private:
     struct TimedTaskResult;
     TimedTaskResult run_model(LoadedModel & model, const engine::runtime::TaskRequest & request);
     HttpResponse handle_speech(const std::string & body_text);
-    HttpResponse handle_transcription(const std::string & body_text);
+    HttpResponse handle_transcription(const HttpRequest & request);
+    HttpResponse handle_transcription_json(const std::string & body_text);
+    HttpResponse handle_transcription_multipart(const std::string & body_text, const std::string & boundary);
+    HttpResponse run_transcription(LoadedModel & model, const engine::runtime::TaskRequest & request);
     HttpResponse handle_generic_run(const std::string & body_text);
     std::string models_json() const;
 

--- a/tests/unittests/test_server_multipart.cpp
+++ b/tests/unittests/test_server_multipart.cpp
@@ -1,0 +1,109 @@
+#include "multipart.h"
+
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+using minitts::server::extract_multipart_boundary;
+using minitts::server::parse_multipart_body;
+
+void require(bool condition, const std::string & message) {
+    if (!condition) {
+        throw std::runtime_error(message);
+    }
+}
+
+void test_extract_multipart_boundary() {
+    require(
+        extract_multipart_boundary("multipart/form-data; boundary=WebKitBoundary123") == std::string("WebKitBoundary123"),
+        "unquoted boundary");
+    require(
+        extract_multipart_boundary("multipart/form-data; boundary=\"abc def\"") == std::string("abc def"),
+        "quoted boundary");
+    require(
+        extract_multipart_boundary("multipart/form-data; charset=utf-8; boundary=xyz") == std::string("xyz"),
+        "boundary after other parameters");
+    require(
+        !extract_multipart_boundary("application/json").has_value(),
+        "non-multipart content-type yields no boundary");
+    require(
+        !extract_multipart_boundary("multipart/form-data").has_value(),
+        "multipart content-type without boundary param yields no boundary");
+}
+
+void test_parse_multipart_body_fields_and_file() {
+    const std::string boundary = "BOUNDARY";
+    const std::string body =
+        "--BOUNDARY\r\n"
+        "Content-Disposition: form-data; name=\"model\"\r\n"
+        "\r\n"
+        "qwen3-asr\r\n"
+        "--BOUNDARY\r\n"
+        "Content-Disposition: form-data; name=\"language\"\r\n"
+        "\r\n"
+        "en\r\n"
+        "--BOUNDARY\r\n"
+        "Content-Disposition: form-data; name=\"file\"; filename=\"clip.wav\"\r\n"
+        "Content-Type: audio/wav\r\n"
+        "\r\n"
+        "RIFF....WAVEfmt \r\n"
+        "--BOUNDARY--\r\n";
+
+    const auto parts = parse_multipart_body(body, boundary);
+    require(parts.size() == 3, "expected three parts");
+
+    require(parts[0].name == "model", "first part name");
+    require(parts[0].filename.empty(), "first part has no filename");
+    require(parts[0].data == "qwen3-asr", "first part data");
+
+    require(parts[1].name == "language", "second part name");
+    require(parts[1].data == "en", "second part data");
+
+    require(parts[2].name == "file", "third part name");
+    require(parts[2].filename == "clip.wav", "third part filename");
+    require(parts[2].data == "RIFF....WAVEfmt ", "third part data (binary-ish, no trailing CRLF)");
+}
+
+void test_parse_multipart_body_binary_with_embedded_nul() {
+    const std::string boundary = "BOUNDARY";
+    std::string payload;
+    payload.push_back('\x00');
+    payload.push_back('\x01');
+    payload.push_back('\xff');
+    payload += "middle";
+    payload.push_back('\x00');
+
+    std::string body = "--BOUNDARY\r\n";
+    body += "Content-Disposition: form-data; name=\"file\"; filename=\"blob.bin\"\r\n";
+    body += "\r\n";
+    body += payload;
+    body += "\r\n--BOUNDARY--\r\n";
+
+    const auto parts = parse_multipart_body(body, boundary);
+    require(parts.size() == 1, "expected a single part");
+    require(parts[0].filename == "blob.bin", "binary part filename");
+    require(parts[0].data.size() == payload.size(), "binary part data length preserved, including embedded NUL bytes");
+    require(parts[0].data == payload, "binary part data is byte-exact");
+}
+
+void test_parse_multipart_body_no_boundary_match() {
+    require(parse_multipart_body("not a multipart body", "BOUNDARY").empty(), "no matching boundary yields no parts");
+}
+
+}  // namespace
+
+int main() {
+    try {
+        test_extract_multipart_boundary();
+        test_parse_multipart_body_fields_and_file();
+        test_parse_multipart_body_binary_with_embedded_nul();
+        test_parse_multipart_body_no_boundary_match();
+    } catch (const std::exception & error) {
+        std::cerr << error.what() << '\n';
+        return 1;
+    }
+    std::cout << "server_multipart_test passed\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary

Two small additions to `audiocpp_server` that make it a better drop-in for OpenAI-API-compatible clients (Open WebUI, llama-swap's playground, etc.):

- **Accept multipart/form-data uploads on `POST /v1/audio/transcriptions`.** The real OpenAI Whisper API (and every client built against it — Open WebUI included) uploads audio as a `multipart/form-data` `file` part. `audiocpp_server` currently only accepts a JSON body with a server-local path (`audio`/`audio_path`/`file` as a string). That's fine for local scripting, but it means the endpoint can't be used as-is behind a client that does real file uploads. This adds a small multipart parser (`app/server/multipart.{h,cpp}`) and routes requests with a `multipart/form-data` `Content-Type` through it: the uploaded bytes are spooled to a temp file and handed to the existing JSON-based request builder, so the original JSON/path request shape keeps working unchanged.

- **Add `GET /v1/audio/voices?model=<id>`.** Clients that build a voice picker (llama-swap's playground does this) have no way to discover which `cached_voice_id` values a TTS model actually supports, so they fall back to generic placeholder names (`alloy`, `nova`, ...) that don't exist as real presets and 500 at inference time. For families that keep voice presets under `model_root/embeddings/*.safetensors` (`pocket_tts` today — see `assets.cpp`), this lists the available ids. Families without an embeddings directory, or an unknown/missing `model` query param, just report an empty list, matching how the frontend already falls back gracefully. This also required capturing the raw query string on `HttpRequest`, which `read_http_request` was previously discarding entirely.

Neither change touches the existing JSON-only request shapes — both are purely additive.

## Testing

- New unit test exercising the multipart parser directly: boundary extraction (unquoted/quoted), multi-part splitting, and byte-exact handling of binary payloads with embedded NUL bytes.
- Built `audiocpp_server` with CUDA (`-DENGINE_ENABLE_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=native -DGGML_NATIVE=ON`) and ran it against real weights (`Qwen3-ASR-0.6B`, `kyutai/pocket-tts`), on an actual GPU:
  - `POST /v1/audio/transcriptions` with a JSON `{"model","audio"}` body (existing behavior) — unchanged, verified no regression.
  - `POST /v1/audio/transcriptions` with a real `multipart/form-data` upload (`-F file=@... -F model=...`, with and without `language`) — new behavior, correct transcript returned, temp file cleaned up afterward.
  - Missing `file`/`model` multipart fields — errors out same as other malformed requests (500, consistent with existing error handling style).
  - `GET /v1/audio/voices?model=pocket-tts` — returns the real cached voice ids (`alba`, `cosette`, `marius`, ...).
  - `GET /v1/audio/voices?model=qwen3-asr` (no embeddings dir), `?model=<unknown>`, and no `model` param — all return `{"voices":[]}`.
  - `POST /v1/audio/speech` — unchanged, verified no regression after both changes.
- Deployed behind [llama-swap](https://github.com/mostlygeek/llama-swap) in front of Open WebUI and confirmed both endpoints work end-to-end through a real client: STT via multipart upload, and TTS with the voice picker now populated from `/v1/audio/voices` instead of guessing.

## Notes for reviewers

- `handle_transcription` now dispatches on `Content-Type` (`multipart/form-data` → new path, otherwise → existing JSON path) rather than replacing the JSON handling.
- The multipart parser is intentionally minimal (no external dependency) and mirrors the existing hand-rolled HTTP parsing style already used in `http.cpp`.
- Voice discovery is scoped to "does `model_root/embeddings` exist" rather than hardcoding `pocket_tts`, so it should pick up other families automatically if they adopt the same layout.