### PR TITLE
GGUF_do_not_need_an_external_model_specs_folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,21 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
+# Keep package layouts editable as JSON in the source tree, but compile them into
+# engine_runtime so deployed CLI/server binaries need no external model_specs directory.
+file(GLOB AUDIOCPP_MODEL_SPEC_FILES CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/model_specs/*.json")
+set(AUDIOCPP_BUILTIN_MODEL_SPEC_ENTRIES "")
+foreach(AUDIOCPP_MODEL_SPEC_FILE IN LISTS AUDIOCPP_MODEL_SPEC_FILES)
+    get_filename_component(AUDIOCPP_MODEL_SPEC_FAMILY "${AUDIOCPP_MODEL_SPEC_FILE}" NAME_WE)
+    file(READ "${AUDIOCPP_MODEL_SPEC_FILE}" AUDIOCPP_MODEL_SPEC_JSON)
+    string(APPEND AUDIOCPP_BUILTIN_MODEL_SPEC_ENTRIES
+        "    {\"${AUDIOCPP_MODEL_SPEC_FAMILY}\", R\"AUDIOCPP_SPEC(${AUDIOCPP_MODEL_SPEC_JSON})AUDIOCPP_SPEC\"},\n")
+endforeach()
+file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/generated")
+file(GENERATE
+    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/generated/model_package_specs.inc"
+    CONTENT "${AUDIOCPP_BUILTIN_MODEL_SPEC_ENTRIES}")
+
 if (NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "Build type" FORCE)
 endif()
@@ -486,6 +501,7 @@ target_compile_definitions(yaml_vendor PUBLIC
 target_include_directories(engine_runtime PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
+target_include_directories(engine_runtime PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/generated")
 
 target_include_directories(engine_runtime PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/external/sentencepiece/src

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,20 +10,33 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
-# Keep package layouts editable as JSON in the source tree, but compile them into
-# engine_runtime so deployed CLI/server binaries need no external model_specs directory.
+option(AUDIOCPP_DEPLOYMENT_BUILD
+    "Compile model package specs into the runtime for self-contained deployments"
+    OFF)
+
+# Package layouts remain editable runtime data in normal builds. The converter always
+# carries the source catalog so the conversion binary is portable. Deployment builds
+# additionally compile the catalog into engine_runtime as a fallback for CLI/server.
 file(GLOB AUDIOCPP_MODEL_SPEC_FILES CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/model_specs/*.json")
 set(AUDIOCPP_BUILTIN_MODEL_SPEC_ENTRIES "")
+set(AUDIOCPP_CONVERTER_MODEL_SPEC_ENTRIES "")
 foreach(AUDIOCPP_MODEL_SPEC_FILE IN LISTS AUDIOCPP_MODEL_SPEC_FILES)
     get_filename_component(AUDIOCPP_MODEL_SPEC_FAMILY "${AUDIOCPP_MODEL_SPEC_FILE}" NAME_WE)
     file(READ "${AUDIOCPP_MODEL_SPEC_FILE}" AUDIOCPP_MODEL_SPEC_JSON)
-    string(APPEND AUDIOCPP_BUILTIN_MODEL_SPEC_ENTRIES
+    string(APPEND AUDIOCPP_CONVERTER_MODEL_SPEC_ENTRIES
         "    {\"${AUDIOCPP_MODEL_SPEC_FAMILY}\", R\"AUDIOCPP_SPEC(${AUDIOCPP_MODEL_SPEC_JSON})AUDIOCPP_SPEC\"},\n")
+    if (AUDIOCPP_DEPLOYMENT_BUILD)
+        string(APPEND AUDIOCPP_BUILTIN_MODEL_SPEC_ENTRIES
+            "    {\"${AUDIOCPP_MODEL_SPEC_FAMILY}\", R\"AUDIOCPP_SPEC(${AUDIOCPP_MODEL_SPEC_JSON})AUDIOCPP_SPEC\"},\n")
+    endif()
 endforeach()
 file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/generated")
 file(GENERATE
     OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/generated/model_package_specs.inc"
     CONTENT "${AUDIOCPP_BUILTIN_MODEL_SPEC_ENTRIES}")
+file(GENERATE
+    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/generated/gguf_converter_model_specs.inc"
+    CONTENT "${AUDIOCPP_CONVERTER_MODEL_SPEC_ENTRIES}")
 
 if (NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "Build type" FORCE)
@@ -575,6 +588,7 @@ add_executable(audiocpp_gguf
     tools/gguf_convert.cpp
 )
 target_link_libraries(audiocpp_gguf PRIVATE engine_runtime ggml)
+target_include_directories(audiocpp_gguf PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/generated")
 if (ENGINE_ENABLE_OPENMP)
     target_link_libraries(audiocpp_gguf PRIVATE OpenMP::OpenMP_CXX)
 endif()

--- a/README.md
+++ b/README.md
@@ -709,21 +709,48 @@ remain architecture-specific. Qwen3 ASR, Qwen3 Forced Aligner, Qwen3 TTS, Nemotr
 3.5 ASR, VibeVoice-ASR, Higgs Audio STT, Hviske ASR, and Citrinet ASR currently accept
 `model.gguf` (including `speech_tokenizer/model.gguf` for TTS). The converter recursively embeds sidecar files
 up to 64 MiB by default using binary-safe metadata, including nested tokenizer models,
-and Qwen3 ASR, Nemotron ASR, VibeVoice-ASR, Higgs Audio STT, Hviske ASR, and Citrinet
-ASR can load the resulting `model.gguf` as a standalone file. Pass `--no-sidecars` when a
-tensor-only container is desired. A
+and Qwen3 ASR, Nemotron ASR, VibeVoice-ASR, Higgs Audio STT, Hviske ASR, and Citrinet ASR
+can load the resulting `model.gguf` as a standalone file. The converter embeds the selected
+package spec in new GGUF files. Standalone conversion with embedded sidecars is the default
+and fails if required package resources are missing. Pass `--no-sidecars` only to explicitly
+create a tensor-only container; its package spec is still embedded and validated. A
 `model.safetensors.index.json` is also a first-class tensor source and is merged from
 its routed shards while converting. Exact original tensor ranks are stored separately
 because GGML normally collapses trailing singleton dimensions. Rank-0 safetensors
 scalars are stored physically as one-element GGML tensors while their scalar rank is
 preserved in the exact-shape metadata.
 
+| Format | Package spec source | External model files |
+|---|---|---:|
+| Safetensors | Override, deployment binary, or discovered `model_specs` | Yes |
+| New standalone GGUF | Embedded in GGUF | No |
+| New tensor-only GGUF created with `--no-sidecars` | Embedded in GGUF | Yes, required sidecars |
+| Legacy GGUF without embedded spec | Deployment binary or discovered `model_specs` | Depends on sidecars |
+
+At runtime the order is explicit override, GGUF metadata, compiled deployment spec, then
+external discovery. Configure with `-DAUDIOCPP_DEPLOYMENT_BUILD=ON` to compile the source
+catalog into CLI/server binaries; the option is off by default. For package-layout
+development or testing, the CLI and server can explicitly replace every fallback with
+`--model-spec-override <json-or-directory>`. When a directory is supplied, the runtime
+selects `<directory>/<family>.json`. The server configuration also accepts
+`model_spec_override` globally or per model. An override is trusted runtime input and
+should only point to a spec you control.
+
 ```bash
 build/bin/audiocpp_gguf \
   --input models/Qwen3-ASR-1.7B-hf/model.safetensors \
+  --family qwen3_asr \
   --output models/Qwen3-ASR-1.7B-hf/model.gguf \
   --type q8_0
 ```
+
+The converter discovers the spec from `--model-spec`, model `config.json`, the model
+root, a discovered external catalog, or its bundled conversion catalog. The converter
+catalog is always embedded in `audiocpp_gguf` even when `AUDIOCPP_DEPLOYMENT_BUILD` is
+off; that option controls the CLI/server fallback catalog. The converter validates the
+requested tensor namespaces and every required GGUF sidecar before writing. Use
+`--allow-missing-model-spec` only for a generic tensor archive that is not intended to be
+loaded by audio.cpp.
 
 Multi-component checkpoints can be packed into one GGUF with repeated namespaced
 inputs. Existing component loaders can open a namespace through

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ scripts/build_linux.sh --backend cuda --target audiocpp_cli --target audiocpp_se
 scripts/build_linux.sh --backend vulkan --target audiocpp_cli --target audiocpp_server
 scripts/build_linux.sh --backend cpu --target audiocpp_cli --target audiocpp_server
 scripts/build_linux.sh --backend cuda --native-cpu OFF --target audiocpp_cli --target audiocpp_server
+scripts/build_linux.sh --backend cuda --deployment-build --target audiocpp_cli --target audiocpp_server
 ```
 
 Use `--build-dir <dir>` only when you intentionally want a custom output directory.
@@ -208,6 +209,7 @@ Useful variants:
 .\scripts\build_windows.ps1 -Preset windows-cpu-release -Target audiocpp_cli
 .\scripts\build_windows.ps1 -Preset windows-cuda-debug -Target audiocpp_cli
 .\scripts\build_windows.ps1 -NativeCpu OFF -Target audiocpp_cli
+.\scripts\build_windows.ps1 -DeploymentBuild -Target audiocpp_cli
 .\scripts\build_windows.ps1 -ConfigureOnly
 .\scripts\build_windows.ps1 -CudaArchitectures 120a-real
 ```
@@ -243,6 +245,7 @@ scripts/build_metal.sh --build-type Release --archs arm64 --target audiocpp_cli
 scripts/build_metal.sh --with-tests --target audio_dsp_test
 scripts/build_metal.sh --openmp auto --target audiocpp_cli
 scripts/build_metal.sh --native-cpu OFF --target audiocpp_cli
+scripts/build_metal.sh --deployment-build --target audiocpp_cli
 ```
 
 The built CLI is written to:
@@ -265,6 +268,7 @@ Build options:
 | `ENGINE_BUILD_EXAMPLES` | Build example binaries. | `OFF` |
 | `ENGINE_BUILD_TESTS` | Build framework unit tests. | `OFF` |
 | `ENGINE_BUILD_WARMBENCH` | Build warmbench helper binaries. | `OFF` |
+| `AUDIOCPP_DEPLOYMENT_BUILD` | Compile package specs into CLI/server binaries for standalone GGUF and package-spec fallback loading. Script builds expose this as `--deployment-build` on Linux/macOS and `-DeploymentBuild` on Windows. | `OFF` |
 
 ### Build Type Notes
 

--- a/app/cli/main.cpp
+++ b/app/cli/main.cpp
@@ -50,7 +50,7 @@ void print_task_list_help() {
         << "    --device <n>\n"
         << "    --threads <n>  Backend and OpenMP worker threads, default 4\n"
         << "    --registry-config <path>\n"
-        << "    --model-spec-override <json-or-directory>  Override the built-in package spec\n"
+        << "    --model-spec-override <json-or-directory>  Override package-spec resolution\n"
         << "    --config <id>\n"
         << "    --weight <id>\n"
         << "    --log  Stream framework progress and timing logs to stdout\n"

--- a/app/cli/main.cpp
+++ b/app/cli/main.cpp
@@ -50,6 +50,7 @@ void print_task_list_help() {
         << "    --device <n>\n"
         << "    --threads <n>  Backend and OpenMP worker threads, default 4\n"
         << "    --registry-config <path>\n"
+        << "    --model-spec-override <json-or-directory>  Override the built-in package spec\n"
         << "    --config <id>\n"
         << "    --weight <id>\n"
         << "    --log  Stream framework progress and timing logs to stdout\n"
@@ -595,6 +596,7 @@ int audiocpp_cli_main(int argc, char ** argv) {
                     collect_key_value_args(argc, argv, "--load-option"),
                     collect_key_value_args(argc, argv, "--session-option"),
                     collect_key_value_args(argc, argv, "--workflow-input"),
+                    optional_path_arg(argc, argv, "--model-spec-override"),
                     find_arg(argc, argv, "--audio-converter").value_or("ffmpeg"),
                 });
             return 0;
@@ -613,6 +615,7 @@ int audiocpp_cli_main(int argc, char ** argv) {
 
         engine::runtime::ModelLoadRequest load_request;
         load_request.model_path = std::filesystem::path(*model_arg);
+        load_request.model_spec_override = optional_path_arg(argc, argv, "--model-spec-override");
         if (const auto family = find_arg(argc, argv, "--family")) {
             load_request.family_hint = *family;
         }

--- a/app/server/README.md
+++ b/app/server/README.md
@@ -48,6 +48,7 @@ cat > server.json <<'JSON'
       "id": "qwen3-asr",
       "family": "qwen3_asr",
       "path": "/path/to/models/Qwen3-ASR-0.6B",
+      "model_spec_override": "/optional/path/to/qwen3_asr.json",
       "task": "asr",
       "mode": "offline"
     }
@@ -57,6 +58,13 @@ JSON
 ```
 
 The server resolves model paths from this JSON exactly as written, so use paths that match your machine. Request-time audio paths are also user-provided paths.
+
+Package specs are built into the server binary. `model_spec_override` is an optional
+development/testing escape hatch and is not required for normal safetensors or GGUF
+loading. It accepts either one JSON file or a directory containing `<family>.json`.
+Set it at the top level to provide a server-wide override, or inside one model entry;
+the per-model value takes precedence. The equivalent command-line option is
+`--model-spec-override <json-or-directory>`.
 
 Set top-level `"backend"` to `"cuda"`, `"cpu"`, `"vulkan"`, or `"metal"`. CUDA is the optimized path for audio.cpp; CPU, Vulkan, and Metal are intended for portability and testing when the binary is built with that backend, but performance and model coverage may be lower. The server prints this expectation-setting message when a non-CUDA backend is selected.
 

--- a/app/server/README.md
+++ b/app/server/README.md
@@ -59,9 +59,10 @@ JSON
 
 The server resolves model paths from this JSON exactly as written, so use paths that match your machine. Request-time audio paths are also user-provided paths.
 
-Package specs are built into the server binary. `model_spec_override` is an optional
-development/testing escape hatch and is not required for normal safetensors or GGUF
-loading. It accepts either one JSON file or a directory containing `<family>.json`.
+Package specs embedded in a GGUF are used automatically. Builds configured with
+`AUDIOCPP_DEPLOYMENT_BUILD=ON` also carry a compiled fallback catalog; normal builds
+discover `model_specs/<family>.json` on disk. `model_spec_override` explicitly replaces
+that resolution order. It accepts either one JSON file or a directory containing `<family>.json`.
 Set it at the top level to provide a server-wide override, or inside one model entry;
 the per-model value takes precedence. The equivalent command-line option is
 `--model-spec-override <json-or-directory>`.

--- a/app/server/config.cpp
+++ b/app/server/config.cpp
@@ -62,6 +62,9 @@ ServerConfig load_server_config(const std::filesystem::path & path) {
     config.device = engine::io::json::optional_i32(root, "device", config.device);
     config.threads = engine::io::json::optional_i32(root, "threads", config.threads);
     config.lazy_load = engine::io::json::optional_bool(root, "lazy_load", config.lazy_load);
+    if (const auto * value = root.find("model_spec_override")) {
+        config.model_spec_override = resolve_path(base, value->as_string());
+    }
     if (config.port <= 0 || config.port > 65535) {
         throw std::runtime_error("server port must be in 1..65535");
     }
@@ -77,6 +80,9 @@ ServerConfig load_server_config(const std::filesystem::path & path) {
         ServerModelConfig model;
         model.id = engine::io::json::require_string(item, "id");
         model.path = resolve_path(base, engine::io::json::require_string(item, "path"));
+        if (const auto * value = item.find("model_spec_override")) {
+            model.model_spec_override = resolve_path(base, value->as_string());
+        }
         model.family = engine::io::json::require_string(item, "family");
         model.task = engine::io::json::optional_string(item, "task", model.task);
         model.mode = engine::io::json::optional_string(item, "mode", model.mode);

--- a/app/server/config.h
+++ b/app/server/config.h
@@ -19,6 +19,7 @@ struct ServerModelConfig {
 
     std::string id;
     std::filesystem::path path;
+    std::optional<std::filesystem::path> model_spec_override;
     std::string family;
     std::string task = "tts";
     std::string mode = "offline";
@@ -39,6 +40,7 @@ struct ServerConfig {
     int device = 0;
     int threads = 1;
     bool lazy_load = false;
+    std::optional<std::filesystem::path> model_spec_override;
     std::vector<ServerModelConfig> models;
 };
 

--- a/app/server/main.cpp
+++ b/app/server/main.cpp
@@ -45,6 +45,7 @@ void print_help() {
     std::cout
         << "audiocpp_server --config <server.json> [--host <ip>] [--port <port>] [--backend <backend>]\n"
         << "                [--device <id>] [--threads <n>]\n"
+        << "                [--model-spec-override <json-or-directory>]\n"
         << "                [--log] [--log-file <path>]\n"
         << "  --backend cpu|cuda|vulkan|metal  default cuda\n"
         << "\n"
@@ -93,6 +94,9 @@ int main(int argc, char ** argv) {
         }
         if (const auto threads = arg_value(argc, argv, "--threads")) {
             config.threads = std::stoi(*threads);
+        }
+        if (const auto model_spec = arg_value(argc, argv, "--model-spec-override")) {
+            config.model_spec_override = std::filesystem::path(*model_spec);
         }
         if (config.threads <= 0) {
             throw std::runtime_error("--threads must be positive");

--- a/app/server/runtime.cpp
+++ b/app/server/runtime.cpp
@@ -647,6 +647,9 @@ void ServerState::ensure_model_loaded_locked(LoadedModel & model) {
 
     engine::runtime::ModelLoadRequest load_request;
     load_request.model_path = model.config.path;
+    load_request.model_spec_override = model.config.model_spec_override.has_value()
+        ? model.config.model_spec_override
+        : config_.model_spec_override;
     load_request.family_hint = model.config.family;
     load_request.config_id = model.config.config_id;
     load_request.weight_id = model.config.weight_id;

--- a/app/workflow/workflow.cpp
+++ b/app/workflow/workflow.cpp
@@ -589,6 +589,7 @@ void run_model_step_impl(
 
     engine::runtime::ModelLoadRequest load_request;
     load_request.model_path = resolve_workflow_path(workflow_string(step, "model"), context);
+    load_request.model_spec_override = options.model_spec_override;
     if (const auto family = workflow_optional_string(step, "family")) {
         load_request.family_hint = *family;
     }
@@ -763,6 +764,7 @@ void run_chunked_model_step(
 
     engine::runtime::ModelLoadRequest load_request;
     load_request.model_path = resolve_workflow_path(workflow_string(step, "model"), context);
+    load_request.model_spec_override = options.model_spec_override;
     if (const auto family = workflow_optional_string(step, "family")) {
         load_request.family_hint = *family;
     }
@@ -974,6 +976,7 @@ void run_model_step_foreach(
 
     engine::runtime::ModelLoadRequest load_request;
     load_request.model_path = resolve_workflow_path(workflow_string(step, "model"), context);
+    load_request.model_spec_override = options.model_spec_override;
     if (const auto family = workflow_optional_string(step, "family")) {
         load_request.family_hint = *family;
     }

--- a/app/workflow/workflow.h
+++ b/app/workflow/workflow.h
@@ -20,6 +20,7 @@ struct WorkflowRunOptions {
     std::unordered_map<std::string, std::string> load_options;
     std::unordered_map<std::string, std::string> session_options;
     std::unordered_map<std::string, std::string> workflow_inputs;
+    std::optional<std::filesystem::path> model_spec_override;
     std::string audio_converter = "ffmpeg";
 };
 

--- a/docs/gguf.md
+++ b/docs/gguf.md
@@ -5,11 +5,28 @@ package spec. GGUF is a container for tensors and sidecar files; it is not a uni
 adapter for arbitrary llama.cpp or whisper.cpp GGUF files. The tensor names and embedded
 metadata still have to match the selected `--family`.
 
-Package specs are maintained as `model_specs/*.json` in the source tree and compiled
-into `engine_runtime` during the CMake build. CLI/server deployments do not need to
-ship those JSON files separately.
+Package specs are maintained as `model_specs/*.json`. New GGUFs contain the selected
+spec in `audiocpp.model_spec.*` metadata, so a standalone GGUF does not depend on a
+`model_specs` directory or on the binary having that family compiled into its spec
+catalog.
 
-Use the built-in spec normally. Developers can test a modified layout without rebuilding:
+Runtime resolution is deterministic:
+
+```text
+explicit --model-spec-override
+              |
+              v
+package spec embedded in the selected GGUF
+              |
+              v
+compiled catalog (AUDIOCPP_DEPLOYMENT_BUILD=ON)
+              |
+              v
+external model_specs/<family>.json discovery
+```
+
+An explicit override is useful for testing a modified layout without rebuilding or
+reconverting:
 
 ```bash
 audiocpp_cli --inspect --family qwen3_asr --model /path/to/model.gguf \
@@ -27,6 +44,19 @@ server-wide value.
 cmake --build build/debug --parallel --target audiocpp_gguf
 ```
 
+Normal builds leave `AUDIOCPP_DEPLOYMENT_BUILD` off. Enable it when one binary must also
+carry fallback specs for safetensors packages or legacy GGUFs that predate embedded spec
+metadata:
+
+```bash
+cmake -S . -B build/deploy -DAUDIOCPP_DEPLOYMENT_BUILD=ON
+cmake --build build/deploy --parallel
+```
+
+`audiocpp_gguf` always carries the conversion catalog. This is separate from the optional
+CLI/server deployment catalog, and keeps a copied converter executable usable when the
+source checkout and its `model_specs` directory are not present.
+
 Check the converter interface:
 
 ```bash
@@ -39,18 +69,25 @@ Current shape:
 audiocpp_gguf --input [namespace=]<weights> [--input namespace=<weights> ...] \
   --output <weights.gguf> \
   --type <orig|f16|bf16|q8_0|q2_k|q3_k|q4_k|q5_k|q6_k> \
+  [--family <family>] \
+  [--model-spec <json-or-directory>] \
   [--root <model-dir>] \
   [--sidecar <source>=<destination>] \
   [--overwrite] \
-  [--no-sidecars]
+  [--no-sidecars] \
+  [--allow-missing-model-spec]
 
 audiocpp_gguf --inspect <model.gguf>
 ```
 
 ## Convert A Single Tensor Source
 
-Use `--root` when the model has tokenizer, config, processor, or other non-weight files
-that should be embedded into the GGUF.
+Standalone conversion is the default. The converter embeds non-weight files recursively
+from the first tensor source's directory, or from `--root` when it is supplied. Use
+`--root` when the model has tokenizer, config, processor, or other non-weight files in
+a different model root. It also finds, validates, and embeds the package spec. Conversion
+fails before writing when the tensor namespaces or required sidecars do not match that
+spec.
 
 ```bash
 audiocpp_gguf \
@@ -102,7 +139,45 @@ audiocpp_gguf \
   --overwrite
 ```
 
-Pass `--no-sidecars` only when you intentionally want a tensor-only container.
+If the default pipeline cannot find any sidecars, conversion fails instead of silently
+creating a tensor-only file. Supply the correct `--root` and any required external
+`--sidecar` mappings. Pass `--no-sidecars` only when you intentionally want a tensor-only
+container; place that GGUF and all package-spec-required sidecars together in one model
+directory when loading it. `--no-sidecars` does not remove the embedded package spec and
+does not disable build-time validation.
+
+## Package Spec Discovery During Conversion
+
+The converter selects the first valid source at the highest available priority:
+
+1. `--model-spec <json-or-directory>` (also accepted as `--model-spec-override`).
+2. A spec object, JSON string, or relative path in the model's `config.json`.
+3. `model_spec.json` or `model_specs/*.json` below the model root.
+4. A discovered `model_specs/*.json` directory from the working directory upward.
+5. The converter's bundled source catalog.
+
+Higher-priority inputs are authoritative. If an explicit override, model-config spec, or
+local spec is present but does not match the tensor namespaces and required files, the
+converter reports that error instead of silently falling back to a lower-priority layout.
+
+Use `--family <family>` to disambiguate models whose configuration does not identify the
+audio.cpp family. A model configuration can declare it directly:
+
+```json
+{
+  "audiocpp_family": "qwen3_asr",
+  "audiocpp_model_spec": "model_spec.json"
+}
+```
+
+`audiocpp_model_spec` may instead be a JSON string or a path relative to `config.json`.
+The nested forms `audiocpp.family`, `audiocpp.model_spec`, and
+`audiocpp.package_spec` are also accepted. The converter additionally recognizes known
+upstream `model_type` values.
+
+`--allow-missing-model-spec` is an explicit escape hatch for creating a tensor archive
+that audio.cpp is not expected to load as a model. It is not recommended for deployable
+GGUFs.
 
 ## Inspect And Run
 
@@ -123,6 +198,15 @@ A directory containing `model.gguf` is also accepted by supported package specs:
 ```bash
 audiocpp_cli --task tts --family qwen3_tts --model /path/to/model-gguf --backend cuda --text "Hello." --out out.wav
 ```
+
+Compatibility summary:
+
+| Format | Where its package spec comes from | Other model files |
+|---|---|---|
+| Safetensors | Override, compiled deployment catalog, or external discovery | Required |
+| New standalone GGUF | Embedded in GGUF | None |
+| New tensor-only GGUF (`--no-sidecars`) | Embedded in GGUF | Required sidecars |
+| Legacy GGUF without embedded spec | Compiled deployment catalog or external discovery | Depends on embedded sidecars |
 
 ## Type Notes
 
@@ -147,6 +231,7 @@ Status labels:
 | `Done` | Package-spec refactor is in place for this family. |
 | `No` | Package-spec refactor is not done, or the tested format is not usable. |
 | `Pass` | Covered by the path-test matrix with acceptable output. |
+| `Pass (TTS + clone)` | Both no-reference TTS and reference-audio voice cloning run successfully. |
 | `Pass (drift)` | Loads and runs, with known acceptable output drift. |
 | `No (...)` | Known unsupported, failing, or too much output drift. |
 | `---` | Not tested in the current GGUF path-test matrix. |

--- a/docs/gguf.md
+++ b/docs/gguf.md
@@ -208,6 +208,20 @@ Compatibility summary:
 | New tensor-only GGUF (`--no-sidecars`) | Embedded in GGUF | Required sidecars |
 | Legacy GGUF without embedded spec | Compiled deployment catalog or external discovery | Depends on embedded sidecars |
 
+Compatibility with older binaries:
+
+| Build | GGUF package | Runtime context | Result |
+|---|---|---|---|
+| Before PR #53 (`14e9258`) | Legacy GGUF without embedded spec | Repo checkout or external `model_specs` visible | Pass |
+| Before PR #53 (`14e9258`) | New standalone GGUF | Repo checkout or external `model_specs` visible | Pass |
+| After PR #53 (`2bd3d93`), normal build | Legacy GGUF without embedded spec | Repo checkout or external `model_specs` visible | Pass |
+| After PR #53 (`2bd3d93`), normal build | New standalone GGUF | Repo checkout or external `model_specs` visible | Pass |
+| Before PR #53 (`14e9258`) | Legacy GGUF without embedded spec | No `model_specs` visible | Fail |
+| Before PR #53 (`14e9258`) | New standalone GGUF | No `model_specs` visible | Fail |
+| After PR #53 (`2bd3d93`), normal build | Legacy GGUF without embedded spec | No `model_specs` visible | Fail; use `--model-spec-override`, a deployment build, or external specs |
+| After PR #53 (`2bd3d93`), normal build | New standalone GGUF | No `model_specs` visible | Pass |
+| After PR #53 (`2bd3d93`), deployment build | Legacy GGUF without embedded spec | No `model_specs` visible | Pass through compiled package specs |
+
 ## Type Notes
 
 | Type | Meaning |

--- a/docs/gguf.md
+++ b/docs/gguf.md
@@ -5,6 +5,22 @@ package spec. GGUF is a container for tensors and sidecar files; it is not a uni
 adapter for arbitrary llama.cpp or whisper.cpp GGUF files. The tensor names and embedded
 metadata still have to match the selected `--family`.
 
+Package specs are maintained as `model_specs/*.json` in the source tree and compiled
+into `engine_runtime` during the CMake build. CLI/server deployments do not need to
+ship those JSON files separately.
+
+Use the built-in spec normally. Developers can test a modified layout without rebuilding:
+
+```bash
+audiocpp_cli --inspect --family qwen3_asr --model /path/to/model.gguf \
+  --model-spec-override /path/to/qwen3_asr.json
+```
+
+The override may also be a directory containing `<family>.json`. The server supports
+the same command-line option and a `model_spec_override` field either at the top level
+or inside an individual model entry. A per-model field takes precedence over the
+server-wide value.
+
 ## Build The Converter
 
 ```bash

--- a/include/engine/framework/assets/model_package.h
+++ b/include/engine/framework/assets/model_package.h
@@ -3,6 +3,7 @@
 #include "engine/framework/assets/resource_bundle.h"
 
 #include <filesystem>
+#include <optional>
 #include <string_view>
 
 namespace engine::assets {
@@ -10,6 +11,18 @@ namespace engine::assets {
 enum class ModelPackageResourceKind {
     Files,
     Tensors,
+};
+
+class ScopedModelPackageSpecOverride {
+public:
+    explicit ScopedModelPackageSpecOverride(const std::optional<std::filesystem::path> & path);
+    ~ScopedModelPackageSpecOverride();
+
+    ScopedModelPackageSpecOverride(const ScopedModelPackageSpecOverride &) = delete;
+    ScopedModelPackageSpecOverride & operator=(const ScopedModelPackageSpecOverride &) = delete;
+
+private:
+    std::optional<std::filesystem::path> previous_;
 };
 
 [[nodiscard]] std::filesystem::path default_model_package_spec_path(std::string_view family);

--- a/include/engine/framework/assets/model_package.h
+++ b/include/engine/framework/assets/model_package.h
@@ -15,7 +15,8 @@ enum class ModelPackageResourceKind {
 
 class ScopedModelPackageSpecOverride {
 public:
-    explicit ScopedModelPackageSpecOverride(const std::optional<std::filesystem::path> & path);
+    explicit ScopedModelPackageSpecOverride(const std::optional<std::filesystem::path> & path,
+                                            const std::filesystem::path & model_path = {});
     ~ScopedModelPackageSpecOverride();
 
     ScopedModelPackageSpecOverride(const ScopedModelPackageSpecOverride &) = delete;
@@ -23,16 +24,15 @@ public:
 
 private:
     std::optional<std::filesystem::path> previous_;
+    std::optional<std::filesystem::path> previous_model_path_;
 };
 
 [[nodiscard]] std::filesystem::path default_model_package_spec_path(std::string_view family);
 
-[[nodiscard]] ResourceBundle load_resource_bundle_from_package_spec(
-    const std::filesystem::path & model_path,
+[[nodiscard]] ResourceBundle load_resource_bundle_from_package_spec(const std::filesystem::path & model_path,
     const std::filesystem::path & spec_path);
 
-[[nodiscard]] std::vector<ResourceFile> discover_resources_from_package_spec(
-    const std::filesystem::path & model_path,
+[[nodiscard]] std::vector<ResourceFile> discover_resources_from_package_spec(const std::filesystem::path & model_path,
     const std::filesystem::path & spec_path,
     ModelPackageResourceKind kind);
 

--- a/include/engine/framework/assets/tensor_source.h
+++ b/include/engine/framework/assets/tensor_source.h
@@ -163,34 +163,31 @@ struct GgufEmbeddedFile {
     std::filesystem::path source_path;
     std::filesystem::path destination;
 };
-void convert_tensor_sources_to_gguf(
-    const std::vector<TensorSourceInput> & inputs,
-    const std::filesystem::path & output_path,
-    TensorStorageType weight_type,
-    bool overwrite = false,
-    bool embed_sidecars = true,
+struct GgufEmbeddedModelSpec {
+    std::string family;
+    std::string json;
+};
+void convert_tensor_sources_to_gguf(const std::vector<TensorSourceInput> & inputs,
+                                    const std::filesystem::path & output_path, TensorStorageType weight_type,
+                                    bool overwrite = false, bool embed_sidecars = true,
     const std::filesystem::path & sidecar_root = {},
-    const std::vector<GgufEmbeddedFile> & extra_sidecars = {});
-void convert_tensor_source_to_gguf(
-    const std::filesystem::path & input_path,
-    const std::filesystem::path & output_path,
-    TensorStorageType weight_type,
-    bool overwrite = false,
-    bool embed_sidecars = true);
+                                    const std::vector<GgufEmbeddedFile> & extra_sidecars = {},
+                                    const std::optional<GgufEmbeddedModelSpec> & model_spec = std::nullopt);
+void convert_tensor_source_to_gguf(const std::filesystem::path & input_path, const std::filesystem::path & output_path,
+                                   TensorStorageType weight_type, bool overwrite = false, bool embed_sidecars = true);
 [[nodiscard]] bool gguf_has_embedded_sidecars(const std::filesystem::path & path);
+[[nodiscard]] std::optional<GgufEmbeddedModelSpec> read_gguf_embedded_model_spec(const std::filesystem::path & path);
 [[nodiscard]] std::filesystem::path materialize_gguf_sidecars(const std::filesystem::path & path);
 struct PreparedModelDirectory {
     std::filesystem::path model_root;
     std::optional<std::filesystem::path> standalone_gguf;
 };
-[[nodiscard]] PreparedModelDirectory prepare_model_directory(
-    const std::filesystem::path & model_path,
+[[nodiscard]] PreparedModelDirectory
+prepare_model_directory(const std::filesystem::path & model_path,
     const std::filesystem::path & gguf_relative_path = "model.gguf");
-std::vector<std::filesystem::path> indexed_tensor_source_shard_paths(
-    const std::filesystem::path & index_path,
+std::vector<std::filesystem::path> indexed_tensor_source_shard_paths(const std::filesystem::path & index_path,
     const std::filesystem::path & model_root);
-std::shared_ptr<const TensorSource> open_indexed_tensor_source(
-    const std::filesystem::path & index_path,
+std::shared_ptr<const TensorSource> open_indexed_tensor_source(const std::filesystem::path & index_path,
     const std::filesystem::path & model_root);
 
 }  // namespace engine::assets

--- a/include/engine/framework/runtime/model.h
+++ b/include/engine/framework/runtime/model.h
@@ -64,6 +64,7 @@ struct ModelInspection {
 
 struct ModelLoadRequest {
     std::filesystem::path model_path;
+    std::optional<std::filesystem::path> model_spec_override = std::nullopt;
     std::optional<std::string> family_hint = std::nullopt;
     std::optional<std::string> config_id = std::nullopt;
     std::optional<std::string> weight_id = std::nullopt;

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -10,6 +10,7 @@ VULKAN_MODE="off"
 WITH_TESTS="OFF"
 WITH_EXAMPLES="OFF"
 WITH_WARMBENCH="OFF"
+AUDIOCPP_DEPLOYMENT_BUILD="OFF"
 NATIVE_CPU="ON"
 LLAMAFILE="ON"
 TARGETS=()
@@ -63,6 +64,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --with-warmbench)
             WITH_WARMBENCH="ON"
+            shift
+            ;;
+        --deployment-build)
+            AUDIOCPP_DEPLOYMENT_BUILD="ON"
             shift
             ;;
         --native-cpu)
@@ -198,6 +203,7 @@ echo "llamafile SGEMM: $LLAMAFILE"
 echo "Building examples: $WITH_EXAMPLES"
 echo "Building tests: $WITH_TESTS"
 echo "Building warmbench: $WITH_WARMBENCH"
+echo "Deployment build: $AUDIOCPP_DEPLOYMENT_BUILD"
 
 "${RUNNER[@]}" cmake \
     -S . \
@@ -210,7 +216,8 @@ echo "Building warmbench: $WITH_WARMBENCH"
     -DENGINE_ENABLE_LLAMAFILE="$LLAMAFILE" \
     -DENGINE_BUILD_EXAMPLES="$WITH_EXAMPLES" \
     -DENGINE_BUILD_TESTS="$WITH_TESTS" \
-    -DENGINE_BUILD_WARMBENCH="$WITH_WARMBENCH"
+    -DENGINE_BUILD_WARMBENCH="$WITH_WARMBENCH" \
+    -DAUDIOCPP_DEPLOYMENT_BUILD="$AUDIOCPP_DEPLOYMENT_BUILD"
 
 BUILD_CMD=("${RUNNER[@]}" cmake --build "$BUILD_DIR" --parallel "$JOBS")
 for target in "${TARGETS[@]}"; do

--- a/scripts/build_metal.sh
+++ b/scripts/build_metal.sh
@@ -10,6 +10,7 @@ BUILD_TYPE="RelWithDebInfo"
 WITH_TESTS="OFF"
 WITH_EXAMPLES="OFF"
 WITH_WARMBENCH="OFF"
+AUDIOCPP_DEPLOYMENT_BUILD="OFF"
 OPENMP_MODE="off"
 LLAMAFILE="ON"
 NATIVE_CPU="ON"
@@ -44,6 +45,7 @@ Options:
   --with-tests             Build framework unit tests.
   --with-examples          Build example binaries.
   --with-warmbench         Build warmbench helper binaries.
+  --deployment-build       Embed package specs for standalone GGUF/model loading.
   --target <name>          Build a specific CMake target. May be repeated.
   -j, --jobs <n>           Parallel build jobs.
   -h, --help               Show this help.
@@ -116,6 +118,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --with-warmbench)
             WITH_WARMBENCH="ON"
+            shift
+            ;;
+        --deployment-build)
+            AUDIOCPP_DEPLOYMENT_BUILD="ON"
             shift
             ;;
         --target)
@@ -207,6 +213,7 @@ CMAKE_CMD=(
     -DENGINE_BUILD_TESTS="$WITH_TESTS"
     -DENGINE_BUILD_EXAMPLES="$WITH_EXAMPLES"
     -DENGINE_BUILD_WARMBENCH="$WITH_WARMBENCH"
+    -DAUDIOCPP_DEPLOYMENT_BUILD="$AUDIOCPP_DEPLOYMENT_BUILD"
 )
 
 if [[ -n "$GENERATOR" ]]; then
@@ -237,6 +244,7 @@ echo "Native CPU optimization: $NATIVE_CPU"
 echo "Building examples: $WITH_EXAMPLES"
 echo "Building tests: $WITH_TESTS"
 echo "Building warmbench: $WITH_WARMBENCH"
+echo "Deployment build: $AUDIOCPP_DEPLOYMENT_BUILD"
 
 "${CMAKE_CMD[@]}"
 

--- a/scripts/build_windows.ps1
+++ b/scripts/build_windows.ps1
@@ -12,6 +12,7 @@ param(
     [string]$NativeCpu = $null,
     [ValidateSet("ON", "OFF")]
     [string]$Llamafile = $null,
+    [switch]$DeploymentBuild,
     [string]$VsInstall = ""
 )
 
@@ -456,6 +457,8 @@ if ($arch -ne "") {
 Write-Host "CPU architecture profile: $($cpuArchSettings.Label)"
 Write-Host "Native CPU optimization: $($settings.Native)"
 Write-Host "llamafile SGEMM: $($settings.Llamafile)"
+$deploymentBuildValue = if ($DeploymentBuild) { "ON" } else { "OFF" }
+Write-Host "Deployment build: $deploymentBuildValue"
 
 if ($Clean) {
     $buildDirForClean = Join-Path (Join-Path (Split-Path $PSScriptRoot -Parent) "build") $Preset
@@ -488,7 +491,8 @@ $configureArgs = @(
     "-DGGML_OPENMP=ON",
     "-DENGINE_ENABLE_NATIVE_CPU=$($settings.Native)",
     "-DENGINE_ENABLE_LLAMAFILE=$($settings.Llamafile)",
-    "-DENGINE_BUILD_TESTS=$($settings.BuildTests)"
+    "-DENGINE_BUILD_TESTS=$($settings.BuildTests)",
+    "-DAUDIOCPP_DEPLOYMENT_BUILD=$deploymentBuildValue"
 )
 $configureArgs += $cpuArchSettings.CMakeArgs
 if ($settings.CFlagsDebug -ne "") {

--- a/scripts/build_xcframework.sh
+++ b/scripts/build_xcframework.sh
@@ -14,6 +14,7 @@ JOBS="$(sysctl -n hw.logicalcpu 2>/dev/null || echo 8)"
 CLEAN="OFF"
 LLAMAFILE="ON"
 NATIVE_CPU="ON"
+AUDIOCPP_DEPLOYMENT_BUILD="OFF"
 
 usage() {
     cat <<'EOF'
@@ -39,6 +40,7 @@ Options:
                         Default: ON
   --native-cpu ON|OFF   Build ggml CPU kernels with native host ISA flags.
                         Default: ON
+  --deployment-build    Embed package specs for standalone GGUF/model loading.
   -j, --jobs <n>        Parallel build jobs.
   -h, --help            Show this help.
 
@@ -86,6 +88,10 @@ while [[ $# -gt 0 ]]; do
         --native-cpu)
             NATIVE_CPU="$2"
             shift 2
+            ;;
+        --deployment-build)
+            AUDIOCPP_DEPLOYMENT_BUILD="ON"
+            shift
             ;;
         -j|--jobs)
             JOBS="$2"
@@ -185,7 +191,8 @@ archive_for_arch() {
         -DENGINE_ENABLE_NATIVE_CPU="$NATIVE_CPU" \
         -DGGML_METAL_EMBED_LIBRARY=ON \
         -DENGINE_BUILD_TESTS=OFF \
-        -DENGINE_BUILD_EXAMPLES=OFF
+        -DENGINE_BUILD_EXAMPLES=OFF \
+        -DAUDIOCPP_DEPLOYMENT_BUILD="$AUDIOCPP_DEPLOYMENT_BUILD"
     )
     if [[ -n "$GENERATOR" ]]; then
         cmake_cmd+=(-G "$GENERATOR")

--- a/src/framework/assets/model_package.cpp
+++ b/src/framework/assets/model_package.cpp
@@ -37,6 +37,16 @@ std::optional<std::string_view> builtin_model_spec(const std::filesystem::path &
     return it->second;
 }
 
+std::string model_spec_description(const std::filesystem::path & spec_path) {
+    if (spec_path.parent_path() == "@gguf") {
+        return "embedded GGUF model package spec for family '" + spec_path.stem().string() + "'";
+    }
+    if (spec_path.parent_path() == "@builtin") {
+        return "builtin model package spec for family '" + spec_path.stem().string() + "'";
+    }
+    return "model package spec '" + spec_path.string() + "'";
+}
+
 bool is_gguf_file(const std::filesystem::path & path) {
     if (!engine::io::is_existing_file(path))
         return false;
@@ -75,8 +85,9 @@ bool external_spec_matches_family(const std::filesystem::path & path, std::strin
     try {
         const auto root = engine::io::json::parse_file(path);
         return engine::io::json::require_string(root, "family") == family;
-    } catch (...) {
-        return false;
+    } catch (const std::exception & error) {
+        throw std::runtime_error("invalid candidate model package spec '" + path.string() +
+                                 "' while resolving family '" + std::string(family) + "': " + error.what());
     }
 }
 
@@ -276,19 +287,21 @@ struct SelectedSource {
     std::filesystem::path model_root;
     engine::io::json::Value source;
     ResourceRoots roots;
+    std::string spec_description;
+    std::string source_format;
 };
 
 SelectedSource select_source(const std::filesystem::path & model_path, const std::filesystem::path & model_root,
-    const engine::io::json::Value & source) {
+    const std::string & spec_description, const engine::io::json::Value & source) {
     const auto format = require_source_format(source);
     if (format == "gguf") {
         const auto prepared = prepare_model_directory(model_path);
         auto roots = resolve_source_roots(prepared.model_root, source, prepared.standalone_gguf);
-        return SelectedSource{prepared.model_root, source, std::move(roots)};
+        return SelectedSource{prepared.model_root, source, std::move(roots), spec_description, format};
     }
     if (format == "safetensors") {
         auto roots = resolve_source_roots(model_root, source, std::nullopt);
-        return SelectedSource{model_root, source, std::move(roots)};
+        return SelectedSource{model_root, source, std::move(roots), spec_description, format};
     }
     throw std::runtime_error("unsupported model package source format: " + format);
 }
@@ -296,7 +309,13 @@ SelectedSource select_source(const std::filesystem::path & model_path, const std
 SelectedSource require_selected_source(const std::filesystem::path & model_path,
     const std::filesystem::path & spec_path) {
     const auto model_root = resolve_model_root(model_path);
-    const auto spec = parse_model_spec(spec_path);
+    const auto spec_description = model_spec_description(spec_path);
+    engine::io::json::Value spec;
+    try {
+        spec = parse_model_spec(spec_path);
+    } catch (const std::exception & error) {
+        throw std::runtime_error("failed to parse " + spec_description + ": " + error.what());
+    }
     const auto & sources = spec.require("sources").as_array();
     const bool explicit_gguf_path = is_gguf_file(model_path);
     const bool directory_has_gguf =
@@ -305,11 +324,16 @@ SelectedSource require_selected_source(const std::filesystem::path & model_path,
     for (const auto & source : sources) {
         const auto format = require_source_format(source);
         if ((use_gguf && format == "gguf") || (!use_gguf && format == "safetensors")) {
-            return select_source(model_path, model_root, source);
+            try {
+                return select_source(model_path, model_root, spec_description, source);
+            } catch (const std::exception & error) {
+                throw std::runtime_error("failed to select " + std::string(use_gguf ? "GGUF" : "safetensors") +
+                                         " source from " + spec_description + ": " + error.what());
+            }
         }
     }
     throw std::runtime_error(std::string("no ") + (use_gguf ? "gguf" : "safetensors") + " model package source in " +
-                             spec_path.string());
+                             spec_description);
 }
 
 }  // namespace
@@ -364,7 +388,12 @@ ResourceBundle load_resource_bundle_from_package_spec(
     const std::filesystem::path & model_path,
     const std::filesystem::path & spec_path) {
     auto selected = require_selected_source(model_path, spec_path);
-    return load_source(selected.model_root, selected.source, selected.roots);
+    try {
+        return load_source(selected.model_root, selected.source, selected.roots);
+    } catch (const std::exception & error) {
+        throw std::runtime_error("failed to load model package resources using " + selected.spec_description +
+                                 " source '" + selected.source_format + "': " + error.what());
+    }
 }
 
 std::vector<ResourceFile> discover_resources_from_package_spec(
@@ -372,7 +401,12 @@ std::vector<ResourceFile> discover_resources_from_package_spec(
     const std::filesystem::path & spec_path,
     ModelPackageResourceKind kind) {
     auto selected = require_selected_source(model_path, spec_path);
-    return discover_safetensors_source_resources(selected.source, kind, selected.roots);
+    try {
+        return discover_safetensors_source_resources(selected.source, kind, selected.roots);
+    } catch (const std::exception & error) {
+        throw std::runtime_error("failed to discover model package resources using " + selected.spec_description +
+                                 " source '" + selected.source_format + "': " + error.what());
+    }
 }
 
 }  // namespace engine::assets

--- a/src/framework/assets/model_package.cpp
+++ b/src/framework/assets/model_package.cpp
@@ -1,18 +1,25 @@
 #include "engine/framework/assets/model_package.h"
 
+#include "engine/framework/assets/tensor_source.h"
 #include "engine/framework/io/filesystem.h"
 #include "engine/framework/io/json.h"
 
+#include <algorithm>
+#include <cctype>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <string_view>
 #include <unordered_map>
-#include <optional>
+#include <vector>
 
 namespace engine::assets {
 namespace {
 
 thread_local std::optional<std::filesystem::path> active_model_spec_override;
+thread_local std::optional<std::filesystem::path> active_model_path;
+thread_local bool active_embedded_spec_checked = false;
+thread_local std::optional<GgufEmbeddedModelSpec> active_embedded_spec;
 
 const std::unordered_map<std::string, std::string_view> & builtin_model_specs() {
     static const std::unordered_map<std::string, std::string_view> specs = {
@@ -22,13 +29,96 @@ const std::unordered_map<std::string, std::string_view> & builtin_model_specs() 
 }
 
 std::optional<std::string_view> builtin_model_spec(const std::filesystem::path & spec_path) {
-    if (spec_path.parent_path() != "@builtin") return std::nullopt;
+    if (spec_path.parent_path() != "@builtin")
+        return std::nullopt;
     const auto it = builtin_model_specs().find(spec_path.stem().string());
-    if (it == builtin_model_specs().end()) return std::nullopt;
+    if (it == builtin_model_specs().end())
+        return std::nullopt;
     return it->second;
 }
 
+bool is_gguf_file(const std::filesystem::path & path) {
+    if (!engine::io::is_existing_file(path))
+        return false;
+    std::string extension = path.extension().string();
+    std::transform(extension.begin(), extension.end(), extension.begin(),
+                   [](unsigned char value) { return static_cast<char>(std::tolower(value)); });
+    return extension == ".gguf";
+}
+
+std::optional<std::filesystem::path> active_gguf_path() {
+    if (!active_model_path.has_value())
+        return std::nullopt;
+    const auto & path = *active_model_path;
+    if (is_gguf_file(path)) {
+        return std::filesystem::weakly_canonical(path);
+    }
+    if (engine::io::is_existing_directory(path) && engine::io::is_existing_file(path / "model.gguf")) {
+        return std::filesystem::weakly_canonical(path / "model.gguf");
+    }
+    return std::nullopt;
+}
+
+const std::optional<GgufEmbeddedModelSpec> & embedded_model_spec() {
+    if (!active_embedded_spec_checked) {
+        active_embedded_spec_checked = true;
+        if (const auto gguf = active_gguf_path()) {
+            active_embedded_spec = read_gguf_embedded_model_spec(*gguf);
+        }
+    }
+    return active_embedded_spec;
+}
+
+bool external_spec_matches_family(const std::filesystem::path & path, std::string_view family) {
+    if (!engine::io::is_existing_file(path))
+        return false;
+    try {
+        const auto root = engine::io::json::parse_file(path);
+        return engine::io::json::require_string(root, "family") == family;
+    } catch (...) {
+        return false;
+    }
+}
+
+std::optional<std::filesystem::path> discover_external_model_spec(std::string_view family) {
+    std::vector<std::filesystem::path> candidates;
+    if (active_model_path.has_value()) {
+        const auto root = engine::io::is_existing_directory(*active_model_path) ? *active_model_path
+                                                                                : active_model_path->parent_path();
+        candidates.push_back(root / "model_specs" / (std::string(family) + ".json"));
+        candidates.push_back(root / (std::string(family) + ".json"));
+        candidates.push_back(root / "model_spec.json");
+        candidates.push_back(root.parent_path() / "model_specs" / (std::string(family) + ".json"));
+    }
+    auto cursor = std::filesystem::current_path();
+    while (true) {
+        candidates.push_back(cursor / "model_specs" / (std::string(family) + ".json"));
+        const auto parent = cursor.parent_path();
+        if (parent == cursor || parent.empty())
+            break;
+        cursor = parent;
+    }
+    for (const auto & candidate : candidates) {
+        if (external_spec_matches_family(candidate, family)) {
+            return std::filesystem::weakly_canonical(candidate);
+        }
+    }
+    return std::nullopt;
+}
+
 engine::io::json::Value parse_model_spec(const std::filesystem::path & spec_path) {
+    if (spec_path.parent_path() == "@gguf") {
+        const auto & spec = embedded_model_spec();
+        if (!spec.has_value() || spec->family != spec_path.stem().string()) {
+            throw std::runtime_error("embedded GGUF model package spec is not available for: " +
+                                     spec_path.stem().string());
+        }
+        auto root = engine::io::json::parse(spec->json);
+        if (engine::io::json::require_string(root, "family") != spec->family) {
+            throw std::runtime_error("embedded GGUF model package spec family metadata does not match its JSON");
+        }
+        return root;
+    }
     if (const auto text = builtin_model_spec(spec_path)) {
         return engine::io::json::parse(*text);
     }
@@ -51,9 +141,7 @@ std::string require_source_format(const engine::io::json::Value & source) {
 
 using ResourceRoots = std::unordered_map<std::string, std::filesystem::path>;
 
-ResourceRoots resolve_source_roots(
-    const std::filesystem::path & model_root,
-    const engine::io::json::Value & source,
+ResourceRoots resolve_source_roots(const std::filesystem::path & model_root, const engine::io::json::Value & source,
     const std::optional<std::filesystem::path> & standalone_gguf) {
     ResourceRoots roots;
     const auto & root_object = source.require("roots").as_object();
@@ -62,9 +150,7 @@ ResourceRoots resolve_source_roots(
         if (root_value == "$gguf" && !standalone_gguf.has_value()) {
             throw std::runtime_error("model package source requires a GGUF root: " + id);
         }
-        const auto root_path = root_value == "$gguf"
-            ? *standalone_gguf
-            : model_root / root_value;
+        const auto root_path = root_value == "$gguf" ? *standalone_gguf : model_root / root_value;
         if (!engine::io::is_existing_directory(root_path) && !engine::io::is_existing_file(root_path)) {
             throw std::runtime_error("missing model package root: " + id + "=" + root_path.string());
         }
@@ -73,8 +159,7 @@ ResourceRoots resolve_source_roots(
     return roots;
 }
 
-std::filesystem::path resolve_resource_ref(
-    const std::unordered_map<std::string, std::filesystem::path> & roots,
+std::filesystem::path resolve_resource_ref(const std::unordered_map<std::string, std::filesystem::path> & roots,
     const std::string & ref) {
     const auto split = ref.find(':');
     if (split == std::string::npos || split == 0) {
@@ -92,10 +177,7 @@ std::filesystem::path resolve_resource_ref(
     return root_it->second / relative_path;
 }
 
-void add_resource_map(
-    ResourceBundle & bundle,
-    const ResourceRoots & roots,
-    const engine::io::json::Value * map_value) {
+void add_resource_map(ResourceBundle & bundle, const ResourceRoots & roots, const engine::io::json::Value * map_value) {
     if (map_value == nullptr || map_value->is_null()) {
         return;
     }
@@ -108,9 +190,7 @@ void add_resource_map(
     }
 }
 
-std::filesystem::path resolve_tensor_source_ref(
-    const ResourceRoots & roots,
-    const engine::io::json::Value & value,
+std::filesystem::path resolve_tensor_source_ref(const ResourceRoots & roots, const engine::io::json::Value & value,
     std::string & prefix) {
     if (value.is_string()) {
         prefix.clear();
@@ -126,10 +206,7 @@ std::filesystem::path resolve_tensor_source_ref(
     return resolve_resource_ref(roots, source_it->second.as_string());
 }
 
-void add_tensor_map(
-    ResourceBundle & bundle,
-    const ResourceRoots & roots,
-    const engine::io::json::Value * map_value) {
+void add_tensor_map(ResourceBundle & bundle, const ResourceRoots & roots, const engine::io::json::Value * map_value) {
     if (map_value == nullptr || map_value->is_null()) {
         return;
     }
@@ -143,9 +220,7 @@ void add_tensor_map(
     }
 }
 
-void add_optional_resource_map(
-    ResourceBundle & bundle,
-    const ResourceRoots & roots,
+void add_optional_resource_map(ResourceBundle & bundle, const ResourceRoots & roots,
     const engine::io::json::Value * map_value) {
     if (map_value == nullptr || map_value->is_null()) {
         return;
@@ -158,10 +233,8 @@ void add_optional_resource_map(
     }
 }
 
-std::vector<ResourceFile> resources_from_resource_map(
-    const ResourceRoots & roots,
-    const engine::io::json::Value * map_value,
-    bool required) {
+std::vector<ResourceFile> resources_from_resource_map(const ResourceRoots & roots,
+                                                      const engine::io::json::Value * map_value, bool required) {
     std::vector<ResourceFile> assets;
     if (map_value == nullptr || map_value->is_null()) {
         return assets;
@@ -178,9 +251,7 @@ std::vector<ResourceFile> resources_from_resource_map(
     return assets;
 }
 
-ResourceBundle load_source(
-    const std::filesystem::path & model_root,
-    const engine::io::json::Value & source,
+ResourceBundle load_source(const std::filesystem::path & model_root, const engine::io::json::Value & source,
     const ResourceRoots & roots) {
     ResourceBundle bundle(model_root);
     add_resource_map(bundle, roots, source.find("files"));
@@ -189,14 +260,11 @@ ResourceBundle load_source(
     return bundle;
 }
 
-std::vector<ResourceFile> discover_safetensors_source_resources(
-    const engine::io::json::Value & source,
+std::vector<ResourceFile> discover_safetensors_source_resources(const engine::io::json::Value & source,
     ModelPackageResourceKind kind,
     const ResourceRoots & roots) {
     auto resources = resources_from_resource_map(
-        roots,
-        source.find(kind == ModelPackageResourceKind::Files ? "files" : "tensors"),
-        true);
+        roots, source.find(kind == ModelPackageResourceKind::Files ? "files" : "tensors"), true);
     if (kind == ModelPackageResourceKind::Files) {
         auto optional = resources_from_resource_map(roots, source.find("optional_files"), false);
         resources.insert(resources.end(), optional.begin(), optional.end());
@@ -210,9 +278,7 @@ struct SelectedSource {
     ResourceRoots roots;
 };
 
-SelectedSource select_source(
-    const std::filesystem::path & model_path,
-    const std::filesystem::path & model_root,
+SelectedSource select_source(const std::filesystem::path & model_path, const std::filesystem::path & model_root,
     const engine::io::json::Value & source) {
     const auto format = require_source_format(source);
     if (format == "gguf") {
@@ -227,42 +293,41 @@ SelectedSource select_source(
     throw std::runtime_error("unsupported model package source format: " + format);
 }
 
-SelectedSource require_selected_source(
-    const std::filesystem::path & model_path,
+SelectedSource require_selected_source(const std::filesystem::path & model_path,
     const std::filesystem::path & spec_path) {
     const auto model_root = resolve_model_root(model_path);
     const auto spec = parse_model_spec(spec_path);
     const auto & sources = spec.require("sources").as_array();
-    const auto prepared = prepare_model_directory(model_path);
-    const bool explicit_gguf_path = engine::io::is_existing_file(model_path) &&
-        model_path.extension() == ".gguf";
-    const bool directory_has_gguf = engine::io::is_existing_directory(model_path) &&
-        engine::io::is_existing_file(model_path / "model.gguf");
+    const bool explicit_gguf_path = is_gguf_file(model_path);
+    const bool directory_has_gguf =
+        engine::io::is_existing_directory(model_path) && engine::io::is_existing_file(model_path / "model.gguf");
     const bool use_gguf = explicit_gguf_path || directory_has_gguf;
-    if (use_gguf && !prepared.standalone_gguf.has_value()) {
-        throw std::runtime_error("model package GGUF source requires embedded sidecars: " + model_path.string());
-    }
     for (const auto & source : sources) {
         const auto format = require_source_format(source);
         if ((use_gguf && format == "gguf") || (!use_gguf && format == "safetensors")) {
             return select_source(model_path, model_root, source);
         }
     }
-    throw std::runtime_error(
-        std::string("no ") + (use_gguf ? "gguf" : "safetensors") +
-        " model package source in " + spec_path.string());
+    throw std::runtime_error(std::string("no ") + (use_gguf ? "gguf" : "safetensors") + " model package source in " +
+                             spec_path.string());
 }
 
 }  // namespace
 
-ScopedModelPackageSpecOverride::ScopedModelPackageSpecOverride(
-    const std::optional<std::filesystem::path> & path)
-    : previous_(active_model_spec_override) {
+ScopedModelPackageSpecOverride::ScopedModelPackageSpecOverride(const std::optional<std::filesystem::path> & path,
+                                                               const std::filesystem::path & model_path)
+    : previous_(active_model_spec_override), previous_model_path_(active_model_path) {
     active_model_spec_override = path;
+    active_model_path = model_path.empty() ? std::nullopt : std::make_optional(model_path);
+    active_embedded_spec_checked = false;
+    active_embedded_spec.reset();
 }
 
 ScopedModelPackageSpecOverride::~ScopedModelPackageSpecOverride() {
     active_model_spec_override = std::move(previous_);
+    active_model_path = std::move(previous_model_path_);
+    active_embedded_spec_checked = false;
+    active_embedded_spec.reset();
 }
 
 std::filesystem::path default_model_package_spec_path(std::string_view family) {
@@ -276,10 +341,23 @@ std::filesystem::path default_model_package_spec_path(std::string_view family) {
         }
         return std::filesystem::weakly_canonical(path);
     }
-    if (builtin_model_specs().find(std::string(family)) == builtin_model_specs().end()) {
-        throw std::runtime_error("built-in model package spec not found: " + std::string(family));
+    if (const auto & embedded = embedded_model_spec(); embedded.has_value()) {
+        if (embedded->family != family) {
+            throw std::runtime_error("GGUF embeds package spec for family '" + embedded->family + "', not '" +
+                                     std::string(family) + "'");
+        }
+        return std::filesystem::path("@gguf") / (std::string(family) + ".json");
     }
-    return std::filesystem::path("@builtin") / (std::string(family) + ".json");
+    if (builtin_model_specs().find(std::string(family)) != builtin_model_specs().end()) {
+        return std::filesystem::path("@builtin") / (std::string(family) + ".json");
+    }
+    if (const auto external = discover_external_model_spec(family)) {
+        return *external;
+    }
+    throw std::runtime_error("model package spec not found for family '" + std::string(family) +
+                             "' (provide --model-spec-override, embed it in the GGUF, enable "
+                             "AUDIOCPP_DEPLOYMENT_BUILD, or install model_specs/" +
+                             std::string(family) + ".json)");
 }
 
 ResourceBundle load_resource_bundle_from_package_spec(

--- a/src/framework/assets/model_package.cpp
+++ b/src/framework/assets/model_package.cpp
@@ -5,11 +5,35 @@
 
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <optional>
 
 namespace engine::assets {
 namespace {
+
+thread_local std::optional<std::filesystem::path> active_model_spec_override;
+
+const std::unordered_map<std::string, std::string_view> & builtin_model_specs() {
+    static const std::unordered_map<std::string, std::string_view> specs = {
+#include "model_package_specs.inc"
+    };
+    return specs;
+}
+
+std::optional<std::string_view> builtin_model_spec(const std::filesystem::path & spec_path) {
+    if (spec_path.parent_path() != "@builtin") return std::nullopt;
+    const auto it = builtin_model_specs().find(spec_path.stem().string());
+    if (it == builtin_model_specs().end()) return std::nullopt;
+    return it->second;
+}
+
+engine::io::json::Value parse_model_spec(const std::filesystem::path & spec_path) {
+    if (const auto text = builtin_model_spec(spec_path)) {
+        return engine::io::json::parse(*text);
+    }
+    return engine::io::json::parse_file(spec_path);
+}
 
 std::filesystem::path resolve_model_root(const std::filesystem::path & model_path) {
     if (engine::io::is_existing_directory(model_path)) {
@@ -207,7 +231,7 @@ SelectedSource require_selected_source(
     const std::filesystem::path & model_path,
     const std::filesystem::path & spec_path) {
     const auto model_root = resolve_model_root(model_path);
-    const auto spec = engine::io::json::parse_file(spec_path);
+    const auto spec = parse_model_spec(spec_path);
     const auto & sources = spec.require("sources").as_array();
     const auto prepared = prepare_model_directory(model_path);
     const bool explicit_gguf_path = engine::io::is_existing_file(model_path) &&
@@ -231,21 +255,31 @@ SelectedSource require_selected_source(
 
 }  // namespace
 
+ScopedModelPackageSpecOverride::ScopedModelPackageSpecOverride(
+    const std::optional<std::filesystem::path> & path)
+    : previous_(active_model_spec_override) {
+    active_model_spec_override = path;
+}
+
+ScopedModelPackageSpecOverride::~ScopedModelPackageSpecOverride() {
+    active_model_spec_override = std::move(previous_);
+}
+
 std::filesystem::path default_model_package_spec_path(std::string_view family) {
-    const std::filesystem::path relative = std::filesystem::path("model_specs") / (std::string(family) + ".json");
-    auto cursor = std::filesystem::current_path();
-    while (true) {
-        const auto candidate = cursor / relative;
-        if (engine::io::is_existing_file(candidate)) {
-            return std::filesystem::weakly_canonical(candidate);
+    if (active_model_spec_override.has_value()) {
+        auto path = *active_model_spec_override;
+        if (engine::io::is_existing_directory(path)) {
+            path /= std::string(family) + ".json";
         }
-        const auto parent = cursor.parent_path();
-        if (parent == cursor || parent.empty()) {
-            break;
+        if (!engine::io::is_existing_file(path)) {
+            throw std::runtime_error("model package spec override not found: " + path.string());
         }
-        cursor = parent;
+        return std::filesystem::weakly_canonical(path);
     }
-    throw std::runtime_error("model package spec not found: " + relative.string());
+    if (builtin_model_specs().find(std::string(family)) == builtin_model_specs().end()) {
+        throw std::runtime_error("built-in model package spec not found: " + std::string(family));
+    }
+    return std::filesystem::path("@builtin") / (std::string(family) + ".json");
 }
 
 ResourceBundle load_resource_bundle_from_package_spec(

--- a/src/framework/assets/tensor_source.cpp
+++ b/src/framework/assets/tensor_source.cpp
@@ -1411,37 +1411,81 @@ bool gguf_has_embedded_sidecars(const std::filesystem::path & path) {
     return !read_gguf_embedded_sidecars(path).empty();
 }
 
+std::optional<GgufEmbeddedModelSpec> read_gguf_embedded_model_spec(const std::filesystem::path & path) {
+    ggml_context * tensor_context = nullptr;
+    gguf_context * gguf = gguf_init_from_file(path.string().c_str(), gguf_init_params{true, &tensor_context});
+    if (gguf == nullptr) {
+        if (tensor_context != nullptr)
+            ggml_free(tensor_context);
+        throw std::runtime_error("failed to read GGUF metadata: " + path.string());
+    }
+    std::optional<GgufEmbeddedModelSpec> result;
+    try {
+        const int64_t version_key = gguf_find_key(gguf, "audiocpp.model_spec.version");
+        const int64_t family_key = gguf_find_key(gguf, "audiocpp.model_spec.family");
+        const int64_t json_key = gguf_find_key(gguf, "audiocpp.model_spec.json");
+        if (version_key >= 0 || family_key >= 0 || json_key >= 0) {
+            if (version_key < 0 || family_key < 0 || json_key < 0 ||
+                gguf_get_kv_type(gguf, version_key) != GGUF_TYPE_UINT32 ||
+                gguf_get_kv_type(gguf, family_key) != GGUF_TYPE_STRING ||
+                gguf_get_kv_type(gguf, json_key) != GGUF_TYPE_STRING) {
+                throw std::runtime_error("GGUF embedded model package spec metadata is invalid");
+            }
+            const uint32_t version = gguf_get_val_u32(gguf, version_key);
+            if (version != 1) {
+                throw std::runtime_error("unsupported GGUF embedded model package spec version: " +
+                                         std::to_string(version));
+            }
+            GgufEmbeddedModelSpec spec;
+            spec.family = gguf_get_val_str(gguf, family_key);
+            spec.json = gguf_get_val_str(gguf, json_key);
+            if (spec.family.empty() || spec.json.empty()) {
+                throw std::runtime_error("GGUF embedded model package spec is empty");
+            }
+            result = std::move(spec);
+        }
+    } catch (...) {
+        gguf_free(gguf);
+        if (tensor_context != nullptr)
+            ggml_free(tensor_context);
+        throw;
+    }
+    gguf_free(gguf);
+    if (tensor_context != nullptr)
+        ggml_free(tensor_context);
+    return result;
+}
+
 std::filesystem::path materialize_gguf_sidecars(const std::filesystem::path & path) {
     const auto canonical = std::filesystem::weakly_canonical(path);
     const auto sidecars = read_gguf_embedded_sidecars(canonical);
     if (sidecars.empty()) {
         throw std::runtime_error("GGUF does not contain embedded model sidecars: " + canonical.string());
     }
-    const auto fingerprint_source = canonical.string() + ":" +
-        std::to_string(std::filesystem::file_size(canonical)) + ":" +
-        std::to_string(static_cast<long long>(
-            std::filesystem::last_write_time(canonical).time_since_epoch().count()));
+    const auto fingerprint_source =
+        canonical.string() + ":" + std::to_string(std::filesystem::file_size(canonical)) + ":" +
+        std::to_string(static_cast<long long>(std::filesystem::last_write_time(canonical).time_since_epoch().count()));
     std::ostringstream fingerprint;
     fingerprint << std::hex << std::hash<std::string>{}(fingerprint_source);
     const auto root = std::filesystem::temp_directory_path() / "audiocpp-gguf" / fingerprint.str();
     std::filesystem::create_directories(root);
     for (const auto & [name, content] : sidecars) {
         const auto output_path = root / name;
-        if (engine::io::is_existing_file(output_path) &&
-            engine::io::read_text_file(output_path) == content) {
+        if (engine::io::is_existing_file(output_path) && engine::io::read_text_file(output_path) == content) {
             continue;
         }
         std::filesystem::create_directories(output_path.parent_path());
         std::ofstream output(output_path, std::ios::binary | std::ios::trunc);
-        if (!output) throw std::runtime_error("failed to materialize GGUF sidecar: " + output_path.string());
+        if (!output)
+            throw std::runtime_error("failed to materialize GGUF sidecar: " + output_path.string());
         output.write(content.data(), static_cast<std::streamsize>(content.size()));
-        if (!output) throw std::runtime_error("failed to write GGUF sidecar: " + output_path.string());
+        if (!output)
+            throw std::runtime_error("failed to write GGUF sidecar: " + output_path.string());
     }
     return root;
 }
 
-PreparedModelDirectory prepare_model_directory(
-    const std::filesystem::path & model_path,
+PreparedModelDirectory prepare_model_directory(const std::filesystem::path & model_path,
     const std::filesystem::path & gguf_relative_path) {
     std::filesystem::path gguf_path;
     if (engine::io::is_existing_directory(model_path)) {
@@ -1451,28 +1495,25 @@ PreparedModelDirectory prepare_model_directory(
     } else {
         throw std::runtime_error("model path does not exist: " + model_path.string());
     }
-    if (engine::io::is_existing_file(gguf_path) &&
-        lower_ascii(gguf_path.extension().string()) == ".gguf" &&
-        gguf_has_embedded_sidecars(gguf_path)) {
-        return {
-            materialize_gguf_sidecars(gguf_path),
-            std::filesystem::weakly_canonical(gguf_path),
-        };
+    if (engine::io::is_existing_file(gguf_path) && lower_ascii(gguf_path.extension().string()) == ".gguf") {
+        const auto canonical_gguf = std::filesystem::weakly_canonical(gguf_path);
+        if (gguf_has_embedded_sidecars(gguf_path)) {
+            return {materialize_gguf_sidecars(gguf_path), canonical_gguf};
+        }
+        const auto external_root =
+            engine::io::is_existing_directory(model_path) ? model_path : model_path.parent_path();
+        return {std::filesystem::weakly_canonical(external_root), canonical_gguf};
     }
-    const auto root = engine::io::is_existing_directory(model_path)
-        ? model_path
-        : model_path.parent_path();
+    const auto root = engine::io::is_existing_directory(model_path) ? model_path : model_path.parent_path();
     return {std::filesystem::weakly_canonical(root), std::nullopt};
 }
 
-void convert_tensor_sources_to_gguf(
-    const std::vector<TensorSourceInput> & inputs,
-    const std::filesystem::path & output_path,
-    TensorStorageType weight_type,
-    bool overwrite,
-    bool embed_sidecars,
+void convert_tensor_sources_to_gguf(const std::vector<TensorSourceInput> & inputs,
+                                    const std::filesystem::path & output_path, TensorStorageType weight_type,
+                                    bool overwrite, bool embed_sidecars,
     const std::filesystem::path & requested_sidecar_root,
-    const std::vector<GgufEmbeddedFile> & extra_sidecars) {
+                                    const std::vector<GgufEmbeddedFile> & extra_sidecars,
+                                    const std::optional<GgufEmbeddedModelSpec> & model_spec) {
     if (inputs.empty()) {
         throw std::runtime_error("GGUF conversion requires at least one tensor source");
     }
@@ -1537,13 +1578,16 @@ void convert_tensor_sources_to_gguf(
         gguf_set_val_str(gguf, "general.architecture", "audiocpp");
         gguf_set_val_str(gguf, "general.name", sidecar_root.filename().string().c_str());
         gguf_set_val_str(gguf, "audiocpp.tensor_name_format", "native");
-        gguf_set_val_str(gguf, "audiocpp.source_format", inputs.size() == 1
-            ? lower_ascii(inputs.front().path.extension().string()).c_str()
-            : "packed");
-        const std::string output_weight_type = preserve_source_dtype
-            ? "orig"
-            : lower_ascii(ggml_type_name(requested_type));
+        gguf_set_val_str(gguf, "audiocpp.source_format",
+                         inputs.size() == 1 ? lower_ascii(inputs.front().path.extension().string()).c_str() : "packed");
+        const std::string output_weight_type =
+            preserve_source_dtype ? "orig" : lower_ascii(ggml_type_name(requested_type));
         gguf_set_val_str(gguf, "audiocpp.weight_type", output_weight_type.c_str());
+        if (model_spec.has_value()) {
+            gguf_set_val_u32(gguf, "audiocpp.model_spec.version", 1);
+            gguf_set_val_str(gguf, "audiocpp.model_spec.family", model_spec->family.c_str());
+            gguf_set_val_str(gguf, "audiocpp.model_spec.json", model_spec->json.c_str());
+        }
 
         std::vector<std::string> source_names;
         std::vector<std::string> source_paths;
@@ -1622,14 +1666,22 @@ void convert_tensor_sources_to_gguf(
                 embedded_data.insert(embedded_data.end(), content.begin(), content.end());
                 embedded_offsets.push_back(static_cast<uint64_t>(embedded_data.size()));
             }
+            if (embedded_names.empty()) {
+                throw std::runtime_error("no GGUF sidecars were found; provide "
+                                         "--root/--sidecar for a standalone GGUF "
+                                         "or pass --no-sidecars to explicitly create a "
+                                         "tensor-only container");
+            }
             embedded_name_ptrs.reserve(embedded_names.size());
-            for (const auto & value : embedded_names) embedded_name_ptrs.push_back(value.c_str());
+            for (const auto & value : embedded_names)
+                embedded_name_ptrs.push_back(value.c_str());
             if (!embedded_names.empty()) {
-                gguf_set_arr_str(gguf, "audiocpp.embedded_files.names", embedded_name_ptrs.data(), embedded_name_ptrs.size());
-                gguf_set_arr_data(gguf, "audiocpp.embedded_files.offsets", GGUF_TYPE_UINT64,
-                    embedded_offsets.data(), embedded_offsets.size());
-                gguf_set_arr_data(gguf, "audiocpp.embedded_files.data", GGUF_TYPE_UINT8,
-                    embedded_data.data(), embedded_data.size());
+                gguf_set_arr_str(gguf, "audiocpp.embedded_files.names", embedded_name_ptrs.data(),
+                                 embedded_name_ptrs.size());
+                gguf_set_arr_data(gguf, "audiocpp.embedded_files.offsets", GGUF_TYPE_UINT64, embedded_offsets.data(),
+                                  embedded_offsets.size());
+                gguf_set_arr_data(gguf, "audiocpp.embedded_files.data", GGUF_TYPE_UINT8, embedded_data.data(),
+                                  embedded_data.size());
             }
         }
 

--- a/src/framework/runtime/registry.cpp
+++ b/src/framework/runtime/registry.cpp
@@ -121,7 +121,7 @@ bool ModelRegistry::supports_family(const std::string & family) const noexcept {
 }
 
 ModelInspection ModelRegistry::inspect(const ModelLoadRequest & request) const {
-    engine::assets::ScopedModelPackageSpecOverride spec_override(request.model_spec_override);
+    engine::assets::ScopedModelPackageSpecOverride spec_override(request.model_spec_override, request.model_path);
     validate_request(request);
     const auto * loader = find_loader(request);
     if (loader == nullptr) {
@@ -137,7 +137,7 @@ ModelInspection ModelRegistry::inspect(const std::filesystem::path & model_path)
 }
 
 std::unique_ptr<ILoadedVoiceModel> ModelRegistry::load(const ModelLoadRequest & request) const {
-    engine::assets::ScopedModelPackageSpecOverride spec_override(request.model_spec_override);
+    engine::assets::ScopedModelPackageSpecOverride spec_override(request.model_spec_override, request.model_path);
     validate_request(request);
     const auto * loader = find_loader(request);
     if (loader == nullptr) {

--- a/src/framework/runtime/registry.cpp
+++ b/src/framework/runtime/registry.cpp
@@ -1,6 +1,7 @@
 #include "engine/framework/runtime/registry.h"
 
 #include "engine/framework/debug/trace.h"
+#include "engine/framework/assets/model_package.h"
 #include "engine/framework/io/config.h"
 #include "engine/framework/io/filesystem.h"
 // Development registry entries from Share/AudioCPP that are not present in this release tree yet:
@@ -120,6 +121,7 @@ bool ModelRegistry::supports_family(const std::string & family) const noexcept {
 }
 
 ModelInspection ModelRegistry::inspect(const ModelLoadRequest & request) const {
+    engine::assets::ScopedModelPackageSpecOverride spec_override(request.model_spec_override);
     validate_request(request);
     const auto * loader = find_loader(request);
     if (loader == nullptr) {
@@ -135,6 +137,7 @@ ModelInspection ModelRegistry::inspect(const std::filesystem::path & model_path)
 }
 
 std::unique_ptr<ILoadedVoiceModel> ModelRegistry::load(const ModelLoadRequest & request) const {
+    engine::assets::ScopedModelPackageSpecOverride spec_override(request.model_spec_override);
     validate_request(request);
     const auto * loader = find_loader(request);
     if (loader == nullptr) {
@@ -162,6 +165,11 @@ void ModelRegistry::validate_request(const ModelLoadRequest & request) const {
     }
     if (request.family_hint.has_value() && !supports_family(*request.family_hint)) {
         throw std::runtime_error("unsupported model family hint: " + *request.family_hint);
+    }
+    if (request.model_spec_override.has_value() &&
+        !engine::io::is_existing_file(*request.model_spec_override) &&
+        !engine::io::is_existing_directory(*request.model_spec_override)) {
+        throw std::runtime_error("model package spec override path does not exist: " + request.model_spec_override->string());
     }
 }
 

--- a/tests/unittests/test_gguf_tensor_source.cpp
+++ b/tests/unittests/test_gguf_tensor_source.cpp
@@ -256,6 +256,54 @@ void test_embedded_model_spec_roundtrip_and_precedence() {
     std::filesystem::remove_all(root);
 }
 
+void test_package_spec_errors_name_selected_spec() {
+    const auto root = std::filesystem::temp_directory_path() / "audiocpp_package_spec_error_test";
+    std::filesystem::remove_all(root);
+    std::filesystem::create_directories(root / "model");
+    const auto malformed_spec = root / "malformed.json";
+    const auto missing_file_spec = root / "missing_file.json";
+
+    {
+        std::ofstream output(malformed_spec, std::ios::binary);
+        output << R"json({"family":"broken","sources":[)json";
+    }
+    {
+        std::ofstream output(missing_file_spec, std::ios::binary);
+        output << R"json({
+            "family":"missing_file_test",
+            "sources":[{
+                "format":"safetensors",
+                "roots":{"model":"."},
+                "files":{"config":"model:config.json"}
+            }]
+        })json";
+    }
+
+    bool malformed_named = false;
+    try {
+        (void)engine::assets::load_resource_bundle_from_package_spec(root / "model", malformed_spec);
+    } catch (const std::runtime_error & error) {
+        const std::string message = error.what();
+        malformed_named = message.find("failed to parse model package spec") != std::string::npos &&
+            message.find(malformed_spec.string()) != std::string::npos;
+    }
+    engine::test::require(malformed_named, "malformed package spec error did not name the selected spec");
+
+    bool selected_source_named = false;
+    try {
+        (void)engine::assets::load_resource_bundle_from_package_spec(root / "model", missing_file_spec);
+    } catch (const std::runtime_error & error) {
+        const std::string message = error.what();
+        selected_source_named = message.find("using model package spec") != std::string::npos &&
+            message.find(missing_file_spec.string()) != std::string::npos &&
+            message.find("source 'safetensors'") != std::string::npos &&
+            message.find("missing model package file 'config'") != std::string::npos;
+    }
+    engine::test::require(selected_source_named, "resource error did not name the selected spec and source");
+
+    std::filesystem::remove_all(root);
+}
+
 }  // namespace
 
 int main() {
@@ -264,6 +312,7 @@ int main() {
         test_packed_multi_source_gguf();
         test_all_rank0_gguf();
         test_embedded_model_spec_roundtrip_and_precedence();
+        test_package_spec_errors_name_selected_spec();
     } catch (const std::exception & error) {
         std::cerr << error.what() << '\n';
         return 1;

--- a/tests/unittests/test_gguf_tensor_source.cpp
+++ b/tests/unittests/test_gguf_tensor_source.cpp
@@ -1,6 +1,7 @@
+#include "engine/framework/assets/model_package.h"
 #include "engine/framework/assets/tensor_source.h"
-#include "engine/framework/io/safetensors.h"
 #include "engine/framework/io/filesystem.h"
+#include "engine/framework/io/safetensors.h"
 #include "test_assert.h"
 
 #include <cstring>
@@ -182,16 +183,76 @@ void test_all_rank0_gguf() {
     const auto safetensors = root / "scalar.safetensors";
     const auto gguf = root / "scalar.gguf";
     write_rank0_safetensors_with_null_metadata(safetensors, "num_batches_tracked", 23);
-    engine::assets::convert_tensor_source_to_gguf(
-        safetensors,
-        gguf,
-        engine::assets::TensorStorageType::F16);
+    engine::assets::convert_tensor_source_to_gguf(safetensors, gguf, engine::assets::TensorStorageType::F16, false,
+                                                  false);
     const auto source = engine::assets::open_tensor_source(gguf);
     engine::test::require(source->tensors().front().shape.empty(), "rank-0-only GGUF lost scalar rank");
-    engine::test::require_eq(
-        source->require_i64_scalar("num_batches_tracked"),
-        int64_t{23},
+    engine::test::require_eq(source->require_i64_scalar("num_batches_tracked"), int64_t{23},
         "rank-0-only GGUF scalar value");
+    std::filesystem::remove_all(root);
+}
+
+void test_embedded_model_spec_roundtrip_and_precedence() {
+    const auto root = std::filesystem::temp_directory_path() / "audiocpp_embedded_model_spec_test";
+    std::filesystem::remove_all(root);
+    std::filesystem::create_directories(root);
+    const auto safetensors = root / "model.safetensors";
+    const auto gguf = root / "model.gguf";
+    const auto override_spec = root / "override.json";
+    engine::io::write_safetensors_file(safetensors, {
+                                                        {"weight", "F32", {1}, bytes_for(std::vector<float>{1.0F})},
+                                                    });
+    const std::string spec_json = R"json({
+        "family":"embedded_test",
+        "sources":[{
+            "format":"gguf",
+            "roots":{"weights":"$gguf"},
+            "tensors":{"weights":"weights:"}
+        }]
+    })json";
+    engine::assets::convert_tensor_sources_to_gguf({{safetensors, ""}}, gguf, engine::assets::TensorStorageType::F16,
+                                                   false, false, {}, {},
+                                                   engine::assets::GgufEmbeddedModelSpec{"embedded_test", spec_json});
+
+    const auto embedded = engine::assets::read_gguf_embedded_model_spec(gguf);
+    engine::test::require(embedded.has_value(), "GGUF lost its embedded model package spec");
+    engine::test::require_eq(embedded->family, std::string("embedded_test"), "embedded spec family");
+    engine::test::require_eq(embedded->json, spec_json, "embedded spec JSON");
+
+    {
+        engine::assets::ScopedModelPackageSpecOverride scope(std::nullopt, gguf);
+        engine::test::require_eq(engine::assets::default_model_package_spec_path("embedded_test"),
+                                 std::filesystem::path("@gguf") / "embedded_test.json",
+                                 "embedded GGUF spec precedence");
+        bool family_mismatch_rejected = false;
+        try {
+            (void)engine::assets::default_model_package_spec_path("another_family");
+        } catch (const std::runtime_error &) {
+            family_mismatch_rejected = true;
+        }
+        engine::test::require(family_mismatch_rejected, "embedded GGUF spec accepted a different family");
+    }
+
+    const auto uppercase_gguf = root / "RENAMED.GGUF";
+    std::filesystem::copy_file(gguf, uppercase_gguf);
+    {
+        engine::assets::ScopedModelPackageSpecOverride scope(std::nullopt, uppercase_gguf);
+        const auto spec_path = engine::assets::default_model_package_spec_path("embedded_test");
+        const auto resources = engine::assets::load_resource_bundle_from_package_spec(uppercase_gguf, spec_path);
+        engine::test::require(resources.open_tensor_source("weights")->has_tensor("weight"),
+                              "uppercase standalone GGUF did not use its embedded package spec");
+    }
+
+    {
+        std::ofstream output(override_spec, std::ios::binary);
+        output << spec_json;
+    }
+    {
+        engine::assets::ScopedModelPackageSpecOverride scope(override_spec, gguf);
+        engine::test::require_eq(engine::assets::default_model_package_spec_path("embedded_test"),
+                                 std::filesystem::weakly_canonical(override_spec),
+                                 "explicit package spec override precedence");
+    }
     std::filesystem::remove_all(root);
 }
 
@@ -202,6 +263,7 @@ int main() {
         test_safetensors_to_gguf_roundtrip();
         test_packed_multi_source_gguf();
         test_all_rank0_gguf();
+        test_embedded_model_spec_roundtrip_and_precedence();
     } catch (const std::exception & error) {
         std::cerr << error.what() << '\n';
         return 1;

--- a/tools/gguf_convert.cpp
+++ b/tools/gguf_convert.cpp
@@ -1,18 +1,441 @@
 #include "engine/framework/assets/tensor_source.h"
+#include "engine/framework/io/filesystem.h"
+#include "engine/framework/io/json.h"
 
+#include <algorithm>
+#include <cctype>
 #include <filesystem>
 #include <iostream>
+#include <optional>
 #include <set>
+#include <sstream>
 #include <stdexcept>
 #include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
 
 namespace {
 
+namespace json = engine::io::json;
+
+struct PackageSpecCandidate {
+    engine::assets::GgufEmbeddedModelSpec spec;
+    std::string origin;
+    int priority = 0;
+};
+
+const std::unordered_map<std::string, std::string_view> & converter_model_specs() {
+    static const std::unordered_map<std::string, std::string_view> specs = {
+#include "gguf_converter_model_specs.inc"
+    };
+    return specs;
+}
+
+std::string lower_ascii(std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return value;
+}
+
+bool excluded_sidecar(const std::filesystem::path & path, const std::filesystem::path & output) {
+    const std::string extension = lower_ascii(path.extension().string());
+    return extension == ".safetensors" || extension == ".gguf" || extension == ".bin" || extension == ".pt" ||
+           extension == ".pth" ||
+           std::filesystem::weakly_canonical(path) == std::filesystem::weakly_canonical(output) ||
+           std::filesystem::file_size(path) > 64u * 1024u * 1024u;
+}
+
+std::set<std::string>
+planned_sidecar_destinations(const std::filesystem::path & root, const std::filesystem::path & output,
+                             const std::vector<engine::assets::GgufEmbeddedFile> & explicit_sidecars,
+                             bool embed_sidecars) {
+    std::set<std::string> destinations;
+    std::error_code error;
+    for (std::filesystem::recursive_directory_iterator it(root, error), end; !error && it != end; it.increment(error)) {
+        if (it->is_directory() && (it->path().filename() == ".cache" || it->path().filename() == ".git")) {
+            it.disable_recursion_pending();
+            continue;
+        }
+        if (!it->is_regular_file() ||
+            (embed_sidecars && excluded_sidecar(it->path(), output)) ||
+            (!embed_sidecars && std::filesystem::weakly_canonical(it->path()) ==
+                                   std::filesystem::weakly_canonical(output)))
+            continue;
+        destinations.insert(std::filesystem::relative(it->path(), root).lexically_normal().generic_string());
+    }
+    if (error)
+        throw std::runtime_error("failed to enumerate model sidecars: " + error.message());
+    std::set<std::string> explicit_destinations;
+    for (const auto & sidecar : explicit_sidecars) {
+        const auto destination = sidecar.destination.lexically_normal();
+        if (!engine::io::is_existing_file(sidecar.source_path)) {
+            throw std::runtime_error("embedded sidecar source does not exist: " + sidecar.source_path.string());
+        }
+        if (destination.empty() || destination.is_absolute() || *destination.begin() == "..") {
+            throw std::runtime_error("invalid embedded sidecar destination: " + sidecar.destination.string());
+        }
+        const auto normalized = destination.generic_string();
+        if (!explicit_destinations.insert(normalized).second) {
+            throw std::runtime_error("duplicate embedded sidecar destination: " + destination.generic_string());
+        }
+        destinations.insert(normalized);
+    }
+    return destinations;
+}
+
+PackageSpecCandidate parse_package_spec(const std::string & text, std::string origin, int priority) {
+    const auto root = json::parse(text);
+    PackageSpecCandidate candidate;
+    candidate.spec.family = json::require_string(root, "family");
+    if (candidate.spec.family.empty())
+        throw std::runtime_error("model package spec family is empty: " + origin);
+    const auto & sources = root.require("sources").as_array();
+    if (sources.empty())
+        throw std::runtime_error("model package spec has no sources: " + origin);
+    bool has_gguf = false;
+    for (const auto & source : sources) {
+        if (json::require_string(source, "format") == "gguf")
+            has_gguf = true;
+    }
+    if (!has_gguf)
+        throw std::runtime_error("model package spec has no GGUF source: " + origin);
+    candidate.spec.json = json::stringify(root);
+    candidate.origin = std::move(origin);
+    candidate.priority = priority;
+    return candidate;
+}
+
+void add_candidate(std::vector<PackageSpecCandidate> & candidates, PackageSpecCandidate candidate) {
+    for (auto & existing : candidates) {
+        if (existing.spec.family == candidate.spec.family && existing.spec.json == candidate.spec.json) {
+            if (candidate.priority < existing.priority)
+                existing = std::move(candidate);
+            return;
+        }
+    }
+    candidates.push_back(std::move(candidate));
+}
+
+void add_spec_file(std::vector<PackageSpecCandidate> & candidates, const std::filesystem::path & path, int priority) {
+    if (!engine::io::is_existing_file(path))
+        return;
+    add_candidate(candidates, parse_package_spec(engine::io::read_text_file(path),
+                                                 std::filesystem::weakly_canonical(path).string(), priority));
+}
+
+void add_spec_path(std::vector<PackageSpecCandidate> & candidates, const std::filesystem::path & path,
+                   const std::optional<std::string> & family, int priority) {
+    if (engine::io::is_existing_file(path)) {
+        add_spec_file(candidates, path, priority);
+        return;
+    }
+    if (!engine::io::is_existing_directory(path)) {
+        throw std::runtime_error("model package spec path does not exist: " + path.string());
+    }
+    if (family.has_value()) {
+        const auto file = path / (*family + ".json");
+        if (!engine::io::is_existing_file(file)) {
+            throw std::runtime_error("model package spec not found: " + file.string());
+        }
+        add_spec_file(candidates, file, priority);
+        return;
+    }
+    for (const auto & entry : std::filesystem::directory_iterator(path)) {
+        if (entry.is_regular_file() && lower_ascii(entry.path().extension().string()) == ".json") {
+            try {
+                add_spec_file(candidates, entry.path(), priority);
+            } catch (...) {
+                // A model_specs directory may contain unrelated JSON files. Only valid
+                // package specs participate in automatic matching.
+            }
+        }
+    }
+}
+
+void add_discovered_spec_directories(std::vector<PackageSpecCandidate> & candidates,
+                                     const std::filesystem::path & start,
+                                     const std::optional<std::string> & family,
+                                     int priority) {
+    auto cursor = std::filesystem::weakly_canonical(start);
+    while (!cursor.empty()) {
+        const auto directory = cursor / "model_specs";
+        if (engine::io::is_existing_directory(directory)) {
+            if (!family.has_value() || engine::io::is_existing_file(directory / (*family + ".json"))) {
+                add_spec_path(candidates, directory, family, priority);
+            }
+        }
+        const auto parent = cursor.parent_path();
+        if (parent == cursor || parent.empty())
+            break;
+        cursor = parent;
+    }
+}
+
+void add_converter_catalog(std::vector<PackageSpecCandidate> & candidates,
+                           const std::optional<std::string> & family,
+                           int priority) {
+    for (const auto & [catalog_family, text] : converter_model_specs()) {
+        if (family.has_value() && *family != catalog_family)
+            continue;
+        add_candidate(candidates,
+                      parse_package_spec(std::string(text), "converter-catalog:" + catalog_family, priority));
+    }
+}
+
+const json::Value * embedded_spec_value(const json::Value & config) {
+    if (const auto * value = config.find("audiocpp_model_spec"))
+        return value;
+    if (const auto * value = config.find("model_spec"))
+        return value;
+    if (const auto * audiocpp = config.find("audiocpp"); audiocpp != nullptr && audiocpp->is_object()) {
+        if (const auto * value = audiocpp->find("model_spec"))
+            return value;
+        if (const auto * value = audiocpp->find("package_spec"))
+            return value;
+    }
+    return nullptr;
+}
+
+std::optional<std::string> infer_family_from_config(const json::Value & config) {
+    if (const auto * value = config.find("audiocpp_family"); value != nullptr && value->is_string()) {
+        return value->as_string();
+    }
+    if (const auto * audiocpp = config.find("audiocpp"); audiocpp != nullptr && audiocpp->is_object()) {
+        if (const auto * value = audiocpp->find("family"); value != nullptr && value->is_string()) {
+            return value->as_string();
+        }
+    }
+    const auto * model_type_value = config.find("model_type");
+    if (model_type_value == nullptr || !model_type_value->is_string())
+        return std::nullopt;
+    const std::string model_type = model_type_value->as_string();
+    if (model_type == "qwen3_asr") {
+        const auto * thinker = config.find("thinker_config");
+        if (thinker != nullptr && thinker->is_object()) {
+            const auto * thinker_type = thinker->find("model_type");
+            if (thinker_type != nullptr && thinker_type->is_string() &&
+                thinker_type->as_string() == "qwen3_forced_aligner") {
+                return "qwen3_forced_aligner";
+            }
+        }
+        return "qwen3_asr";
+    }
+    if (model_type == "nemotron3_5_asr")
+        return "nemotron_asr";
+    if (model_type == "vibevoice")
+        return "vibevoice_asr";
+    if (model_type == "higgs_audio_3")
+        return "higgs_audio_stt";
+    if (model_type == "cohere_asr")
+        return "hviske_asr";
+    if (model_type == "qwen3_tts")
+        return "qwen3_tts";
+    return std::nullopt;
+}
+
+std::optional<std::string> add_model_config_spec(std::vector<PackageSpecCandidate> & candidates,
+                                                 const std::filesystem::path & model_root) {
+    const auto config_path = model_root / "config.json";
+    if (!engine::io::is_existing_file(config_path))
+        return std::nullopt;
+    const auto config = json::parse_file(config_path);
+    if (const auto * value = embedded_spec_value(config)) {
+        if (value->is_object()) {
+            add_candidate(candidates,
+                          parse_package_spec(json::stringify(*value), config_path.string() + "#model_spec", 1));
+        } else if (value->is_string()) {
+            const std::string stored = value->as_string();
+            const size_t first_content = stored.find_first_not_of(" \t\r\n");
+            if (first_content == std::string::npos) {
+                throw std::runtime_error("config.json model_spec string is empty");
+            }
+            if (stored[first_content] == '{') {
+                add_candidate(candidates, parse_package_spec(stored, config_path.string() + "#model_spec", 1));
+            } else {
+                const auto stored_path = model_root / stored;
+                if (!engine::io::is_existing_file(stored_path)) {
+                    throw std::runtime_error("config.json model_spec file does not exist: " + stored_path.string());
+                }
+                add_spec_file(candidates, stored_path, 1);
+            }
+        } else {
+            throw std::runtime_error("config.json model_spec must be an object, JSON "
+                                     "string, or relative path");
+        }
+    }
+    return infer_family_from_config(config);
+}
+
+const json::Value & require_gguf_source(const json::Value & spec) {
+    for (const auto & source : spec.require("sources").as_array()) {
+        if (json::require_string(source, "format") == "gguf")
+            return source;
+    }
+    throw std::runtime_error("model package spec has no GGUF source");
+}
+
+std::string tensor_prefix(const json::Value & value) {
+    if (value.is_string())
+        return {};
+    const auto * prefix = value.find("prefix");
+    return prefix == nullptr ? std::string() : prefix->as_string();
+}
+
+std::optional<std::string> required_destination(const json::Value & source, const std::string & reference) {
+    const size_t separator = reference.find(':');
+    if (separator == std::string::npos || separator == 0) {
+        throw std::runtime_error("invalid package resource reference: " + reference);
+    }
+    const std::string root_id = reference.substr(0, separator);
+    const std::string relative = reference.substr(separator + 1);
+    const auto & roots = source.require("roots").as_object();
+    const auto root = roots.find(root_id);
+    if (root == roots.end())
+        throw std::runtime_error("unknown package root: " + root_id);
+    if (root->second.as_string() == "$gguf")
+        return std::nullopt;
+    const auto destination = (std::filesystem::path(root->second.as_string()) / relative).lexically_normal();
+    if (destination.is_absolute() || destination.empty() || *destination.begin() == "..") {
+        throw std::runtime_error("unsafe GGUF package resource destination: " + destination.string());
+    }
+    return destination.generic_string();
+}
+
+std::vector<std::string> validate_candidate(const PackageSpecCandidate & candidate,
+                                            const std::set<std::string> & actual_prefixes,
+                                            const std::set<std::string> & sidecars) {
+    std::vector<std::string> errors;
+    try {
+        const auto spec = json::parse(candidate.spec.json);
+        const auto & source = require_gguf_source(spec);
+        std::set<std::string> expected_prefixes;
+        for (const auto & [unused, value] : source.require("tensors").as_object()) {
+            (void)unused;
+            expected_prefixes.insert(tensor_prefix(value));
+        }
+        for (const auto & prefix : expected_prefixes) {
+            if (actual_prefixes.find(prefix) == actual_prefixes.end()) {
+                errors.push_back("missing tensor namespace '" + (prefix.empty() ? std::string("<root>") : prefix) +
+                                 "'");
+            }
+        }
+        for (const auto & prefix : actual_prefixes) {
+            if (expected_prefixes.find(prefix) == expected_prefixes.end()) {
+                errors.push_back("unexpected tensor namespace '" + (prefix.empty() ? std::string("<root>") : prefix) +
+                                 "'");
+            }
+        }
+        if (const auto * files = source.find("files")) {
+            for (const auto & [id, value] : files->as_object()) {
+                const auto destination = required_destination(source, value.as_string());
+                if (destination.has_value() && sidecars.find(*destination) == sidecars.end()) {
+                    errors.push_back("missing required sidecar '" + id + "' at " + *destination);
+                }
+            }
+        }
+    } catch (const std::exception & error) {
+        errors.push_back(error.what());
+    }
+    return errors;
+}
+
+PackageSpecCandidate select_package_spec(const std::vector<engine::assets::TensorSourceInput> & inputs,
+                                         const std::filesystem::path & model_root, const std::filesystem::path & output,
+                                         const std::vector<engine::assets::GgufEmbeddedFile> & explicit_sidecars,
+                                         const std::optional<std::filesystem::path> & requested_spec,
+                                         std::optional<std::string> family,
+                                         bool embed_sidecars) {
+    std::vector<PackageSpecCandidate> candidates;
+    if (requested_spec.has_value()) {
+        add_spec_path(candidates, *requested_spec, family, 0);
+    } else {
+        const size_t config_candidate_count = candidates.size();
+        const auto config_family = add_model_config_spec(candidates, model_root);
+        if (!family.has_value())
+            family = config_family;
+
+        if (candidates.size() == config_candidate_count) {
+            if (engine::io::is_existing_file(model_root / "model_spec.json")) {
+                add_spec_file(candidates, model_root / "model_spec.json", 2);
+            }
+            if (engine::io::is_existing_directory(model_root / "model_specs")) {
+                add_spec_path(candidates, model_root / "model_specs", family, 2);
+            }
+            add_discovered_spec_directories(candidates, std::filesystem::current_path(), family, 3);
+            add_converter_catalog(candidates, family, 4);
+        }
+    }
+    if (candidates.empty()) {
+        throw std::runtime_error("no model package spec was found; pass --family/--model-spec, add "
+                                 "model_spec to config.json, "
+                                 "install model_specs/*.json, or use --allow-missing-model-spec for a "
+                                 "non-runtime tensor archive");
+    }
+
+    std::set<std::string> prefixes;
+    for (const auto & input : inputs) {
+        if (!prefixes.insert(input.tensor_prefix).second) {
+            throw std::runtime_error("duplicate tensor namespace in conversion inputs: '" +
+                                     (input.tensor_prefix.empty() ? std::string("<root>") : input.tensor_prefix) + "'");
+        }
+    }
+    const auto sidecars = planned_sidecar_destinations(model_root, output, explicit_sidecars, embed_sidecars);
+    std::vector<std::pair<PackageSpecCandidate, std::vector<std::string>>> matches;
+    std::vector<std::pair<std::string, std::vector<std::string>>> rejected;
+
+    std::optional<int> selected_priority;
+    for (const auto & candidate : candidates) {
+        if (family.has_value() && candidate.spec.family != *family)
+            continue;
+        if (!selected_priority.has_value() || candidate.priority < *selected_priority)
+            selected_priority = candidate.priority;
+    }
+    if (!selected_priority.has_value()) {
+        throw std::runtime_error("no model package spec was found for family '" +
+                                 (family.has_value() ? *family : std::string("<auto>")) + "'");
+    }
+    for (const auto & candidate : candidates) {
+        if ((family.has_value() && candidate.spec.family != *family) || candidate.priority != *selected_priority)
+            continue;
+        auto errors = validate_candidate(candidate, prefixes, sidecars);
+        if (errors.empty())
+            matches.push_back({candidate, {}});
+        else
+            rejected.push_back({candidate.spec.family + " (" + candidate.origin + ")", std::move(errors)});
+    }
+    if (matches.empty()) {
+        std::ostringstream message;
+        message << "no model package spec matches the conversion inputs";
+        if (family.has_value())
+            message << " for family '" << *family << "'";
+        for (const auto & [name, errors] : rejected) {
+            message << "\n  " << name << ':';
+            for (const auto & error : errors)
+                message << "\n    - " << error;
+        }
+        throw std::runtime_error(message.str());
+    }
+    if (matches.size() != 1) {
+        std::ostringstream message;
+        message << "multiple model package specs match:";
+        for (const auto & match : matches)
+            message << ' ' << match.first.spec.family;
+        message << "; pass --family or --model-spec explicitly";
+        throw std::runtime_error(message.str());
+    }
+    return matches.front().first;
+}
+
 void print_usage() {
-    std::cout
-        << "Usage: audiocpp_gguf --input [namespace=]<weights> [--input namespace=<weights> ...] "
-           "--output <weights.gguf> --type <orig|f16|bf16|q8_0|q2_k|q3_k|q4_k|q5_k|q6_k> "
-           "[--root <model-dir>] [--sidecar <source>=<destination>] [--overwrite] [--no-sidecars]\n"
+    std::cout << "Usage: audiocpp_gguf --input [namespace=]<weights> [--input "
+                 "namespace=<weights> ...] "
+                 "--output <weights.gguf> --type "
+                 "<orig|f16|bf16|q8_0|q2_k|q3_k|q4_k|q5_k|q6_k> "
+                 "[--family <family>] [--model-spec <json-or-directory>] "
+                 "[--root <model-dir>] [--sidecar <source>=<destination>] "
+                 "[--overwrite] [--no-sidecars] "
+                 "[--allow-missing-model-spec]\n"
         << "       audiocpp_gguf --inspect <model.gguf>\n";
 }
 
@@ -25,9 +448,12 @@ int main(int argc, char ** argv) {
         std::filesystem::path output;
         std::filesystem::path inspect_path;
         std::filesystem::path sidecar_root;
+        std::optional<std::filesystem::path> model_spec_path;
+        std::optional<std::string> family;
         std::string type;
         bool overwrite = false;
         bool embed_sidecars = true;
+        bool allow_missing_model_spec = false;
         for (int i = 1; i < argc; ++i) {
             const std::string arg = argv[i];
             if (arg == "--help" || arg == "-h") {
@@ -42,19 +468,33 @@ int main(int argc, char ** argv) {
                 embed_sidecars = false;
                 continue;
             }
-            if ((arg == "--input" || arg == "--output" || arg == "--type" || arg == "--inspect" ||
-                 arg == "--root" || arg == "--sidecar") && i + 1 < argc) {
+            if (arg == "--allow-missing-model-spec") {
+                allow_missing_model_spec = true;
+                continue;
+            }
+            if ((arg == "--input" || arg == "--output" || arg == "--type" || arg == "--inspect" || arg == "--root" ||
+                 arg == "--sidecar" || arg == "--family" || arg == "--model-spec" || arg == "--model-spec-override") &&
+                i + 1 < argc) {
                 const std::string value = argv[++i];
                 if (arg == "--input") {
                     const auto separator = value.find('=');
-                    if (separator == std::string::npos) inputs.push_back({value, ""});
-                    else inputs.push_back({value.substr(separator + 1), value.substr(0, separator)});
-                }
-                else if (arg == "--output") output = value;
-                else if (arg == "--type") type = value;
-                else if (arg == "--inspect") inspect_path = value;
-                else if (arg == "--root") sidecar_root = value;
-                else {
+                    if (separator == std::string::npos)
+                        inputs.push_back({value, ""});
+                    else
+                        inputs.push_back({value.substr(separator + 1), value.substr(0, separator)});
+                } else if (arg == "--output")
+                    output = value;
+                else if (arg == "--type")
+                    type = value;
+                else if (arg == "--inspect")
+                    inspect_path = value;
+                else if (arg == "--root")
+                    sidecar_root = value;
+                else if (arg == "--family")
+                    family = value;
+                else if (arg == "--model-spec" || arg == "--model-spec-override") {
+                    model_spec_path = std::filesystem::path(value);
+                } else {
                     const auto separator = value.find('=');
                     if (separator == std::string::npos || separator == 0 || separator + 1 == value.size()) {
                         throw std::runtime_error("--sidecar requires <source>=<destination>");
@@ -71,20 +511,31 @@ int main(int argc, char ** argv) {
             size_t scalar_count = 0;
             std::set<std::string> namespaces;
             for (const auto & tensor : tensors) {
-                if (tensor.shape.empty()) ++scalar_count;
+                if (tensor.shape.empty())
+                    ++scalar_count;
                 const auto separator = tensor.name.find('/');
-                if (separator != std::string::npos) namespaces.insert(tensor.name.substr(0, separator));
+                if (separator != std::string::npos)
+                    namespaces.insert(tensor.name.substr(0, separator));
             }
             std::cout << "gguf=" << std::filesystem::weakly_canonical(inspect_path).string() << "\n";
             std::cout << "tensors=" << tensors.size() << "\n";
             std::cout << "rank0_scalars=" << scalar_count << "\n";
-            std::cout << "embedded_sidecars=" << (engine::assets::gguf_has_embedded_sidecars(inspect_path) ? "true" : "false") << "\n";
-            for (const auto & value : namespaces) std::cout << "namespace=" << value << "\n";
+            std::cout << "embedded_sidecars="
+                      << (engine::assets::gguf_has_embedded_sidecars(inspect_path) ? "true" : "false") << "\n";
+            const auto model_spec = engine::assets::read_gguf_embedded_model_spec(inspect_path);
+            std::cout << "embedded_model_spec=" << (model_spec.has_value() ? "true" : "false") << "\n";
+            if (model_spec.has_value())
+                std::cout << "model_spec_family=" << model_spec->family << "\n";
+            for (const auto & value : namespaces)
+                std::cout << "namespace=" << value << "\n";
             return 0;
         }
         if (inputs.empty() || output.empty() || type.empty()) {
             print_usage();
             return 2;
+        }
+        if (!embed_sidecars && !sidecars.empty()) {
+            throw std::runtime_error("--sidecar cannot be combined with --no-sidecars");
         }
         for (const auto & input : inputs) {
             if (!std::filesystem::is_regular_file(input.path)) {
@@ -97,11 +548,33 @@ int main(int argc, char ** argv) {
             }
         }
         const auto storage_type = engine::assets::parse_tensor_storage_type(type);
-        engine::assets::convert_tensor_sources_to_gguf(
-            inputs, output, storage_type, overwrite, embed_sidecars, sidecar_root, sidecars);
+        const auto resolved_sidecar_root =
+            std::filesystem::weakly_canonical(sidecar_root.empty() ? inputs.front().path.parent_path() : sidecar_root);
+        std::optional<engine::assets::GgufEmbeddedModelSpec> embedded_model_spec;
+        if (!allow_missing_model_spec) {
+            embedded_model_spec =
+                select_package_spec(inputs, resolved_sidecar_root, output, sidecars, model_spec_path, family,
+                                    embed_sidecars).spec;
+        } else {
+            try {
+                embedded_model_spec =
+                    select_package_spec(inputs, resolved_sidecar_root, output, sidecars, model_spec_path, family,
+                                        embed_sidecars).spec;
+            } catch (const std::exception & warning) {
+                std::cerr << "warning: creating GGUF without model package spec: " << warning.what() << "\n";
+            }
+        }
+        engine::assets::convert_tensor_sources_to_gguf(inputs, output, storage_type, overwrite, embed_sidecars,
+                                                       resolved_sidecar_root, sidecars, embedded_model_spec);
         std::cout << "gguf=" << std::filesystem::weakly_canonical(output).string() << "\n";
         std::cout << "weight_type=" << type << "\n";
         std::cout << "tensor_sources=" << inputs.size() << "\n";
+        std::cout << "embedded_sidecars=" << (engine::assets::gguf_has_embedded_sidecars(output) ? "true" : "false")
+                  << "\n";
+        std::cout << "embedded_model_spec=" << (embedded_model_spec.has_value() ? "true" : "false") << "\n";
+        if (embedded_model_spec.has_value()) {
+            std::cout << "model_spec_family=" << embedded_model_spec->family << "\n";
+        }
         return 0;
     } catch (const std::exception & error) {
         std::cerr << "error: " << error.what() << "\n";


### PR DESCRIPTION
## Summary

This PR makes model package specifications portable without forcing every runtime binary to carry every model layout.

- New GGUF files embed the resolved package spec and family in GGUF metadata.
- CLI and server support an explicit --model-spec-override file or directory.
- Runtime resolution is deterministic and preserves compatibility with older packages.
- audiocpp_gguf always carries the conversion-time package catalog, even when copied away from the source tree.
- Standalone conversion validates required tensor namespaces and sidecars before writing.
- --no-sidecars creates an intentional tensor-only GGUF, but still embeds and validates the package spec.
- AUDIOCPP_DEPLOYMENT_BUILD=ON optionally compiles fallback specs into CLI/server binaries for safetensors and legacy GGUF deployments.

## Runtime package-spec resolution

    explicit --model-spec-override
                  |
                  v
       package spec embedded in GGUF
                  |
                  v
      compiled deployment catalog
      AUDIOCPP_DEPLOYMENT_BUILD=ON
                  |
                  v
       external model_specs discovery

An explicit override is authoritative. If it is invalid, loading fails instead of silently falling through to another source.

## Deployment behavior

| Model format | Package spec source | External model files |
|---|---|---|
| Safetensors | Override, deployment binary, or discovered model_specs | Required |
| New standalone GGUF | Embedded in GGUF | None |
| New tensor-only GGUF made with --no-sidecars | Embedded in GGUF | Required sidecars |
| Legacy GGUF without embedded spec | Deployment binary or discovered model_specs | Depends on sidecars |

A normal new standalone GGUF deployment can therefore be:

    application/
    +-- audiocpp_cli.exe or audiocpp_server.exe
    +-- model.gguf
    +-- runtime/CUDA libraries when required

No external model_specs folder is needed for that GGUF.

## Converter behavior

The converter finds a package spec in this order:

1. --model-spec or --model-spec-override
2. Model config.json metadata
3. model_spec.json or model_specs below the model root
4. An externally discovered model_specs catalog
5. The converter's bundled catalog

The selected spec is embedded as versioned audiocpp.model_spec metadata. The converter rejects missing required namespaces and sidecars before producing a deployable model. --allow-missing-model-spec remains an explicit escape hatch for generic tensor archives that are not expected to load as audio.cpp models.

## Compatibility

- Existing safetensors layouts continue to work.
- Legacy GGUF files continue to use compiled or externally discovered specs.
- Explicit CLI and server overrides support custom and development layouts.
- Uppercase .GGUF paths are handled.

## Validation

- Clean MinGW CPU compilation of engine_runtime, audiocpp_gguf, and both targeted tests
- gguf_tensor_source_test passed
- asr_standalone_gguf_test passed
- CPU and CUDA builds were completed during implementation
- Deployment catalog enabled and disabled configurations tested
- Portable copied converter tested without a neighboring model_specs directory
- Standalone Citrinet conversion and CLI loading tested
- Explicit override precedence and invalid-override failure tested
- Qwen3 ASR 1.7B and Forced Aligner family inference tested
- git diff --check passed

The MinGW CLI executable link still encounters the repository's existing WinMain entry-point mismatch; all changed CLI sources compile, and the supported Windows build/check remains covered by CI.