### PR TITLE
Remove temporary file writes for multipart upload

### DIFF
--- a/app/cli/request.cpp
+++ b/app/cli/request.cpp
@@ -53,6 +53,15 @@ engine::runtime::AudioBuffer read_audio_buffer(std::istream & input) {
     };
 }
 
+engine::runtime::AudioBuffer read_audio_buffer(std::string_view input) {
+    const auto wav = engine::audio::read_wav_f32(input);
+    return engine::runtime::AudioBuffer{
+        wav.sample_rate,
+        wav.channels,
+        wav.samples,
+    };
+}
+
 std::string json_option_string(const engine::io::json::Value & value) {
     if (value.is_string()) {
         return value.as_string();

--- a/app/cli/request.cpp
+++ b/app/cli/request.cpp
@@ -44,6 +44,15 @@ engine::runtime::AudioBuffer read_audio_buffer(const std::filesystem::path & pat
     };
 }
 
+engine::runtime::AudioBuffer read_audio_buffer(std::istream & input) {
+    const auto wav = engine::audio::read_wav_f32(input);
+    return engine::runtime::AudioBuffer{
+        wav.sample_rate,
+        wav.channels,
+        wav.samples,
+    };
+}
+
 std::string json_option_string(const engine::io::json::Value & value) {
     if (value.is_string()) {
         return value.as_string();

--- a/app/cli/request.h
+++ b/app/cli/request.h
@@ -6,12 +6,14 @@
 #include <filesystem>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 
 namespace minitts::cli {
 
 engine::runtime::AudioBuffer read_audio_buffer(const std::filesystem::path & path);
 engine::runtime::AudioBuffer read_audio_buffer(std::istream & path);
+engine::runtime::AudioBuffer read_audio_buffer(std::string_view input);
 std::string json_option_string(const engine::io::json::Value & value);
 std::unordered_map<std::string, std::string> json_options_map(const engine::io::json::Value * value);
 std::optional<std::string> json_optional_string(

--- a/app/cli/request.h
+++ b/app/cli/request.h
@@ -11,6 +11,7 @@
 namespace minitts::cli {
 
 engine::runtime::AudioBuffer read_audio_buffer(const std::filesystem::path & path);
+engine::runtime::AudioBuffer read_audio_buffer(std::istream & path);
 std::string json_option_string(const engine::io::json::Value & value);
 std::unordered_map<std::string, std::string> json_options_map(const engine::io::json::Value * value);
 std::optional<std::string> json_optional_string(

--- a/app/server/README.md
+++ b/app/server/README.md
@@ -221,7 +221,7 @@ curl http://127.0.0.1:8080/v1/audio/transcriptions \
   -F file=@/path/to/input.wav
 ```
 
-`file` and `model` are required; `language` is optional. The uploaded bytes are spooled to a temporary file for the duration of the request and removed afterward.
+`file` and `model` are required; `language` is optional. Uploaded WAV bytes are decoded in memory and are not written to a temporary file.
 
 For streaming-capable ASR models configured with `mode: "streaming"`, pass `stream=true` to receive OpenAI-style transcription SSE:
 

--- a/app/server/runtime.cpp
+++ b/app/server/runtime.cpp
@@ -482,28 +482,26 @@ const engine::runtime::AudioBuffer & select_audio_output(const engine::runtime::
     throw std::runtime_error("model result did not contain exactly one audio output");
 }
 
-engine::runtime::TaskRequest build_openai_transcription_request(const Value & body, const std::filesystem::path & base_dir) {
+engine::runtime::TaskRequest build_openai_transcription_request(
+    const Value & body,
+    const std::filesystem::path & base_dir,
+    const std::string * uploaded_audio = nullptr) {
     const auto * audio = body.find("audio");
-    const Value * audio_data = nullptr;
     if (audio == nullptr) {
         audio = body.find("audio_path");
     }
     if (audio == nullptr) {
-        audio = audio_data = body.find("audio_data");
-    }
-    if (audio == nullptr) {
         audio = body.find("file");
     }
-    if (audio == nullptr || !audio->is_string()) {
-        throw std::runtime_error("transcription request requires audio, audio_data, audio_path, or file path");
+    if (uploaded_audio == nullptr && (audio == nullptr || !audio->is_string())) {
+        throw std::runtime_error("transcription request requires audio, audio_path, or file path");
     }
 
     engine::runtime::TaskRequest request;
-    if (audio_data == nullptr) {
+    if (uploaded_audio == nullptr) {
         request.audio_input = minitts::cli::read_audio_buffer(resolve_path(base_dir, audio->as_string()));
     } else {
-        auto audio_stream = std::istringstream(audio_data->as_string());
-        request.audio_input = minitts::cli::read_audio_buffer(audio_stream);
+        request.audio_input = minitts::cli::read_audio_buffer(std::string_view(*uploaded_audio));
     }
     request.options = options_from_object(body.find("options"));
     std::string language;
@@ -966,14 +964,13 @@ HttpResponse ServerState::handle_transcription_multipart(const std::string & bod
 
     engine::io::json::Value::Object fields;
     fields.emplace("model", engine::io::json::Value::make_string(model_id));
-    fields.emplace("audio_data", engine::io::json::Value::make_string(file_part->data));
     if (!language.empty()) {
         fields.emplace("language", engine::io::json::Value::make_string(language));
     }
     const auto body = engine::io::json::Value::make_object(std::move(fields));
 
     auto & model = require_model(body);
-    const auto request = build_openai_transcription_request(body, request_base_);
+    const auto request = build_openai_transcription_request(body, request_base_, &file_part->data);
     if (stream) {
         return run_transcription_stream(model, request);
     }

--- a/app/server/runtime.cpp
+++ b/app/server/runtime.cpp
@@ -485,7 +485,7 @@ const engine::runtime::AudioBuffer & select_audio_output(const engine::runtime::
 engine::runtime::TaskRequest build_openai_transcription_request(
     const Value & body,
     const std::filesystem::path & base_dir,
-    const std::string * uploaded_audio = nullptr) {
+    const std::string * uploaded_audio_bytes = nullptr) {
     const auto * audio = body.find("audio");
     if (audio == nullptr) {
         audio = body.find("audio_path");
@@ -493,15 +493,15 @@ engine::runtime::TaskRequest build_openai_transcription_request(
     if (audio == nullptr) {
         audio = body.find("file");
     }
-    if (uploaded_audio == nullptr && (audio == nullptr || !audio->is_string())) {
+    if (uploaded_audio_bytes == nullptr && (audio == nullptr || !audio->is_string())) {
         throw std::runtime_error("transcription request requires audio, audio_path, or file path");
     }
 
     engine::runtime::TaskRequest request;
-    if (uploaded_audio == nullptr) {
+    if (uploaded_audio_bytes == nullptr) {
         request.audio_input = minitts::cli::read_audio_buffer(resolve_path(base_dir, audio->as_string()));
     } else {
-        request.audio_input = minitts::cli::read_audio_buffer(std::string_view(*uploaded_audio));
+        request.audio_input = minitts::cli::read_audio_buffer(std::string_view(*uploaded_audio_bytes));
     }
     request.options = options_from_object(body.find("options"));
     std::string language;

--- a/app/server/runtime.cpp
+++ b/app/server/runtime.cpp
@@ -235,37 +235,6 @@ bool is_wav_upload_filename(const std::string & filename) {
     return ext.empty() || ext == ".wav";
 }
 
-// Multipart file uploads arrive as in-memory bytes, but the WAV decoder only reads from disk,
-// so uploaded audio is spooled to a uniquely named temp file before decoding.
-std::filesystem::path write_temp_upload(const std::string & filename, const std::string & data) {
-    std::filesystem::path ext = std::filesystem::path(filename).extension();
-    if (ext.empty()) {
-        ext = ".wav";
-    }
-    static std::atomic<uint64_t> counter{0};
-    std::ostringstream name;
-    name << "audiocpp_upload_" << Clock::now().time_since_epoch().count() << "_" << counter.fetch_add(1)
-         << ext.string();
-    const auto path = std::filesystem::temp_directory_path() / name.str();
-    std::ofstream out(path, std::ios::binary);
-    if (!out) {
-        throw std::runtime_error("failed to create temp file for upload: " + path.string());
-    }
-    out.write(data.data(), static_cast<std::streamsize>(data.size()));
-    if (!out) {
-        throw std::runtime_error("failed to write temp file for upload: " + path.string());
-    }
-    return path;
-}
-
-struct TempFileGuard {
-    std::filesystem::path path;
-    ~TempFileGuard() {
-        std::error_code ec;
-        std::filesystem::remove(path, ec);
-    }
-};
-
 double elapsed_ms(Clock::time_point started) {
     return std::chrono::duration<double, std::milli>(Clock::now() - started).count();
 }
@@ -515,18 +484,27 @@ const engine::runtime::AudioBuffer & select_audio_output(const engine::runtime::
 
 engine::runtime::TaskRequest build_openai_transcription_request(const Value & body, const std::filesystem::path & base_dir) {
     const auto * audio = body.find("audio");
+    const Value * audio_data = nullptr;
     if (audio == nullptr) {
         audio = body.find("audio_path");
+    }
+    if (audio == nullptr) {
+        audio = audio_data = body.find("audio_data");
     }
     if (audio == nullptr) {
         audio = body.find("file");
     }
     if (audio == nullptr || !audio->is_string()) {
-        throw std::runtime_error("transcription request requires audio, audio_path, or file path");
+        throw std::runtime_error("transcription request requires audio, audio_data, audio_path, or file path");
     }
 
     engine::runtime::TaskRequest request;
-    request.audio_input = minitts::cli::read_audio_buffer(resolve_path(base_dir, audio->as_string()));
+    if (audio_data == nullptr) {
+        request.audio_input = minitts::cli::read_audio_buffer(resolve_path(base_dir, audio->as_string()));
+    } else {
+        auto audio_stream = std::istringstream(audio_data->as_string());
+        request.audio_input = minitts::cli::read_audio_buffer(audio_stream);
+    }
     request.options = options_from_object(body.find("options"));
     std::string language;
     if (const auto * value = body.find("language")) {
@@ -986,11 +964,9 @@ HttpResponse ServerState::handle_transcription_multipart(const std::string & bod
             "invalid_request_error");
     }
 
-    const TempFileGuard guard{write_temp_upload(file_part->filename, file_part->data)};
-
     engine::io::json::Value::Object fields;
     fields.emplace("model", engine::io::json::Value::make_string(model_id));
-    fields.emplace("audio", engine::io::json::Value::make_string(guard.path.string()));
+    fields.emplace("audio_data", engine::io::json::Value::make_string(file_part->data));
     if (!language.empty()) {
         fields.emplace("language", engine::io::json::Value::make_string(language));
     }

--- a/app/workflow/workflow.cpp
+++ b/app/workflow/workflow.cpp
@@ -55,6 +55,11 @@ std::string workflow_string(const engine::io::json::Value & object, const std::s
     return value->as_string();
 }
 
+std::istringstream workflow_buffer(const engine::io::json::Value & object, const std::string & key) {
+    const auto str = workflow_string(object, key);
+    return std::istringstream(str);
+}
+
 std::string workflow_string_or(
     const engine::io::json::Value & object,
     const std::string & key,
@@ -725,8 +730,14 @@ void run_chunked_model_step(
         throw std::runtime_error("chunked_model step requires request object: " + id);
     }
     const std::string audio_key = workflow_string_or(step, "audio_key", "audio");
-    const auto input_audio_path = resolve_workflow_path(workflow_string(*request_value, audio_key), context);
-    const auto input_wav = engine::audio::read_wav_f32(input_audio_path);
+    engine::audio::WavData input_wav;
+    if (workflow_has_field(*request_value, "audio_data")) {
+        auto input_audio_data = workflow_buffer(*request_value, "audio_data");
+        input_wav = engine::audio::read_wav_f32(input_audio_data);
+    } else {
+        const auto input_audio_path = resolve_workflow_path(workflow_string(*request_value, audio_key), context);
+        input_wav = engine::audio::read_wav_f32(input_audio_path);
+    }
     if (input_wav.channels <= 0 || input_wav.sample_rate <= 0 || input_wav.samples.empty()) {
         throw std::runtime_error("chunked_model input audio is invalid: " + id);
     }

--- a/include/engine/framework/audio/wav_reader.h
+++ b/include/engine/framework/audio/wav_reader.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <filesystem>
+#include <istream>
+#include <string_view>
 #include <vector>
 
 namespace engine::audio {
@@ -12,6 +14,7 @@ struct WavData {
 };
 
 WavData read_wav_f32(std::istream & input);
+WavData read_wav_f32(std::string_view input);
 WavData read_wav_f32(const std::filesystem::path & path);
 
 }  // namespace engine::audio

--- a/include/engine/framework/audio/wav_reader.h
+++ b/include/engine/framework/audio/wav_reader.h
@@ -11,6 +11,7 @@ struct WavData {
     std::vector<float> samples;
 };
 
+WavData read_wav_f32(std::istream & input);
 WavData read_wav_f32(const std::filesystem::path & path);
 
 }  // namespace engine::audio

--- a/src/framework/audio/wav_reader.cpp
+++ b/src/framework/audio/wav_reader.cpp
@@ -4,9 +4,46 @@
 #include <fstream>
 #include <stdexcept>
 #include <string>
+#include <string_view>
+#include <streambuf>
 
 namespace engine::audio {
 namespace {
+
+class MemoryStreamBuffer : public std::streambuf {
+public:
+    explicit MemoryStreamBuffer(std::string_view data) {
+        auto * begin = const_cast<char *>(data.data());
+        setg(begin, begin, begin + data.size());
+    }
+
+protected:
+    pos_type seekoff(off_type offset, std::ios_base::seekdir dir, std::ios_base::openmode which) override {
+        if ((which & std::ios_base::in) == 0) {
+            return pos_type(off_type(-1));
+        }
+        char * base = eback();
+        char * next = gptr();
+        char * end = egptr();
+        char * target = nullptr;
+        if (dir == std::ios_base::beg) {
+            target = base + offset;
+        } else if (dir == std::ios_base::cur) {
+            target = next + offset;
+        } else if (dir == std::ios_base::end) {
+            target = end + offset;
+        }
+        if (target == nullptr || target < base || target > end) {
+            return pos_type(off_type(-1));
+        }
+        setg(base, target, end);
+        return pos_type(target - base);
+    }
+
+    pos_type seekpos(pos_type position, std::ios_base::openmode which) override {
+        return seekoff(off_type(position), std::ios_base::beg, which);
+    }
+};
 
 template <typename T>
 T read_scalar(std::istream & input) {
@@ -131,6 +168,12 @@ WavData read_wav_f32(std::istream & input) {
     }
 
     throw std::runtime_error("unsupported WAV encoding (need PCM16, PCM24, or float32)");
+}
+
+WavData read_wav_f32(std::string_view input) {
+    MemoryStreamBuffer buffer(input);
+    std::istream stream(&buffer);
+    return read_wav_f32(stream);
 }
 
 WavData read_wav_f32(const std::filesystem::path & path) {

--- a/src/framework/audio/wav_reader.cpp
+++ b/src/framework/audio/wav_reader.cpp
@@ -9,7 +9,7 @@ namespace engine::audio {
 namespace {
 
 template <typename T>
-T read_scalar(std::ifstream & input) {
+T read_scalar(std::istream & input) {
     T value{};
     input.read(reinterpret_cast<char *>(&value), sizeof(T));
     if (!input) {
@@ -18,7 +18,7 @@ T read_scalar(std::ifstream & input) {
     return value;
 }
 
-void skip_bytes(std::ifstream & input, std::streamoff count) {
+void skip_bytes(std::istream & input, std::streamoff count) {
     input.seekg(count, std::ios::cur);
     if (!input) {
         throw std::runtime_error("failed to seek inside WAV file");
@@ -27,22 +27,21 @@ void skip_bytes(std::ifstream & input, std::streamoff count) {
 
 }  // namespace
 
-WavData read_wav_f32(const std::filesystem::path & path) {
-    std::ifstream input(path, std::ios::binary);
+WavData read_wav_f32(std::istream & input) {
     if (!input) {
-        throw std::runtime_error("could not open WAV input: " + path.string());
+        throw std::runtime_error("could not open WAV input");
     }
 
     char riff[4];
     input.read(riff, 4);
     if (!input || std::string(riff, 4) != "RIFF") {
-        throw std::runtime_error("invalid WAV RIFF header: " + path.string());
+        throw std::runtime_error("invalid WAV RIFF header");
     }
     skip_bytes(input, 4);
     char wave[4];
     input.read(wave, 4);
     if (!input || std::string(wave, 4) != "WAVE") {
-        throw std::runtime_error("invalid WAV WAVE header: " + path.string());
+        throw std::runtime_error("invalid WAV WAVE header");
     }
 
     uint16_t audio_format = 0;
@@ -72,7 +71,7 @@ WavData read_wav_f32(const std::filesystem::path & path) {
             data.resize(chunk_size);
             input.read(data.data(), static_cast<std::streamsize>(chunk_size));
             if (!input) {
-                throw std::runtime_error("failed to read WAV data chunk: " + path.string());
+                throw std::runtime_error("failed to read WAV data chunk");
             }
         } else {
             skip_bytes(input, chunk_size);
@@ -83,7 +82,7 @@ WavData read_wav_f32(const std::filesystem::path & path) {
     }
 
     if (channels == 0 || sample_rate == 0 || bits_per_sample == 0 || data.empty()) {
-        throw std::runtime_error("incomplete WAV file: " + path.string());
+        throw std::runtime_error("incomplete WAV file");
     }
 
     WavData wav;
@@ -102,7 +101,7 @@ WavData read_wav_f32(const std::filesystem::path & path) {
 
     if (audio_format == 1 && bits_per_sample == 24) {
         if (data.size() % 3 != 0) {
-            throw std::runtime_error("malformed PCM24 WAV data chunk: " + path.string());
+            throw std::runtime_error("malformed PCM24 WAV data chunk");
         }
         const size_t sample_count = data.size() / 3;
         wav.samples.resize(sample_count);
@@ -131,7 +130,16 @@ WavData read_wav_f32(const std::filesystem::path & path) {
         return wav;
     }
 
-    throw std::runtime_error("unsupported WAV encoding in " + path.string() + " (need PCM16, PCM24, or float32)");
+    throw std::runtime_error("unsupported WAV encoding (need PCM16, PCM24, or float32)");
+}
+
+WavData read_wav_f32(const std::filesystem::path & path) {
+    std::ifstream input(path, std::ios::binary);
+    if (!input) {
+        throw std::runtime_error("could not open WAV input: " + path.string());
+    }
+
+    return read_wav_f32(input);
 }
 
 }  // namespace engine::audio

--- a/src/framework/audio/wav_reader.cpp
+++ b/src/framework/audio/wav_reader.cpp
@@ -10,9 +10,10 @@
 namespace engine::audio {
 namespace {
 
-class MemoryStreamBuffer : public std::streambuf {
+class ReadOnlyMemoryStreamBuffer final : public std::streambuf {
 public:
-    explicit MemoryStreamBuffer(std::string_view data) {
+    explicit ReadOnlyMemoryStreamBuffer(std::string_view data) {
+        // std::streambuf::setg takes char*, but this input stream only reads from the buffer.
         auto * begin = const_cast<char *>(data.data());
         setg(begin, begin, begin + data.size());
     }
@@ -171,7 +172,7 @@ WavData read_wav_f32(std::istream & input) {
 }
 
 WavData read_wav_f32(std::string_view input) {
-    MemoryStreamBuffer buffer(input);
+    ReadOnlyMemoryStreamBuffer buffer(input);
     std::istream stream(&buffer);
     return read_wav_f32(stream);
 }


### PR DESCRIPTION
Wanting to run audio.cpp as an ASR server, it used to hurt thinking about the disk getting hit every time. It no longer hurts with this patch :)