### PR TITLE
Return voices for single-model servers when model param is omitted

### DIFF
--- a/app/server/README.md
+++ b/app/server/README.md
@@ -237,7 +237,7 @@ The stream emits `transcript.text.delta` events, one final `transcript.text.done
 
 ### `GET /v1/audio/voices?model=<id>`
 
-Lists the cached voice ids and configured server voice preset names available for a TTS model, so a client can populate a voice picker instead of guessing generic names. For families that keep voice presets under `model_root/embeddings/*.safetensors` (`pocket_tts` today), this returns those ids too; for other families with no configured presets, or an unknown/missing `model` parameter, it returns an empty list.
+Lists the cached voice ids and configured server voice preset names available for a TTS model, so a client can populate a voice picker instead of guessing generic names. For families that keep voice presets under `model_root/embeddings/*.safetensors` (`pocket_tts` today), this returns those ids too. If `model` is omitted and the server has exactly one configured model, that model is used; if multiple models are configured, omit `model` only when an empty list is acceptable.
 
 ```bash
 curl 'http://127.0.0.1:8080/v1/audio/voices?model=pocket-tts'

--- a/app/server/runtime.cpp
+++ b/app/server/runtime.cpp
@@ -1104,13 +1104,21 @@ HttpResponse ServerState::handle_voices(const HttpRequest & request) const {
     const std::string model_id = query_param(request.query, "model");
     std::vector<std::string> voices;
 
-    const auto it = model_index_.find(model_id);
-    if (it != model_index_.end()) {
-        for (const auto & [name, preset] : models_.at(it->second)->voice_presets) {
+    size_t model_idx = SIZE_MAX;
+    if (!model_id.empty()) {
+        const auto it = model_index_.find(model_id);
+        if (it != model_index_.end()) {
+            model_idx = it->second;
+        }
+    } else if (models_.size() == 1) {
+        model_idx = 0;
+    }
+    if (model_idx != SIZE_MAX) {
+        for (const auto & [name, preset] : models_.at(model_idx)->voice_presets) {
             (void) preset;
             voices.push_back(name);
         }
-        const auto embeddings_dir = models_.at(it->second)->config.path / "embeddings";
+        const auto embeddings_dir = models_.at(model_idx)->config.path / "embeddings";
         std::error_code ec;
         if (std::filesystem::is_directory(embeddings_dir, ec)) {
             for (const auto & entry : std::filesystem::directory_iterator(embeddings_dir, ec)) {


### PR DESCRIPTION
## Problem

When the server has a single model configured, `GET /v1/audio/voices` without a `?model=` query parameter returns `{"voices":[]}`. Clients that call this endpoint to populate a voice picker — without prior knowledge of model IDs — receive an empty list and cannot discover available voices.

## Fix

When no `?model=` param is provided and exactly one model is configured, fall back to that model's voices. When multiple models are configured, the existing behavior is unchanged (empty response, since voices cannot be attributed to a specific model without the param).

```cpp
size_t model_idx = SIZE_MAX;
if (!model_id.empty()) {
    const auto it = model_index_.find(model_id);
    if (it != model_index_.end()) {
        model_idx = it->second;
    }
} else if (models_.size() == 1) {
    model_idx = 0;
}
```

## Rationale

The change is purely additive — it only affects the `models_.size() == 1` path that previously returned empty. The multi-model path and the explicit `?model=` path are unchanged.

Voice presets are static config metadata parsed at startup, so this works regardless of `lazy_load` setting. No runtime state or model session is involved — `handle_voices` only reads the in-memory `voice_presets` map and the `embeddings/` directory listing.

## Tested

- `GET /v1/audio/voices` (no param) → voices returned (was `[]`)
- `GET /v1/audio/voices?model=<id>` → unchanged
- Backend: CUDA