### PR TITLE
Extend Qwen decoder RoPE configuration

### DIFF
--- a/include/engine/framework/modules/attention/qwen_decoder.h
+++ b/include/engine/framework/modules/attention/qwen_decoder.h
@@ -48,6 +48,7 @@ struct QwenDecoderLayerConfig {
     int64_t intermediate_size = 0;
     float rms_norm_eps = 1e-5f;
     float rope_theta = 10000.0f;
+    int rope_type = GGML_ROPE_TYPE_NEOX;
     ggml_prec attention_precision = GGML_PREC_F32;
     ggml_prec projection_precision = GGML_PREC_DEFAULT;
     bool use_qk_norm = true;
@@ -67,6 +68,9 @@ struct QwenDecoderLayerWeights {
     NormWeights k_norm;
     NormWeights post_norm;
     QwenMLPWeights mlp;
+    // Optional per-frequency RoPE divisors (head_dim / 2), used by Llama-3
+    // scaling and compatible checkpoints.
+    std::optional<core::TensorValue> rope_frequency_factors;
 };
 
 struct QwenDecoderLayerOutputs {
@@ -117,6 +121,7 @@ struct QwenDecoderStackConfig {
     int64_t layers = 0;
     float rms_norm_eps = 1e-5f;
     float rope_theta = 10000.0f;
+    int rope_type = GGML_ROPE_TYPE_NEOX;
     ggml_prec attention_precision = GGML_PREC_F32;
     ggml_prec projection_precision = GGML_PREC_DEFAULT;
     bool use_qk_norm = true;

--- a/include/engine/framework/modules/positional_modules.h
+++ b/include/engine/framework/modules/positional_modules.h
@@ -24,7 +24,8 @@ public:
     core::TensorValue build(
         core::ModuleBuildContext & ctx,
         const core::TensorValue & input,
-        const core::TensorValue & positions) const;
+        const core::TensorValue & positions,
+        const core::TensorValue * frequency_factors = nullptr) const;
 
 private:
     RoPEConfig config_;

--- a/src/framework/modules/attention/qwen_decoder.cpp
+++ b/src/framework/modules/attention/qwen_decoder.cpp
@@ -234,6 +234,7 @@ QwenDecoderLayerConfig qwen_decoder_layer_config_from_stack(const QwenDecoderSta
     out.intermediate_size = config.intermediate_size;
     out.rms_norm_eps = config.rms_norm_eps;
     out.rope_theta = config.rope_theta;
+    out.rope_type = config.rope_type;
     out.attention_precision = config.attention_precision;
     out.projection_precision = config.projection_precision;
     out.use_qk_norm = config.use_qk_norm;
@@ -346,8 +347,11 @@ QwenDecoderLayerOutputs QwenDecoderLayerModule::build(
     }
     v = reshape_qwen_heads(ctx, v, config_.num_key_value_heads, dim);
 
-    q = RoPEModule({dim, GGML_ROPE_TYPE_NEOX, config_.rope_theta}).build(ctx, q, positions);
-    k = RoPEModule({dim, GGML_ROPE_TYPE_NEOX, config_.rope_theta}).build(ctx, k, positions);
+    const core::TensorValue * rope_factors = weights.rope_frequency_factors.has_value()
+        ? &*weights.rope_frequency_factors
+        : nullptr;
+    q = RoPEModule({dim, config_.rope_type, config_.rope_theta}).build(ctx, q, positions, rope_factors);
+    k = RoPEModule({dim, config_.rope_type, config_.rope_theta}).build(ctx, k, positions, rope_factors);
     k = core::ensure_backend_addressable_layout(ctx, k);
     v = core::ensure_backend_addressable_layout(ctx, v);
 
@@ -478,8 +482,11 @@ QwenDecoderLayerOutputs QwenDecoderLayerModule::build_with_static_cache_tail(
     }
     v = reshape_qwen_heads(ctx, v, config_.num_key_value_heads, dim);
 
-    q = RoPEModule({dim, GGML_ROPE_TYPE_NEOX, config_.rope_theta}).build(ctx, q, positions);
-    k = RoPEModule({dim, GGML_ROPE_TYPE_NEOX, config_.rope_theta}).build(ctx, k, positions);
+    const core::TensorValue * rope_factors = weights.rope_frequency_factors.has_value()
+        ? &*weights.rope_frequency_factors
+        : nullptr;
+    q = RoPEModule({dim, config_.rope_type, config_.rope_theta}).build(ctx, q, positions, rope_factors);
+    k = RoPEModule({dim, config_.rope_type, config_.rope_theta}).build(ctx, k, positions, rope_factors);
     k = core::ensure_backend_addressable_layout(ctx, k);
     v = core::ensure_backend_addressable_layout(ctx, v);
 

--- a/src/framework/modules/positional_modules.cpp
+++ b/src/framework/modules/positional_modules.cpp
@@ -21,7 +21,8 @@ RoPEModule::RoPEModule(RoPEConfig config) : config_(config) {
 core::TensorValue RoPEModule::build(
     core::ModuleBuildContext & ctx,
     const core::TensorValue & input,
-    const core::TensorValue & positions) const {
+    const core::TensorValue & positions,
+    const core::TensorValue * frequency_factors) const {
     if (ctx.ggml == nullptr) {
         throw std::runtime_error("ModuleBuildContext.ggml is null");
     }
@@ -33,12 +34,18 @@ core::TensorValue RoPEModule::build(
     if (config_.dimensions > input.shape.last_dim()) {
         throw std::runtime_error("RoPE dimensions exceed input last dimension");
     }
+    if (frequency_factors != nullptr) {
+        core::validate_shape(
+            *frequency_factors,
+            core::TensorShape::from_dims({config_.dimensions / 2}),
+            "RoPE frequency factors");
+    }
     return core::wrap_tensor(
         ggml_rope_ext(
             ctx.ggml,
             input.tensor,
             positions.tensor,
-            nullptr,
+            frequency_factors != nullptr ? frequency_factors->tensor : nullptr,
             static_cast<int>(config_.dimensions),
             config_.mode,
             0,


### PR DESCRIPTION
## Summary

- make the shared Qwen decoder RoPE mode configurable at stack and layer level
- allow an optional per-frequency RoPE divisor tensor for Llama-3-style scaling
- validate frequency factors as `head_dim / 2` before passing them to `ggml_rope_ext`
- apply the same behavior to normal decoding and the static-cache-tail path

This is a framework-only extension intended for reuse by autoregressive model implementations. It contains no OuteTTS model or asset-loading changes.

## Compatibility

Existing users keep the current behavior by default:

- RoPE mode defaults to `GGML_ROPE_TYPE_NEOX`
- frequency factors default to `nullptr`

## Validation

Windows CPU CLI build:

```powershell
.\scripts\build_windows.ps1 -Preset windows-cpu-release -Target audiocpp_cli -Jobs 4
```

Windows CUDA CLI build used CUDA 12.4, MSVC 19.43, compute capability 8.6, `/openmp:experimental`, and `-allow-unsupported-compiler` for this local CUDA/MSVC combination:

```powershell
cmake -S . -B build/windows-cuda-release -G Ninja -DENGINE_ENABLE_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=86-real '-DCMAKE_CUDA_FLAGS=-allow-unsupported-compiler -Xcompiler=/utf-8' '-DOpenMP_C_FLAGS=/openmp:experimental' '-DOpenMP_CXX_FLAGS=/openmp:experimental'
cmake --build build/windows-cuda-release --target audiocpp_cli --parallel 4
```

CUDA runtime smoke test on an NVIDIA GeForce RTX 3090:

```powershell
.\build\windows-cuda-release\bin\audiocpp_cli.exe --task asr --family qwen3_asr --model '..\models\Qwen3-ASR-0.6B_Q8\Qwen3-ASR-0.6B_Q8.gguf' --backend cuda --audio '..\SAMPLES\EN_2.wav' --text-out '.\build\windows-cuda-release\qwen_rope_smoke.txt' --max-tokens 128 --log
```

Result:

- transcript: `If you actually care about security.`
- output: `build/windows-cuda-release/qwen_rope_smoke.txt`
- session wall time: 159.75 ms
- audio encoder: 70.46 ms
- thinker: 86.59 ms

No runtime behavior changes unless a caller selects a different RoPE mode or supplies frequency factors.
