### PR TITLE
build: require CUDA 12.0+ and document the Linux CUDA toolchain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,16 @@ set(AUDIOCPP_GGML_SOURCE_DIR
 
 if (ENGINE_ENABLE_CUDA)
     enable_language(CUDA)
-    find_package(CUDAToolkit REQUIRED)
+    # 12.0 is a floor, not a target: any 12.x or 13.x works (the Dockerfile pins
+    # 12.9.0, and docs/build/windows.md ships a CUDA 13 package). The minimum is
+    # enforced because an older toolkit configures happily and only fails at the
+    # first .cu file, which reads as a code bug rather than a toolchain one: nvcc
+    # < 11.6 cannot parse libstdc++ >= 11.3 headers ("parameter packs not expanded
+    # with '...'" in <functional>), and distros still ship such pairings (Ubuntu
+    # 22.04's nvidia-cuda-toolkit is 11.5). Fail here, with a pointer, instead.
+    # The upper bound is the host compiler the chosen toolkit accepts, not CUDA
+    # itself (e.g. CUDA 12.9 supports GCC <= 14), so it is left to the toolkit.
+    find_package(CUDAToolkit 12.0 REQUIRED)
     if (NOT MSVC)
         set(CMAKE_CUDA_FLAGS_DEBUG "${AUDIOCPP_DEBUG_OPT_FLAGS}" CACHE STRING "Optimized debug CUDA flags" FORCE)
     endif()

--- a/docs/build/linux.md
+++ b/docs/build/linux.md
@@ -7,6 +7,10 @@ This document covers direct CMake builds on Linux. For the quick script-based pa
 - GCC 13 or newer
 - CMake
 - A supported backend toolchain when enabling CUDA or Vulkan
+- For CUDA: CUDA Toolkit 12.0 or newer — any 12.x or 13.x is fine (the Docker image
+  pins 12.9, and a CUDA 13 package is documented for Windows). The real upper bound
+  is the host GCC the chosen toolkit accepts, not the CUDA version: e.g. CUDA 12.9
+  supports up to GCC 14
 
 Native ggml CPU optimization is enabled by default for local performance. If your compiler or assembler rejects a generated CPU instruction such as `vpdpbusd`, reconfigure with `-DENGINE_ENABLE_NATIVE_CPU=OFF` to build portable CPU kernels.
 
@@ -25,6 +29,38 @@ CUDA:
 ```bash
 cmake -S . -B build -DENGINE_ENABLE_CUDA=ON
 ```
+
+CMake picks the first `nvcc` on `PATH`, which is often **not** the toolkit you want:
+distro packages install an old one to `/usr/bin/nvcc` (Ubuntu 22.04's
+`nvidia-cuda-toolkit` is CUDA 11.5) while the toolkit from NVIDIA lands in
+`/usr/local/cuda-<version>`. Point at it explicitly, and set the architecture of the
+GPU you are building for, rather than relying on `PATH`:
+
+```bash
+cmake -S . -B build -DENGINE_ENABLE_CUDA=ON \
+  -DCUDAToolkit_ROOT=/usr/local/cuda-12.9 \
+  -DCMAKE_CUDA_COMPILER=/usr/local/cuda-12.9/bin/nvcc \
+  -DCMAKE_CUDA_ARCHITECTURES=86      # 86 = RTX 3000, 89 = RTX 4000, 120 = Blackwell
+```
+
+Set **both**. `CMAKE_CUDA_COMPILER` only chooses the compiler, and `CUDAToolkit_ROOT`
+only chooses the libraries — with a distro CUDA also installed, setting just the
+compiler produces a build that compiles with the new `nvcc` but silently links the
+old `libcudart`/`libcublas` from `/usr/lib/x86_64-linux-gnu` (owned by
+`nvidia-cuda-dev`). That mismatch links without warning. Check the result:
+
+```bash
+readelf -d build/bin/audiocpp_server | grep NEEDED | grep cuda
+# want libcudart.so.12 / libcublas.so.12 — libcudart.so.11.0 means a mixed build
+```
+
+Leave `CMAKE_CUDA_ARCHITECTURES` unset to build for the GPUs present at build time
+(`native`). Note that CMake caches the CUDA compiler: switching toolkits in an
+existing build directory requires deleting `CMakeCache.txt` and `CMakeFiles/`.
+
+On WSL2, install the toolkit only — `cuda-toolkit-<version>` from the `wsl-ubuntu`
+repo. The `cuda` and `cuda-drivers` metapackages pull a Linux display driver that
+breaks the GPU passthrough provided by the Windows host driver.
 
 Vulkan:
 


### PR DESCRIPTION
A native Linux CUDA build had no documented toolkit version: docs/build/linux.md asked only for "a supported backend toolchain", CMake set no minimum, and Linux CI builds with ENGINE_ENABLE_CUDA=OFF, so nothing caught an unusable toolkit.

That combination fails badly on a stock Ubuntu 22.04 box. CMake takes the first nvcc on PATH, which is the distro nvidia-cuda-toolkit (CUDA 11.5); nvcc < 11.6 cannot parse libstdc++ >= 11.3 headers, so configure succeeds and the build dies at the first .cu file with "parameter packs not expanded with '...'" inside <functional> -- a toolchain fault that reads as a code fault.

find_package(CUDAToolkit 12.0 REQUIRED) turns that into a clear configure-time error. 12.0 is a floor, not a target: any 12.x or 13.x works (the Dockerfile pins 12.9.0 and a CUDA 13 package is documented for Windows). The upper bound is the host compiler the chosen toolkit accepts, not the CUDA version, so it is left to the toolkit.

The docs also cover the trap that CMAKE_CUDA_COMPILER alone does not close: it selects the compiler but not the libraries, so with a distro CUDA also installed the link silently picks up libcudart/libcublas 11 from /usr/lib/x86_64-linux-gnu while compiling with the newer nvcc. CUDAToolkit_ROOT is what pins the libraries.