### PR TITLE
Harden PocketTTS FlowLM step allocation against OOM (follow-up to #55 decoder fix)

### DIFF
--- a/src/models/pocket_tts/flow_lm.cpp
+++ b/src/models/pocket_tts/flow_lm.cpp
@@ -381,6 +381,13 @@ public:
         combined_scratch_.resize(static_cast<size_t>(config_.latent_size + 1));
 
         params_buffer_ = ggml_backend_alloc_ctx_tensors(ggml_ctx_, backend_);
+        if (params_buffer_ == nullptr) {
+            // Under VRAM pressure the CUDA buffer alloc fails and returns null;
+            // the write_tensor calls below would then trip GGML_ASSERT and
+            // SIGABRT the whole server. Fail the request instead (see #55).
+            release_runtime();
+            throw std::runtime_error("FlowLM step parameter buffer allocation failed (out of memory)");
+        }
         if (prompt_steps_ > 0) {
             core::write_tensor_f32(prompt_embeddings_, prompt_embeddings_buffer_);
             core::write_tensor_i32(prompt_positions_, std::vector<int32_t>(static_cast<size_t>(prompt_steps_), 0));
@@ -413,12 +420,18 @@ public:
                 }
             }
             prompt_galloc_ = ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend_));
-            ggml_gallocr_alloc_graph(prompt_galloc_, prompt_graph_);
+            if (prompt_galloc_ == nullptr ||
+                !ggml_gallocr_reserve(prompt_galloc_, prompt_graph_) ||
+                !ggml_gallocr_alloc_graph(prompt_galloc_, prompt_graph_)) {
+                release_runtime();
+                throw std::runtime_error("FlowLM prompt graph allocation failed (out of memory)");
+            }
             if (engine::core::uses_host_graph_plan(backend_)) {
                 const auto prompt_plan_started = std::chrono::steady_clock::now();
                 prompt_plan_ = engine::core::create_backend_graph_plan_if_host(backend_, prompt_graph_);
                 prompt_plan_create_ms_ = engine::debug::elapsed_ms(prompt_plan_started);
                 if (prompt_plan_ == nullptr) {
+                    release_runtime();
                     throw std::runtime_error("Failed to create FlowLM prompt graph plan");
                 }
             }
@@ -428,23 +441,37 @@ public:
     }
 
     ~FlowLMStepRuntime() {
+        release_runtime();
+    }
+
+    // Free every owned backend resource and null it, so the constructor can
+    // call this on an allocation-failure throw path (a throw from the
+    // constructor skips the destructor, which would otherwise leak the ggml
+    // context and any buffers allocated before the failure). Idempotent.
+    void release_runtime() {
         if (prompt_plan_ != nullptr) {
             engine::core::free_backend_graph_plan(backend_, prompt_plan_);
+            prompt_plan_ = nullptr;
         }
         if (step_plan_ != nullptr) {
             engine::core::free_backend_graph_plan(backend_, step_plan_);
+            step_plan_ = nullptr;
         }
         if (prompt_galloc_ != nullptr) {
             ggml_gallocr_free(prompt_galloc_);
+            prompt_galloc_ = nullptr;
         }
         if (step_galloc_ != nullptr) {
             ggml_gallocr_free(step_galloc_);
+            step_galloc_ = nullptr;
         }
         if (params_buffer_ != nullptr) {
             ggml_backend_buffer_free(params_buffer_);
+            params_buffer_ = nullptr;
         }
         if (ggml_ctx_ != nullptr) {
             ggml_free(ggml_ctx_);
+            ggml_ctx_ = nullptr;
         }
     }
 
@@ -644,7 +671,18 @@ private:
             return;
         }
         step_galloc_ = ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend_));
-        ggml_gallocr_alloc_graph(step_galloc_, step_graph_);
+        if (step_galloc_ == nullptr ||
+            !ggml_gallocr_reserve(step_galloc_, step_graph_) ||
+            !ggml_gallocr_alloc_graph(step_galloc_, step_graph_)) {
+            // Lazy per-step allocation: free the partial gallocr so a later
+            // retry (step_graph_allocated_ stays false) does not leak it, then
+            // fail the request instead of asserting (see #55).
+            if (step_galloc_ != nullptr) {
+                ggml_gallocr_free(step_galloc_);
+                step_galloc_ = nullptr;
+            }
+            throw std::runtime_error("FlowLM step graph allocation failed (out of memory)");
+        }
         if (engine::core::uses_host_graph_plan(backend_)) {
             const auto step_plan_started = std::chrono::steady_clock::now();
             step_plan_ = engine::core::create_backend_graph_plan_if_host(backend_, step_graph_);


### PR DESCRIPTION
**Draft** — follow-up to the Mimi decoder OOM hardening on `fix/pocket-tts-mimi-decoder-oom` (this PR is based on that branch; retarget to `main` once it merges).

While verifying that branch on a 3090 under real VRAM pressure (#55), I found the SIGABRT still reproduces at tighter memory — just in a sibling `pocket_tts` runtime the branch doesn't touch: `FlowLMStepRuntime`, reached via `PocketTTSSession::prepare`. Its `ggml_backend_alloc_ctx_tensors` (and two `ggml_gallocr_alloc_graph` calls) are unguarded, so a failed CUDA buffer alloc returns null and the following `write_tensor`/graph use trips `GGML_ASSERT(buf != NULL)` at ggml-backend.cpp:327.

This applies the same treatment you used in the decoder to all three FlowLM allocation sites:
- **params buffer** (`alloc_ctx_tensors`) — null-check → `runtime_error`
- **prompt graph** — `ggml_gallocr_reserve` + `alloc_graph`-or-throw
- **lazy step graph** (`ensure_step_graph_allocated`) — same, freeing the partial gallocr so a retry doesn't leak

Because a throw from the constructor skips the destructor, the destructor cleanup is factored into an idempotent `release_runtime()` that the failure paths call, so the ggml context and any partial buffers are freed rather than leaked.

**Verified on an RTX 3090** (A/B, squeezing free VRAM with a filler then synthesizing a cloned voice):
- Original bug: `main` SIGABRTs on the ~3 GB Mimi reserve at ~1.1 GB free.
- Your branch: fixes that, and lowers peak VRAM (same synth that aborted `main` at 1143 MiB free succeeds at 997 MiB free) — but still SIGABRTs in FlowLM at ~250 MiB free.
- With this change: at **227 MiB free** the same synthesis returns a clean `500` (`FlowLM step parameter buffer allocation failed (out of memory)`) and the server stays responsive — no abort.

Draft because you may prefer to fold it into the decoder branch or adjust the messages/idiom. Happy to adapt.
