### PR TITLE
Support Qwen3 ASR 1.7B HF checkpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Current model status in the framework:
 | **omnivoice** | TTS, voice cloning, voice design | 646+ langs | OmniVoice, Qwen3-0.6B based | **released** |
 | **pocket_tts** | TTS, voice cloning | en, de, it, pt, es | PocketTTS-100M | **released** |
 | **nemotron_asr** | ASR | 100+ ASR prompt codes incl. auto | Nemotron 3.5 ASR Streaming 0.6B | **released** |
-| **qwen3_asr** | ASR | zh, en, yue, ar, de, fr, es, pt, id, it, ko, ru, th, vi, ja, tr, hi, ms, nl, sv, da, fi, pl, cs, fil, fa, el, ro, hu, mk | Qwen3-ASR-0.6B | **released** |
+| **qwen3_asr** | ASR | zh, en, yue, ar, de, fr, es, pt, id, it, ko, ru, th, vi, ja, tr, hi, ms, nl, sv, da, fi, pl, cs, fil, fa, el, ro, hu, mk | Qwen3-ASR-0.6B, Qwen3-ASR-1.7B-hf | **released** |
 | **qwen3_forced_aligner** | forced alignment | zh, yue, en, de, es, fr, it, pt, ru, ko, ja | Qwen3-ForcedAligner-0.6B | **released** |
 | **qwen3_tts** | TTS, voice cloning, voice design | zh, en, fr, de, it, ja, ko, pt, ru, es | Qwen3-TTS-12Hz-0.6B-Base, Qwen3-TTS-12Hz-1.7B-Base, Qwen3-TTS-12Hz-1.7B-CustomVoice, Qwen3-TTS-12Hz-1.7B-VoiceDesign | **released** |
 | **seed_vc** | voice conversion | lang agnostic | SeedVC XLS-R + HiFT, SeedVC Whisper-small + BigVGAN | **released** |
@@ -450,6 +450,7 @@ Recommended top-level install packages:
 | `parakeet_tdt_0_6b_v3` | Parakeet TDT 0.6B v3 | **Yes** |
 | `pocket_tts` | PocketTTS | **Yes** |
 | `qwen3_asr_0_6b` | Qwen3 ASR 0.6B | **Yes** |
+| `qwen3_asr_1_7b_hf` | Qwen3 ASR 1.7B HF | **Yes** |
 | `qwen3_forced_aligner_0_6b` | Qwen3 Forced Aligner 0.6B | **Yes** |
 | `qwen3_tts_0_6b_base` | Qwen3 TTS 12Hz 0.6B Base | **Yes** |
 | `qwen3_tts_1_7b_base` | Qwen3 TTS 12Hz 1.7B Base | **Yes** |

--- a/docs/qwen3.md
+++ b/docs/qwen3.md
@@ -112,7 +112,7 @@ internally to choose speech-aware chunks before running ASR and alignment.
 | Field | Value |
 |---|---|
 | Family | `qwen3_asr` |
-| Model directory | `models/Qwen3-ASR-0.6B` |
+| Model directory | `models/Qwen3-ASR-0.6B` or `models/Qwen3-ASR-1.7B-hf` |
 | Task | `asr` |
 | Modes | `offline` |
 | Input | Speech WAV through `--audio` |
@@ -120,6 +120,15 @@ internally to choose speech-aware chunks before running ASR and alignment.
 
 ```bash
 audiocpp_cli --task asr --family qwen3_asr --model models/Qwen3-ASR-0.6B --backend cuda --audio speech_16k.wav --text "" --text-out transcript.txt
+```
+
+The native Hugging Face Transformers layout of `Qwen/Qwen3-ASR-1.7B-hf` is
+also accepted directly. It uses `processor_config.json`, `tokenizer.json`, and
+the `model.audio_tower` / `model.language_model` tensor namespaces; no model
+conversion is required:
+
+```bash
+audiocpp_cli --task asr --family qwen3_asr --model models/Qwen3-ASR-1.7B-hf --backend cuda --audio speech_16k.wav --text "" --text-out transcript.txt
 ```
 
 With word timestamps:

