### PR TITLE
Add standalone GGUF support for Hviske v5.3 and Citrinet-256

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -822,6 +822,17 @@ if (ENGINE_BUILD_TESTS)
         COMMAND scaled_dot_product_attention_test
     )
 
+    add_engine_unittest(asr_standalone_gguf_test tests/unittests/test_asr_standalone_gguf.cpp)
+    target_include_directories(asr_standalone_gguf_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests/unittests)
+    target_compile_definitions(asr_standalone_gguf_test PRIVATE
+        ENGINE_TEST_ASSET_ROOT="${ENGINE_UNITTEST_ASSET_ROOT}"
+    )
+
+    add_test(
+        NAME asr_standalone_gguf_test
+        COMMAND asr_standalone_gguf_test
+    )
+
     add_executable(server_multipart_test
         tests/unittests/test_server_multipart.cpp
         app/server/multipart.cpp

--- a/README.md
+++ b/README.md
@@ -706,11 +706,12 @@ The framework also has a reusable GGUF tensor source and a streaming converter. 
 container reader is shared by all model families; a family still has to list a `.gguf`
 checkpoint as one of its accepted assets because model configuration and tensor naming
 remain architecture-specific. Qwen3 ASR, Qwen3 Forced Aligner, Qwen3 TTS, Nemotron
-3.5 ASR, VibeVoice-ASR, and Higgs Audio STT currently accept `model.gguf` (including
-`speech_tokenizer/model.gguf` for TTS). The converter recursively embeds sidecar files
+3.5 ASR, VibeVoice-ASR, Higgs Audio STT, Hviske ASR, and Citrinet ASR currently accept
+`model.gguf` (including `speech_tokenizer/model.gguf` for TTS). The converter recursively embeds sidecar files
 up to 64 MiB by default using binary-safe metadata, including nested tokenizer models,
-and Qwen3 ASR, Nemotron ASR, VibeVoice-ASR, and Higgs Audio STT can load the resulting
-`model.gguf` as a standalone file. Pass `--no-sidecars` when a tensor-only container is desired. A
+and Qwen3 ASR, Nemotron ASR, VibeVoice-ASR, Higgs Audio STT, Hviske ASR, and Citrinet
+ASR can load the resulting `model.gguf` as a standalone file. Pass `--no-sidecars` when a
+tensor-only container is desired. A
 `model.safetensors.index.json` is also a first-class tensor source and is merged from
 its routed shards while converting. Exact original tensor ranks are stored separately
 because GGML normally collapses trailing singleton dimensions. Rank-0 safetensors

--- a/docs/asr.md
+++ b/docs/asr.md
@@ -27,6 +27,15 @@ Citrinet is an offline CTC ASR model. It produces transcription text from speech
 audiocpp_cli --task asr --family citrinet_asr --model models/citrinet --backend cuda --audio speech_16k.wav
 ```
 
+Create a standalone Q8_0 GGUF from the converted Citrinet safetensors layout:
+
+```powershell
+audiocpp_gguf.exe --input models\citrinet\citrinet_256.safetensors --root models\citrinet --output models\citrinet-Q8_0\model.gguf --type q8_0
+```
+
+The GGUF embeds `citrinet_256_config.json` and the vocabulary/tokenizer sidecars, so the
+completed `model.gguf` can be moved, renamed, and passed directly to `--model`.
+
 | Option | Values | Default | Meaning |
 |---|---|---:|---|
 | `--audio` | WAV path | required | Speech input. Use 16 kHz WAV for the example path. |
@@ -99,6 +108,15 @@ Hviske ASR is an offline Cohere ASR model path. The integration exposes Danish p
 ```bash
 audiocpp_cli --task asr --family hviske_asr --model models/hviske-v5.3 --backend cuda --audio speech_16k.wav --text-out transcript.txt
 ```
+
+Create a standalone Q8_0 GGUF:
+
+```powershell
+audiocpp_gguf.exe --input models\hviske-v5.3\model.safetensors --root models\hviske-v5.3 --output models\hviske-v5.3-Q8_0\model.gguf --type q8_0
+```
+
+Configuration, generation settings, and the SentencePiece tokenizer are embedded. The
+completed GGUF can therefore be moved, renamed, and passed directly to `--model`.
 
 | Option | Values | Default | Meaning |
 |---|---|---:|---|

--- a/docs/gguf.md
+++ b/docs/gguf.md
@@ -139,11 +139,11 @@ Status labels:
 |---|---|---|---|---|---|
 | `ace_step` | No | --- | --- | --- | --- |
 | `chatterbox` | No | --- | --- | --- | --- |
-| `citrinet_asr` | No | --- | --- | --- | --- |
+| `citrinet_asr` | Done | Pass | --- | --- | Pass |
 | `heartmula` | No | --- | --- | --- | --- |
 | `higgs_audio_stt` | Done | Pass | Pass | --- | Pass |
 | `htdemucs` | No | --- | --- | --- | --- |
-| `hviske_asr` | No | --- | --- | --- | --- |
+| `hviske_asr` | Done | Pass | --- | --- | Pass |
 | `index_tts2` | Done | Pass | Pass (drift) | Pass | No (similarity drift, frame drift, text minor drift) |
 | `irodori_tts` | Done | Pass | Pass | --- | Pass (drift) |
 | `marblenet_vad` | No | --- | --- | --- | --- |

--- a/include/engine/framework/core/backend_weight_store.h
+++ b/include/engine/framework/core/backend_weight_store.h
@@ -244,9 +244,10 @@ private:
         if (!ggml_is_quantized(type)) {
             return resolved_type;
         }
-        if (storage_type == assets::TensorStorageType::Native) {
-            return resolved_type;
-        }
+        // A GGUF may store a source matrix in quantized form even when a model
+        // reshapes it into a convolution kernel. Quantized GGML rows cannot end
+        // in a non-block-sized dimension (for example a 1-wide Conv1D kernel),
+        // so decode such native tensors to F32 for the reshaped backend weight.
         if (shape.rank < 2 || shape.last_dim() % ggml_blck_size(type) != 0) {
             return assets::TensorStorageType::F32;
         }

--- a/include/engine/models/citrinet_asr/assets.h
+++ b/include/engine/models/citrinet_asr/assets.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "engine/framework/assets/tensor_source.h"
+#include "engine/framework/assets/resource_bundle.h"
 
 #include <cstdint>
 #include <filesystem>
@@ -100,14 +100,6 @@ struct CitrinetWeights {
     std::vector<std::string> vocab;
 };
 
-struct CitrinetAssetPaths {
-    std::filesystem::path model_root;
-    std::filesystem::path checkpoint_path;
-    std::filesystem::path config_path;
-    std::filesystem::path vocab_path;
-};
-
-CitrinetAssetPaths resolve_citrinet_assets(const std::filesystem::path & checkpoint_path);
-std::shared_ptr<const CitrinetWeights> load_citrinet_weights_cached(const std::filesystem::path & checkpoint_path);
+std::shared_ptr<const CitrinetWeights> load_citrinet_weights_cached(const std::filesystem::path & model_path);
 
 }  // namespace engine::models::citrinet_asr

--- a/include/engine/models/hviske_asr/assets.h
+++ b/include/engine/models/hviske_asr/assets.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "engine/framework/assets/tensor_source.h"
+#include "engine/framework/assets/resource_bundle.h"
 #include "engine/framework/tokenizers/sentencepiece.h"
 
 #include <cstdint>
@@ -63,13 +63,13 @@ struct HviskeConfig {
 };
 
 struct HviskeAssets {
-    std::filesystem::path model_root;
+    engine::assets::ResourceBundle resources;
     HviskeConfig config;
     std::vector<engine::tokenizers::SentencePiecePiece> tokenizer_pieces;
     std::shared_ptr<const engine::assets::TensorSource> model_weights;
 };
 
-std::shared_ptr<const HviskeAssets> load_hviske_assets(const std::filesystem::path & model_root);
+std::shared_ptr<const HviskeAssets> load_hviske_assets(const std::filesystem::path & model_path);
 
 std::vector<int32_t> tokenize_hviske_prompt(
     const HviskeAssets & assets,

--- a/model_specs/citrinet_asr.json
+++ b/model_specs/citrinet_asr.json
@@ -1,0 +1,34 @@
+{
+  "family": "citrinet_asr",
+  "sources": [
+    {
+      "format": "gguf",
+      "roots": {
+        "model": ".",
+        "weights": "$gguf"
+      },
+      "files": {
+        "config": "model:citrinet_256_config.json",
+        "tokenizer": "model:citrinet_256_tokenizer.model",
+        "vocab": "model:citrinet_256_vocab.txt"
+      },
+      "tensors": {
+        "weights": "weights:"
+      }
+    },
+    {
+      "format": "safetensors",
+      "roots": {
+        "model": "."
+      },
+      "files": {
+        "config": "model:citrinet_256_config.json",
+        "tokenizer": "model:citrinet_256_tokenizer.model",
+        "vocab": "model:citrinet_256_vocab.txt"
+      },
+      "tensors": {
+        "weights": "model:citrinet_256.safetensors"
+      }
+    }
+  ]
+}

--- a/model_specs/hviske_asr.json
+++ b/model_specs/hviske_asr.json
@@ -1,0 +1,34 @@
+{
+  "family": "hviske_asr",
+  "sources": [
+    {
+      "format": "gguf",
+      "roots": {
+        "model": ".",
+        "weights": "$gguf"
+      },
+      "files": {
+        "config": "model:config.json",
+        "generation_config": "model:generation_config.json",
+        "tokenizer": "model:tokenizer.model"
+      },
+      "tensors": {
+        "weights": "weights:"
+      }
+    },
+    {
+      "format": "safetensors",
+      "roots": {
+        "model": "."
+      },
+      "files": {
+        "config": "model:config.json",
+        "generation_config": "model:generation_config.json",
+        "tokenizer": "model:tokenizer.model"
+      },
+      "tensors": {
+        "weights": "model:model.safetensors"
+      }
+    }
+  ]
+}

--- a/src/models/citrinet_asr/assets.cpp
+++ b/src/models/citrinet_asr/assets.cpp
@@ -1,6 +1,6 @@
 #include "engine/models/citrinet_asr/assets.h"
 
-#include "engine/framework/assets/resource_bundle.h"
+#include "engine/framework/assets/model_package.h"
 #include "engine/framework/assets/tensor_source.h"
 #include "engine/framework/assets/weight_metadata.h"
 #include "engine/framework/io/filesystem.h"
@@ -15,25 +15,6 @@
 namespace engine::models::citrinet_asr {
 namespace io = engine::io;
 namespace asset_meta = engine::assets;
-CitrinetAssetPaths resolve_citrinet_assets(const std::filesystem::path & checkpoint_path) {
-    assets::ResourceBundle resources(checkpoint_path.parent_path());
-    resources.add_file("weights", checkpoint_path);
-    resources.add_file("config", assets::checkpoint_sidecar_config_path(checkpoint_path));
-
-    const auto config = resources.parse_json("config");
-    const auto * vocab_file = config.find("vocab_file");
-    if (vocab_file == nullptr || !vocab_file->is_string()) {
-        throw std::runtime_error("Citrinet config is missing vocab_file");
-    }
-    resources.add_model_file("vocab", vocab_file->as_string());
-
-    CitrinetAssetPaths paths;
-    paths.model_root = resources.model_root();
-    paths.checkpoint_path = resources.require_file("weights");
-    paths.config_path = resources.require_file("config");
-    paths.vocab_path = resources.require_file("vocab");
-    return paths;
-}
 
 namespace {
 
@@ -153,20 +134,17 @@ CitrinetConfig parse_config(const io::json::Value & root) {
     return cfg;
 }
 
-CitrinetWeights load_citrinet_weights(const std::filesystem::path & checkpoint_path) {
-    const auto assets = resolve_citrinet_assets(checkpoint_path);
+CitrinetWeights load_citrinet_weights(engine::assets::ResourceBundle resources) {
     CitrinetWeights weights;
-    engine::assets::ResourceBundle resources(assets.model_root);
-    resources.add_file("weights", assets.checkpoint_path);
     const auto source = resources.open_tensor_source("weights");
     weights.source = source;
-    weights.config = parse_config(io::json::parse_file(assets.config_path));
+    weights.config = parse_config(resources.parse_json("config"));
     weights.window = source->require_f32("preprocessor.featurizer.window", {weights.config.win_length});
     weights.fb = source->require_f32(
         "preprocessor.featurizer.fb",
         {1, weights.config.n_mels, weights.config.n_fft / 2 + 1});
 
-    weights.vocab = load_vocab_file(assets.vocab_path);
+    weights.vocab = load_vocab_file(resources.require_file("vocab"));
     if (static_cast<int64_t>(weights.vocab.size()) != weights.config.vocab_size) {
         throw std::runtime_error("vocab size mismatch");
     }
@@ -262,10 +240,13 @@ std::string checkpoint_cache_key(const std::filesystem::path & checkpoint_path) 
 
 }  // namespace
 
-std::shared_ptr<const CitrinetWeights> load_citrinet_weights_cached(const std::filesystem::path & checkpoint_path) {
+std::shared_ptr<const CitrinetWeights> load_citrinet_weights_cached(const std::filesystem::path & model_path) {
     static std::mutex cache_mutex;
     static std::unordered_map<std::string, std::weak_ptr<const CitrinetWeights>> cache;
-    const auto key = checkpoint_cache_key(checkpoint_path);
+    auto resources = engine::assets::load_resource_bundle_from_package_spec(
+        model_path,
+        engine::assets::default_model_package_spec_path("citrinet_asr"));
+    const auto key = checkpoint_cache_key(resources.require_file("weights"));
     {
         std::lock_guard<std::mutex> lock(cache_mutex);
         if (const auto it = cache.find(key); it != cache.end()) {
@@ -274,7 +255,7 @@ std::shared_ptr<const CitrinetWeights> load_citrinet_weights_cached(const std::f
             }
         }
     }
-    auto loaded = std::make_shared<const CitrinetWeights>(load_citrinet_weights(checkpoint_path));
+    auto loaded = std::make_shared<const CitrinetWeights>(load_citrinet_weights(std::move(resources)));
     {
         std::lock_guard<std::mutex> lock(cache_mutex);
         cache[key] = loaded;

--- a/src/models/citrinet_asr/session.cpp
+++ b/src/models/citrinet_asr/session.cpp
@@ -1,9 +1,8 @@
 #include "engine/models/citrinet_asr/session.h"
 
-#include "engine/framework/assets/tensor_source.h"
+#include "engine/framework/assets/model_package.h"
 #include "engine/framework/debug/profiler.h"
 #include "engine/framework/debug/trace.h"
-#include "engine/framework/io/filesystem.h"
 
 #include <chrono>
 #include <stdexcept>
@@ -12,27 +11,8 @@
 namespace engine::models::citrinet_asr {
 namespace {
 
-std::filesystem::path resolve_weight_path(const std::filesystem::path & model_path) {
-    if (engine::io::is_existing_file(model_path)) {
-        return std::filesystem::weakly_canonical(model_path);
-    }
-    if (!engine::io::is_existing_directory(model_path)) {
-        throw std::runtime_error("Citrinet ASR model path does not exist: " + model_path.string());
-    }
-    const auto candidate = model_path / "citrinet_256.safetensors";
-    if (!engine::io::is_existing_file(candidate)) {
-        throw std::runtime_error("Citrinet ASR weights not found: " + candidate.string());
-    }
-    return std::filesystem::weakly_canonical(candidate);
-}
-
-std::vector<runtime::NamedAsset> discover_weight_assets(const runtime::ModelLoadRequest & request) {
-    if (engine::io::is_existing_file(request.model_path)) {
-        return {{"default", std::filesystem::weakly_canonical(request.model_path)}};
-    }
-    return runtime::discover_named_assets(
-        std::filesystem::weakly_canonical(request.model_path),
-        {"citrinet_256.safetensors"});
+std::filesystem::path spec_path() {
+    return engine::assets::default_model_package_spec_path("citrinet_asr");
 }
 
 engine::assets::TensorStorageType citrinet_weight_type_from_options(const runtime::SessionOptions & options) {
@@ -62,7 +42,7 @@ public:
             return false;
         }
         try {
-            (void) resolve_citrinet_assets(resolve_weight_path(request.model_path));
+            (void) engine::assets::load_resource_bundle_from_package_spec(request.model_path, spec_path());
             return true;
         } catch (...) {
             return false;
@@ -73,19 +53,27 @@ public:
         if (request.config_id.has_value()) {
             throw std::runtime_error("Citrinet ASR does not expose selectable config assets");
         }
-        const auto weight_path = resolve_weight_path(request.model_path);
-        const auto assets = resolve_citrinet_assets(weight_path);
+        const auto resources = engine::assets::load_resource_bundle_from_package_spec(
+            request.model_path,
+            spec_path());
+        const auto & weight_path = resources.require_file("weights");
         runtime::ModelInspection inspection;
-        inspection.model_root = assets.model_root;
+        inspection.model_root = resources.model_root();
         inspection.metadata.family = family();
         inspection.metadata.variant = weight_path.stem().string();
-        inspection.metadata.description = "Citrinet ASR loaded from safetensors weights.";
-        inspection.metadata.weight_candidates = {"citrinet_256.safetensors"};
+        inspection.metadata.description = "Citrinet ASR loaded from local tensor assets.";
         inspection.capabilities.supported_tasks = {
             {runtime::VoiceTaskKind::Asr, {runtime::RunMode::Offline}},
         };
         inspection.capabilities.supports_timestamps = false;
-        inspection.discovered_weights = discover_weight_assets(request);
+        inspection.discovered_configs = runtime::discover_named_assets_from_package_spec(
+            request.model_path,
+            spec_path(),
+            engine::assets::ModelPackageResourceKind::Files);
+        inspection.discovered_weights = runtime::discover_named_assets_from_package_spec(
+            request.model_path,
+            spec_path(),
+            engine::assets::ModelPackageResourceKind::Tensors);
         return inspection;
     }
 
@@ -170,15 +158,14 @@ std::unique_ptr<CitrinetASRLoadedModel> load_citrinet_asr_model(const runtime::M
     if (request.config_id.has_value()) {
         throw std::runtime_error("Citrinet ASR does not expose selectable config assets");
     }
-    const auto weights = discover_weight_assets(request);
-    const auto * selected_weight = runtime::select_named_asset(weights, request.weight_id, "weight");
-    const auto weight_path = selected_weight != nullptr ? selected_weight->path : resolve_weight_path(request.model_path);
-    const auto assets = resolve_citrinet_assets(weight_path);
+    const auto resources = engine::assets::load_resource_bundle_from_package_spec(
+        request.model_path,
+        spec_path());
+    const auto & weight_path = resources.require_file("weights");
     runtime::ModelMetadata metadata;
     metadata.family = "citrinet_asr";
     metadata.variant = weight_path.stem().string();
-    metadata.description = "Citrinet ASR loaded from safetensors weights.";
-    metadata.weight_candidates = {"citrinet_256.safetensors"};
+    metadata.description = "Citrinet ASR loaded from local tensor assets.";
     runtime::CapabilitySet capabilities;
     capabilities.supported_tasks = {
         {runtime::VoiceTaskKind::Asr, {runtime::RunMode::Offline}},
@@ -187,7 +174,7 @@ std::unique_ptr<CitrinetASRLoadedModel> load_citrinet_asr_model(const runtime::M
     return std::make_unique<CitrinetASRLoadedModel>(
         std::move(metadata),
         std::move(capabilities),
-        load_citrinet_weights_cached(assets.checkpoint_path));
+        load_citrinet_weights_cached(request.model_path));
 }
 
 std::shared_ptr<runtime::IVoiceModelLoader> make_citrinet_asr_loader() {

--- a/src/models/hviske_asr/assets.cpp
+++ b/src/models/hviske_asr/assets.cpp
@@ -1,6 +1,6 @@
 #include "engine/models/hviske_asr/assets.h"
 
-#include "engine/framework/assets/resource_bundle.h"
+#include "engine/framework/assets/model_package.h"
 #include "engine/framework/io/json.h"
 
 #include <stdexcept>
@@ -21,8 +21,7 @@ std::vector<std::string> string_array(const engine::io::json::Value & value) {
     return out;
 }
 
-HviskeConfig load_config(const std::filesystem::path & path) {
-    const auto root = engine::io::json::parse_file(path);
+HviskeConfig load_config(const engine::io::json::Value & root) {
     HviskeConfig config;
     config.model_type = root.require("model_type").as_string();
     if (const auto * architectures = root.find("architectures");
@@ -68,8 +67,7 @@ HviskeConfig load_config(const std::filesystem::path & path) {
     return config;
 }
 
-void apply_generation_config(HviskeConfig & config, const std::filesystem::path & path) {
-    const auto root = engine::io::json::parse_file(path);
+void apply_generation_config(HviskeConfig & config, const engine::io::json::Value & root) {
     config.decoder.pad_token_id = root.require("pad_token_id").as_i64();
     config.decoder.eos_token_id = root.require("eos_token_id").as_i64();
     config.decoder.bos_token_id = root.require("bos_token_id").as_i64();
@@ -78,24 +76,19 @@ void apply_generation_config(HviskeConfig & config, const std::filesystem::path 
 
 }  // namespace
 
-std::shared_ptr<const HviskeAssets> load_hviske_assets(const std::filesystem::path & model_root) {
-    engine::assets::ResourceBundle resources(model_root);
-    resources.add_model_files({
-        {"config", "config.json"},
-        {"generation_config", "generation_config.json"},
-        {"tokenizer", "tokenizer.model"},
-        {"weights", "model.safetensors"},
-    });
-
+std::shared_ptr<const HviskeAssets> load_hviske_assets(const std::filesystem::path & model_path) {
     auto assets = std::make_shared<HviskeAssets>();
-    assets->model_root = resources.model_root();
-    assets->config = load_config(resources.require_file("config"));
-    apply_generation_config(assets->config, resources.require_file("generation_config"));
+    assets->resources = engine::assets::load_resource_bundle_from_package_spec(
+        model_path,
+        engine::assets::default_model_package_spec_path("hviske_asr"));
+    assets->config = load_config(assets->resources.parse_json("config"));
+    apply_generation_config(assets->config, assets->resources.parse_json("generation_config"));
     if (assets->config.model_type != "cohere_asr") {
         throw std::runtime_error("Hviske ASR expects Cohere ASR config, got: " + assets->config.model_type);
     }
-    assets->tokenizer_pieces = engine::tokenizers::load_sentencepiece_model(resources.require_file("tokenizer"));
-    assets->model_weights = resources.open_tensor_source("weights");
+    assets->tokenizer_pieces = engine::tokenizers::load_sentencepiece_model(
+        assets->resources.require_file("tokenizer"));
+    assets->model_weights = assets->resources.open_tensor_source("weights");
     return assets;
 }
 

--- a/src/models/hviske_asr/loader.cpp
+++ b/src/models/hviske_asr/loader.cpp
@@ -1,6 +1,6 @@
 #include "engine/models/hviske_asr/loader.h"
 
-#include "engine/framework/io/filesystem.h"
+#include "engine/framework/assets/model_package.h"
 #include "engine/models/hviske_asr/session.h"
 
 #include <stdexcept>
@@ -9,28 +9,8 @@
 namespace engine::models::hviske_asr {
 namespace {
 
-std::filesystem::path resolve_model_root(const std::filesystem::path & model_path) {
-    if (engine::io::is_existing_directory(model_path)) {
-        return std::filesystem::weakly_canonical(model_path);
-    }
-    if (engine::io::is_existing_file(model_path)) {
-        return std::filesystem::weakly_canonical(model_path.parent_path());
-    }
-    throw std::runtime_error("Hviske ASR model path does not exist: " + model_path.string());
-}
-
-bool has_hviske_assets(const std::filesystem::path & root) {
-    return engine::io::is_existing_file(root / "config.json") &&
-        engine::io::is_existing_file(root / "model.safetensors") &&
-        engine::io::is_existing_file(root / "tokenizer.model");
-}
-
-std::vector<runtime::NamedAsset> discover_config_assets(const runtime::ModelLoadRequest & request) {
-    return runtime::discover_named_assets(resolve_model_root(request.model_path), {"config.json", "generation_config.json"});
-}
-
-std::vector<runtime::NamedAsset> discover_weight_assets(const runtime::ModelLoadRequest & request) {
-    return runtime::discover_named_assets(resolve_model_root(request.model_path), {"model.safetensors"});
+std::filesystem::path spec_path() {
+    return engine::assets::default_model_package_spec_path("hviske_asr");
 }
 
 class HviskeASRLoader final : public runtime::IVoiceModelLoader {
@@ -41,34 +21,33 @@ public:
 
     bool can_load(const runtime::ModelLoadRequest & request) const override {
         try {
-            const auto root = resolve_model_root(request.model_path);
-            if (!has_hviske_assets(root)) {
-                return false;
-            }
-            const auto assets = load_hviske_assets(root);
-            return assets->config.model_type == "cohere_asr" &&
-                (!request.family_hint.has_value() || *request.family_hint == family());
+            (void) engine::assets::load_resource_bundle_from_package_spec(request.model_path, spec_path());
+            return !request.family_hint.has_value() || *request.family_hint == family();
         } catch (...) {
             return false;
         }
     }
 
     runtime::ModelInspection inspect(const runtime::ModelLoadRequest & request) const override {
-        const auto assets = load_hviske_assets(resolve_model_root(request.model_path));
+        const auto assets = load_hviske_assets(request.model_path);
         runtime::ModelInspection inspection;
-        inspection.model_root = assets->model_root;
+        inspection.model_root = assets->resources.model_root();
         inspection.metadata.family = family();
         inspection.metadata.variant = assets->config.variant.empty() ? assets->config.model_type : assets->config.variant;
-        inspection.metadata.description = "Hviske/Cohere ASR loaded from local safetensors assets.";
-        inspection.metadata.config_candidates = {"config.json", "generation_config.json"};
-        inspection.metadata.weight_candidates = {"model.safetensors"};
+        inspection.metadata.description = "Hviske/Cohere ASR loaded from local tensor assets.";
         inspection.capabilities.supported_tasks = {
             {runtime::VoiceTaskKind::Asr, {runtime::RunMode::Offline}},
         };
         inspection.capabilities.languages = assets->config.supported_languages;
         inspection.capabilities.supports_timestamps = false;
-        inspection.discovered_configs = discover_config_assets(request);
-        inspection.discovered_weights = discover_weight_assets(request);
+        inspection.discovered_configs = runtime::discover_named_assets_from_package_spec(
+            request.model_path,
+            spec_path(),
+            engine::assets::ModelPackageResourceKind::Files);
+        inspection.discovered_weights = runtime::discover_named_assets_from_package_spec(
+            request.model_path,
+            spec_path(),
+            engine::assets::ModelPackageResourceKind::Tensors);
         inspection.cli.request_options = {
             {"language", "code", "ASR language code; defaults to da."},
             {"punctuation", "bool", "Enable or disable punctuation tokens in the decoder prompt."},
@@ -93,7 +72,7 @@ public:
     }
 
     std::unique_ptr<runtime::ILoadedVoiceModel> load(const runtime::ModelLoadRequest & request) const override {
-        return load_hviske_asr_model(resolve_model_root(request.model_path));
+        return load_hviske_asr_model(request.model_path);
     }
 };
 
@@ -133,9 +112,7 @@ std::unique_ptr<HviskeASRLoadedModel> load_hviske_asr_model(const std::filesyste
     runtime::ModelMetadata metadata;
     metadata.family = "hviske_asr";
     metadata.variant = assets->config.variant.empty() ? assets->config.model_type : assets->config.variant;
-    metadata.description = "Hviske/Cohere ASR loaded from local safetensors assets.";
-    metadata.config_candidates = {"config.json", "generation_config.json"};
-    metadata.weight_candidates = {"model.safetensors"};
+    metadata.description = "Hviske/Cohere ASR loaded from local tensor assets.";
 
     runtime::CapabilitySet capabilities;
     capabilities.supported_tasks = {

--- a/tests/unittests/test_asr_standalone_gguf.cpp
+++ b/tests/unittests/test_asr_standalone_gguf.cpp
@@ -170,6 +170,44 @@ void test_native_q8_matrix_reshape_falls_back_to_f32() {
     std::filesystem::remove_all(root);
 }
 
+void test_native_q8_matrix_reshape_preserves_q8_when_block_aligned() {
+    const auto root = std::filesystem::temp_directory_path() / "audiocpp_q8_block_aligned_reshape_test";
+    std::filesystem::remove_all(root);
+    std::filesystem::create_directories(root);
+    const auto safetensors = root / "model.safetensors";
+    const auto gguf = root / "model.gguf";
+    write_quantizable_matrix(safetensors);
+    engine::assets::convert_tensor_source_to_gguf(
+        safetensors,
+        gguf,
+        engine::assets::TensorStorageType::Q8_0,
+        false,
+        false);
+    const auto source = engine::assets::open_tensor_source(gguf);
+    engine::test::require_eq(
+        source->require_metadata("conv.weight").dtype,
+        std::string("q8_0"),
+        "quantized block-aligned source type");
+    auto * backend = engine::core::init_backend({engine::core::BackendType::Cpu, 0, 1});
+    {
+        engine::core::BackendWeightStore store(
+            backend,
+            engine::core::BackendType::Cpu,
+            "q8_block_aligned_reshape_test",
+            1024 * 1024);
+        const auto weight = store.load_tensor_as_shape(
+            *source,
+            "conv.weight",
+            engine::assets::TensorStorageType::Native,
+            {32, 256},
+            engine::core::TensorShape::from_dims({32, 256}));
+        engine::test::require_eq(weight.tensor->type, GGML_TYPE_Q8_0, "block-aligned native q8 backend type");
+        store.upload();
+    }
+    ggml_backend_free(backend);
+    std::filesystem::remove_all(root);
+}
+
 }  // namespace
 
 int main() {
@@ -177,6 +215,7 @@ int main() {
         test_hviske_standalone_gguf();
         test_citrinet_standalone_gguf();
         test_native_q8_matrix_reshape_falls_back_to_f32();
+        test_native_q8_matrix_reshape_preserves_q8_when_block_aligned();
     } catch (const std::exception & error) {
         std::cerr << error.what() << '\n';
         return 1;

--- a/tests/unittests/test_asr_standalone_gguf.cpp
+++ b/tests/unittests/test_asr_standalone_gguf.cpp
@@ -1,0 +1,186 @@
+#include "engine/framework/assets/tensor_source.h"
+#include "engine/framework/assets/model_package.h"
+#include "engine/framework/core/backend.h"
+#include "engine/framework/core/backend_weight_store.h"
+#include "engine/framework/io/safetensors.h"
+#include "engine/models/citrinet_asr/assets.h"
+#include "engine/models/hviske_asr/assets.h"
+#include "test_assert.h"
+
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::vector<unsigned char> float_bytes(float value) {
+    std::vector<unsigned char> bytes(sizeof(value));
+    std::memcpy(bytes.data(), &value, sizeof(value));
+    return bytes;
+}
+
+void write_text(const std::filesystem::path & path, const std::string & text) {
+    std::ofstream output(path, std::ios::binary);
+    output << text;
+}
+
+void write_dummy_weights(const std::filesystem::path & path) {
+    engine::io::write_safetensors_file(path, {
+        {"dummy.weight", "F32", {1}, float_bytes(1.0F)},
+    });
+}
+
+void write_quantizable_matrix(const std::filesystem::path & path) {
+    std::vector<float> values(32 * 256, 0.25F);
+    std::vector<unsigned char> bytes(values.size() * sizeof(float));
+    std::memcpy(bytes.data(), values.data(), bytes.size());
+    engine::io::write_safetensors_file(path, {
+        {"conv.weight", "F32", {32, 256}, std::move(bytes)},
+    });
+}
+
+void test_hviske_standalone_gguf() {
+    const auto root = std::filesystem::temp_directory_path() / "audiocpp_hviske_standalone_test";
+    std::filesystem::remove_all(root);
+    const auto native = root / "native";
+    const auto packed = root / "unrelated";
+    std::filesystem::create_directories(native);
+    std::filesystem::create_directories(packed);
+    write_dummy_weights(native / "model.safetensors");
+    write_text(native / "config.json", R"json({
+        "model_type":"cohere_asr","architectures":["CohereAsrForConditionalGeneration"],
+        "max_audio_clip_s":35,"overlap_chunk_second":5,"min_energy_window_samples":1600,
+        "supported_languages":["da"],"vocab_size":10,
+        "preprocessor":{"sample_rate":16000,"features":128,"n_fft":512,"window_size":0.025,"window_stride":0.01,"pad_to":16,"dither":0.0},
+        "encoder":{"feat_in":128,"d_model":8,"ff_expansion_factor":4,"n_layers":1,"n_heads":1,"conv_kernel_size":3,"subsampling_conv_channels":8,"subsampling_factor":1,"pos_emb_max_len":16},
+        "transf_decoder":{"config_dict":{"hidden_size":8,"inner_size":16,"num_layers":1,"num_attention_heads":1,"max_sequence_length":16}},
+        "head":{"log_softmax":true}
+    })json");
+    write_text(native / "generation_config.json", R"json({
+        "pad_token_id":2,"eos_token_id":3,"bos_token_id":4,"decoder_start_token_id":5
+    })json");
+    std::filesystem::copy_file(
+        std::filesystem::path(ENGINE_TEST_ASSET_ROOT) / "tokenizers" / "tokenizer-1.model",
+        native / "tokenizer.model");
+
+    const auto gguf = packed / "renamed-hviske.gguf";
+    engine::assets::convert_tensor_source_to_gguf(
+        native / "model.safetensors",
+        gguf,
+        engine::assets::TensorStorageType::F16);
+    const auto assets = engine::models::hviske_asr::load_hviske_assets(gguf);
+    engine::test::require_eq(assets->config.model_type, std::string("cohere_asr"), "Hviske model type");
+    engine::test::require(assets->model_weights->has_tensor("dummy.weight"), "Hviske standalone GGUF weights");
+    engine::test::require(!assets->tokenizer_pieces.empty(), "Hviske embedded tokenizer");
+
+    std::filesystem::copy_file(gguf, native / "model.gguf");
+    const auto explicitly_native = engine::models::hviske_asr::load_hviske_assets(native / "model.safetensors");
+    engine::test::require_eq(
+        explicitly_native->model_weights->require_metadata("dummy.weight").dtype,
+        std::string("F32"),
+        "Hviske explicit safetensors selection");
+    std::filesystem::remove_all(root);
+}
+
+void test_citrinet_standalone_gguf() {
+    const auto root = std::filesystem::temp_directory_path() / "audiocpp_citrinet_standalone_test";
+    std::filesystem::remove_all(root);
+    const auto native = root / "native";
+    const auto packed = root / "unrelated";
+    std::filesystem::create_directories(native);
+    std::filesystem::create_directories(packed);
+    write_dummy_weights(native / "citrinet_256.safetensors");
+    write_text(native / "citrinet_256_config.json", R"json({"vocab_file":"citrinet_256_vocab.txt"})json");
+    write_text(native / "citrinet_256_tokenizer.model", "test tokenizer sidecar");
+    write_text(native / "citrinet_256_vocab.txt", "a\nb\n");
+
+    const auto gguf = packed / "renamed-citrinet.gguf";
+    engine::assets::convert_tensor_source_to_gguf(
+        native / "citrinet_256.safetensors",
+        gguf,
+        engine::assets::TensorStorageType::F16);
+    const auto assets = engine::assets::load_resource_bundle_from_package_spec(
+        gguf,
+        engine::assets::default_model_package_spec_path("citrinet_asr"));
+    engine::test::require_eq(
+        assets.require_file("weights"),
+        std::filesystem::weakly_canonical(gguf),
+        "Citrinet standalone GGUF checkpoint");
+    engine::test::require_eq(
+        assets.require_file("config").filename().string(),
+        std::string("citrinet_256_config.json"),
+        "Citrinet embedded config");
+    engine::test::require_eq(
+        assets.require_file("vocab").filename().string(),
+        std::string("citrinet_256_vocab.txt"),
+        "Citrinet embedded vocabulary");
+    engine::test::require_eq(
+        assets.require_file("tokenizer").filename().string(),
+        std::string("citrinet_256_tokenizer.model"),
+        "Citrinet embedded tokenizer");
+
+    const auto native_assets = engine::assets::load_resource_bundle_from_package_spec(
+        native / "citrinet_256.safetensors",
+        engine::assets::default_model_package_spec_path("citrinet_asr"));
+    engine::test::require_eq(
+        native_assets.open_tensor_source("weights")->require_metadata("dummy.weight").dtype,
+        std::string("F32"),
+        "Citrinet explicit safetensors selection");
+    std::filesystem::remove_all(root);
+}
+
+void test_native_q8_matrix_reshape_falls_back_to_f32() {
+    const auto root = std::filesystem::temp_directory_path() / "audiocpp_q8_conv_reshape_test";
+    std::filesystem::remove_all(root);
+    std::filesystem::create_directories(root);
+    const auto safetensors = root / "model.safetensors";
+    const auto gguf = root / "model.gguf";
+    write_quantizable_matrix(safetensors);
+    engine::assets::convert_tensor_source_to_gguf(
+        safetensors,
+        gguf,
+        engine::assets::TensorStorageType::Q8_0,
+        false,
+        false);
+    const auto source = engine::assets::open_tensor_source(gguf);
+    engine::test::require_eq(
+        source->require_metadata("conv.weight").dtype,
+        std::string("q8_0"),
+        "quantized reshape source type");
+    auto * backend = engine::core::init_backend({engine::core::BackendType::Cpu, 0, 1});
+    {
+        engine::core::BackendWeightStore store(
+            backend,
+            engine::core::BackendType::Cpu,
+            "q8_conv_reshape_test",
+            1024 * 1024);
+        const auto weight = store.load_tensor_as_shape(
+            *source,
+            "conv.weight",
+            engine::assets::TensorStorageType::Native,
+            {32, 256},
+            engine::core::TensorShape::from_dims({32, 256, 1}));
+        engine::test::require_eq(weight.tensor->type, GGML_TYPE_F32, "quantized reshape backend type");
+        store.upload();
+    }
+    ggml_backend_free(backend);
+    std::filesystem::remove_all(root);
+}
+
+}  // namespace
+
+int main() {
+    try {
+        test_hviske_standalone_gguf();
+        test_citrinet_standalone_gguf();
+        test_native_q8_matrix_reshape_falls_back_to_f32();
+    } catch (const std::exception & error) {
+        std::cerr << error.what() << '\n';
+        return 1;
+    }
+    std::cout << "asr_standalone_gguf_test passed\n";
+    return 0;
+}


### PR DESCRIPTION
## What changed

- sync the change onto `main` at `66d233b`
- add `model_specs/hviske_asr.json` and `model_specs/citrinet_asr.json`
- describe native safetensors and standalone GGUF layouts, including named configuration, tokenizer, vocabulary, and tensor resources, in those specs
- refactor both model loaders to consume the framework-resolved named resources instead of selecting model filenames in C++
- accept direct, renamed GGUF files while retaining native safetensors support
- decode quantized source matrices to F32 when a model reshapes them into an incompatible Conv1D layout
- document Q8_0 conversion commands and update the package-spec/GGUF test matrix in `docs/gguf.md`
- add regression coverage for native/GGUF package resolution and the quantized matrix-to-Conv1D reshape path

## Why

The shared GGUF core could package these checkpoints, but these families did not have package specs. Citrinet Q8_0 also exposed a GGML row-layout mismatch when a quantized matrix was reshaped into a convolution kernel whose final dimension was not block-sized.

This change lets a completed `model.gguf` be moved, renamed, and passed directly to the CLI or server without the original model directory.

## Validation

- focused CPU targets (`asr_standalone_gguf_test`, CLI, and server) build successfully on `66d233b`
- `asr_standalone_gguf_test` passes through the package-spec resolver
- CUDA CLI and server load both real Q8_0 files successfully through their package specs
- CUDA CLI loads both native safetensors layouts successfully through their package specs
- Hviske native and Q8_0 produced the same transcript on the test WAV
- Citrinet native and Q8_0 produced the same transcript on the test WAV

The complete default CPU build on `66d233b` is currently blocked by the existing MOSS codec parity targets, which still pass filesystem paths to constructors that now require `TensorSource` objects. Those unrelated targets are not changed by this PR.
