### PR TITLE
[Experimental] Add ROCm/HIP support (100% vibe‑coded, for testing purposes)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ if (NOT MSVC)
 endif()
 
 set(ENGINE_DEFAULT_ENABLE_CUDA OFF)
+set(ENGINE_DEFAULT_ENABLE_HIP OFF)
 set(ENGINE_DEFAULT_ENABLE_VULKAN OFF)
 set(ENGINE_DEFAULT_ENABLE_METAL OFF)
 set(ENGINE_DEFAULT_ENABLE_LLAMAFILE ON)
@@ -60,6 +61,9 @@ if (APPLE)
 endif()
 if (DEFINED GGML_CUDA)
     set(ENGINE_DEFAULT_ENABLE_CUDA ${GGML_CUDA})
+endif()
+if (DEFINED GGML_HIP)
+    set(ENGINE_DEFAULT_ENABLE_HIP ${GGML_HIP})
 endif()
 if (DEFINED GGML_VULKAN)
     set(ENGINE_DEFAULT_ENABLE_VULKAN ${GGML_VULKAN})
@@ -75,6 +79,7 @@ if (DEFINED GGML_CUDA_GRAPHS)
 endif()
 
 option(ENGINE_ENABLE_CUDA "Build ggml with CUDA backend support" ${ENGINE_DEFAULT_ENABLE_CUDA})
+option(ENGINE_ENABLE_HIP "Build ggml with HIP/ROCm backend support" ${ENGINE_DEFAULT_ENABLE_HIP})
 option(ENGINE_ENABLE_VULKAN "Build ggml with Vulkan backend support" ${ENGINE_DEFAULT_ENABLE_VULKAN})
 option(ENGINE_ENABLE_METAL "Build ggml with Metal backend support" ${ENGINE_DEFAULT_ENABLE_METAL})
 option(ENGINE_ENABLE_LLAMAFILE "Build ggml with llamafile SGEMM support" ${ENGINE_DEFAULT_ENABLE_LLAMAFILE})
@@ -91,7 +96,7 @@ set(AUDIOCPP_GGML_SOURCE_DIR
     "${CMAKE_CURRENT_SOURCE_DIR}/external/ggml"
     CACHE PATH "ggml source tree to build with AudioCPP")
 
-if (ENGINE_ENABLE_CUDA)
+if (ENGINE_ENABLE_CUDA AND NOT ENGINE_ENABLE_HIP)
     enable_language(CUDA)
     # 12.0 is a floor, not a target: any 12.x or 13.x works (the Dockerfile pins
     # 12.9.0, and docs/build/windows.md ships a CUDA 13 package). The minimum is
@@ -132,6 +137,7 @@ set(GGML_BUILD_TESTS OFF CACHE BOOL "Do not build upstream tests" FORCE)
 set(GGML_ALL_WARNINGS OFF CACHE BOOL "Keep upstream warnings quiet in this sample" FORCE)
 set(GGML_CCACHE OFF CACHE BOOL "Do not probe for ccache in this local setup" FORCE)
 set(GGML_CUDA ${ENGINE_ENABLE_CUDA} CACHE BOOL "Build ggml with CUDA backend support" FORCE)
+set(GGML_HIP ${ENGINE_ENABLE_HIP} CACHE BOOL "Build ggml with HIP backend support" FORCE)
 set(GGML_VULKAN ${ENGINE_ENABLE_VULKAN} CACHE BOOL "Build ggml with Vulkan backend support" FORCE)
 set(GGML_METAL ${ENGINE_ENABLE_METAL} CACHE BOOL "Build ggml with Metal backend support" FORCE)
 set(GGML_LLAMAFILE ${ENGINE_ENABLE_LLAMAFILE} CACHE BOOL "Build ggml with llamafile SGEMM support" FORCE)
@@ -632,7 +638,11 @@ if (ENGINE_ENABLE_OPENMP)
     endif()
 endif()
 