--- a/include/engine/models/qwen3_asr/assets.h
+++ b/include/engine/models/qwen3_asr/assets.h
@@ -63,6 +63,8 @@ struct Qwen3ASRConfig {
     int64_t classify_num = 0;
     int64_t timestamp_token_id = 0;
     int64_t timestamp_segment_time_ms = 0;
+    bool hf_transformers_layout = false;
+    bool tie_word_embeddings = false;
     Qwen3ASRFrontendConfig frontend;
     Qwen3ASRAudioEncoderConfig audio_encoder;
     Qwen3ASRTextDecoderConfig text_decoder;
@@ -74,11 +76,13 @@ struct Qwen3ASRAssetPaths {
     std::filesystem::path config_path;
     std::filesystem::path generation_config_path;
     std::filesystem::path preprocessor_config_path;
+    std::filesystem::path processor_config_path;
     std::filesystem::path chat_template_path;
     std::filesystem::path model_weights_path;
     std::filesystem::path tokenizer_config_path;
     std::filesystem::path tokenizer_vocab_path;
     std::filesystem::path tokenizer_merges_path;
+    std::filesystem::path tokenizer_json_path;
 };
 
 struct Qwen3ASRAssets {

--- a/src/models/qwen3_asr/assets.cpp
+++ b/src/models/qwen3_asr/assets.cpp
@@ -5,6 +5,7 @@
 #include "engine/framework/io/json.h"
 
 #include <stdexcept>
+#include <string_view>
 #include <utility>
 
 namespace engine::models::qwen3_asr {
@@ -28,7 +29,10 @@ Qwen3ASRAudioEncoderConfig parse_audio_encoder_config(const engine::io::json::Va
     config.encoder_attention_heads = value.require("encoder_attention_heads").as_i64();
     config.encoder_ffn_dim = value.require("encoder_ffn_dim").as_i64();
     config.d_model = value.require("d_model").as_i64();
-    config.max_source_positions = value.require("max_source_positions").as_i64();
+    // The Transformers checkpoint calls a small RoPE setting
+    // max_position_embeddings. The audio tower still uses the same 1500-frame
+    // sinusoidal table as the original Qwen checkpoint.
+    config.max_source_positions = json::optional_i64(value, "max_source_positions", 1500);
     config.n_window = value.require("n_window").as_i64();
     config.n_window_infer = value.require("n_window_infer").as_i64();
     config.conv_chunksize = value.require("conv_chunksize").as_i64();
@@ -55,11 +59,16 @@ Qwen3ASRTextDecoderConfig parse_text_decoder_config(
     config.head_dim = json::optional_i64(text_config, "head_dim", config.hidden_size / config.num_attention_heads);
     config.max_position_embeddings = text_config.require("max_position_embeddings").as_i64();
     config.audio_token_id = thinker_config.require("audio_token_id").as_i64();
-    config.audio_start_token_id = thinker_config.require("audio_start_token_id").as_i64();
-    config.audio_end_token_id = thinker_config.require("audio_end_token_id").as_i64();
+    config.audio_start_token_id = json::optional_i64(thinker_config, "audio_start_token_id", 0);
+    config.audio_end_token_id = json::optional_i64(thinker_config, "audio_end_token_id", 0);
+    config.pad_token_id = json::optional_i64(thinker_config, "pad_token_id", config.pad_token_id);
     config.pad_token_id = json::optional_i64(text_config, "pad_token_id", config.pad_token_id);
     config.rms_norm_eps = json::optional_f32(text_config, "rms_norm_eps", config.rms_norm_eps);
     config.rope_theta = json::optional_f32(text_config, "rope_theta", config.rope_theta);
+    const auto * rope_parameters = text_config.find("rope_parameters");
+    if (rope_parameters != nullptr && rope_parameters->is_object()) {
+        config.rope_theta = json::optional_f32(*rope_parameters, "rope_theta", config.rope_theta);
+    }
     const auto * rope_scaling = text_config.find("rope_scaling");
     if (rope_scaling != nullptr && rope_scaling->is_object()) {
         config.mrope_section = json::optional_i64_array_or_scalar(*rope_scaling, "mrope_section", config.mrope_section);
@@ -67,42 +76,87 @@ Qwen3ASRTextDecoderConfig parse_text_decoder_config(
     return config;
 }
 
+int64_t require_added_token_id(const assets::ResourceBundle & resources, std::string_view content) {
+    const auto tokenizer = resources.parse_json("tokenizer_json");
+    for (const auto & item : tokenizer.require("added_tokens").as_array()) {
+        const auto * token_content = item.find("content");
+        const auto * token_id = item.find("id");
+        if (token_content != nullptr && token_content->is_string() &&
+            token_id != nullptr && token_id->is_number() && token_content->as_string() == content) {
+            return token_id->as_i64();
+        }
+    }
+    throw std::runtime_error("Qwen3 ASR tokenizer.json is missing token: " + std::string(content));
+}
+
+void add_supported_languages(Qwen3ASRConfig & config, const engine::io::json::Value & root) {
+    static constexpr const char * kLanguages[] = {
+        "Chinese", "English", "Cantonese", "Arabic", "German", "French", "Spanish", "Portuguese",
+        "Indonesian", "Italian", "Korean", "Russian", "Thai", "Vietnamese", "Japanese", "Turkish",
+        "Hindi", "Malay", "Dutch", "Swedish", "Danish", "Finnish", "Polish", "Czech", "Filipino",
+        "Persian", "Greek", "Romanian", "Hungarian", "Macedonian",
+    };
+    config.supported_languages = {"Auto"};
+    const auto * languages = root.find("support_languages");
+    if (languages != nullptr && languages->is_array()) {
+        for (const auto & language : languages->as_array()) {
+            config.supported_languages.push_back(language.as_string());
+        }
+        return;
+    }
+    for (const char * language : kLanguages) {
+        config.supported_languages.emplace_back(language);
+    }
+}
+
 Qwen3ASRConfig parse_config(const assets::ResourceBundle & resources) {
     const auto root = resources.parse_json("config");
-    const auto & thinker_config = root.require("thinker_config");
+    const auto * legacy_thinker = root.find("thinker_config");
+    const bool hf_layout = legacy_thinker == nullptr;
+    const auto & thinker_config = hf_layout ? root : *legacy_thinker;
     const auto & audio_config = thinker_config.require("audio_config");
     const auto & text_config = thinker_config.require("text_config");
 
     Qwen3ASRConfig config;
+    config.hf_transformers_layout = hf_layout;
     config.model_type = root.require("model_type").as_string();
-    config.thinker_model_type = thinker_config.require("model_type").as_string();
-    config.model_size = json::optional_string(root, "model_size", config.model_type);
-    config.classify_num = json::optional_i64(root.require("thinker_config"), "classify_num", 0);
+    config.thinker_model_type = json::optional_string(thinker_config, "model_type", config.model_type);
+    config.model_size = json::optional_string(root, "model_size", hf_layout ? "Qwen3-ASR-1.7B-hf" : config.model_type);
+    config.classify_num = json::optional_i64(thinker_config, "classify_num", 0);
     config.timestamp_token_id = json::optional_i64(root, "timestamp_token_id", 0);
-    config.timestamp_segment_time_ms = json::optional_i64(root, "timestamp_segment_time", 0);
+    config.tie_word_embeddings = json::optional_bool(
+        root,
+        "tie_word_embeddings",
+        json::optional_bool(text_config, "tie_word_embeddings", false));
     config.audio_encoder = parse_audio_encoder_config(audio_config);
     config.text_decoder = parse_text_decoder_config(thinker_config, text_config);
+    if (hf_layout) {
+        config.text_decoder.audio_start_token_id = require_added_token_id(resources, "<|audio_start|>");
+        config.text_decoder.audio_end_token_id = require_added_token_id(resources, "<|audio_end|>");
+    }
 
     const auto generation = resources.parse_json("generation_config");
     config.max_new_tokens = json::optional_i64(generation, "max_new_tokens", config.max_new_tokens);
     config.text_decoder.pad_token_id = json::optional_i64(generation, "pad_token_id", config.text_decoder.pad_token_id);
     config.text_decoder.eos_token_ids = json::require_i64_array_or_scalar(generation, "eos_token_id");
 
-    const auto preprocessor = resources.parse_json("preprocessor_config");
-    config.frontend.sample_rate = static_cast<int>(json::optional_i64(preprocessor, "sampling_rate", config.frontend.sample_rate));
-    config.frontend.feature_size = preprocessor.require("feature_size").as_i64();
-    config.frontend.hop_length = preprocessor.require("hop_length").as_i64();
-    config.frontend.n_fft = preprocessor.require("n_fft").as_i64();
+    const auto processor = resources.parse_json(resources.has_file("processor_config") ? "processor_config" : "preprocessor_config");
+    const auto * feature_extractor = processor.find("feature_extractor");
+    const auto & frontend = feature_extractor != nullptr && feature_extractor->is_object() ? *feature_extractor : processor;
+    config.frontend.sample_rate = static_cast<int>(json::optional_i64(frontend, "sampling_rate", config.frontend.sample_rate));
+    config.frontend.feature_size = frontend.require("feature_size").as_i64();
+    config.frontend.hop_length = frontend.require("hop_length").as_i64();
+    config.frontend.n_fft = frontend.require("n_fft").as_i64();
+    config.timestamp_segment_time_ms = json::optional_i64(processor, "timestamp_segment_time", 0);
+    if (config.timestamp_segment_time_ms == 0) {
+        config.timestamp_segment_time_ms = json::optional_i64(root, "timestamp_segment_time", 0);
+    }
     config.sample_rate = config.frontend.sample_rate;
     if (config.frontend.feature_size != config.audio_encoder.num_mel_bins) {
         throw std::runtime_error("Qwen3 ASR frontend feature size does not match audio encoder config");
     }
 
-    config.supported_languages.clear();
-    config.supported_languages.push_back("Auto");
-    for (const auto & language : root.require("support_languages").as_array()) {
-        config.supported_languages.push_back(language.as_string());
-    }
+    add_supported_languages(config, root);
     return config;
 }
 
@@ -111,47 +165,53 @@ assets::ResourceBundle make_resource_bundle(const std::filesystem::path & model_
     resources.add_model_files({
         {"config", "config.json", true},
         {"generation_config", "generation_config.json", true},
-        {"preprocessor_config", "preprocessor_config.json", true},
-        {"chat_template", "chat_template.json", false},
+        {"preprocessor_config", "preprocessor_config.json", false},
+        {"processor_config", "processor_config.json", false},
         {"weights", "model.safetensors", true},
         {"tokenizer_config", "tokenizer_config.json", true},
-        {"vocab", "vocab.json", true},
-        {"merges", "merges.txt", true},
+        {"vocab", "vocab.json", false},
+        {"merges", "merges.txt", false},
+        {"tokenizer_json", "tokenizer.json", false},
     });
+    if (!resources.add_optional_model_file("chat_template", "chat_template.json")) {
+        (void) resources.add_optional_model_file("chat_template", "chat_template.jinja");
+    }
+    if (!resources.has_file("preprocessor_config") && !resources.has_file("processor_config")) {
+        throw std::runtime_error("Qwen3 ASR requires preprocessor_config.json or processor_config.json");
+    }
+    const bool has_legacy_tokenizer = resources.has_file("vocab") && resources.has_file("merges");
+    if (!has_legacy_tokenizer && !resources.has_file("tokenizer_json")) {
+        throw std::runtime_error("Qwen3 ASR requires vocab.json plus merges.txt, or tokenizer.json");
+    }
     return resources;
+}
+
+Qwen3ASRAssetPaths paths_from_resources(const assets::ResourceBundle & resources) {
+    Qwen3ASRAssetPaths paths;
+    paths.model_root = resources.model_root();
+    paths.config_path = resources.require_file("config");
+    paths.generation_config_path = resources.require_file("generation_config");
+    if (const auto * value = resources.find_file("preprocessor_config")) paths.preprocessor_config_path = *value;
+    if (const auto * value = resources.find_file("processor_config")) paths.processor_config_path = *value;
+    if (const auto * value = resources.find_file("chat_template")) paths.chat_template_path = *value;
+    paths.model_weights_path = resources.require_file("weights");
+    paths.tokenizer_config_path = resources.require_file("tokenizer_config");
+    if (const auto * value = resources.find_file("vocab")) paths.tokenizer_vocab_path = *value;
+    if (const auto * value = resources.find_file("merges")) paths.tokenizer_merges_path = *value;
+    if (const auto * value = resources.find_file("tokenizer_json")) paths.tokenizer_json_path = *value;
+    return paths;
 }
 
 }  // namespace
 
 Qwen3ASRAssetPaths resolve_qwen3_asr_assets(const std::filesystem::path & model_path) {
-    auto resources = make_resource_bundle(model_path);
-    const auto * chat_template = resources.find_file("chat_template");
-    Qwen3ASRAssetPaths paths;
-    paths.model_root = resources.model_root();
-    paths.config_path = resources.require_file("config");
-    paths.generation_config_path = resources.require_file("generation_config");
-    paths.preprocessor_config_path = resources.require_file("preprocessor_config");
-    paths.chat_template_path = chat_template != nullptr ? *chat_template : std::filesystem::path{};
-    paths.model_weights_path = resources.require_file("weights");
-    paths.tokenizer_config_path = resources.require_file("tokenizer_config");
-    paths.tokenizer_vocab_path = resources.require_file("vocab");
-    paths.tokenizer_merges_path = resources.require_file("merges");
-    return paths;
+    return paths_from_resources(make_resource_bundle(model_path));
 }
 
 std::shared_ptr<const Qwen3ASRAssets> load_qwen3_asr_assets(const std::filesystem::path & model_path) {
     auto resources = make_resource_bundle(model_path);
     Qwen3ASRAssets assets;
-    const auto * chat_template = resources.find_file("chat_template");
-    assets.paths.model_root = resources.model_root();
-    assets.paths.config_path = resources.require_file("config");
-    assets.paths.generation_config_path = resources.require_file("generation_config");
-    assets.paths.preprocessor_config_path = resources.require_file("preprocessor_config");
-    assets.paths.chat_template_path = chat_template != nullptr ? *chat_template : std::filesystem::path{};
-    assets.paths.model_weights_path = resources.require_file("weights");
-    assets.paths.tokenizer_config_path = resources.require_file("tokenizer_config");
-    assets.paths.tokenizer_vocab_path = resources.require_file("vocab");
-    assets.paths.tokenizer_merges_path = resources.require_file("merges");
+    assets.paths = paths_from_resources(resources);
     assets.config = parse_config(resources);
     assets.model_weights = resources.open_tensor_source("weights");
     return std::make_shared<Qwen3ASRAssets>(std::move(assets));

--- a/src/models/qwen3_asr/audio_encoder.cpp
+++ b/src/models/qwen3_asr/audio_encoder.cpp
@@ -237,6 +237,12 @@ std::shared_ptr<const Qwen3ASRAudioEncoderWeights> load_weights(
     assets::TensorStorageType storage_type) {
     const auto & config = assets.config.audio_encoder;
     const auto & source = *assets.model_weights;
+    const std::string audio_prefix = assets.config.hf_transformers_layout
+        ? "model.audio_tower"
+        : "thinker.audio_tower";
+    const std::string projector_prefix = assets.config.hf_transformers_layout
+        ? "model.multi_modal_projector"
+        : audio_prefix;
     auto weights = std::make_shared<Qwen3ASRAudioEncoderWeights>();
     auto store = std::make_shared<core::BackendWeightStore>(
         backend,
@@ -247,33 +253,33 @@ std::shared_ptr<const Qwen3ASRAudioEncoderWeights> load_weights(
     weights->conv1 = load_conv2d(
         *store,
         source,
-        "thinker.audio_tower.conv2d1",
+        audio_prefix + ".conv2d1",
         storage_type,
         {config.downsample_hidden_size, 1, 3, 3},
         config.downsample_hidden_size);
     weights->conv2 = load_conv2d(
         *store,
         source,
-        "thinker.audio_tower.conv2d2",
+        audio_prefix + ".conv2d2",
         storage_type,
         {config.downsample_hidden_size, config.downsample_hidden_size, 3, 3},
         config.downsample_hidden_size);
     weights->conv3 = load_conv2d(
         *store,
         source,
-        "thinker.audio_tower.conv2d3",
+        audio_prefix + ".conv2d3",
         storage_type,
         {config.downsample_hidden_size, config.downsample_hidden_size, 3, 3},
         config.downsample_hidden_size);
     const int64_t conv_freq = (((config.num_mel_bins + 1) / 2 + 1) / 2 + 1) / 2;
     weights->conv_out_weight = store->load_tensor(
         source,
-        "thinker.audio_tower.conv_out.weight",
+        audio_prefix + ".conv_out.weight",
         storage_type,
         {config.d_model, config.downsample_hidden_size * conv_freq});
     weights->layers.reserve(static_cast<size_t>(config.encoder_layers));
     for (int64_t layer = 0; layer < config.encoder_layers; ++layer) {
-        const std::string prefix = "thinker.audio_tower.layers." + std::to_string(layer);
+        const std::string prefix = audio_prefix + ".layers." + std::to_string(layer);
         AudioLayerWeights w;
         w.self_attn_norm_weight = store->load_f32_tensor(source, prefix + ".self_attn_layer_norm.weight", {config.d_model});
         w.self_attn_norm_bias = store->load_f32_tensor(source, prefix + ".self_attn_layer_norm.bias", {config.d_model});
@@ -293,15 +299,17 @@ std::shared_ptr<const Qwen3ASRAudioEncoderWeights> load_weights(
         w.fc2_bias = store->load_f32_tensor(source, prefix + ".fc2.bias", {config.d_model});
         weights->layers.push_back(std::move(w));
     }
-    weights->ln_post_weight = store->load_f32_tensor(source, "thinker.audio_tower.ln_post.weight", {config.d_model});
-    weights->ln_post_bias = store->load_f32_tensor(source, "thinker.audio_tower.ln_post.bias", {config.d_model});
+    weights->ln_post_weight = store->load_f32_tensor(source, audio_prefix + ".ln_post.weight", {config.d_model});
+    weights->ln_post_bias = store->load_f32_tensor(source, audio_prefix + ".ln_post.bias", {config.d_model});
+    const std::string proj1 = assets.config.hf_transformers_layout ? ".linear_1" : ".proj1";
+    const std::string proj2 = assets.config.hf_transformers_layout ? ".linear_2" : ".proj2";
     weights->proj1 = {
-        store->load_tensor(source, "thinker.audio_tower.proj1.weight", storage_type, {config.d_model, config.d_model}),
-        store->load_f32_tensor(source, "thinker.audio_tower.proj1.bias", {config.d_model}),
+        store->load_tensor(source, projector_prefix + proj1 + ".weight", storage_type, {config.d_model, config.d_model}),
+        store->load_f32_tensor(source, projector_prefix + proj1 + ".bias", {config.d_model}),
     };
     weights->proj2 = {
-        store->load_tensor(source, "thinker.audio_tower.proj2.weight", storage_type, {config.output_dim, config.d_model}),
-        store->load_f32_tensor(source, "thinker.audio_tower.proj2.bias", {config.output_dim}),
+        store->load_tensor(source, projector_prefix + proj2 + ".weight", storage_type, {config.output_dim, config.d_model}),
+        store->load_f32_tensor(source, projector_prefix + proj2 + ".bias", {config.output_dim}),
     };
     weights->positional_embedding = store->make_f32(
         core::TensorShape::from_dims({config.max_source_positions, config.d_model}),

--- a/src/models/qwen3_asr/loader.cpp
+++ b/src/models/qwen3_asr/loader.cpp
@@ -21,18 +21,25 @@ std::filesystem::path resolve_model_root(const std::filesystem::path & model_pat
 }
 
 bool has_qwen3_asr_assets(const std::filesystem::path & root) {
+    const bool has_frontend = engine::io::is_existing_file(root / "preprocessor_config.json")
+        || engine::io::is_existing_file(root / "processor_config.json");
+    const bool has_tokenizer = engine::io::is_existing_file(root / "tokenizer.json")
+        || (engine::io::is_existing_file(root / "vocab.json")
+            && engine::io::is_existing_file(root / "merges.txt"));
     return engine::io::is_existing_file(root / "config.json")
         && engine::io::is_existing_file(root / "model.safetensors")
         && engine::io::is_existing_file(root / "tokenizer_config.json")
-        && engine::io::is_existing_file(root / "vocab.json")
-        && engine::io::is_existing_file(root / "merges.txt");
+        && engine::io::is_existing_file(root / "generation_config.json")
+        && has_frontend
+        && has_tokenizer;
 }
 
 std::vector<runtime::NamedAsset> discover_config_assets(const runtime::ModelLoadRequest & request) {
     const auto root = resolve_model_root(request.model_path);
     return runtime::discover_named_assets(
         root,
-        {"config.json", "generation_config.json", "tokenizer_config.json"});
+        {"config.json", "generation_config.json", "preprocessor_config.json", "processor_config.json",
+         "tokenizer_config.json", "tokenizer.json", "vocab.json", "merges.txt"});
 }
 
 std::vector<runtime::NamedAsset> discover_weight_assets(const runtime::ModelLoadRequest & request) {

--- a/src/models/qwen3_asr/thinker.cpp
+++ b/src/models/qwen3_asr/thinker.cpp
@@ -159,6 +159,9 @@ ThinkerWeights load_weights(
     assets::TensorStorageType storage_type) {
     const auto & config = assets.config.text_decoder;
     const auto & source = *assets.model_weights;
+    const std::string model_prefix = assets.config.hf_transformers_layout
+        ? "model.language_model"
+        : "thinker.model";
     ThinkerWeights weights;
     weights.store = std::make_shared<core::BackendWeightStore>(
         backend,
@@ -167,13 +170,13 @@ ThinkerWeights load_weights(
         weight_context_bytes);
     weights.token_embedding = weights.store->load_tensor(
         source,
-        "thinker.model.embed_tokens.weight",
+        model_prefix + ".embed_tokens.weight",
         storage_type,
         {config.vocab_size, config.hidden_size});
     weights.layers.reserve(static_cast<size_t>(config.num_hidden_layers));
     const int64_t dim = head_dim(config);
     for (int64_t layer = 0; layer < config.num_hidden_layers; ++layer) {
-        const std::string prefix = "thinker.model.layers." + std::to_string(layer);
+        const std::string prefix = model_prefix + ".layers." + std::to_string(layer);
         TextLayerWeights w;
         w.input_norm = weights.store->load_f32_tensor(source, prefix + ".input_layernorm.weight", {config.hidden_size});
         w.q_proj = weights.store->load_tensor(source, prefix + ".self_attn.q_proj.weight", storage_type, {config.num_attention_heads * dim, config.hidden_size});
@@ -188,8 +191,22 @@ ThinkerWeights load_weights(
         w.down_proj = weights.store->load_tensor(source, prefix + ".mlp.down_proj.weight", storage_type, {config.hidden_size, config.intermediate_size});
         weights.layers.push_back(std::move(w));
     }
-    weights.norm = weights.store->load_f32_tensor(source, "thinker.model.norm.weight", {config.hidden_size});
-    weights.lm_head = weights.store->load_tensor(source, "thinker.lm_head.weight", storage_type, {config.output_size, config.hidden_size});
+    weights.norm = weights.store->load_f32_tensor(source, model_prefix + ".norm.weight", {config.hidden_size});
+    if (assets.config.hf_transformers_layout && assets.config.tie_word_embeddings) {
+        if (config.output_size != config.vocab_size) {
+            throw std::runtime_error("Qwen3 ASR tied output embedding requires output_size == vocab_size");
+        }
+        weights.lm_head = weights.token_embedding;
+    } else {
+        const std::string lm_head_name = assets.config.hf_transformers_layout
+            ? "lm_head.weight"
+            : "thinker.lm_head.weight";
+        weights.lm_head = weights.store->load_tensor(
+            source,
+            lm_head_name,
+            storage_type,
+            {config.output_size, config.hidden_size});
+    }
     weights.store->upload();
     return weights;
 }

--- a/src/models/qwen3_asr/tokenizer_text.cpp
+++ b/src/models/qwen3_asr/tokenizer_text.cpp
@@ -19,6 +19,9 @@ std::shared_ptr<const Qwen3ASRTextTokenizer::Impl> load_impl(const Qwen3ASRAsset
     spec.vocab_path = assets.paths.tokenizer_vocab_path;
     spec.merges_path = assets.paths.tokenizer_merges_path;
     spec.tokenizer_config_path = assets.paths.tokenizer_config_path;
+    if (!assets.paths.tokenizer_json_path.empty()) {
+        spec.tokenizer_json_path = assets.paths.tokenizer_json_path;
+    }
     spec.pre_type = engine::tokenizers::LlamaBpePreTokenizer::Qwen2;
 
     auto impl = std::make_shared<Qwen3ASRTextTokenizer::Impl>();

--- a/tools/model_manager.py
+++ b/tools/model_manager.py
@@ -260,6 +260,31 @@ CATALOG: tuple[ModelPackage, ...] = (
         ),
     ),
     ModelPackage(
+        id="qwen3_asr_1_7b_hf",
+        display_name="Qwen3 ASR 1.7B HF",
+        target_directory="Qwen3-ASR-1.7B-hf",
+        source=SnapshotSource(
+            repo_id="Qwen/Qwen3-ASR-1.7B-hf",
+            include_prefixes=(
+                "config.json",
+                "generation_config.json",
+                "model.safetensors",
+                "processor_config.json",
+                "tokenizer_config.json",
+                "tokenizer.json",
+            ),
+        ),
+        required_files=(
+            "config.json",
+            "generation_config.json",
+            "model.safetensors",
+            "processor_config.json",
+            "tokenizer_config.json",
+            "tokenizer.json",
+        ),
+        description="Native Hugging Face Transformers checkpoint; no conversion is required.",
+    ),
+    ModelPackage(
         id="higgs_audio_stt",
         display_name="Higgs Audio STT",
         target_directory="higgs-audio-v3-stt",


### PR DESCRIPTION
## Summary

- add support for loading official `Qwen/Qwen3-ASR-1.7B-hf` checkpoints
- support the flat Hugging Face configuration, processor metadata, tokenizer format, tensor namespaces, and tied language-model output used by the 1.7B model
- retain compatibility with Qwen3-ASR 0.6B
- update the model manager and documentation for the new model

## Why

The official Qwen3-ASR 1.7B Hugging Face checkpoint differs from the existing 0.6B layout and could not be loaded directly by audio.cpp.

## Validation

- built and tested the Windows CPU CLI
- built and tested the Windows CUDA CLI and server
- inspected both Qwen3-ASR 1.7B and 0.6B checkpoint layouts
- ran real Japanese WAV inference on an RTX 3090
- tested the managed server and model-manager workflows