-if (ENGINE_ENABLE_CUDA)
+if (MSVC)
+    target_compile_options(engine_runtime PRIVATE /utf-8)
+endif()
+
+if (ENGINE_ENABLE_CUDA AND NOT ENGINE_ENABLE_HIP)
     target_sources(engine_runtime PRIVATE
         src/framework/audio/istft_cuda_runtime.cu
         src/framework/sampling/torch_random_cuda_runtime.cu

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,15 @@ set(AUDIOCPP_GGML_SOURCE_DIR
     "${CMAKE_CURRENT_SOURCE_DIR}/external/ggml"
     CACHE PATH "ggml source tree to build with AudioCPP")
 
+# HIP compiles ggml's CUDA backend sources as HIP code, so the two options drive the
+# same ggml backend and cannot coexist: enabling both starts CUDA backend setup and
+# HIP backend setup in the same configure, which fails in confusing ways downstream.
+if (ENGINE_ENABLE_CUDA AND ENGINE_ENABLE_HIP)
+    message(FATAL_ERROR
+        "ENGINE_ENABLE_CUDA and ENGINE_ENABLE_HIP are mutually exclusive; "
+        "configure with exactly one of them (e.g. -DENGINE_ENABLE_CUDA=OFF -DENGINE_ENABLE_HIP=ON)")
+endif()
+
 if (ENGINE_ENABLE_CUDA AND NOT ENGINE_ENABLE_HIP)
     enable_language(CUDA)
     # 12.0 is a floor, not a target: any 12.x or 13.x works (the Dockerfile pins

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,9 @@ set(GGML_VULKAN ${ENGINE_ENABLE_VULKAN} CACHE BOOL "Build ggml with Vulkan backe
 set(GGML_METAL ${ENGINE_ENABLE_METAL} CACHE BOOL "Build ggml with Metal backend support" FORCE)
 set(GGML_LLAMAFILE ${ENGINE_ENABLE_LLAMAFILE} CACHE BOOL "Build ggml with llamafile SGEMM support" FORCE)
 set(GGML_CUDA_GRAPHS ${ENGINE_ENABLE_CUDA_GRAPHS} CACHE BOOL "Enable ggml CUDA graphs support" FORCE)
+# HIP graphs are controlled by a separate upstream option that defaults to ON;
+# keep it in sync so ENGINE_ENABLE_CUDA_GRAPHS=OFF also disables graphs on HIP builds
+set(GGML_HIP_GRAPHS ${ENGINE_ENABLE_CUDA_GRAPHS} CACHE BOOL "Enable ggml HIP graphs support" FORCE)
 
 set(SPM_ENABLE_SHARED OFF CACHE BOOL "Build sentencepiece shared libs" FORCE)
 set(SPM_BUILD_TEST OFF CACHE BOOL "Do not build sentencepiece tests" FORCE)

--- a/app/cli/args.cpp
+++ b/app/cli/args.cpp
@@ -96,6 +96,9 @@ engine::core::BackendType parse_backend(const std::string & value) {
     if (value == "cuda") {
         return engine::core::BackendType::Cuda;
     }
+    if (value == "hip") {
+        return engine::core::BackendType::Hip;
+    }
     if (value == "vulkan") {
         return engine::core::BackendType::Vulkan;
     }

--- a/app/cli/args.cpp
+++ b/app/cli/args.cpp
@@ -96,7 +96,7 @@ engine::core::BackendType parse_backend(const std::string & value) {
     if (value == "cuda") {
         return engine::core::BackendType::Cuda;
     }
-    if (value == "hip") {
+    if (value == "hip" || value == "rocm") {
         return engine::core::BackendType::Hip;
     }
     if (value == "vulkan") {

--- a/app/cli/main.cpp
+++ b/app/cli/main.cpp
@@ -48,7 +48,7 @@ void print_task_list_help() {
         << "    --task vad|asr|diar|sep|gen|tts|clon|vc|s2s|align|vdes|spk|svc\n"
         << "    --family <name>\n"
         << "    --model <path>\n"
-        << "    --backend cpu|cuda|hip|vulkan|metal|best\n"
+        << "    --backend cpu|cuda|hip|rocm|vulkan|metal|best  (rocm is an alias for hip)\n"
         << "    --mode offline|streaming  default offline\n"
         << "    --device <n>\n"
         << "    --threads <n>  Backend and OpenMP worker threads, default 4\n"

--- a/app/cli/main.cpp
+++ b/app/cli/main.cpp
@@ -48,7 +48,7 @@ void print_task_list_help() {
         << "    --task vad|asr|diar|sep|gen|tts|clon|vc|s2s|align|vdes|spk|svc\n"
         << "    --family <name>\n"
         << "    --model <path>\n"
-        << "    --backend cpu|cuda|vulkan|metal|best\n"
+        << "    --backend cpu|cuda|hip|vulkan|metal|best\n"
         << "    --mode offline|streaming  default offline\n"
         << "    --device <n>\n"
         << "    --threads <n>  Backend and OpenMP worker threads, default 4\n"

--- a/app/server/main.cpp
+++ b/app/server/main.cpp
@@ -48,7 +48,7 @@ void print_help() {
         << "                [--model-spec-override <json-or-directory>]\n"
         << "                [--log] [--log-file <path>]\n"
         << "                [--cors-origins <origins>]\n"
-        << "  --backend cpu|cuda|vulkan|metal  default cuda\n"
+        << "  --backend cpu|cuda|hip|rocm|vulkan|metal  default cuda (rocm is an alias for hip)\n"
         << "  --busy-timeout-ms <ms>           fail a request with 503 when the model has been\n"
         << "                                   busy this long; default 300000, 0 disables\n"
         << "  --cors-origins \"*\"              experimental; disabled by default. Allows browser\n"

--- a/app/server/runtime.cpp
+++ b/app/server/runtime.cpp
@@ -80,6 +80,8 @@ const char * backend_name(engine::core::BackendType type) {
             return "cpu";
         case engine::core::BackendType::Cuda:
             return "cuda";
+        case engine::core::BackendType::Hip:
+            return "hip";
         case engine::core::BackendType::Vulkan:
             return "vulkan";
         case engine::core::BackendType::Metal:

--- a/docs/HIP.md
+++ b/docs/HIP.md
@@ -216,6 +216,13 @@ Multiple GPU targets (for distribution):
 -DGPU_TARGETS="gfx1030;gfx1100;gfx1101;gfx1102;gfx1150;gfx1151"
 ```
 
+**iGPU vs discrete GPU (Linux):**
+
+- **Discrete GPU (gfx1100/1101/1102, gfx1200/1201):** the defaults are fine. `ENGINE_ENABLE_CUDA_GRAPHS` is ON by default and dGPUs have the VRAM headroom for it. Optionally add `-DGGML_HIP_NO_VMM=OFF` — HIP VMM works on Linux dGPUs and improves ggml's memory-pool reuse under varying shapes.
+- **iGPU (gfx1103 780M, gfx1150, gfx1151):** add `-DENGINE_ENABLE_CUDA_GRAPHS=OFF` if you see `out of memory` during graph warmup — each cached graph reserves its own buffers out of shared system memory (see Known Limitations). Keep `GGML_HIP_NO_VMM=ON` (the default).
+- **gfx1103 note:** with the default hipBLASLt GEMM path, no `HSA_OVERRIDE_GFX_VERSION=11.0.0` is needed. That override is only required if you force the legacy rocBLAS path with `-DGGML_HIP_HIPBLASLT=OFF`.
+- **rocWMMA fattn** (`GGML_HIP_ROCWMMA_FATTN`): keep OFF on both — the default `fattn-tile` kernels are faster on RDNA3/RDNA4.
+
 ### Windows
 
 > **hipBLASLt GEMM (default):** HIP builds use hipBLASLt instead of hipBLAS (rocBLAS) for all cuBLAS-equivalent GEMM calls. hipBLASLt ships Tensile kernels for more GPU architectures than rocBLAS on Windows — notably **gfx1103 (Radeon 780M) works**, even though rocBLAS has no gfx1103 library. Disable with `-DGGML_HIP_HIPBLASLT=OFF` to fall back to hipBLAS.
@@ -256,6 +263,22 @@ cmake --build build/hip
 ```
 
 The resulting binaries need the ROCm `bin` directory on `PATH` at runtime (for `amdhip64_6.dll`, `hipblas.dll`, `hipblaslt.dll`, ...).
+
+**iGPU vs discrete GPU:**
+
+The script defaults are tuned for memory-constrained iGPUs (780M, Strix Point/Halo). On a discrete GPU (gfx1100/1101/1102, gfx1200/1201) adjust the following:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts\build_windows_hip.ps1 `
+  -GpuTargets gfx1100 `   # your dGPU arch; see the support matrix below
+  -Graphs `               # re-enable CUDA graphs: dGPUs have VRAM headroom, avoids per-request graph rebuild overhead
+  -WithVmm                # optional: HIP VMM improves ggml memory-pool reuse; keep OFF on iGPUs
+```
+
+- **CUDA graphs** (`-Graphs`): each cached graph reserves its own VRAM buffers. Fine on a dGPU with 8+ GB; on UMA iGPUs it can exhaust shared memory during warmup (see Known Limitations).
+- **VMM** (`-WithVmm`): with `GGML_HIP_NO_VMM=ON` (the default) ggml's memory pool reuses less, which costs performance under varying shapes. It is required on Windows iGPUs but generally works on dGPUs.
+- **hipBLASLt**: keep the default ON. Unlike gfx1103, rocBLAS does ship Tensile kernels for the dGPU arches on Windows, so `-NoHipblasLt` is viable there — but there is no performance reason to prefer it.
+- **rocWMMA fattn**: stays OFF on dGPUs too; the default `fattn-tile` kernels are the faster path on RDNA3/RDNA4.
 
 > **Legacy workaround (pre-hipBLASLt):** `-DGGML_CUDA_FORCE_MMQ=ON` bypasses BLAS for *quantized* matmul only; FP16/FP32 GEMM still required rocBLAS and failed on gfx1103. Renaming rocBLAS `gfx1100` Tensile files to `gfx1103` segfaults with ROCm 6.4 on Windows — do not use. hipBLASLt is the supported path.
 
@@ -313,7 +336,7 @@ The following locations check `BackendType::Cuda` specifically and will not appl
 
 ### CUDA graphs on iGPUs / limited VRAM
 
-`ENGINE_ENABLE_CUDA_GRAPHS` defaults to ON (inherited from the CUDA build), but every cached graph reserves its own VRAM buffers. On memory-constrained GPUs (notably UMA iGPUs like the 780M, where `GGML_HIP_NO_VMM` also reduces ggml's memory-pool reuse), a burst of new shapes (e.g. the second inference request) can exhaust VRAM with `cudaMalloc failed: out of memory` during graph warmup. `scripts/build_windows_hip.ps1` therefore builds with `-DENGINE_ENABLE_CUDA_GRAPHS=OFF` by default; pass `-Graphs` to re-enable on discrete GPUs with headroom.
+`ENGINE_ENABLE_CUDA_GRAPHS` defaults to ON (inherited from the CUDA build), but every cached graph reserves its own VRAM buffers. On memory-constrained GPUs (notably UMA iGPUs like the 780M, where `GGML_HIP_NO_VMM` also reduces ggml's memory-pool reuse), a burst of new shapes (e.g. the second inference request) can exhaust VRAM with `cudaMalloc failed: out of memory` during graph warmup. `scripts/build_windows_hip.ps1` therefore builds with `-DENGINE_ENABLE_CUDA_GRAPHS=OFF` by default; pass `-Graphs` to re-enable on discrete GPUs with headroom (recommended there — it removes per-request graph rebuild overhead).
 
 ### audio.cpp CUDA-specific `.cu` files
 

--- a/docs/HIP.md
+++ b/docs/HIP.md
@@ -151,7 +151,6 @@ if (value == "hip") {
 ---
 
 ### 6. `external/sentencepiece/src/CMakeLists.txt` (build compatibility fix)
-
 **L266** -- Disable `-fPIC` on Windows (clang Windows target does not support it):
 ```cmake
 # Original:
@@ -164,13 +163,34 @@ if (NOT MSVC AND NOT WIN32)
 
 ---
 
+### 7. `external/ggml` -- hipBLASLt GEMM path
+
+rocBLAS does not ship Tensile kernels for every AMD GPU arch (e.g. gfx1103 on Windows), while hipBLASLt covers more arches. HIP builds therefore route every cuBLAS-equivalent GEMM through hipBLASLt by default.
+
+**`external/ggml/src/ggml-hip/CMakeLists.txt`** -- New option `GGML_HIP_HIPBLASLT` (default `ON`). Runs `find_package(hipblaslt)`; when found, defines `GGML_HIP_USE_HIPBLASLT` and links `roc::hipblaslt`. When not found (e.g. older ROCm without the hipblaslt dev package), it warns and falls back to the original hipBLAS (rocBLAS) path, so Linux builds are unaffected.
+
+**`external/ggml/src/ggml-cuda/common.cuh`** -- Includes `<hipblaslt/hipblaslt.h>` when `GGML_HIP_USE_HIPBLASLT` is defined; adds a `HIPBLASLT_CHECK` error macro; adds lazily-created per-device `hipblasLtHandle_t` handles and a 32 MiB per-device workspace to `ggml_backend_cuda_context` (freed in the context destructor in `ggml-cuda.cu`).
+
+**`external/ggml/src/ggml-cuda/ggml-cuda.cu`** -- New `ggml_hipblaslt_gemm()` helper mirroring the cublas call semantics (`OP_T`/`OP_N`, column-major, strided-batch support), plus a `hipblasDatatype_t` -> `hipDataType` conversion (the legacy hipBLAS enum values, 150+, differ from hipDataType, 0-based, on ROCm < 6.5). All GEMM call sites are switched to it when `GGML_HIP_USE_HIPBLASLT` is defined, with the original cublas code kept as `#else` fallback:
+
+- `ggml_cuda_op_mul_mat_cublas()`: BF16, FP16->FP32, FP16->FP16, and FP32 GEMM paths
+- `ggml_cuda_mul_mat_batched_cublas_impl()`: strided-batched path (native hipBLASLt batched layouts) and pointer-array batched path (emulated with a per-batch-element GEMM loop; hipBLASLt has no pointer-array API)
+
+All Lt GEMMs use `HIPBLAS_COMPUTE_32F` with FP32 scale for accuracy. The algorithm heuristic is queried per call -- caching heuristics per shape is future work.
+
+### 8. `scripts/build_windows_hip.ps1`
+
+Dedicated Windows HIP build script. Auto-detects ROCm (`HIP_PATH` or `C:\Program Files\AMD\ROCm\*`), GPU targets (`amdgpu-arch`), cmake, and ninja (PATH or the VS-bundled copy), then configures and builds with `ENGINE_ENABLE_HIP=ON`. See the Windows build section below for options.
+
+---
+
 ## Build Instructions
 
-### Linux (Recommended -- full rocBLAS support)
+### Linux
 
 Prerequisites:
 - ROCm 6.1+ installed (`/opt/rocm` or custom path)
-- hipBLAS, rocBLAS packages
+- hipBLAS, rocBLAS, hipBLASLt packages (hipBLASLt is used for GEMM by default; without it the build falls back to hipBLAS/rocBLAS)
 - Find your GPU target: `rocminfo | grep gfx | head -1 | awk '{print $2}'`
   (e.g. `gfx1100` for RX 7900 XTX, `gfx1151` for Strix Halo iGPU)
 
@@ -198,56 +218,63 @@ Multiple GPU targets (for distribution):
 
 ### Windows
 
-> **IMPORTANT:** ROCm on Windows only ships rocBLAS Tensile libraries for the GPU architectures listed below. If your AMD GPU is not in this list (notably: RDNA3 iGPU `gfx1103` / Radeon 780M is NOT supported), you will need to use the workaround build flags.
->
-> Supported: `gfx1030`, `gfx1100`, `gfx1101`, `gfx1102`, `gfx1150`, `gfx1151`, `gfx1200`, `gfx1201`, `gfx906`
+> **hipBLASLt GEMM (default):** HIP builds use hipBLASLt instead of hipBLAS (rocBLAS) for all cuBLAS-equivalent GEMM calls. hipBLASLt ships Tensile kernels for more GPU architectures than rocBLAS on Windows — notably **gfx1103 (Radeon 780M) works**, even though rocBLAS has no gfx1103 library. Disable with `-DGGML_HIP_HIPBLASLT=OFF` to fall back to hipBLAS.
 
-**Standard build (supported GPU):**
+**Build script (recommended):**
+
+```powershell
+# Auto-detects ROCm (HIP_PATH), GPU targets (amdgpu-arch), cmake, and ninja
+powershell -ExecutionPolicy Bypass -File scripts\build_windows_hip.ps1
+
+# Useful options:
+#   -GpuTargets gfx1103        override target arch
+#   -NoHipblasLt               use hipBLAS (rocBLAS) instead of hipBLASLt
+#   -ForceMmq                  route quantized matmul through GGML MMQ kernels
+#   -WithVmm                   enable HIP virtual memory management
+#   -ConfigureOnly / -Clean / -Target audiocpp_cli / -Jobs 8
+```
+
+**Manual build:**
 
 ```cmd
 # Set ROCm environment
 set PATH=C:\Program Files\AMD\ROCm\6.4\bin;%PATH%
 set HIP_PATH=C:\Program Files\AMD\ROCm\6.4
+set ROCM_PATH=C:\Program Files\AMD\ROCm\6.4
 
-# Install ninja if not present:
-# Download from https://github.com/ninja-build/ninja/releases
-
-# Configure
-cmake -S . -B build_hip -G Ninja ^
-  -DCMAKE_MAKE_PROGRAM=<path-to-ninja.exe> ^
+# Configure (ninja: bundled with Visual Studio CMake tools or standalone)
+cmake -S . -B build/hip -G Ninja ^
   -DENGINE_ENABLE_HIP=ON ^
   -DENGINE_ENABLE_OPENMP=OFF ^
-  -DGPU_TARGETS=gfx1100 ^
+  -DGPU_TARGETS=gfx1103 ^
   -DCMAKE_C_COMPILER="%HIP_PATH%\bin\clang.exe" ^
   -DCMAKE_CXX_COMPILER="%HIP_PATH%\bin\clang++.exe" ^
   -DCMAKE_BUILD_TYPE=Release
 
 # Build
-cmake --build build_hip
+cmake --build build/hip
 ```
 
-**Workaround build (unsupported GPU, e.g. 780M / gfx1103):**
+The resulting binaries need the ROCm `bin` directory on `PATH` at runtime (for `amdhip64_6.dll`, `hipblas.dll`, `hipblaslt.dll`, ...).
 
-Add `-DGGML_CUDA_FORCE_MMQ=ON -DGGML_HIP_NO_VMM=ON` to the cmake command above. This bypasses hipBLAS/rocBLAS for matrix multiplication and uses GGML's own MMQ kernels instead. Performance will be lower for large matrix multiplications but functionally correct.
-
-Why: rocBLAS requires pre-compiled Tensile library files per GPU architecture. If none exist for your GPU, `hipblasCreate()` fails fatally. `GGML_CUDA_FORCE_MMQ` routes all matmul through GGML's custom dequant+matmul kernels, avoiding rocBLAS entirely.
+> **Legacy workaround (pre-hipBLASLt):** `-DGGML_CUDA_FORCE_MMQ=ON` bypasses BLAS for *quantized* matmul only; FP16/FP32 GEMM still required rocBLAS and failed on gfx1103. Renaming rocBLAS `gfx1100` Tensile files to `gfx1103` segfaults with ROCm 6.4 on Windows — do not use. hipBLASLt is the supported path.
 
 ---
 
 ## Architecture Support Matrix
 
-| GPU Target | Type | rocBLAS Tensile (Linux) | rocBLAS Tensile (Windows) | MMQ Workaround |
+| GPU Target | Type | rocBLAS Tensile (Linux) | rocBLAS Tensile (Windows) | hipBLASLt (Linux + Windows) |
 |---|---|---|---|---|
-| gfx1100 | RDNA3 discrete (7900 XTX/XT) | Yes | Yes | Not needed |
-| gfx1101 | RDNA3 discrete (7900 GRE) | Yes | Yes | Not needed |
-| gfx1102 | RDNA3 discrete (7600 XT) | Yes | Yes | Not needed |
-| **gfx1103** | **RDNA3 iGPU (780M)** | Yes 1 | **No** | **Required on Windows** |
-| gfx1150 | RDNA3.5 iGPU (Strix Point) | Yes | Yes | Not needed |
-| gfx1151 | RDNA3.5 iGPU (Strix Halo) | Yes | Yes | Not needed |
-| gfx1200 | RDNA4 discrete | Yes | Yes | Not needed |
-| gfx1201 | RDNA4 discrete | Yes | Yes | Not needed |
+| gfx1100 | RDNA3 discrete (7900 XTX/XT) | Yes | Yes | Yes |
+| gfx1101 | RDNA3 discrete (7900 GRE) | Yes | Yes | Yes |
+| gfx1102 | RDNA3 discrete (7600 XT) | Yes | Yes | Yes |
+| **gfx1103** | **RDNA3 iGPU (780M)** | Yes 1 | **No** | **Yes** |
+| gfx1150 | RDNA3.5 iGPU (Strix Point) | Yes | Yes | Yes |
+| gfx1151 | RDNA3.5 iGPU (Strix Halo) | Yes | Yes | Yes |
+| gfx1200 | RDNA4 discrete | Yes | Yes | Yes |
+| gfx1201 | RDNA4 discrete | Yes | Yes | Yes |
 
-> 1 gfx1103 on Linux requires `HSA_OVERRIDE_GFX_VERSION=11.0.0`. This environment variable is [not supported on Windows](https://github.com/ROCm/ROCm/issues/2654).
+> 1 gfx1103 on Linux requires `HSA_OVERRIDE_GFX_VERSION=11.0.0` for rocBLAS. This environment variable is [not supported on Windows](https://github.com/ROCm/ROCm/issues/2654). With the hipBLASLt GEMM path (default), gfx1103 works on both Linux and Windows without any override.
 
 ---
 
@@ -275,13 +302,18 @@ The following locations check `BackendType::Cuda` specifically and will not appl
 
 ### Switch statements missing `Hip` case (compiler warnings)
 
-These produce `-Wswitch` warnings but behave correctly (fall through to `default` or implicit return):
+- `app/server/runtime.cpp` (`backend_name()`) and `src/models/ace_step/planner.cpp` (`planner_prefill_uses_host_backend()`) now handle `Hip` explicitly.
+- `src/models/moss/moss_tts_local/session.cpp` (`resolve_auto_weight_type()`) intentionally keeps HIP on the `Native` dtype default; enabling the CUDA-style BF16 path for HIP needs validation with real models first.
 
-| File | Line | Notes |
-|---|---|---|
-| `app/server/runtime.cpp` | 61 | `backend_name()` returns `"unknown"` for HIP |
-| `src/models/ace_step/planner.cpp` | 153 | Falls through; HIP treated same as CUDA/Cpu/Metal for this path |
-| `src/models/moss/moss_tts_local/session.cpp` | 157 | Falls through |
+### hipBLASLt GEMM path notes
+
+- Heuristics are queried per GEMM call (shape-keyed algo caching is future work).
+- The pointer-array batched GEMM (`cublasGemmBatchedEx` equivalent) is emulated with a per-batch-element loop.
+- Verified on gfx1103 / ROCm 6.4 / Windows: F32 and F16 2D GEMM, strided-batched, and broadcast-batched all match CPU reference within 1e-4.
+
+### CUDA graphs on iGPUs / limited VRAM
+
+`ENGINE_ENABLE_CUDA_GRAPHS` defaults to ON (inherited from the CUDA build), but every cached graph reserves its own VRAM buffers. On memory-constrained GPUs (notably UMA iGPUs like the 780M, where `GGML_HIP_NO_VMM` also reduces ggml's memory-pool reuse), a burst of new shapes (e.g. the second inference request) can exhaust VRAM with `cudaMalloc failed: out of memory` during graph warmup. `scripts/build_windows_hip.ps1` therefore builds with `-DENGINE_ENABLE_CUDA_GRAPHS=OFF` by default; pass `-Graphs` to re-enable on discrete GPUs with headroom.
 
 ### audio.cpp CUDA-specific `.cu` files
 
@@ -297,8 +329,10 @@ These are skipped entirely on HIP builds. To enable GPU acceleration for ISTFT a
 - [ ] Linux: `cmake -DENGINE_ENABLE_HIP=ON ...` configures without errors
 - [ ] Linux: `cmake --build build_hip` completes without errors
 - [ ] Linux: `--backend hip --device 0` initializes and detects AMD GPU
-- [ ] Windows: Same as above (standard GPU only)
-- [ ] Windows: `--backend hip` appears in `--help` output
+- [x] Windows: HIP build configures and compiles (ROCm 6.4, gfx1103)
+- [x] Windows: `--backend hip` appears in `--help` output
+- [x] Windows: HIP backend initializes and detects the GPU (`ROCm0`, gfx1103)
+- [x] Windows: F32/F16/BF16 GEMM via hipBLASLt matches CPU reference (2D, strided-batched, broadcast-batched)
 - [ ] `backend_type()` returns `BackendType::Hip` for ROCm-initialized backends
 - [ ] `query_backend_memory()` works for HIP
 - [ ] `release_backend_graph_resources()` works for HIP

--- a/docs/HIP.md
+++ b/docs/HIP.md
@@ -134,18 +134,18 @@ case BackendType::Hip:       // <-- fall-through to CUDA path
 
 ### 4. `app/cli/args.cpp`
 
-**L99-L101** -- CLI string to BackendType mapping:
+CLI string to BackendType mapping (`rocm` accepted as an alias):
 ```cpp
-if (value == "hip") {
+if (value == "hip" || value == "rocm") {
     return engine::core::BackendType::Hip;
 }
 ```
 
 ### 5. `app/cli/main.cpp`
 
-**L48** -- Help text:
+Help text:
 ```
---backend cpu|cuda|hip|vulkan|metal|best
+--backend cpu|cuda|hip|rocm|vulkan|metal|best  (rocm is an alias for hip)
 ```
 
 ---

--- a/docs/HIP.md
+++ b/docs/HIP.md
@@ -1,0 +1,316 @@
+# HIP/ROCm Backend Support
+
+## Overview
+
+This document describes the HIP/ROCm backend support added to audio.cpp for running models on AMD GPUs.
+
+The GGML library vendored at `external/ggml/` already contains a HIP backend that compiles CUDA kernels (`ggml-cuda/*.cu`) as HIP code via a vendor header mapping (`ggml-cuda/vendors/hip.h`). The changes in this PR expose that functionality through audio.cpp's build system, backend abstraction layer, and CLI.
+
+### How It Works
+
+```
+audio.cpp ENGINE_ENABLE_HIP=ON
+  -> CMakeLists.txt sets GGML_HIP=ON
+    -> external/ggml/src/ggml-hip/CMakeLists.txt
+      -> compiles ../ggml-cuda/*.cu with GGML_USE_HIP
+      -> vendor header maps cudaMalloc->hipMalloc, cublasCreate->hipblasCreate, etc.
+      -> sets GGML_USE_CUDA on ggml target (same register path as native CUDA)
+        -> audio.cpp backend.cpp sees #ifdef GGML_USE_CUDA == true
+        -> ggml_backend_cuda_init() / ggml_backend_cuda_reg() work for HIP
+        -> device name "ROCm0" distinguishes HIP from "CUDA0"
+```
+
+Key insight: HIP and CUDA share **the same GGML backend code**. The `ggml-hip/` directory contains only a `CMakeLists.txt` -- zero lines of unique kernel code. The runtime distinction is made via device name prefix (`"ROCm"` vs `"CUDA"`).
+
+---
+
+## File-by-File Changes
+
+### 1. `CMakeLists.txt` (root)
+
+**L24** -- New option default:
+```cmake
+set(ENGINE_DEFAULT_ENABLE_HIP OFF)
+```
+
+**L36-L38** -- Forward pre-existing GGML_HIP variable (allows `-DGGML_HIP=ON` to auto-enable):
+```cmake
+if (DEFINED GGML_HIP)
+    set(ENGINE_DEFAULT_ENABLE_HIP ${GGML_HIP})
+endif()
+```
+
+**L53** -- New CMake option:
+```cmake
+option(ENGINE_ENABLE_HIP "Build ggml with HIP/ROCm backend support" ${ENGINE_DEFAULT_ENABLE_HIP})
+```
+
+**L64** -- Guard CUDA language/Toolkit to CUDA-only builds:
+```cmake
+if (ENGINE_ENABLE_CUDA AND NOT ENGINE_ENABLE_HIP)
+    enable_language(CUDA)
+    find_package(CUDAToolkit REQUIRED)
+```
+
+**L81** -- Forward to vendored GGML:
+```cmake
+set(GGML_HIP ${ENGINE_ENABLE_HIP} CACHE BOOL "Build ggml with HIP backend support" FORCE)
+```
+
+**L497** -- Guard audio.cpp's own `.cu` files to CUDA-only builds:
+```cmake
+if (ENGINE_ENABLE_CUDA AND NOT ENGINE_ENABLE_HIP)
+    target_sources(engine_runtime PRIVATE
+        src/framework/audio/istft_cuda_runtime.cu
+        src/framework/sampling/torch_random_cuda_runtime.cu
+    )
+```
+
+> **Rationale:** `istft_cuda_runtime.cu` and `torch_random_cuda_runtime.cu` call CUDA APIs directly (`cuda_runtime.h`, `cufft.h`). They are optional GPU-accelerated paths with CPU fallbacks (gated by `ENGINE_HAS_CUDA_ISTFT` and `ENGINE_HAS_CUDA_TORCH_RANDOM`). Skipping them on HIP builds is safe and avoids adding a HIP port of these audio.cpp-specific routines.
+
+---
+
+### 2. `include/engine/framework/core/module.h`
+
+**L16** -- New enum value:
+```cpp
+enum class BackendType {
+    Cpu,
+    Cuda,
+    Hip,      // <-- added
+    Vulkan,
+    Metal,
+    BestAvailable,
+};
+```
+
+---
+
+### 3. `src/framework/core/backend.cpp`
+
+All HIP code paths reuse `#ifdef GGML_USE_CUDA` because `ggml-hip/CMakeLists.txt` defines `GGML_USE_CUDA` on the `ggml` target for static builds (line 92 of `external/ggml/src/ggml-hip/CMakeLists.txt`).
+
+**L107-L117** -- `init_backend()` Hip case:
+```cpp
+case BackendType::Hip: {
+#ifdef GGML_USE_CUDA
+    ggml_backend_t backend = ggml_backend_cuda_init(config.device);
+    // ...
+#endif
+}
+```
+
+**L183-L190** -- `backend_type()` CUDA/HIP distinction:
+```cpp
+if (is_cuda_backend_handle(backend)) {
+#ifdef GGML_USE_CUDA
+    if (backend_name_has_prefix(backend, "ROCm")) {
+        return BackendType::Hip;
+    }
+#endif
+    return BackendType::Cuda;
+}
+```
+
+`is_cuda_backend_handle()` compares device registration against `ggml_backend_cuda_reg()`, which returns the same registry for both CUDA and HIP. We disambiguate by checking the backend name prefix: HIP devices are named `"ROCm0"`, `"ROCm1"`, etc.
+
+**L217** -- `release_backend_graph_resources()` by backend handle:
+```cpp
+if (backend_name_has_prefix(backend, "CUDA") || backend_name_has_prefix(backend, "ROCm")) {
+```
+
+**L228** -- `release_backend_graph_resources()` by BackendType:
+```cpp
+if (backend_type == BackendType::Cuda || backend_type == BackendType::Hip) {
+```
+
+**L318** -- `query_backend_memory()` by BackendConfig:
+```cpp
+case BackendType::Cuda:
+case BackendType::Hip:       // <-- fall-through to CUDA path
+```
+
+---
+
+### 4. `app/cli/args.cpp`
+
+**L99-L101** -- CLI string to BackendType mapping:
+```cpp
+if (value == "hip") {
+    return engine::core::BackendType::Hip;
+}
+```
+
+### 5. `app/cli/main.cpp`
+
+**L48** -- Help text:
+```
+--backend cpu|cuda|hip|vulkan|metal|best
+```
+
+---
+
+### 6. `external/sentencepiece/src/CMakeLists.txt` (build compatibility fix)
+
+**L266** -- Disable `-fPIC` on Windows (clang Windows target does not support it):
+```cmake
+# Original:
+if (NOT MSVC)
+# Fixed:
+if (NOT MSVC AND NOT WIN32)
+```
+
+> This is not HIP-specific, but is required when compiling with clang (the HIP compiler) on Windows.
+
+---
+
+## Build Instructions
+
+### Linux (Recommended -- full rocBLAS support)
+
+Prerequisites:
+- ROCm 6.1+ installed (`/opt/rocm` or custom path)
+- hipBLAS, rocBLAS packages
+- Find your GPU target: `rocminfo | grep gfx | head -1 | awk '{print $2}'`
+  (e.g. `gfx1100` for RX 7900 XTX, `gfx1151` for Strix Halo iGPU)
+
+```bash
+# Configure
+cmake -S . -B build_hip \
+  -DENGINE_ENABLE_HIP=ON \
+  -DGPU_TARGETS=gfx1151 \
+  -DCMAKE_C_COMPILER="$(hipconfig -l)/clang" \
+  -DCMAKE_CXX_COMPILER="$(hipconfig -l)/clang++" \
+  -DCMAKE_BUILD_TYPE=Release
+
+# Build
+cmake --build build_hip -j$(nproc)
+
+# Run
+./build_hip/bin/audiocpp_server --config server.json
+./build_hip/bin/audiocpp_cli --task tts --family index_tts2 --model ./model --backend hip --device 0
+```
+
+Multiple GPU targets (for distribution):
+```bash
+-DGPU_TARGETS="gfx1030;gfx1100;gfx1101;gfx1102;gfx1150;gfx1151"
+```
+
+### Windows
+
+> **IMPORTANT:** ROCm on Windows only ships rocBLAS Tensile libraries for the GPU architectures listed below. If your AMD GPU is not in this list (notably: RDNA3 iGPU `gfx1103` / Radeon 780M is NOT supported), you will need to use the workaround build flags.
+>
+> Supported: `gfx1030`, `gfx1100`, `gfx1101`, `gfx1102`, `gfx1150`, `gfx1151`, `gfx1200`, `gfx1201`, `gfx906`
+
+**Standard build (supported GPU):**
+
+```cmd
+# Set ROCm environment
+set PATH=C:\Program Files\AMD\ROCm\6.4\bin;%PATH%
+set HIP_PATH=C:\Program Files\AMD\ROCm\6.4
+
+# Install ninja if not present:
+# Download from https://github.com/ninja-build/ninja/releases
+
+# Configure
+cmake -S . -B build_hip -G Ninja ^
+  -DCMAKE_MAKE_PROGRAM=<path-to-ninja.exe> ^
+  -DENGINE_ENABLE_HIP=ON ^
+  -DENGINE_ENABLE_OPENMP=OFF ^
+  -DGPU_TARGETS=gfx1100 ^
+  -DCMAKE_C_COMPILER="%HIP_PATH%\bin\clang.exe" ^
+  -DCMAKE_CXX_COMPILER="%HIP_PATH%\bin\clang++.exe" ^
+  -DCMAKE_BUILD_TYPE=Release
+
+# Build
+cmake --build build_hip
+```
+
+**Workaround build (unsupported GPU, e.g. 780M / gfx1103):**
+
+Add `-DGGML_CUDA_FORCE_MMQ=ON -DGGML_HIP_NO_VMM=ON` to the cmake command above. This bypasses hipBLAS/rocBLAS for matrix multiplication and uses GGML's own MMQ kernels instead. Performance will be lower for large matrix multiplications but functionally correct.
+
+Why: rocBLAS requires pre-compiled Tensile library files per GPU architecture. If none exist for your GPU, `hipblasCreate()` fails fatally. `GGML_CUDA_FORCE_MMQ` routes all matmul through GGML's custom dequant+matmul kernels, avoiding rocBLAS entirely.
+
+---
+
+## Architecture Support Matrix
+
+| GPU Target | Type | rocBLAS Tensile (Linux) | rocBLAS Tensile (Windows) | MMQ Workaround |
+|---|---|---|---|---|
+| gfx1100 | RDNA3 discrete (7900 XTX/XT) | Yes | Yes | Not needed |
+| gfx1101 | RDNA3 discrete (7900 GRE) | Yes | Yes | Not needed |
+| gfx1102 | RDNA3 discrete (7600 XT) | Yes | Yes | Not needed |
+| **gfx1103** | **RDNA3 iGPU (780M)** | Yes 1 | **No** | **Required on Windows** |
+| gfx1150 | RDNA3.5 iGPU (Strix Point) | Yes | Yes | Not needed |
+| gfx1151 | RDNA3.5 iGPU (Strix Halo) | Yes | Yes | Not needed |
+| gfx1200 | RDNA4 discrete | Yes | Yes | Not needed |
+| gfx1201 | RDNA4 discrete | Yes | Yes | Not needed |
+
+> 1 gfx1103 on Linux requires `HSA_OVERRIDE_GFX_VERSION=11.0.0`. This environment variable is [not supported on Windows](https://github.com/ROCm/ROCm/issues/2654).
+
+---
+
+## Known Limitations & Future Work
+
+### Model-level GPU optimizations not yet enabled for HIP
+
+The following locations check `BackendType::Cuda` specifically and will not apply their CUDA optimizations for HIP backends. They fall back to generic CPU-equivalent paths, which are functionally correct but may have lower performance.
+
+| File | Line | Optimization |
+|---|---|---|
+| `src/framework/sampling/torch_random.cpp` | 311 | TorchCUDA random sampling policy probe |
+| `src/framework/modules/conv_modules.cpp` | 254 | CUDA depthwise conv1d fast path |
+| `src/models/irodori_tts/rf_dit.cpp` | 141, 535 | CUDA-specific attention path |
+| `src/models/demucs/pipeline.cpp` | 474, 561 | CUDA-specific tensor pipeline |
+| `src/models/demucs/session.cpp` | 154 | CUDA-specific tensor storage |
+| `src/framework/modules/optimizations/fast_projection_modules.cpp` | 62 | CUDA projection acceleration |
+| `src/models/miocodec/audio_pipeline.cpp` | 294 | CUDA audio pipeline |
+| `src/models/index_tts2/gpt.cpp` | 83 | CUDA-required GPT module |
+| `src/models/vibevoice/session.cpp` | 164 | CUDA-specific max seconds |
+| `src/models/vibevoice_asr/session.cpp` | 543, 545 | CUDA-specific weight storage |
+| `src/models/vibevoice_asr/speech_encoder.cpp` | 54 | CUDA-specific speech encoder |
+
+**To enable:** Change `== BackendType::Cuda` to `== BackendType::Cuda || == BackendType::Hip` on a per-file basis after verifying each optimization works correctly on AMD hardware.
+
+### Switch statements missing `Hip` case (compiler warnings)
+
+These produce `-Wswitch` warnings but behave correctly (fall through to `default` or implicit return):
+
+| File | Line | Notes |
+|---|---|---|
+| `app/server/runtime.cpp` | 61 | `backend_name()` returns `"unknown"` for HIP |
+| `src/models/ace_step/planner.cpp` | 153 | Falls through; HIP treated same as CUDA/Cpu/Metal for this path |
+| `src/models/moss/moss_tts_local/session.cpp` | 157 | Falls through |
+
+### audio.cpp CUDA-specific `.cu` files
+
+- `src/framework/audio/istft_cuda_runtime.cu` -- uses `cufft`
+- `src/framework/sampling/torch_random_cuda_runtime.cu` -- uses CUDA Driver API
+
+These are skipped entirely on HIP builds. To enable GPU acceleration for ISTFT and TorchRandom on AMD GPUs, they would need to be ported (`cufft` -> `hipfft`, `cuInit`/`cuDeviceGet` -> `hipInit`/`hipDeviceGet`).
+
+---
+
+## Verification Checklist
+
+- [ ] Linux: `cmake -DENGINE_ENABLE_HIP=ON ...` configures without errors
+- [ ] Linux: `cmake --build build_hip` completes without errors
+- [ ] Linux: `--backend hip --device 0` initializes and detects AMD GPU
+- [ ] Windows: Same as above (standard GPU only)
+- [ ] Windows: `--backend hip` appears in `--help` output
+- [ ] `backend_type()` returns `BackendType::Hip` for ROCm-initialized backends
+- [ ] `query_backend_memory()` works for HIP
+- [ ] `release_backend_graph_resources()` works for HIP
+- [ ] Model inference runs on HIP without crashes
+- [ ] Model inference produces numerically correct results
+- [ ] Server JSON config accepts `"backend": "hip"`
+
+---
+
+## References
+
+- GGML HIP vendor header: `external/ggml/src/ggml-cuda/vendors/hip.h` (~300 lines, ~150 CUDA-to-HIP mappings)
+- GGML HIP backend CMake: `external/ggml/src/ggml-hip/CMakeLists.txt`
+- GGML backend registry: `external/ggml/src/ggml-backend-reg.cpp` (L116: HIP registers via `GGML_USE_CUDA`)
+- llama.cpp HIP build docs: `docs/build.md` (upstream GGML documentation)

--- a/docs/HIP.md
+++ b/docs/HIP.md
@@ -225,6 +225,14 @@ Multiple GPU targets (for distribution):
 
 ### Windows
 
+> **MSVC 14.51 (Visual Studio 2026) incompatibility:** ROCm's HIP clang headers conflict with the `cmath` shipped in MSVC 14.51 — every `.cu` compile fails with `__device__ function 'isless'/'isgreater' cannot overload __host__ __device__ function` in `__clang_cuda_math_forward_declares.h`. This affects at least ROCm 6.4 and 7.1 and can be intermittent (see [llama.cpp#22570](https://github.com/ggml-org/llama.cpp/issues/22570)). Until AMD ships a fix, configure and build from a prompt that selects an older MSVC toolset (14.44 or earlier):
+>
+> ```cmd
+> "C:\Program Files\Microsoft Visual Studio\18\Community\VC\Auxiliary\Build\vcvarsall.bat" x64 -vcvars_ver=14.44
+> ```
+>
+> Install an older v143 toolset via the VS Installer if it is missing, then run the build script or the manual cmake commands below from that same prompt — the HIP clang picks up the MSVC headers selected by vcvars. (Verified on ROCm 6.4 / gfx1103: `.cu` compilation succeeds under 14.44, fails under 14.51.)
+
 > **hipBLASLt GEMM (default):** HIP builds use hipBLASLt instead of hipBLAS (rocBLAS) for all cuBLAS-equivalent GEMM calls. hipBLASLt ships Tensile kernels for more GPU architectures than rocBLAS on Windows — notably **gfx1103 (Radeon 780M) works**, even though rocBLAS has no gfx1103 library. Disable with `-DGGML_HIP_HIPBLASLT=OFF` to fall back to hipBLAS.
 
 **Build script (recommended):**

--- a/docs/HIP.md
+++ b/docs/HIP.md
@@ -14,13 +14,14 @@ audio.cpp ENGINE_ENABLE_HIP=ON
     -> external/ggml/src/ggml-hip/CMakeLists.txt
       -> compiles ../ggml-cuda/*.cu with GGML_USE_HIP
       -> vendor header maps cudaMalloc->hipMalloc, cublasCreate->hipblasCreate, etc.
-      -> sets GGML_USE_CUDA on ggml target (same register path as native CUDA)
-        -> audio.cpp backend.cpp sees #ifdef GGML_USE_CUDA == true
-        -> ggml_backend_cuda_init() / ggml_backend_cuda_reg() work for HIP
-        -> device name "ROCm0" distinguishes HIP from "CUDA0"
+      -> the ggml CUDA backend registers itself under the name "ROCm" (GGML_CUDA_NAME under HIP)
+        -> audio.cpp backend.cpp maps registry name "ROCm" to BackendType::Hip
+        -> init_backend() uses the generic dynamic-loading path
+           (ggml_backend_load_all + init_device_backend), no #ifdef guards
+        -> registry name "ROCm" vs "CUDA"/"MUSA" distinguishes HIP from CUDA
 ```
 
-Key insight: HIP and CUDA share **the same GGML backend code**. The `ggml-hip/` directory contains only a `CMakeLists.txt` -- zero lines of unique kernel code. The runtime distinction is made via device name prefix (`"ROCm"` vs `"CUDA"`).
+Key insight: HIP and CUDA share **the same GGML backend code**. The `ggml-hip/` directory contains only a `CMakeLists.txt` -- zero lines of unique kernel code. The runtime distinction is made via the ggml backend **registry name** (`"ROCm"` vs `"CUDA"`), which is how backends are identified when they are loaded dynamically (`ggml_backend_load_all`).
 
 ---
 
@@ -28,36 +29,41 @@ Key insight: HIP and CUDA share **the same GGML backend code**. The `ggml-hip/` 
 
 ### 1. `CMakeLists.txt` (root)
 
-**L24** -- New option default:
+**L53** -- New option default:
 ```cmake
 set(ENGINE_DEFAULT_ENABLE_HIP OFF)
 ```
 
-**L36-L38** -- Forward pre-existing GGML_HIP variable (allows `-DGGML_HIP=ON` to auto-enable):
+**L65-L66** -- Forward pre-existing GGML_HIP variable (allows `-DGGML_HIP=ON` to auto-enable):
 ```cmake
 if (DEFINED GGML_HIP)
     set(ENGINE_DEFAULT_ENABLE_HIP ${GGML_HIP})
 endif()
 ```
 
-**L53** -- New CMake option:
+**L82** -- New CMake option:
 ```cmake
 option(ENGINE_ENABLE_HIP "Build ggml with HIP/ROCm backend support" ${ENGINE_DEFAULT_ENABLE_HIP})
 ```
 
-**L64** -- Guard CUDA language/Toolkit to CUDA-only builds:
+**L99** -- Guard CUDA language/Toolkit to CUDA-only builds:
 ```cmake
 if (ENGINE_ENABLE_CUDA AND NOT ENGINE_ENABLE_HIP)
     enable_language(CUDA)
     find_package(CUDAToolkit REQUIRED)
 ```
 
-**L81** -- Forward to vendored GGML:
+**L140** -- Forward to vendored GGML:
 ```cmake
 set(GGML_HIP ${ENGINE_ENABLE_HIP} CACHE BOOL "Build ggml with HIP backend support" FORCE)
 ```
 
-**L497** -- Guard audio.cpp's own `.cu` files to CUDA-only builds:
+**L147** -- Keep ggml's separate HIP graphs option in sync with the CUDA graphs toggle, so `ENGINE_ENABLE_CUDA_GRAPHS=OFF` also disables graphs on HIP builds:
+```cmake
+set(GGML_HIP_GRAPHS ${ENGINE_ENABLE_CUDA_GRAPHS} CACHE BOOL "Enable ggml HIP graphs support" FORCE)
+```
+
+**L648** -- Guard audio.cpp's own `.cu` files to CUDA-only builds:
 ```cmake
 if (ENGINE_ENABLE_CUDA AND NOT ENGINE_ENABLE_HIP)
     target_sources(engine_runtime PRIVATE
@@ -88,47 +94,46 @@ enum class BackendType {
 
 ### 3. `src/framework/core/backend.cpp`
 
-All HIP code paths reuse `#ifdef GGML_USE_CUDA` because `ggml-hip/CMakeLists.txt` defines `GGML_USE_CUDA` on the `ggml` target for static builds (line 92 of `external/ggml/src/ggml-hip/CMakeLists.txt`).
+HIP support is expressed through the dynamic backend-registry architecture shared with the other GPU backends: `ensure_backends_loaded()` calls `ggml_backend_load_all()`, and each backend is identified by the name of the ggml registry that owns it. There are no `#ifdef GGML_USE_CUDA` guards or direct `ggml_backend_cuda_*` calls in this file -- those headers resolve against the backend's own build flags, which are not visible from this translation unit.
 
-**L107-L117** -- `init_backend()` Hip case:
+**L34-L39** -- Registry name table. HIP builds share the ggml CUDA backend but register as `"ROCm"`, so they get their own entry (upstream maps `"ROCm"` to Cuda; here it is moved to the dedicated Hip type):
 ```cpp
-case BackendType::Hip: {
-#ifdef GGML_USE_CUDA
-    ggml_backend_t backend = ggml_backend_cuda_init(config.device);
+constexpr BackendRegNames k_backend_reg_names[] = {
+    {BackendType::Cuda,   {"CUDA", "MUSA", nullptr}},
+    {BackendType::Hip,    {"ROCm", nullptr, nullptr}},
     // ...
-#endif
+};
+```
+
+**L71-L73** -- `is_hip_backend_handle()` helper, matching the owning registry's name through the shared `backend_handle_matches()`:
+```cpp
+bool is_hip_backend_handle(ggml_backend_t backend) {
+    return backend_handle_matches(backend, BackendType::Hip);
 }
 ```
 
-**L183-L190** -- `backend_type()` CUDA/HIP distinction:
+**L203-L204** -- `init_backend()` Hip case, using the generic device init path:
 ```cpp
-if (is_cuda_backend_handle(backend)) {
-#ifdef GGML_USE_CUDA
-    if (backend_name_has_prefix(backend, "ROCm")) {
-        return BackendType::Hip;
-    }
-#endif
-    return BackendType::Cuda;
+case BackendType::Hip:
+    return init_device_backend(BackendType::Hip, "HIP", config);
+```
+
+**L251-L253** -- `backend_type()` HIP/CUDA distinction (HIP is checked first, since both match the ggml CUDA backend family):
+```cpp
+if (is_hip_backend_handle(backend)) {
+    return BackendType::Hip;
 }
 ```
 
-`is_cuda_backend_handle()` compares device registration against `ggml_backend_cuda_reg()`, which returns the same registry for both CUDA and HIP. We disambiguate by checking the backend name prefix: HIP devices are named `"ROCm0"`, `"ROCm1"`, etc.
-
-**L217** -- `release_backend_graph_resources()` by backend handle:
+**L290, L294** -- `release_backend_graph_resources()` includes HIP in both overloads:
 ```cpp
-if (backend_name_has_prefix(backend, "CUDA") || backend_name_has_prefix(backend, "ROCm")) {
+if (is_cuda_backend_handle(backend) || is_hip_backend_handle(backend)) cuda_clear_graph(backend, graph);
+// and
+if (backend_type == BackendType::Cuda || backend_type == BackendType::Hip) cuda_clear_graph(backend, graph);
 ```
+`cuda_clear_graph()` resolves `ggml_backend_cuda_clear_graph` by proc-address lookup, which works on HIP builds because HIP shares the ggml CUDA backend and is compatible with `GGML_BACKEND_DL`.
 
-**L228** -- `release_backend_graph_resources()` by BackendType:
-```cpp
-if (backend_type == BackendType::Cuda || backend_type == BackendType::Hip) {
-```
-
-**L318** -- `query_backend_memory()` by BackendConfig:
-```cpp
-case BackendType::Cuda:
-case BackendType::Hip:       // <-- fall-through to CUDA path
-```
+**`query_backend_memory()`** -- no Hip-specific case needed: GPU backend types fall through the `switch` to the generic `find_device_by_backend_type()` path, which covers HIP automatically.
 
 ---
 
@@ -150,20 +155,7 @@ Help text:
 
 ---
 
-### 6. `external/sentencepiece/src/CMakeLists.txt` (build compatibility fix)
-**L266** -- Disable `-fPIC` on Windows (clang Windows target does not support it):
-```cmake
-# Original:
-if (NOT MSVC)
-# Fixed:
-if (NOT MSVC AND NOT WIN32)
-```
-
-> This is not HIP-specific, but is required when compiling with clang (the HIP compiler) on Windows.
-
----
-
-### 7. `external/ggml` -- hipBLASLt GEMM path
+### 6. `external/ggml` -- hipBLASLt GEMM path
 
 rocBLAS does not ship Tensile kernels for every AMD GPU arch (e.g. gfx1103 on Windows), while hipBLASLt covers more arches. HIP builds therefore route every cuBLAS-equivalent GEMM through hipBLASLt by default.
 
@@ -178,7 +170,7 @@ rocBLAS does not ship Tensile kernels for every AMD GPU arch (e.g. gfx1103 on Wi
 
 All Lt GEMMs use `HIPBLAS_COMPUTE_32F` with FP32 scale for accuracy. The algorithm heuristic is queried per call -- caching heuristics per shape is future work.
 
-### 8. `scripts/build_windows_hip.ps1`
+### 7. `scripts/build_windows_hip.ps1`
 
 Dedicated Windows HIP build script. Auto-detects ROCm (`HIP_PATH` or `C:\Program Files\AMD\ROCm\*`), GPU targets (`amdgpu-arch`), cmake, and ninja (PATH or the VS-bundled copy), then configures and builds with `ENGINE_ENABLE_HIP=ON`. See the Windows build section below for options.
 

--- a/docs/HIP.md
+++ b/docs/HIP.md
@@ -46,24 +46,31 @@ endif()
 option(ENGINE_ENABLE_HIP "Build ggml with HIP/ROCm backend support" ${ENGINE_DEFAULT_ENABLE_HIP})
 ```
 
-**L99** -- Guard CUDA language/Toolkit to CUDA-only builds:
+**L100-L106** -- Reject configurations that enable both CUDA and HIP. HIP compiles ggml's CUDA backend sources as HIP code, so both options drive the same ggml backend and cannot coexist in one configure:
+```cmake
+if (ENGINE_ENABLE_CUDA AND ENGINE_ENABLE_HIP)
+    message(FATAL_ERROR ...)
+endif()
+```
+
+**L108** -- Guard CUDA language/Toolkit to CUDA-only builds:
 ```cmake
 if (ENGINE_ENABLE_CUDA AND NOT ENGINE_ENABLE_HIP)
     enable_language(CUDA)
     find_package(CUDAToolkit REQUIRED)
 ```
 
-**L140** -- Forward to vendored GGML:
+**L149** -- Forward to vendored GGML:
 ```cmake
 set(GGML_HIP ${ENGINE_ENABLE_HIP} CACHE BOOL "Build ggml with HIP backend support" FORCE)
 ```
 
-**L147** -- Keep ggml's separate HIP graphs option in sync with the CUDA graphs toggle, so `ENGINE_ENABLE_CUDA_GRAPHS=OFF` also disables graphs on HIP builds:
+**L156** -- Keep ggml's separate HIP graphs option in sync with the CUDA graphs toggle, so `ENGINE_ENABLE_CUDA_GRAPHS=OFF` also disables graphs on HIP builds:
 ```cmake
 set(GGML_HIP_GRAPHS ${ENGINE_ENABLE_CUDA_GRAPHS} CACHE BOOL "Enable ggml HIP graphs support" FORCE)
 ```
 
-**L648** -- Guard audio.cpp's own `.cu` files to CUDA-only builds:
+**L657** -- Guard audio.cpp's own `.cu` files to CUDA-only builds:
 ```cmake
 if (ENGINE_ENABLE_CUDA AND NOT ENGINE_ENABLE_HIP)
     target_sources(engine_runtime PRIVATE

--- a/external/ggml/src/ggml-cuda/common.cuh
+++ b/external/ggml/src/ggml-cuda/common.cuh
@@ -31,6 +31,9 @@
 
 #if defined(GGML_USE_HIP)
 #include "vendors/hip.h"
+#if defined(GGML_HIP_USE_HIPBLASLT)
+#include <hipblaslt/hipblaslt.h>
+#endif // defined(GGML_HIP_USE_HIPBLASLT)
 #elif defined(GGML_USE_MUSA)
 #include "vendors/musa.h"
 #else
@@ -187,6 +190,15 @@ void ggml_cuda_error(const char * stmt, const char * func, const char * file, in
 #endif // CUDART_VERSION >= 12000
 
 #define CUBLAS_CHECK(err) CUDA_CHECK_GEN(err, CUBLAS_STATUS_SUCCESS, cublas_get_error_str)
+
+#if defined(GGML_USE_HIP) && defined(GGML_HIP_USE_HIPBLASLT)
+    static const char * hipblaslt_get_error_str(const hipblasStatus_t err) {
+        return hipblasStatusToString(err);
+    }
+#define HIPBLASLT_CHECK(err) CUDA_CHECK_GEN(err, HIPBLAS_STATUS_SUCCESS, hipblaslt_get_error_str)
+
+#define HIPBLASLT_WORKSPACE_SIZE ((size_t) 32 * 1024 * 1024)
+#endif // defined(GGML_USE_HIP) && defined(GGML_HIP_USE_HIPBLASLT)
 
 #ifdef GGML_USE_NCCL
 #define NCCL_CHECK(err) CUDA_CHECK_GEN(err, ncclSuccess, ncclGetErrorString)
@@ -1457,6 +1469,32 @@ struct ggml_backend_cuda_context {
     cublasHandle_t cublas_handle() {
         return cublas_handle(device);
     }
+
+#if defined(GGML_USE_HIP) && defined(GGML_HIP_USE_HIPBLASLT)
+    hipblasLtHandle_t hipblaslt_handles[GGML_CUDA_MAX_DEVICES] = {nullptr};
+    void * hipblaslt_workspaces[GGML_CUDA_MAX_DEVICES] = {nullptr};
+
+    hipblasLtHandle_t hipblaslt_handle(int device) {
+        if (hipblaslt_handles[device] == nullptr) {
+            ggml_cuda_set_device(device);
+            HIPBLASLT_CHECK(hipblasLtCreate(&hipblaslt_handles[device]));
+        }
+        return hipblaslt_handles[device];
+    }
+
+    hipblasLtHandle_t hipblaslt_handle() {
+        return hipblaslt_handle(device);
+    }
+
+    // hipBLASLt requires a user-provided workspace; allocate it once per device
+    void * hipblaslt_workspace(int device) {
+        if (hipblaslt_workspaces[device] == nullptr) {
+            ggml_cuda_set_device(device);
+            CUDA_CHECK(cudaMalloc(&hipblaslt_workspaces[device], HIPBLASLT_WORKSPACE_SIZE));
+        }
+        return hipblaslt_workspaces[device];
+    }
+#endif // defined(GGML_USE_HIP) && defined(GGML_HIP_USE_HIPBLASLT)
 
     // pool
     std::unique_ptr<ggml_cuda_pool> pools[GGML_CUDA_MAX_DEVICES][GGML_CUDA_MAX_STREAMS];

--- a/external/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/external/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -616,6 +616,14 @@ ggml_backend_cuda_context::~ggml_backend_cuda_context() {
         if (cublas_handles[i] != nullptr) {
             CUBLAS_CHECK(cublasDestroy(cublas_handles[i]));
         }
+#if defined(GGML_USE_HIP) && defined(GGML_HIP_USE_HIPBLASLT)
+        if (hipblaslt_handles[i] != nullptr) {
+            HIPBLASLT_CHECK(hipblasLtDestroy(hipblaslt_handles[i]));
+        }
+        if (hipblaslt_workspaces[i] != nullptr) {
+            CUDA_CHECK(cudaFree(hipblaslt_workspaces[i]));
+        }
+#endif // defined(GGML_USE_HIP) && defined(GGML_HIP_USE_HIPBLASLT)
     }
 }
 
@@ -1622,6 +1630,88 @@ static const cublas_force_compute_type & ggml_cuda_cublas_get_force_compute_type
     return compute_type;
 }
 
+#if defined(GGML_USE_HIP) && defined(GGML_HIP_USE_HIPBLASLT)
+// hipBLASLt equivalent of the cublasGemm* calls used below.
+// rocBLAS does not ship Tensile kernels for every AMD GPU arch (e.g. gfx1103 on Windows),
+// while hipBLASLt covers them, so HIP builds route GEMM through hipBLASLt when available.
+// Computes C = op(A) * op(B) with op(A) = A^T, op(B) = B (column-major, same as the cublas calls).
+// hipBLASLt only accepts hipDataType. ROCm < 6.5 routes cudaDataType_t to the legacy
+// hipblasDatatype_t enum (150/151/168), while ROCm >= 6.5 uses hipDataType (0/2/14) directly.
+// Accept the raw integer value and map both numbering schemes, so this compiles on all ROCm versions.
+static hipDataType ggml_hipblaslt_convert_type(int type) {
+    switch (type) {
+        case 150: return HIP_R_16F;  // legacy HIPBLAS_R_16F
+        case 151: return HIP_R_32F;  // legacy HIPBLAS_R_32F
+        case 168: return HIP_R_16BF; // legacy HIPBLAS_R_16B
+        default:
+            GGML_ASSERT(type == HIP_R_16F || type == HIP_R_32F || type == HIP_R_16BF);
+            return (hipDataType) type;
+    }
+}
+
+static void ggml_hipblaslt_gemm(
+    ggml_backend_cuda_context & ctx, cudaStream_t stream,
+    int64_t m, int64_t n, int64_t k,
+    const void * A, int type_a, int64_t lda, int64_t stride_a,
+    const void * B, int type_b, int64_t ldb, int64_t stride_b,
+    void *       C, int type_c, int64_t ldc, int64_t stride_c,
+    int64_t batch_count) {
+
+    const hipblasOperation_t trans_a = HIPBLAS_OP_T;
+    const hipblasOperation_t trans_b = HIPBLAS_OP_N;
+
+    const float alpha = 1.0f;
+    const float beta  = 0.0f;
+
+    hipblasLtHandle_t lt       = ctx.hipblaslt_handle();
+    void *            workspace = ctx.hipblaslt_workspace(ctx.device);
+
+    hipblasLtMatmulDesc_t    matmul_desc;
+    hipblasLtMatrixLayout_t  layout_a, layout_b, layout_c;
+    hipblasLtMatmulPreference_t pref;
+
+    HIPBLASLT_CHECK(hipblasLtMatmulDescCreate(&matmul_desc, HIPBLAS_COMPUTE_32F, HIP_R_32F));
+    HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(matmul_desc, HIPBLASLT_MATMUL_DESC_TRANSA, &trans_a, sizeof(trans_a)));
+    HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(matmul_desc, HIPBLASLT_MATMUL_DESC_TRANSB, &trans_b, sizeof(trans_b)));
+
+    // layout dims describe the stored (pre-op) matrix: A is stored [k, m], B is stored [k, n], C is [m, n]
+    HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&layout_a, ggml_hipblaslt_convert_type(type_a), k, m, lda));
+    HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&layout_b, ggml_hipblaslt_convert_type(type_b), k, n, ldb));
+    HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&layout_c, ggml_hipblaslt_convert_type(type_c), m, n, ldc));
+
+    if (batch_count > 1) {
+        int batch_count_i32 = (int) batch_count;
+        HIPBLASLT_CHECK(hipblasLtMatrixLayoutSetAttribute(layout_a, HIPBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &batch_count_i32, sizeof(batch_count_i32)));
+        HIPBLASLT_CHECK(hipblasLtMatrixLayoutSetAttribute(layout_a, HIPBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &stride_a, sizeof(stride_a)));
+        HIPBLASLT_CHECK(hipblasLtMatrixLayoutSetAttribute(layout_b, HIPBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &batch_count_i32, sizeof(batch_count_i32)));
+        HIPBLASLT_CHECK(hipblasLtMatrixLayoutSetAttribute(layout_b, HIPBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &stride_b, sizeof(stride_b)));
+        HIPBLASLT_CHECK(hipblasLtMatrixLayoutSetAttribute(layout_c, HIPBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &batch_count_i32, sizeof(batch_count_i32)));
+        HIPBLASLT_CHECK(hipblasLtMatrixLayoutSetAttribute(layout_c, HIPBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &stride_c, sizeof(stride_c)));
+    }
+
+    HIPBLASLT_CHECK(hipblasLtMatmulPreferenceCreate(&pref));
+    size_t max_workspace = HIPBLASLT_WORKSPACE_SIZE;
+    HIPBLASLT_CHECK(hipblasLtMatmulPreferenceSetAttribute(pref, HIPBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES, &max_workspace, sizeof(max_workspace)));
+
+    hipblasLtMatmulHeuristicResult_t heuristic;
+    int algo_count = 0;
+    HIPBLASLT_CHECK(hipblasLtMatmulAlgoGetHeuristic(lt, matmul_desc, layout_a, layout_b, layout_c, layout_c,
+                                                    pref, 1, &heuristic, &algo_count));
+    GGML_ASSERT(algo_count > 0);
+
+    HIPBLASLT_CHECK(hipblasLtMatmul(lt, matmul_desc,
+                                    &alpha, A, layout_a, B, layout_b,
+                                    &beta,  C, layout_c, C, layout_c,
+                                    &heuristic.algo, workspace, max_workspace, stream));
+
+    HIPBLASLT_CHECK(hipblasLtMatmulPreferenceDestroy(pref));
+    HIPBLASLT_CHECK(hipblasLtMatrixLayoutDestroy(layout_a));
+    HIPBLASLT_CHECK(hipblasLtMatrixLayoutDestroy(layout_b));
+    HIPBLASLT_CHECK(hipblasLtMatrixLayoutDestroy(layout_c));
+    HIPBLASLT_CHECK(hipblasLtMatmulDescDestroy(matmul_desc));
+}
+#endif // defined(GGML_USE_HIP) && defined(GGML_HIP_USE_HIPBLASLT)
+
 static void ggml_cuda_op_mul_mat_cublas(
     ggml_backend_cuda_context & ctx,
     const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst, const char * src0_dd_i, const float * src1_ddf_i,
@@ -1673,6 +1763,15 @@ static void ggml_cuda_op_mul_mat_cublas(
         const float alpha_f32 = 1.0f;
         const float beta_f32  = 0.0f;
 
+#if defined(GGML_USE_HIP) && defined(GGML_HIP_USE_HIPBLASLT)
+        ggml_hipblaslt_gemm(ctx, stream,
+                row_diff, src1_ncols, ne10,
+                src0_ptr,       CUDA_R_16BF, ne00, 0,
+                src1_ptr,       CUDA_R_16BF, ne10, 0,
+                dst_bf16.get(), CUDA_R_16BF, ldc,  0,
+                1);
+        GGML_UNUSED_VARS(alpha_f32, beta_f32);
+#else
         CUBLAS_CHECK(cublasSetStream(ctx.cublas_handle(id), stream));
         CUBLAS_CHECK(
             cublasGemmEx(ctx.cublas_handle(id), CUBLAS_OP_T, CUBLAS_OP_N,
@@ -1682,6 +1781,7 @@ static void ggml_cuda_op_mul_mat_cublas(
                     &beta_f32,   dst_bf16.get(), CUDA_R_16BF, ldc,
                     CUBLAS_COMPUTE_32F,
                     CUBLAS_GEMM_DEFAULT_TENSOR_OP));
+#endif // defined(GGML_USE_HIP) && defined(GGML_HIP_USE_HIPBLASLT)
 
         const to_fp32_cuda_t to_fp32_cuda = ggml_get_to_fp32_cuda(GGML_TYPE_BF16);
         to_fp32_cuda(dst_bf16.get(), dst_dd_i, row_diff*src1_ncols, stream);
@@ -1718,6 +1818,15 @@ static void ggml_cuda_op_mul_mat_cublas(
         {
             const float alpha = 1.0f;
             const float beta = 0.0f;
+#if defined(GGML_USE_HIP) && defined(GGML_HIP_USE_HIPBLASLT)
+            GGML_UNUSED_VARS(alpha, beta);
+            ggml_hipblaslt_gemm(ctx, stream,
+                    row_diff, src1_ncols, ne10,
+                    src0_ptr, CUDA_R_16F, ne00, 0,
+                    src1_ptr, CUDA_R_16F, ne10, 0,
+                    dst_dd_i, CUDA_R_32F, ldc,  0,
+                    1);
+#else
             CUBLAS_CHECK(
                 cublasGemmEx(ctx.cublas_handle(id), CUBLAS_OP_T, CUBLAS_OP_N,
                         row_diff, src1_ncols, ne10,
@@ -1726,12 +1835,22 @@ static void ggml_cuda_op_mul_mat_cublas(
                         &beta,   dst_dd_i, CUDA_R_32F, ldc,
                         CUBLAS_COMPUTE_32F,
                         CUBLAS_GEMM_DEFAULT_TENSOR_OP));
+#endif // defined(GGML_USE_HIP) && defined(GGML_HIP_USE_HIPBLASLT)
         } else {
             ggml_cuda_pool_alloc<half> dst_f16(ctx.pool(id), row_diff*src1_ncols);
 
             const half alpha_f16 = 1.0f;
             const half beta_f16 = 0.0f;
 
+#if defined(GGML_USE_HIP) && defined(GGML_HIP_USE_HIPBLASLT)
+            GGML_UNUSED_VARS(alpha_f16, beta_f16);
+            ggml_hipblaslt_gemm(ctx, stream,
+                    row_diff, src1_ncols, ne10,
+                    src0_ptr,      CUDA_R_16F, ne00, 0,
+                    src1_ptr,      CUDA_R_16F, ne10, 0,
+                    dst_f16.get(), CUDA_R_16F, ldc,  0,
+                    1);
+#else
             CUBLAS_CHECK(
                 cublasGemmEx(ctx.cublas_handle(id), CUBLAS_OP_T, CUBLAS_OP_N,
                         row_diff, src1_ncols, ne10,
@@ -1740,6 +1859,7 @@ static void ggml_cuda_op_mul_mat_cublas(
                         &beta_f16,  dst_f16.get(), CUDA_R_16F, ldc,
                         CUBLAS_COMPUTE_16F,
                         CUBLAS_GEMM_DEFAULT_TENSOR_OP));
+#endif // defined(GGML_USE_HIP) && defined(GGML_HIP_USE_HIPBLASLT)
 
             const to_fp32_cuda_t to_fp32_cuda = ggml_get_to_fp32_cuda(GGML_TYPE_F16);
             to_fp32_cuda(dst_f16.get(), dst_dd_i, row_diff*src1_ncols, stream);
@@ -1767,6 +1887,15 @@ static void ggml_cuda_op_mul_mat_cublas(
         const float alpha = 1.0f;
         const float beta = 0.0f;
 
+#if defined(GGML_USE_HIP) && defined(GGML_HIP_USE_HIPBLASLT)
+        GGML_UNUSED_VARS(alpha, beta);
+        ggml_hipblaslt_gemm(ctx, stream,
+                row_diff, src1_ncols, ne10,
+                src0_ddf_i,  CUDA_R_32F, ne00, 0,
+                src1_ddf1_i, CUDA_R_32F, ne10, 0,
+                dst_dd_i,    CUDA_R_32F, ldc,  0,
+                1);
+#else
         CUBLAS_CHECK(cublasSetStream(ctx.cublas_handle(id), stream));
         CUBLAS_CHECK(
             cublasSgemm(ctx.cublas_handle(id), CUBLAS_OP_T, CUBLAS_OP_N,
@@ -1774,6 +1903,7 @@ static void ggml_cuda_op_mul_mat_cublas(
                     &alpha, src0_ddf_i,  ne00,
                             src1_ddf1_i, ne10,
                     &beta,  dst_dd_i,    ldc));
+#endif // defined(GGML_USE_HIP) && defined(GGML_HIP_USE_HIPBLASLT)
     }
 
     GGML_UNUSED_VARS(dst, src1_ddq_i, src1_padded_row_size);
@@ -2251,6 +2381,9 @@ static void ggml_cuda_mul_mat_batched_cublas_impl(ggml_backend_cuda_context & ct
     size_t nbd3 = dst->nb[3];
 
     cublasComputeType_t cu_compute_type = traits::compute_type;
+#if defined(GGML_USE_HIP) && defined(GGML_HIP_USE_HIPBLASLT)
+    GGML_UNUSED(cu_compute_type); // only referenced by the cublas fallback paths
+#endif // defined(GGML_USE_HIP) && defined(GGML_HIP_USE_HIPBLASLT)
     cudaDataType_t cu_data_type = traits::data_type;
     cudaDataType_t cu_data_type_a = traits::data_type;
     cudaDataType_t cu_data_type_b = traits::data_type;
@@ -2302,6 +2435,15 @@ static void ggml_cuda_mul_mat_batched_cublas_impl(ggml_backend_cuda_context & ct
 
         // there is no broadcast and src0, src1 are contiguous across dims 2, 3
         // use cublasGemmStridedBatchedEx
+#if defined(GGML_USE_HIP) && defined(GGML_HIP_USE_HIPBLASLT)
+        GGML_UNUSED_VARS(alpha, beta);
+        ggml_hipblaslt_gemm(ctx, main_stream,
+                ne01, ne11, ne10,
+                src0_ptr, cu_data_type_a, nb01/nb00, sma,
+                src1_ptr, cu_data_type_b, s11,       smb,
+                dst_t,    cu_data_type,   ne0,       ne1*ne0,
+                ne12*ne13);
+#else
         CUBLAS_CHECK(
         cublasGemmStridedBatchedEx(ctx.cublas_handle(), CUBLAS_OP_T, CUBLAS_OP_N,
                 ne01, ne11, ne10,
@@ -2311,7 +2453,27 @@ static void ggml_cuda_mul_mat_batched_cublas_impl(ggml_backend_cuda_context & ct
                 ne12*ne13,
                 cu_compute_type,
                 CUBLAS_GEMM_DEFAULT_TENSOR_OP));
+#endif // defined(GGML_USE_HIP) && defined(GGML_HIP_USE_HIPBLASLT)
     } else {
+#if defined(GGML_USE_HIP) && defined(GGML_HIP_USE_HIPBLASLT)
+        // hipBLASLt has no pointer-array batched GEMM; issue one GEMM per batch element instead.
+        GGML_UNUSED_VARS(alpha, beta);
+        const size_t src1_nb2 = (src1->type == src0_type) ? nb12 : s12*sizeof(cuda_t);
+        const size_t src1_nb3 = (src1->type == src0_type) ? nb13 : s13*sizeof(cuda_t);
+        for (int64_t i13 = 0; i13 < ne13; i13++) {
+            for (int64_t i12 = 0; i12 < ne12; i12++) {
+                const char * ptr_a = (const char *) src0_ptr + (i12/r2)*nb02 + (i13/r3)*nb03;
+                const char * ptr_b = (const char *) src1_ptr + i12*src1_nb2 + i13*src1_nb3;
+                char *       ptr_c = (      char *) dst_t    + i12*nbd2    + i13*nbd3;
+                ggml_hipblaslt_gemm(ctx, main_stream,
+                        ne01, ne11, ne10,
+                        ptr_a, cu_data_type_a, nb01/nb00, 0,
+                        ptr_b, cu_data_type_b, s11,       0,
+                        ptr_c, cu_data_type,   ne0,       0,
+                        1);
+            }
+        }
+#else
         // use cublasGemmBatchedEx
         const int64_t ne23 = ne12*ne13;
 
@@ -2350,6 +2512,7 @@ static void ggml_cuda_mul_mat_batched_cublas_impl(ggml_backend_cuda_context & ct
                 ne23,
                 cu_compute_type,
                 CUBLAS_GEMM_DEFAULT_TENSOR_OP));
+#endif // defined(GGML_USE_HIP) && defined(GGML_HIP_USE_HIPBLASLT)
     }
 
     // Convert output back to F32 if needed

--- a/external/ggml/src/ggml-hip/CMakeLists.txt
+++ b/external/ggml/src/ggml-hip/CMakeLists.txt
@@ -47,6 +47,18 @@ find_package(hip     REQUIRED)
 find_package(hipblas REQUIRED)
 find_package(rocblas REQUIRED)
 
+option(GGML_HIP_HIPBLASLT "ggml: use hipBLASLt instead of hipBLAS (rocBLAS) for GEMM" ON)
+
+if (GGML_HIP_HIPBLASLT)
+    find_package(hipblaslt)
+    if (hipblaslt_FOUND)
+        set(GGML_HIP_USE_HIPBLASLT ON)
+        message(STATUS "HIP: using hipBLASLt for GEMM")
+    else()
+        message(WARNING "GGML_HIP_HIPBLASLT is ON but hipblaslt was not found; falling back to hipBLAS (rocBLAS)")
+    endif()
+endif()
+
 if (GGML_HIP_RCCL)
     find_package(rccl REQUIRED)
 endif()
@@ -114,6 +126,10 @@ if (GGML_HIP_NO_VMM)
     add_compile_definitions(GGML_HIP_NO_VMM)
 endif()
 
+if (GGML_HIP_USE_HIPBLASLT)
+    add_compile_definitions(GGML_HIP_USE_HIPBLASLT)
+endif()
+
 if (GGML_HIP_ROCWMMA_FATTN)
     add_compile_definitions(GGML_HIP_ROCWMMA_FATTN)
 endif()
@@ -155,3 +171,7 @@ if (GGML_HIP_RCCL)
 endif()
 
 target_link_libraries(ggml-hip PRIVATE ggml-base hip::host roc::rocblas roc::hipblas)
+
+if (GGML_HIP_USE_HIPBLASLT)
+    target_link_libraries(ggml-hip PRIVATE roc::hipblaslt)
+endif()

--- a/external/ggml/src/ggml-hip/CMakeLists.txt
+++ b/external/ggml/src/ggml-hip/CMakeLists.txt
@@ -34,10 +34,10 @@ if (CXX_IS_HIPCC)
 else()
     # Forward (AMD)GPU_TARGETS to CMAKE_HIP_ARCHITECTURES.
     if(AMDGPU_TARGETS AND NOT GPU_TARGETS)
-        set(GPU_TARGETS ${AMDGPU_TARGETS})
+        set(GPU_TARGETS "${AMDGPU_TARGETS}" CACHE STRING "GPU targets to compile for")
     endif()
     if(GPU_TARGETS AND NOT CMAKE_HIP_ARCHITECTURES)
-        set(CMAKE_HIP_ARCHITECTURES ${GPU_TARGETS})
+        set(CMAKE_HIP_ARCHITECTURES "${GPU_TARGETS}" CACHE STRING "HIP architectures")
     endif()
     cmake_minimum_required(VERSION 3.21)
     enable_language(HIP)
@@ -92,6 +92,12 @@ else()
         ../ggml-cuda/template-instances/fattn-vec-instance-q4_0-q4_0.cu
         ../ggml-cuda/template-instances/fattn-vec-instance-q8_0-q8_0.cu
         ../ggml-cuda/template-instances/fattn-vec-instance-bf16-bf16.cu)
+endif()
+
+if (CXX_IS_HIPCC)
+    set_source_files_properties(${GGML_SOURCES_ROCM} PROPERTIES LANGUAGE CXX)
+else()
+    set_source_files_properties(${GGML_SOURCES_ROCM} PROPERTIES LANGUAGE HIP)
 endif()
 
 ggml_add_backend_library(ggml-hip
@@ -151,15 +157,22 @@ if (NOT GGML_CUDA_FA)
 endif()
 
 if (CXX_IS_HIPCC)
-    set_source_files_properties(${GGML_SOURCES_ROCM} PROPERTIES LANGUAGE CXX)
     if (WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
         # CMake on Windows doesn't support the HIP language yet.
         # Therefore we workaround debug build's failure on HIP backend this way.
         set_source_files_properties(${GGML_SOURCES_ROCM} PROPERTIES COMPILE_FLAGS "-O2 -g")
     endif()
     target_link_libraries(ggml-hip PRIVATE hip::device)
+    # Workaround for https://github.com/ROCm/ROCm/issues/5826
+    # The AMDGPU backend can emit illegal DPP instructions for GFX10+ at -O0.
+    target_compile_options(ggml-hip PRIVATE -O2)
 else()
-    set_source_files_properties(${GGML_SOURCES_ROCM} PROPERTIES LANGUAGE HIP)
+    if (CMAKE_HIP_COMPILER MATCHES "clang" OR CMAKE_HIP_COMPILER_ID MATCHES "Clang")
+        target_compile_options(ggml-hip PRIVATE $<$<COMPILE_LANGUAGE:HIP>:-xhip>)
+        # Workaround for https://github.com/ROCm/ROCm/issues/5826
+        # The AMDGPU backend can emit illegal DPP instructions for GFX10+ at -O0.
+        target_compile_options(ggml-hip PRIVATE $<$<COMPILE_LANGUAGE:HIP>:-O2>)
+    endif()
 endif()
 
 if (GGML_STATIC)

--- a/include/engine/framework/core/module.h
+++ b/include/engine/framework/core/module.h
@@ -13,6 +13,7 @@ namespace engine::core {
 enum class BackendType {
     Cpu,
     Cuda,
+    Hip,
     Vulkan,
     Metal,
     BestAvailable,

--- a/scripts/build_windows_hip.ps1
+++ b/scripts/build_windows_hip.ps1
@@ -1,0 +1,155 @@
+[CmdletBinding()]
+param(
+    [string]$RocmPath = "",
+    [string]$GpuTargets = "",
+    [string]$BuildType = "Release",
+    [string]$Target = "",
+    [int]$Jobs = 0,
+    [switch]$ConfigureOnly,
+    [switch]$Clean,
+    [switch]$NoHipblasLt,    # fall back to hipBLAS (rocBLAS) GEMM
+    [switch]$ForceMmq,       # route quantized matmul through GGML MMQ kernels instead of BLAS
+    [switch]$NoVmm = $true,  # disable HIP virtual memory management (required on Windows iGPUs)
+    [switch]$WithVmm,        # explicitly re-enable VMM
+    [switch]$Graphs          # enable CUDA graphs (memory-hungry on iGPUs: each cached graph reserves its own VRAM)
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Invoke-Checked {
+    param(
+        [Parameter(Mandatory = $true)][string]$FilePath,
+        [Parameter()][string[]]$Arguments = @()
+    )
+    Write-Host "> $FilePath $($Arguments -join ' ')"
+    & $FilePath @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "Command failed with exit code $LASTEXITCODE`: $FilePath $($Arguments -join ' ')"
+    }
+}
+
+function Convert-ToCMakePath {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    return ($Path -replace "\\", "/")
+}
+
+function Find-FirstFile {
+    param([Parameter(Mandatory = $true)][string[]]$Patterns)
+    foreach ($pattern in $Patterns) {
+        $found = Get-ChildItem -Path $pattern -ErrorAction SilentlyContinue | Sort-Object FullName -Descending | Select-Object -First 1
+        if ($null -ne $found) {
+            return $found.FullName
+        }
+    }
+    return ""
+}
+
+# --- ROCm ---
+if ($RocmPath -eq "") {
+    if ($env:HIP_PATH -and (Test-Path (Join-Path $env:HIP_PATH "bin\clang++.exe"))) {
+        $RocmPath = (Resolve-Path $env:HIP_PATH).Path
+    } else {
+        $clang = Find-FirstFile @("C:\Program Files\AMD\ROCm\*\bin\clang++.exe")
+        if ($clang -eq "") {
+            throw "ROCm was not found. Install the AMD HIP SDK or pass -RocmPath."
+        }
+        $RocmPath = (Resolve-Path (Join-Path (Split-Path $clang -Parent) "..")).Path
+    }
+}
+$clangxx = Join-Path $RocmPath "bin\clang++.exe"
+$clangc  = Join-Path $RocmPath "bin\clang.exe"
+if (-not (Test-Path $clangxx) -or -not (Test-Path $clangc)) {
+    throw "ROCm clang not found under $RocmPath\bin"
+}
+
+# --- GPU targets ---
+if ($GpuTargets -eq "") {
+    $amdgpuArch = Join-Path $RocmPath "bin\amdgpu-arch.exe"
+    if (Test-Path $amdgpuArch) {
+        $detected = & $amdgpuArch 2>$null | Where-Object { $_ -match "^gfx" } | Select-Object -Unique
+        if ($detected) {
+            $GpuTargets = ($detected | Sort-Object -Unique) -join ";"
+        }
+    }
+    if ($GpuTargets -eq "") {
+        throw "Could not detect GPU targets with amdgpu-arch. Pass -GpuTargets gfxXXXX."
+    }
+}
+
+# --- tools ---
+$cmake = Get-Command "cmake.exe" -ErrorAction SilentlyContinue
+if ($null -eq $cmake) {
+    throw "cmake.exe was not found on PATH"
+}
+$cmake = $cmake.Source
+
+$ninjaCmd = Get-Command "ninja.exe" -ErrorAction SilentlyContinue
+if ($null -ne $ninjaCmd) {
+    $ninja = $ninjaCmd.Source
+} else {
+    $ninja = Find-FirstFile @("C:\Program Files\Microsoft Visual Studio\*\*\Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja\ninja.exe")
+    if ($ninja -eq "") {
+        throw "ninja.exe was not found. Install ninja or Visual Studio with the CMake tools component."
+    }
+}
+
+$sourceDir = Split-Path $PSScriptRoot -Parent
+$buildDir = Join-Path (Join-Path $sourceDir "build") "hip"
+
+$hipblasLtValue = if ($NoHipblasLt) { "OFF" } else { "ON" }
+$forceMmqValue  = if ($ForceMmq) { "ON" } else { "OFF" }
+$noVmmValue     = if ($WithVmm) { "OFF" } elseif ($NoVmm) { "ON" } else { "OFF" }
+$graphsValue    = if ($Graphs) { "ON" } else { "OFF" }
+
+Write-Host "ROCm:        $RocmPath"
+Write-Host "GPU targets: $GpuTargets"
+Write-Host "CMake:       $cmake"
+Write-Host "Ninja:       $ninja"
+Write-Host "Build dir:   $buildDir"
+Write-Host "hipBLASLt GEMM: $hipblasLtValue, FORCE_MMQ: $forceMmqValue, NO_VMM: $noVmmValue, CUDA graphs: $graphsValue"
+
+if ($Clean) {
+    Invoke-Checked $cmake @("--build", $buildDir, "--target", "clean")
+    exit 0
+}
+
+$env:HIP_PATH = $RocmPath
+$env:ROCM_PATH = $RocmPath
+$env:PATH = @((Join-Path $RocmPath "bin"), $env:PATH) -join [IO.Path]::PathSeparator
+
+$configureArgs = @(
+    "-S", $sourceDir,
+    "-B", $buildDir,
+    "-G", "Ninja",
+    "-DCMAKE_MAKE_PROGRAM=$(Convert-ToCMakePath $ninja)",
+    "-DCMAKE_BUILD_TYPE=$BuildType",
+    "-DCMAKE_C_COMPILER=$(Convert-ToCMakePath $clangc)",
+    "-DCMAKE_CXX_COMPILER=$(Convert-ToCMakePath $clangxx)",
+    "-DENGINE_ENABLE_HIP=ON",
+    "-DENGINE_ENABLE_OPENMP=OFF",
+    "-DGPU_TARGETS=$GpuTargets",
+    "-DGGML_HIP_HIPBLASLT=$hipblasLtValue",
+    "-DGGML_CUDA_FORCE_MMQ=$forceMmqValue",
+    "-DGGML_HIP_NO_VMM=$noVmmValue",
+    "-DENGINE_ENABLE_CUDA_GRAPHS=$graphsValue"
+)
+
+Invoke-Checked $cmake $configureArgs
+
+if ($ConfigureOnly) {
+    exit 0
+}
+
+$effectiveJobs = if ($Jobs -gt 0) { $Jobs } else { [Math]::Max(2, [Environment]::ProcessorCount) }
+$buildArgs = @("--build", $buildDir, "-j", $effectiveJobs.ToString())
+if ($Target -ne "") {
+    $buildArgs += @("--target", $Target)
+}
+
+Write-Host "Build jobs: $effectiveJobs"
+Invoke-Checked $cmake $buildArgs
+
+Write-Host ""
+Write-Host "Binaries: $buildDir\bin"
+Write-Host "Note: run with '$RocmPath\bin' on PATH so the ROCm DLLs (amdhip64, hipblas, hipblaslt) are found."

--- a/scripts/build_windows_hip.ps1
+++ b/scripts/build_windows_hip.ps1
@@ -126,6 +126,7 @@ $configureArgs = @(
     "-DCMAKE_BUILD_TYPE=$BuildType",
     "-DCMAKE_C_COMPILER=$(Convert-ToCMakePath $clangc)",
     "-DCMAKE_CXX_COMPILER=$(Convert-ToCMakePath $clangxx)",
+    "-DENGINE_ENABLE_CUDA=OFF",
     "-DENGINE_ENABLE_HIP=ON",
     "-DENGINE_ENABLE_OPENMP=OFF",
     "-DGPU_TARGETS=$GpuTargets",

--- a/src/framework/core/backend.cpp
+++ b/src/framework/core/backend.cpp
@@ -21,8 +21,9 @@ void ensure_backends_loaded() {
 // (GPU/IGPU/ACCEL) deliberately plays no part in that: Metal reports GPU rather than ACCEL,
 // Vulkan reports IGPU on integrated GPUs, and those values are free to change upstream.
 //
-// The CUDA registry name depends on how ggml was built - GGML_CUDA_NAME is "ROCm" under HIP
-// and "MUSA" under MUSA - so every alias has to be accepted. The names are spelled out here
+// The CUDA registry name depends on how ggml was built - GGML_CUDA_NAME is "MUSA" under
+// MUSA - so every alias has to be accepted. HIP builds share the ggml CUDA backend but
+// register as "ROCm" and get their own BackendType::Hip. The names are spelled out here
 // instead of pulled from ggml-cuda.h/ggml-vulkan.h because those headers resolve against the
 // backend's own build flags, which are not visible from this translation unit.
 struct BackendRegNames {
@@ -31,7 +32,8 @@ struct BackendRegNames {
 };
 
 constexpr BackendRegNames k_backend_reg_names[] = {
-    {BackendType::Cuda,   {"CUDA", "ROCm", "MUSA"}},
+    {BackendType::Cuda,   {"CUDA", "MUSA", nullptr}},
+    {BackendType::Hip,    {"ROCm", nullptr, nullptr}},
     {BackendType::Vulkan, {"Vulkan", nullptr, nullptr}},
     {BackendType::Metal,  {"MTL", nullptr, nullptr}},
 };
@@ -64,6 +66,10 @@ bool backend_handle_matches(ggml_backend_t backend, BackendType type) {
 
 bool is_cuda_backend_handle(ggml_backend_t backend) {
     return backend_handle_matches(backend, BackendType::Cuda);
+}
+
+bool is_hip_backend_handle(ggml_backend_t backend) {
+    return backend_handle_matches(backend, BackendType::Hip);
 }
 
 bool is_vulkan_backend_handle(ggml_backend_t backend) {
@@ -194,6 +200,8 @@ ggml_backend_t init_backend(const BackendConfig & config) {
             }
             return backend;
         }
+        case BackendType::Hip:
+            return init_device_backend(BackendType::Hip, "HIP", config);
         case BackendType::Cuda:
             return init_device_backend(BackendType::Cuda, "CUDA", config);
         case BackendType::Vulkan:
@@ -240,6 +248,9 @@ BackendType backend_type(ggml_backend_t backend) {
     if (is_host_backend(backend)) {
         return BackendType::Cpu;
     }
+    if (is_hip_backend_handle(backend)) {
+        return BackendType::Hip;
+    }
     if (is_cuda_backend_handle(backend)) {
         return BackendType::Cuda;
     }
@@ -276,11 +287,11 @@ static void cuda_clear_graph(ggml_backend_t backend, ggml_cgraph * graph) {
 }
 
 void release_backend_graph_resources(ggml_backend_t backend, ggml_cgraph * graph) {
-    if (is_cuda_backend_handle(backend)) cuda_clear_graph(backend, graph);
+    if (is_cuda_backend_handle(backend) || is_hip_backend_handle(backend)) cuda_clear_graph(backend, graph);
 }
 
 void release_backend_graph_resources(BackendType backend_type, ggml_backend_t backend, ggml_cgraph * graph) {
-    if (backend_type == BackendType::Cuda) cuda_clear_graph(backend, graph);
+    if (backend_type == BackendType::Cuda || backend_type == BackendType::Hip) cuda_clear_graph(backend, graph);
 }
 
 void validate_backend_graph_supported(ggml_backend_t backend, ggml_cgraph * graph, const char * label) {

--- a/src/models/ace_step/planner.cpp
+++ b/src/models/ace_step/planner.cpp
@@ -158,6 +158,7 @@ bool planner_prefill_uses_host_backend(core::BackendType backend_type) {
     case core::BackendType::Metal:
     case core::BackendType::Cpu:
     case core::BackendType::Cuda:
+    case core::BackendType::Hip:
     case core::BackendType::BestAvailable:
         return false;
     }


### PR DESCRIPTION
Test Summary – ROCm/HIP Backend (Qwen3-TTS)
GPU：AMD Radeon Graphics (gfx1151, Strix Halo), 120 GiB VRAM

ROCm：7.2.4 

Build：cmake -S . -B build_hip   -DENGINE_ENABLE_HIP=ON   -DGPU_TARGETS=gfx1151   -DCMAKE_C_COMPILER="$(hipconfig -l)/clang"   -DCMAKE_CXX_COMPILER="$(hipconfig -l)/clang++"   -DCMAKE_BUILD_TYPE=Release 

Model：Qwen3-TTS-12Hz-1.7B-CustomVoice

Input：
```
{
    "model": "qwen3-tts",
    "input": "Hey, you. You’re finally awake. You were trying to cross the border, right? Walked right into that Imperial ambush, same as us, and that thief over there.",
    "options": {
      "speaker": "Vivian"
    }
  }
```

Generation time：9.8 s → RTF = 0.89× (faster than real‑time)

Output：
11 s audio file
[test-rocm.wav](https://github.com/user-attachments/files/29996886/test-rocm.wav)

Detection：ggml_cuda_init correctly identifies ROCm device, backend_type() returns Hip, memory queries accurate

About this PR: 
I noticed that llama.cpp already has ROCm support via its ggml-hip backend, and the key insight is that HIP maps almost all CUDA APIs to HIP equivalents at compile time through a vendor header. Since audio.cpp reuses GGML's CUDA backend code, I thought: “If it works for llama.cpp, there’s no reason it shouldn't work for audio.cpp – there might be tricky bugs, but at least I should prove the concept.”

To get started, I took the ROCm‑related CMakeLists.txt from llama.cpp and fed it to DeepSeek V4 PRO (an LLM), asking it to adapt the build logic for this codebase. The result was a clean CMake configuration that successfully compiled and ran on Linux with the HIP backend enabled. This is therefore a 100% vibe‑coded proof‑of‑concept – it works, but please treat it as a reference/test implementation rather than a fully polished production feature.

I'm not English speaker, so please forgive any unclear phrasing. I'm happy to clarify or adjust anything.