### PR TITLE
Add machine-readable loader and package catalog exports

### DIFF
--- a/app/cli/main.cpp
+++ b/app/cli/main.cpp
@@ -10,7 +10,9 @@
 #include "engine/framework/audio/chunking.h"
 #include "engine/framework/audio/conversion.h"
 #include "engine/framework/debug/trace.h"
+#include "engine/framework/io/json.h"
 #include "engine/framework/runtime/registry.h"
+#include "engine/framework/runtime/session.h"
 
 #include <algorithm>
 #include <cmath>
@@ -141,7 +143,7 @@ void print_task_list_help() {
         << "    --mode streaming uses the selected model's default streaming policy\n"
         << "  Utility:\n"
         << "    --inspect\n"
-        << "    --list-loaders\n"
+        << "    --list-loaders [--json]\n"
         << "\n"
         << "  Tasks:\n"
         << "    vad    voice activity detection\n"
@@ -564,10 +566,67 @@ int audiocpp_cli_main(int argc, char ** argv) {
             return 0;
         }
         if (has_arg(argc, argv, "--list-loaders")) {
-            const auto families = registry.families();
-            std::cout << "registered_loaders=" << registry.size() << "\n";
-            for (const auto & family : families) {
-                std::cout << family << "\n";
+            const auto advertisements = registry.advertise_loaders();
+            if (has_arg(argc, argv, "--json")) {
+                engine::io::json::Value::Object loaders_object;
+                for (const auto & row : advertisements) {
+                    engine::io::json::Value::Object tasks_object;
+                    for (const auto & task_cap : row.capabilities.supported_tasks) {
+                        engine::io::json::Value::Array modes;
+                        for (const auto mode : task_cap.modes) {
+                            modes.push_back(engine::io::json::Value::make_string(engine::runtime::to_string(mode)));
+                        }
+                        tasks_object.emplace(
+                            engine::runtime::to_string(task_cap.task),
+                            engine::io::json::Value::make_array(std::move(modes)));
+                    }
+                    engine::io::json::Value::Array endpoints;
+                    for (const auto & endpoint : row.api_endpoints) {
+                        endpoints.push_back(engine::io::json::Value::make_string(endpoint));
+                    }
+                    engine::io::json::Value::Object loader_object;
+                    loader_object.emplace("tasks", engine::io::json::Value::make_object(std::move(tasks_object)));
+                    loader_object.emplace(
+                        "instructions_policy",
+                        engine::io::json::Value::make_string(row.instructions_policy));
+                    loader_object.emplace(
+                        "api_endpoints",
+                        engine::io::json::Value::make_array(std::move(endpoints)));
+                    loaders_object.emplace(
+                        row.family,
+                        engine::io::json::Value::make_object(std::move(loader_object)));
+                }
+                engine::io::json::Value::Object root;
+                root.emplace("schema_version", engine::io::json::Value::make_number(1));
+                root.emplace("loaders", engine::io::json::Value::make_object(std::move(loaders_object)));
+                std::cout << engine::io::json::stringify(engine::io::json::Value::make_object(std::move(root)))
+                          << "\n";
+            } else {
+                std::cout << "registered_loaders=" << advertisements.size() << "\n";
+                for (const auto & row : advertisements) {
+                    std::cout << row.family;
+                    if (!row.capabilities.supported_tasks.empty()) {
+                        std::cout << ":";
+                        for (size_t i = 0; i < row.capabilities.supported_tasks.size(); ++i) {
+                            const auto & task_cap = row.capabilities.supported_tasks[i];
+                            if (i > 0) {
+                                std::cout << ",";
+                            }
+                            std::cout << " " << engine::runtime::to_string(task_cap.task);
+                            if (!task_cap.modes.empty()) {
+                                std::cout << " (";
+                                for (size_t m = 0; m < task_cap.modes.size(); ++m) {
+                                    if (m > 0) {
+                                        std::cout << "|";
+                                    }
+                                    std::cout << engine::runtime::to_string(task_cap.modes[m]);
+                                }
+                                std::cout << ")";
+                            }
+                        }
+                    }
+                    std::cout << "\n";
+                }
             }
             return 0;
         }

--- a/include/engine/framework/runtime/model.h
+++ b/include/engine/framework/runtime/model.h
@@ -105,6 +105,18 @@ public:
         const SessionOptions & options) const = 0;
 };
 
+struct LoaderAdvertisement {
+    std::string family;
+    CapabilitySet capabilities;
+    std::string instructions_policy;
+    std::vector<std::string> api_endpoints;
+};
+
+/** Path-free defaults used by ``--list-loaders --json`` when a loader does not override. */
+CapabilitySet default_advertised_capabilities_for_family(const std::string & family);
+std::string default_instructions_policy_for_family(const std::string & family);
+std::vector<std::string> default_api_endpoints_for_capabilities(const CapabilitySet & capabilities);
+
 class IVoiceModelLoader {
 public:
     virtual ~IVoiceModelLoader() = default;
@@ -113,6 +125,12 @@ public:
     virtual bool can_load(const ModelLoadRequest & request) const = 0;
     virtual ModelInspection inspect(const ModelLoadRequest & request) const = 0;
     virtual std::unique_ptr<ILoadedVoiceModel> load(const ModelLoadRequest & request) const = 0;
+
+    /** Catalog-time capabilities (no model path). Override when defaults are wrong. */
+    virtual CapabilitySet advertised_capabilities() const;
+    virtual std::string advertised_instructions_policy() const;
+    virtual std::vector<std::string> advertised_api_endpoints() const;
+    LoaderAdvertisement advertise() const;
 };
 
 }  // namespace engine::runtime

--- a/include/engine/framework/runtime/model.h
+++ b/include/engine/framework/runtime/model.h
@@ -112,9 +112,7 @@ struct LoaderAdvertisement {
     std::vector<std::string> api_endpoints;
 };
 
-/** Path-free defaults used by ``--list-loaders --json`` when a loader does not override. */
-CapabilitySet default_advertised_capabilities_for_family(const std::string & family);
-std::string default_instructions_policy_for_family(const std::string & family);
+/** Map advertised capabilities to the HTTP surfaces they normally use. */
 std::vector<std::string> default_api_endpoints_for_capabilities(const CapabilitySet & capabilities);
 
 class IVoiceModelLoader {
@@ -126,7 +124,10 @@ public:
     virtual ModelInspection inspect(const ModelLoadRequest & request) const = 0;
     virtual std::unique_ptr<ILoadedVoiceModel> load(const ModelLoadRequest & request) const = 0;
 
-    /** Catalog-time capabilities (no model path). Override when defaults are wrong. */
+    /**
+     * Path-free loader catalog for ``--list-loaders --json``.
+     * Override ``advertised_capabilities`` (and policy when non-default) on each loader.
+     */
     virtual CapabilitySet advertised_capabilities() const;
     virtual std::string advertised_instructions_policy() const;
     virtual std::vector<std::string> advertised_api_endpoints() const;

--- a/include/engine/framework/runtime/registry.h
+++ b/include/engine/framework/runtime/registry.h
@@ -22,6 +22,8 @@ public:
     size_t size() const noexcept;
     std::vector<std::string> families() const;
     bool supports_family(const std::string & family) const noexcept;
+    /** Path-free loader catalog for ``--list-loaders --json``. */
+    std::vector<LoaderAdvertisement> advertise_loaders() const;
     ModelInspection inspect(const ModelLoadRequest & request) const;
     ModelInspection inspect(const std::filesystem::path & model_path) const;
     std::unique_ptr<ILoadedVoiceModel> load(const ModelLoadRequest & request) const;

--- a/src/framework/runtime/model.cpp
+++ b/src/framework/runtime/model.cpp
@@ -96,4 +96,164 @@ const NamedAsset * select_named_asset(
     return &assets.front();
 }
 
+namespace {
+
+bool contains_token(const std::string & family, const char * token) {
+    return family.find(token) != std::string::npos;
+}
+
+bool ends_with(const std::string & family, const char * suffix) {
+    const std::string needle(suffix);
+    return family.size() >= needle.size()
+        && family.compare(family.size() - needle.size(), needle.size(), needle) == 0;
+}
+
+CapabilitySet caps_for_task(VoiceTaskKind task, bool streaming = false) {
+    CapabilitySet caps;
+    TaskCapability row;
+    row.task = task;
+    row.modes.push_back(RunMode::Offline);
+    if (streaming) {
+        row.modes.push_back(RunMode::Streaming);
+    }
+    caps.supported_tasks.push_back(std::move(row));
+    return caps;
+}
+
+}  // namespace
+
+CapabilitySet default_advertised_capabilities_for_family(const std::string & family) {
+    const std::string key = family;
+    if (contains_token(key, "forced_aligner") || ends_with(key, "_aligner") || ends_with(key, "_align")) {
+        return caps_for_task(VoiceTaskKind::Alignment);
+    }
+    if (ends_with(key, "_asr") || ends_with(key, "_stt") || key == "parakeet_tdt" || key == "whisper") {
+        const bool streaming = contains_token(key, "higgs") || contains_token(key, "nemotron")
+            || contains_token(key, "vibevoice");
+        return caps_for_task(VoiceTaskKind::Asr, streaming);
+    }
+    if (contains_token(key, "vad")) {
+        return caps_for_task(VoiceTaskKind::Vad, contains_token(key, "silero"));
+    }
+    if (contains_token(key, "diar") || contains_token(key, "sortformer")) {
+        return caps_for_task(VoiceTaskKind::Diarization);
+    }
+    if (contains_token(key, "demucs") || contains_token(key, "roformer")) {
+        return caps_for_task(VoiceTaskKind::SourceSeparation);
+    }
+    if (key == "stable_audio" || key == "ace_step" || key == "heartmula" || ends_with(key, "_gen")) {
+        return caps_for_task(VoiceTaskKind::AudioGeneration);
+    }
+    if (key == "seed_vc" || key == "vevo2" || ends_with(key, "_vc")) {
+        CapabilitySet caps = caps_for_task(VoiceTaskKind::VoiceConversion);
+        if (key == "vevo2") {
+            caps.supported_tasks.push_back(TaskCapability{VoiceTaskKind::Tts, {RunMode::Offline}});
+            caps.supported_tasks.push_back(TaskCapability{VoiceTaskKind::Svc, {RunMode::Offline}});
+        }
+        return caps;
+    }
+    if (key == "miocodec" || ends_with(key, "_codec")) {
+        // Codec helpers are exposed via tasks/run style surfaces.
+        return caps_for_task(VoiceTaskKind::VoiceConversion);
+    }
+    if (contains_token(key, "chatterbox")) {
+        CapabilitySet caps = caps_for_task(VoiceTaskKind::Tts);
+        caps.supported_tasks.push_back(TaskCapability{VoiceTaskKind::VoiceConversion, {RunMode::Offline}});
+        return caps;
+    }
+    if (contains_token(key, "vibevoice") && contains_token(key, "asr")) {
+        return caps_for_task(VoiceTaskKind::Asr, true);
+    }
+    if (key == "qwen3_tts" || (contains_token(key, "tts") && contains_token(key, "voice_design"))) {
+        CapabilitySet caps = caps_for_task(VoiceTaskKind::Tts);
+        caps.supported_tasks.push_back(TaskCapability{VoiceTaskKind::VoiceDesign, {RunMode::Offline}});
+        return caps;
+    }
+    // Default speech families (tts / omnivoice / vibevoice / moss / etc.)
+    if (contains_token(key, "tts") || contains_token(key, "kokoro") || contains_token(key, "voxcpm")
+        || contains_token(key, "omnivoice") || contains_token(key, "supertonic")
+        || contains_token(key, "miotts") || contains_token(key, "pocket")
+        || contains_token(key, "irodori") || contains_token(key, "moss")
+        || contains_token(key, "index_tts") || contains_token(key, "vibevoice")) {
+        const bool streaming = contains_token(key, "voxcpm") || contains_token(key, "supertonic");
+        return caps_for_task(VoiceTaskKind::Tts, streaming);
+    }
+    return {};
+}
+
+std::string default_instructions_policy_for_family(const std::string & family) {
+    if (contains_token(family, "irodori")) {
+        return "caption_option";
+    }
+    if (contains_token(family, "voxcpm")) {
+        return "text_prefix";
+    }
+    if (family == "omnivoice" || contains_token(family, "omnivoice")) {
+        return "soft_tags";
+    }
+    if (contains_token(family, "qwen3_tts") || contains_token(family, "voice_design")) {
+        return "openai_instruct";
+    }
+    const auto caps = default_advertised_capabilities_for_family(family);
+    for (const auto & task : caps.supported_tasks) {
+        if (task.task == VoiceTaskKind::Tts || task.task == VoiceTaskKind::VoiceDesign
+            || task.task == VoiceTaskKind::VoiceCloning) {
+            return "openai_instruct";
+        }
+    }
+    return "none";
+}
+
+std::vector<std::string> default_api_endpoints_for_capabilities(const CapabilitySet & capabilities) {
+    bool has_asr = false;
+    bool has_speech = false;
+    bool has_other = false;
+    for (const auto & task : capabilities.supported_tasks) {
+        switch (task.task) {
+        case VoiceTaskKind::Asr:
+            has_asr = true;
+            break;
+        case VoiceTaskKind::Tts:
+        case VoiceTaskKind::VoiceCloning:
+        case VoiceTaskKind::VoiceDesign:
+            has_speech = true;
+            break;
+        default:
+            has_other = true;
+            break;
+        }
+    }
+    if (has_asr && !has_speech && !has_other) {
+        return {"/v1/audio/transcriptions"};
+    }
+    if (has_speech && !has_other) {
+        return {"/v1/audio/speech"};
+    }
+    if (has_speech && has_other) {
+        return {"/v1/tasks/run", "/v1/audio/speech"};
+    }
+    return {"/v1/tasks/run"};
+}
+
+CapabilitySet IVoiceModelLoader::advertised_capabilities() const {
+    return default_advertised_capabilities_for_family(family());
+}
+
+std::string IVoiceModelLoader::advertised_instructions_policy() const {
+    return default_instructions_policy_for_family(family());
+}
+
+std::vector<std::string> IVoiceModelLoader::advertised_api_endpoints() const {
+    return default_api_endpoints_for_capabilities(advertised_capabilities());
+}
+
+LoaderAdvertisement IVoiceModelLoader::advertise() const {
+    LoaderAdvertisement row;
+    row.family = family();
+    row.capabilities = advertised_capabilities();
+    row.instructions_policy = advertised_instructions_policy();
+    row.api_endpoints = advertised_api_endpoints();
+    return row;
+}
+
 }  // namespace engine::runtime

--- a/src/framework/runtime/model.cpp
+++ b/src/framework/runtime/model.cpp
@@ -96,114 +96,6 @@ const NamedAsset * select_named_asset(
     return &assets.front();
 }
 
-namespace {
-
-bool contains_token(const std::string & family, const char * token) {
-    return family.find(token) != std::string::npos;
-}
-
-bool ends_with(const std::string & family, const char * suffix) {
-    const std::string needle(suffix);
-    return family.size() >= needle.size()
-        && family.compare(family.size() - needle.size(), needle.size(), needle) == 0;
-}
-
-CapabilitySet caps_for_task(VoiceTaskKind task, bool streaming = false) {
-    CapabilitySet caps;
-    TaskCapability row;
-    row.task = task;
-    row.modes.push_back(RunMode::Offline);
-    if (streaming) {
-        row.modes.push_back(RunMode::Streaming);
-    }
-    caps.supported_tasks.push_back(std::move(row));
-    return caps;
-}
-
-}  // namespace
-
-CapabilitySet default_advertised_capabilities_for_family(const std::string & family) {
-    const std::string key = family;
-    if (contains_token(key, "forced_aligner") || ends_with(key, "_aligner") || ends_with(key, "_align")) {
-        return caps_for_task(VoiceTaskKind::Alignment);
-    }
-    if (ends_with(key, "_asr") || ends_with(key, "_stt") || key == "parakeet_tdt" || key == "whisper") {
-        const bool streaming = contains_token(key, "higgs") || contains_token(key, "nemotron")
-            || contains_token(key, "vibevoice");
-        return caps_for_task(VoiceTaskKind::Asr, streaming);
-    }
-    if (contains_token(key, "vad")) {
-        return caps_for_task(VoiceTaskKind::Vad, contains_token(key, "silero"));
-    }
-    if (contains_token(key, "diar") || contains_token(key, "sortformer")) {
-        return caps_for_task(VoiceTaskKind::Diarization);
-    }
-    if (contains_token(key, "demucs") || contains_token(key, "roformer")) {
-        return caps_for_task(VoiceTaskKind::SourceSeparation);
-    }
-    if (key == "stable_audio" || key == "ace_step" || key == "heartmula" || ends_with(key, "_gen")) {
-        return caps_for_task(VoiceTaskKind::AudioGeneration);
-    }
-    if (key == "seed_vc" || key == "vevo2" || ends_with(key, "_vc")) {
-        CapabilitySet caps = caps_for_task(VoiceTaskKind::VoiceConversion);
-        if (key == "vevo2") {
-            caps.supported_tasks.push_back(TaskCapability{VoiceTaskKind::Tts, {RunMode::Offline}});
-            caps.supported_tasks.push_back(TaskCapability{VoiceTaskKind::Svc, {RunMode::Offline}});
-        }
-        return caps;
-    }
-    if (key == "miocodec" || ends_with(key, "_codec")) {
-        // Codec helpers are exposed via tasks/run style surfaces.
-        return caps_for_task(VoiceTaskKind::VoiceConversion);
-    }
-    if (contains_token(key, "chatterbox")) {
-        CapabilitySet caps = caps_for_task(VoiceTaskKind::Tts);
-        caps.supported_tasks.push_back(TaskCapability{VoiceTaskKind::VoiceConversion, {RunMode::Offline}});
-        return caps;
-    }
-    if (contains_token(key, "vibevoice") && contains_token(key, "asr")) {
-        return caps_for_task(VoiceTaskKind::Asr, true);
-    }
-    if (key == "qwen3_tts" || (contains_token(key, "tts") && contains_token(key, "voice_design"))) {
-        CapabilitySet caps = caps_for_task(VoiceTaskKind::Tts);
-        caps.supported_tasks.push_back(TaskCapability{VoiceTaskKind::VoiceDesign, {RunMode::Offline}});
-        return caps;
-    }
-    // Default speech families (tts / omnivoice / vibevoice / moss / etc.)
-    if (contains_token(key, "tts") || contains_token(key, "kokoro") || contains_token(key, "voxcpm")
-        || contains_token(key, "omnivoice") || contains_token(key, "supertonic")
-        || contains_token(key, "miotts") || contains_token(key, "pocket")
-        || contains_token(key, "irodori") || contains_token(key, "moss")
-        || contains_token(key, "index_tts") || contains_token(key, "vibevoice")) {
-        const bool streaming = contains_token(key, "voxcpm") || contains_token(key, "supertonic");
-        return caps_for_task(VoiceTaskKind::Tts, streaming);
-    }
-    return {};
-}
-
-std::string default_instructions_policy_for_family(const std::string & family) {
-    if (contains_token(family, "irodori")) {
-        return "caption_option";
-    }
-    if (contains_token(family, "voxcpm")) {
-        return "text_prefix";
-    }
-    if (family == "omnivoice" || contains_token(family, "omnivoice")) {
-        return "soft_tags";
-    }
-    if (contains_token(family, "qwen3_tts") || contains_token(family, "voice_design")) {
-        return "openai_instruct";
-    }
-    const auto caps = default_advertised_capabilities_for_family(family);
-    for (const auto & task : caps.supported_tasks) {
-        if (task.task == VoiceTaskKind::Tts || task.task == VoiceTaskKind::VoiceDesign
-            || task.task == VoiceTaskKind::VoiceCloning) {
-            return "openai_instruct";
-        }
-    }
-    return "none";
-}
-
 std::vector<std::string> default_api_endpoints_for_capabilities(const CapabilitySet & capabilities) {
     bool has_asr = false;
     bool has_speech = false;
@@ -236,11 +128,20 @@ std::vector<std::string> default_api_endpoints_for_capabilities(const Capability
 }
 
 CapabilitySet IVoiceModelLoader::advertised_capabilities() const {
-    return default_advertised_capabilities_for_family(family());
+    // Path-free catalog entry. Each loader overrides with the same task/mode
+    // contract it exposes via inspect/load (without requiring a model path).
+    return {};
 }
 
 std::string IVoiceModelLoader::advertised_instructions_policy() const {
-    return default_instructions_policy_for_family(family());
+    // Generic default from advertised tasks. Loaders with a different contract override.
+    for (const auto & task : advertised_capabilities().supported_tasks) {
+        if (task.task == VoiceTaskKind::Tts || task.task == VoiceTaskKind::VoiceDesign
+            || task.task == VoiceTaskKind::VoiceCloning) {
+            return "openai_instruct";
+        }
+    }
+    return "none";
 }
 
 std::vector<std::string> IVoiceModelLoader::advertised_api_endpoints() const {

--- a/src/framework/runtime/registry.cpp
+++ b/src/framework/runtime/registry.cpp
@@ -120,6 +120,21 @@ bool ModelRegistry::supports_family(const std::string & family) const noexcept {
     return false;
 }
 
+std::vector<LoaderAdvertisement> ModelRegistry::advertise_loaders() const {
+    std::vector<LoaderAdvertisement> out;
+    out.reserve(loaders_.size());
+    for (const auto & loader : loaders_) {
+        if (loader == nullptr) {
+            continue;
+        }
+        out.push_back(loader->advertise());
+    }
+    std::sort(out.begin(), out.end(), [](const LoaderAdvertisement & a, const LoaderAdvertisement & b) {
+        return a.family < b.family;
+    });
+    return out;
+}
+
 ModelInspection ModelRegistry::inspect(const ModelLoadRequest & request) const {
     engine::assets::ScopedModelPackageSpecOverride spec_override(request.model_spec_override, request.model_path);
     validate_request(request);

--- a/src/models/ace_step/loader.cpp
+++ b/src/models/ace_step/loader.cpp
@@ -90,6 +90,14 @@ public:
         return "ace_step";
     }
 
+    runtime::CapabilitySet advertised_capabilities() const override {
+        runtime::CapabilitySet out;
+        out.supported_tasks = {
+            {runtime::VoiceTaskKind::AudioGeneration, {runtime::RunMode::Offline}},
+        };
+        return out;
+    }
+
     bool can_load(const runtime::ModelLoadRequest & request) const override {
         try {
             const auto root = resolve_model_root(request.model_path);

--- a/src/models/chatterbox/loader.cpp
+++ b/src/models/chatterbox/loader.cpp
@@ -66,6 +66,17 @@ public:
         return "chatterbox";
     }
 
+    runtime::CapabilitySet advertised_capabilities() const override {
+        runtime::CapabilitySet out;
+        out.supported_tasks = {
+            {runtime::VoiceTaskKind::VoiceCloning, {runtime::RunMode::Offline}},
+            {runtime::VoiceTaskKind::VoiceConversion, {runtime::RunMode::Offline}},
+        };
+        out.supports_speaker_reference = true;
+        out.supports_style_condition = true;
+        return out;
+    }
+
     bool can_load(const runtime::ModelLoadRequest & request) const override {
         try {
             const auto root = resolve_model_root(request.model_path);

--- a/src/models/citrinet_asr/session.cpp
+++ b/src/models/citrinet_asr/session.cpp
@@ -37,6 +37,15 @@ public:
         return "citrinet_asr";
     }
 
+    runtime::CapabilitySet advertised_capabilities() const override {
+        runtime::CapabilitySet out;
+        out.supported_tasks = {
+            {runtime::VoiceTaskKind::Asr, {runtime::RunMode::Offline}},
+        };
+        out.supports_timestamps = true;
+        return out;
+    }
+
     bool can_load(const runtime::ModelLoadRequest & request) const override {
         if (request.family_hint.has_value() && *request.family_hint != family()) {
             return false;

--- a/src/models/demucs/loader.cpp
+++ b/src/models/demucs/loader.cpp
@@ -40,6 +40,14 @@ public:
         return "htdemucs";
     }
 
+    runtime::CapabilitySet advertised_capabilities() const override {
+        runtime::CapabilitySet out;
+        out.supported_tasks = {
+            {runtime::VoiceTaskKind::SourceSeparation, {runtime::RunMode::Offline}},
+        };
+        return out;
+    }
+
     bool can_load(const runtime::ModelLoadRequest & request) const override {
         try {
             const auto package_spec = assets::default_model_package_spec_path(family());

--- a/src/models/heartmula/loader.cpp
+++ b/src/models/heartmula/loader.cpp
@@ -84,6 +84,15 @@ public:
         return "heartmula";
     }
 
+    runtime::CapabilitySet advertised_capabilities() const override {
+        runtime::CapabilitySet out;
+        out.supported_tasks = {
+            {runtime::VoiceTaskKind::AudioGeneration, {runtime::RunMode::Offline}},
+        };
+        out.supports_style_condition = true;
+        return out;
+    }
+
     bool can_load(const runtime::ModelLoadRequest & request) const override {
         try {
             const auto root = resolve_model_root(request.model_path);

--- a/src/models/higgs_audio_stt/loader.cpp
+++ b/src/models/higgs_audio_stt/loader.cpp
@@ -54,6 +54,15 @@ public:
         return "higgs_audio_stt";
     }
 
+    runtime::CapabilitySet advertised_capabilities() const override {
+        runtime::CapabilitySet out;
+        out.supported_tasks = {
+            {runtime::VoiceTaskKind::Asr, {runtime::RunMode::Offline, runtime::RunMode::Streaming}},
+        };
+        out.supports_timestamps = true;
+        return out;
+    }
+
     bool can_load(const runtime::ModelLoadRequest & request) const override {
         try {
             const auto package_spec = engine::assets::default_model_package_spec_path(family());

--- a/src/models/hviske_asr/loader.cpp
+++ b/src/models/hviske_asr/loader.cpp
@@ -58,6 +58,15 @@ public:
         return "hviske_asr";
     }
 
+    runtime::CapabilitySet advertised_capabilities() const override {
+        runtime::CapabilitySet out;
+        out.supported_tasks = {
+            {runtime::VoiceTaskKind::Asr, {runtime::RunMode::Offline}},
+        };
+        out.supports_timestamps = true;
+        return out;
+    }
+
     bool can_load(const runtime::ModelLoadRequest & request) const override {
         try {
             const auto package_spec = engine::assets::default_model_package_spec_path(family());

--- a/src/models/index_tts2/loader.cpp
+++ b/src/models/index_tts2/loader.cpp
@@ -66,6 +66,17 @@ public:
         return "index_tts2";
     }
 
+    runtime::CapabilitySet advertised_capabilities() const override {
+        runtime::CapabilitySet out;
+        out.supported_tasks = {
+            {runtime::VoiceTaskKind::Tts, {runtime::RunMode::Offline}},
+            {runtime::VoiceTaskKind::VoiceCloning, {runtime::RunMode::Offline}},
+        };
+        out.supports_speaker_reference = true;
+        out.supports_style_condition = true;
+        return out;
+    }
+
     bool can_load(const runtime::ModelLoadRequest & request) const override {
         try {
             const auto package_spec = engine::assets::default_model_package_spec_path(family());

--- a/src/models/irodori_tts/loader.cpp
+++ b/src/models/irodori_tts/loader.cpp
@@ -73,6 +73,22 @@ public:
         return "irodori_tts";
     }
 
+    runtime::CapabilitySet advertised_capabilities() const override {
+        runtime::CapabilitySet out;
+        out.supported_tasks = {
+            {runtime::VoiceTaskKind::Tts, {runtime::RunMode::Offline}},
+            {runtime::VoiceTaskKind::VoiceCloning, {runtime::RunMode::Offline}},
+            {runtime::VoiceTaskKind::VoiceDesign, {runtime::RunMode::Offline}},
+        };
+        out.supports_speaker_reference = true;
+        out.supports_style_condition = true;
+        return out;
+    }
+
+    std::string advertised_instructions_policy() const override {
+        return "caption_option";
+    }
+
     bool can_load(const runtime::ModelLoadRequest & request) const override {
         try {
             (void) engine::assets::load_resource_bundle_from_package_spec(

--- a/src/models/marblenet_vad/session.cpp
+++ b/src/models/marblenet_vad/session.cpp
@@ -60,6 +60,15 @@ public:
         return "marblenet_vad";
     }
 
+    runtime::CapabilitySet advertised_capabilities() const override {
+        runtime::CapabilitySet out;
+        out.supported_tasks = {
+            {runtime::VoiceTaskKind::Vad, {runtime::RunMode::Offline}},
+        };
+        out.supports_timestamps = true;
+        return out;
+    }
+
     bool can_load(const runtime::ModelLoadRequest & request) const override {
         if (request.family_hint.has_value() && *request.family_hint != family()) {
             return false;

--- a/src/models/miocodec/loader.cpp
+++ b/src/models/miocodec/loader.cpp
@@ -35,6 +35,18 @@ public:
         return "miocodec";
     }
 
+    runtime::CapabilitySet advertised_capabilities() const override {
+        runtime::CapabilitySet out;
+        out.supported_tasks = {
+            {runtime::VoiceTaskKind::VoiceConversion, {runtime::RunMode::Offline}},
+            {runtime::VoiceTaskKind::SpeechToSpeech, {runtime::RunMode::Offline}},
+        };
+        out.supports_speaker_reference = true;
+        out.supports_style_condition = true;
+        out.supports_timestamps = true;
+        return out;
+    }
+
     bool can_load(const runtime::ModelLoadRequest & request) const override {
         if (request.family_hint.has_value() && *request.family_hint != family()) {
             return false;

--- a/src/models/miotts/loader.cpp
+++ b/src/models/miotts/loader.cpp
@@ -33,6 +33,16 @@ public:
         return "miotts";
     }
 
+    runtime::CapabilitySet advertised_capabilities() const override {
+        runtime::CapabilitySet out;
+        out.supported_tasks = {
+            {runtime::VoiceTaskKind::Tts, {runtime::RunMode::Offline}},
+        };
+        out.supports_speaker_reference = true;
+        out.supports_timestamps = true;
+        return out;
+    }
+
     bool can_load(const runtime::ModelLoadRequest & request) const override {
         if (request.family_hint.has_value() && *request.family_hint != family()) {
             return false;

--- a/src/models/moss/moss_tts_local/loader.cpp
+++ b/src/models/moss/moss_tts_local/loader.cpp
@@ -94,6 +94,16 @@ public:
         return "moss_tts_local";
     }
 
+    runtime::CapabilitySet advertised_capabilities() const override {
+        runtime::CapabilitySet out;
+        out.supported_tasks = {
+            {runtime::VoiceTaskKind::Tts, {runtime::RunMode::Offline}},
+            {runtime::VoiceTaskKind::VoiceCloning, {runtime::RunMode::Offline}},
+        };
+        out.supports_speaker_reference = true;
+        return out;
+    }
+
     bool can_load(const runtime::ModelLoadRequest & request) const override {
         try {
             (void) engine::assets::load_resource_bundle_from_package_spec(

--- a/src/models/moss/moss_tts_nano/loader.cpp
+++ b/src/models/moss/moss_tts_nano/loader.cpp
@@ -64,6 +64,16 @@ public:
         return "moss_tts_nano";
     }
 
+    runtime::CapabilitySet advertised_capabilities() const override {
+        runtime::CapabilitySet out;
+        out.supported_tasks = {
+            {runtime::VoiceTaskKind::Tts, {runtime::RunMode::Offline}},
+            {runtime::VoiceTaskKind::VoiceCloning, {runtime::RunMode::Offline}},
+        };
+        out.supports_speaker_reference = true;
+        return out;
+    }
+
     bool can_load(const runtime::ModelLoadRequest & request) const override {
         try {
             (void) engine::assets::load_resource_bundle_from_package_spec(

--- a/src/models/nemotron_asr/loader.cpp
+++ b/src/models/nemotron_asr/loader.cpp
@@ -35,6 +35,15 @@ public:
         return "nemotron_asr";
     }
 
+    runtime::CapabilitySet advertised_capabilities() const override {
+        runtime::CapabilitySet out;
+        out.supported_tasks = {
+            {runtime::VoiceTaskKind::Asr, {runtime::RunMode::Offline, runtime::RunMode::Streaming}},
+        };
+        out.supports_timestamps = true;
+        return out;
+    }
+
     bool can_load(const runtime::ModelLoadRequest & request) const override {
         try {
             const auto package_spec = engine::assets::default_model_package_spec_path(family());

--- a/src/models/omnivoice/loader.cpp
+++ b/src/models/omnivoice/loader.cpp
@@ -45,6 +45,20 @@ public:
         return "omnivoice";
     }
 
+    runtime::CapabilitySet advertised_capabilities() const override {
+        runtime::CapabilitySet out;
+        out.supported_tasks = {
+            {runtime::VoiceTaskKind::Tts, {runtime::RunMode::Offline}},
+        };
+        out.supports_speaker_reference = true;
+        out.supports_style_condition = true;
+        return out;
+    }
+
+    std::string advertised_instructions_policy() const override {
+        return "soft_tags";
+    }
+
     bool can_load(const runtime::ModelLoadRequest & request) const override {
         try {
             const auto package_spec = engine::assets::default_model_package_spec_path(family());

--- a/src/models/pocket_tts/loader.cpp
+++ b/src/models/pocket_tts/loader.cpp
@@ -123,6 +123,16 @@ public:
         return "pocket_tts";
     }
 
+    runtime::CapabilitySet advertised_capabilities() const override {
+        runtime::CapabilitySet out;
+        out.supported_tasks = {
+            {runtime::VoiceTaskKind::Tts, {runtime::RunMode::Offline}},
+        };
+        out.supports_speaker_reference = true;
+        out.supports_style_condition = true;
+        return out;
+    }
+
     bool can_load(const runtime::ModelLoadRequest & request) const override {
         if (request.family_hint.has_value() && *request.family_hint != family()) {
             return false;

--- a/src/models/qwen3_asr/loader.cpp
+++ b/src/models/qwen3_asr/loader.cpp
@@ -34,6 +34,15 @@ public:
         return "qwen3_asr";
     }
 
+    runtime::CapabilitySet advertised_capabilities() const override {
+        runtime::CapabilitySet out;
+        out.supported_tasks = {
+            {runtime::VoiceTaskKind::Asr, {runtime::RunMode::Offline}},
+        };
+        out.supports_timestamps = true;
+        return out;
+    }
+
     bool can_load(const runtime::ModelLoadRequest & request) const override {
         try {
             const auto package_spec = engine::assets::default_model_package_spec_path(family());

--- a/src/models/qwen3_forced_aligner/loader.cpp
+++ b/src/models/qwen3_forced_aligner/loader.cpp
@@ -43,6 +43,15 @@ public:
         return "qwen3_forced_aligner";
     }
 
+    runtime::CapabilitySet advertised_capabilities() const override {
+        runtime::CapabilitySet out;
+        out.supported_tasks = {
+            {runtime::VoiceTaskKind::Alignment, {runtime::RunMode::Offline}},
+        };
+        out.supports_timestamps = true;
+        return out;
+    }
+
     bool can_load(const runtime::ModelLoadRequest & request) const override {
         try {
             (void) load_qwen3_forced_aligner_assets(request.model_path);

--- a/src/models/qwen3_tts/loader.cpp
+++ b/src/models/qwen3_tts/loader.cpp
@@ -67,6 +67,17 @@ public:
         return "qwen3_tts";
     }
 
+    runtime::CapabilitySet advertised_capabilities() const override {
+        runtime::CapabilitySet out;
+        out.supported_tasks = {
+            {runtime::VoiceTaskKind::Tts, {runtime::RunMode::Offline}},
+            {runtime::VoiceTaskKind::VoiceDesign, {runtime::RunMode::Offline}},
+        };
+        out.supports_speaker_reference = true;
+        out.supports_style_condition = true;
+        return out;
+    }
+
     bool can_load(const runtime::ModelLoadRequest & request) const override {
         try {
             const auto package_spec = engine::assets::default_model_package_spec_path(family());

--- a/src/models/roformer/loader.cpp
+++ b/src/models/roformer/loader.cpp
@@ -62,6 +62,14 @@ public:
         return std::string(kMelBandRoformerFamily);
     }
 
+    runtime::CapabilitySet advertised_capabilities() const override {
+        runtime::CapabilitySet out;
+        out.supported_tasks = {
+            {runtime::VoiceTaskKind::SourceSeparation, {runtime::RunMode::Offline}},
+        };
+        return out;
+    }
+
     bool can_load(const runtime::ModelLoadRequest & request) const override {
         if (request.family_hint.has_value() && *request.family_hint != family()) {
             return false;

--- a/src/models/seed_vc/loader.cpp
+++ b/src/models/seed_vc/loader.cpp
@@ -96,6 +96,17 @@ public:
         return "seed_vc";
     }
 
+    runtime::CapabilitySet advertised_capabilities() const override {
+        runtime::CapabilitySet out;
+        out.supported_tasks = {
+            {runtime::VoiceTaskKind::VoiceConversion, {runtime::RunMode::Offline}},
+            {runtime::VoiceTaskKind::Svc, {runtime::RunMode::Offline}},
+        };
+        out.supports_speaker_reference = true;
+        out.supports_style_condition = true;
+        return out;
+    }
+
     bool can_load(const runtime::ModelLoadRequest & request) const override {
         if (request.family_hint.has_value() && *request.family_hint != family()) {
             return false;

--- a/src/models/silero_vad/session.cpp
+++ b/src/models/silero_vad/session.cpp
@@ -80,6 +80,15 @@ public:
         return "silero_vad";
     }
 
+    runtime::CapabilitySet advertised_capabilities() const override {
+        runtime::CapabilitySet out;
+        out.supported_tasks = {
+            {runtime::VoiceTaskKind::Vad, {runtime::RunMode::Offline, runtime::RunMode::Streaming}},
+        };
+        out.supports_timestamps = true;
+        return out;
+    }
+
     bool can_load(const runtime::ModelLoadRequest & request) const override {
         if (request.family_hint.has_value() && *request.family_hint != family()) {
             return false;

--- a/src/models/sortformer_diar/loader.cpp
+++ b/src/models/sortformer_diar/loader.cpp
@@ -49,6 +49,15 @@ public:
         return "sortformer_diar";
     }
 
+    runtime::CapabilitySet advertised_capabilities() const override {
+        runtime::CapabilitySet out;
+        out.supported_tasks = {
+            {runtime::VoiceTaskKind::Diarization, {runtime::RunMode::Offline}},
+        };
+        out.supports_timestamps = true;
+        return out;
+    }
+
     bool can_load(const runtime::ModelLoadRequest & request) const override {
         try {
             const auto root = resolve_model_root(request.model_path);

--- a/src/models/stable_audio/loader.cpp
+++ b/src/models/stable_audio/loader.cpp
@@ -74,6 +74,14 @@ public:
         return "stable_audio";
     }
 
+    runtime::CapabilitySet advertised_capabilities() const override {
+        runtime::CapabilitySet out;
+        out.supported_tasks = {
+            {runtime::VoiceTaskKind::AudioGeneration, {runtime::RunMode::Offline}},
+        };
+        return out;
+    }
+
     bool can_load(const runtime::ModelLoadRequest & request) const override {
         try {
             const auto package_spec = engine::assets::default_model_package_spec_path(family());

--- a/src/models/supertonic/loader.cpp
+++ b/src/models/supertonic/loader.cpp
@@ -50,6 +50,15 @@ class SupertonicLoader final : public runtime::IVoiceModelLoader {
 public:
     std::string family() const override { return "supertonic"; }
 
+    runtime::CapabilitySet advertised_capabilities() const override {
+        runtime::CapabilitySet out;
+        out.supported_tasks = {
+            {runtime::VoiceTaskKind::Tts, {runtime::RunMode::Offline, runtime::RunMode::Streaming}},
+        };
+        out.supports_style_condition = true;
+        return out;
+    }
+
     bool can_load(const runtime::ModelLoadRequest & request) const override {
         try {
             (void) engine::assets::load_resource_bundle_from_package_spec(

--- a/src/models/vevo2/loader.cpp
+++ b/src/models/vevo2/loader.cpp
@@ -146,6 +146,19 @@ public:
         return "vevo2";
     }
 
+    runtime::CapabilitySet advertised_capabilities() const override {
+        runtime::CapabilitySet out;
+        out.supported_tasks = {
+            {runtime::VoiceTaskKind::Tts, {runtime::RunMode::Offline}},
+            {runtime::VoiceTaskKind::VoiceConversion, {runtime::RunMode::Offline}},
+            {runtime::VoiceTaskKind::SpeechToSpeech, {runtime::RunMode::Offline}},
+            {runtime::VoiceTaskKind::Svc, {runtime::RunMode::Offline}},
+        };
+        out.supports_speaker_reference = true;
+        out.supports_style_condition = true;
+        return out;
+    }
+
     bool can_load(const runtime::ModelLoadRequest & request) const override {
         if (request.family_hint.has_value() && *request.family_hint != family()) {
             return false;

--- a/src/models/vibevoice/loader.cpp
+++ b/src/models/vibevoice/loader.cpp
@@ -82,6 +82,15 @@ public:
         return "vibevoice";
     }
 
+    runtime::CapabilitySet advertised_capabilities() const override {
+        runtime::CapabilitySet out;
+        out.supported_tasks = {
+            {runtime::VoiceTaskKind::Tts, {runtime::RunMode::Offline}},
+        };
+        out.supports_speaker_reference = true;
+        return out;
+    }
+
     bool can_load(const runtime::ModelLoadRequest & request) const override {
         try {
             const auto root = resolve_model_root(request.model_path);

--- a/src/models/vibevoice_asr/loader.cpp
+++ b/src/models/vibevoice_asr/loader.cpp
@@ -60,6 +60,15 @@ public:
         return "vibevoice_asr";
     }
 
+    runtime::CapabilitySet advertised_capabilities() const override {
+        runtime::CapabilitySet out;
+        out.supported_tasks = {
+            {runtime::VoiceTaskKind::Asr, {runtime::RunMode::Offline}},
+        };
+        out.supports_timestamps = true;
+        return out;
+    }
+
     bool can_load(const runtime::ModelLoadRequest & request) const override {
         try {
             const auto package_spec = engine::assets::default_model_package_spec_path(family());

--- a/src/models/voxcpm2/loader.cpp
+++ b/src/models/voxcpm2/loader.cpp
@@ -47,6 +47,20 @@ class VoxCPM2Loader final : public runtime::IVoiceModelLoader {
 public:
   std::string family() const override { return "voxcpm2"; }
 
+  runtime::CapabilitySet advertised_capabilities() const override {
+    runtime::CapabilitySet out;
+    out.supported_tasks = {
+        {runtime::VoiceTaskKind::Tts,
+         {runtime::RunMode::Offline, runtime::RunMode::Streaming}},
+    };
+    out.supports_speaker_reference = true;
+    return out;
+  }
+
+  std::string advertised_instructions_policy() const override {
+    return "text_prefix";
+  }
+
   bool can_load(const runtime::ModelLoadRequest &request) const override {
     try {
       (void)engine::assets::load_resource_bundle_from_package_spec(

--- a/tools/model_manager.py
+++ b/tools/model_manager.py
@@ -20,10 +20,31 @@ from urllib.error import HTTPError
 from urllib.parse import quote
 from urllib.request import Request, urlopen
 
-import torch
-from safetensors import safe_open
-from safetensors.torch import load_file, save_file
-import yaml
+# Heavy install/convert deps are imported lazily so ``list --json`` / ``info``
+# work without Torch in the environment.
+torch: Any = None
+safe_open: Any = None
+load_file: Any = None
+save_file: Any = None
+yaml: Any = None
+
+
+def _ensure_install_deps() -> None:
+    """Import Torch / safetensors / yaml on first install/convert use."""
+    global torch, safe_open, load_file, save_file, yaml
+    if torch is not None:
+        return
+    import torch as _torch
+    from safetensors import safe_open as _safe_open
+    from safetensors.torch import load_file as _load_file
+    from safetensors.torch import save_file as _save_file
+    import yaml as _yaml
+
+    torch = _torch
+    safe_open = _safe_open
+    load_file = _load_file
+    save_file = _save_file
+    yaml = _yaml
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -121,10 +142,26 @@ class ModelPackage:
     required_files: tuple[str, ...]
     source: SnapshotSource | CompositeSnapshotSource | ConverterSource | UnsupportedSource
     description: str = ""
+    # Optional discovery overrides for ``list --json`` / tooling consumers.
+    family: str | None = None
+    standalone: bool | None = None
+    parent_package_id: str | None = None
+    tasks: tuple[str, ...] = ()
+    gated: bool | None = None
 
 
 UTILITY_CONVERTER_KINDS = {"pytorch_to_safetensors"}
 POSTPROCESS_SNAPSHOT_PACKAGE_IDS = {"voxcpm2"}
+_GATED_REPO_MARKERS = (
+    "kyutai/pocket-tts",
+    "stabilityai/",
+)
+_GATED_TEXT_MARKERS = (
+    "gated",
+    "requires access",
+    "accept the license",
+    "accept the conditions",
+)
 
 
 def package_install_kind(package: ModelPackage) -> str:
@@ -1200,6 +1237,129 @@ def resolve_path(path: str) -> Path:
     return REPO_ROOT / candidate
 
 
+def _infer_family_from_package_id(package_id: str) -> str:
+    key = str(package_id or "").strip().lower()
+    aliases = (
+        ("qwen3_forced_aligner", "qwen3_forced_aligner"),
+        ("qwen3_tts", "qwen3_tts"),
+        ("qwen3_asr", "qwen3_asr"),
+        ("vibevoice_asr", "vibevoice_asr"),
+        ("vibevoice", "vibevoice"),
+        ("moss_tts_nano", "moss_tts_nano"),
+        ("moss_tts_local", "moss_tts_local"),
+        ("higgs_audio", "higgs_audio_stt"),
+        ("irodori_tts", "irodori_tts"),
+        ("index_tts", "index_tts2"),
+        ("sortformer", "sortformer_diar"),
+        ("marblenet", "marblenet_vad"),
+        ("stable_audio", "stable_audio"),
+        ("mel_band_roformer", "mel_band_roformer"),
+        ("htdemucs", "htdemucs"),
+        ("miocodec", "miocodec"),
+        ("miotts", "miotts"),
+        ("omnivoice", "omnivoice"),
+        ("pocket_tts", "pocket_tts"),
+        ("supertonic", "supertonic"),
+        ("voxcpm2", "voxcpm2"),
+        ("chatterbox", "chatterbox"),
+        ("citrinet", "citrinet_asr"),
+        ("hviske", "hviske_asr"),
+        ("nemotron", "nemotron_asr"),
+        ("seed_vc", "seed_vc"),
+        ("vevo2", "vevo2"),
+        ("ace_step", "ace_step"),
+        ("heartmula", "heartmula"),
+        ("silero", "silero_vad"),
+        ("kokoro", "kokoro_tts"),
+        ("parakeet", "parakeet_tdt"),
+    )
+    for prefix, family in aliases:
+        if key == prefix or key.startswith(prefix + "_"):
+            return family
+    return key
+
+
+def _infer_tasks_from_family(family: str) -> list[str]:
+    key = str(family or "").strip().lower()
+    if "forced_aligner" in key or key.endswith("_aligner") or key.endswith("_align"):
+        return ["align"]
+    if key.endswith("_asr") or key.endswith("_stt") or key in {"parakeet_tdt", "whisper"}:
+        return ["asr"]
+    if "vad" in key:
+        return ["vad"]
+    if "diar" in key or "sortformer" in key:
+        return ["diar"]
+    if any(token in key for token in ("demucs", "roformer", "separator")):
+        return ["sep"]
+    if key in {"stable_audio", "ace_step", "heartmula"} or key.endswith("_gen"):
+        return ["gen"]
+    if key in {"seed_vc", "vevo2"} or key.endswith("_vc"):
+        return ["vc"]
+    if key == "miocodec" or key.startswith("miocodec") or key.endswith("_codec"):
+        return ["codec"]
+    if any(
+        token in key
+        for token in (
+            "tts",
+            "kokoro",
+            "chatterbox",
+            "voxcpm",
+            "omnivoice",
+            "supertonic",
+            "miotts",
+            "pocket",
+            "irodori",
+            "moss_tts",
+            "index_tts",
+            "vibevoice",
+        )
+    ):
+        if key.endswith("_asr") or key.endswith("_stt"):
+            return ["asr"]
+        return ["tts"]
+    return []
+
+
+def _collect_package_repo_ids(package: ModelPackage) -> list[str]:
+    source = package.source
+    repos: list[str] = []
+    if isinstance(source, SnapshotSource):
+        repos.append(source.repo_id)
+    elif isinstance(source, CompositeSnapshotSource):
+        for placement in source.placements:
+            repos.append(placement.source.repo_id)
+    return [repo for repo in repos if isinstance(repo, str) and repo]
+
+
+def _package_is_gated(package: ModelPackage) -> bool:
+    if isinstance(package.gated, bool):
+        return package.gated
+    repos = [repo.lower() for repo in _collect_package_repo_ids(package)]
+    if any(any(marker in repo for marker in _GATED_REPO_MARKERS) for repo in repos):
+        return True
+    text = str(package.description or "").lower()
+    return any(marker in text for marker in _GATED_TEXT_MARKERS)
+
+
+def _package_standalone_fields(package: ModelPackage) -> tuple[bool, str | None]:
+    if isinstance(package.standalone, bool):
+        return package.standalone, package.parent_package_id
+    desc = str(package.description or "").strip().lower()
+    kind = package_install_kind(package)
+    if desc.startswith("subcomponent only.") or desc.startswith("utility only.") or kind == "utility":
+        parent = package.parent_package_id
+        if not parent:
+            # "Use moss_tts_nano_100m for the full framework..."
+            for token in desc.replace(".", " ").replace(",", " ").split():
+                if token in PACKAGE_BY_ID and token != package.id:
+                    parent = token
+                    break
+        return False, parent
+    if "tokenizer" in package.id.lower() or "audiovae" in package.id.lower():
+        return False, package.parent_package_id
+    return True, None
+
+
 def package_payload(package: ModelPackage) -> dict[str, object]:
     source = package.source
     if isinstance(source, SnapshotSource):
@@ -1227,6 +1387,7 @@ def package_payload(package: ModelPackage) -> dict[str, object]:
                 }
                 for placement in source.placements
             ],
+            "repo_ids": _collect_package_repo_ids(package),
         }
         installable = True
     elif isinstance(source, ConverterSource):
@@ -1249,6 +1410,9 @@ def package_payload(package: ModelPackage) -> dict[str, object]:
             "reason": source.reason,
         }
         installable = False
+    family = package.family or _infer_family_from_package_id(package.id)
+    tasks = list(package.tasks) if package.tasks else _infer_tasks_from_family(family)
+    standalone, parent_package_id = _package_standalone_fields(package)
     return {
         "id": package.id,
         "display_name": package.display_name,
@@ -1259,6 +1423,12 @@ def package_payload(package: ModelPackage) -> dict[str, object]:
         "usage_examples": package_usage_examples(package),
         "required_files": list(package.required_files),
         "source": source_payload,
+        "family": family,
+        "tasks": tasks,
+        "modes": ["offline"] if tasks else [],
+        "standalone": standalone,
+        "parent_package_id": parent_package_id,
+        "gated": _package_is_gated(package),
     }
 
 
@@ -2251,6 +2421,7 @@ def command_info(args: argparse.Namespace) -> int:
 
 
 def command_install(args: argparse.Namespace) -> int:
+    _ensure_install_deps()
     package = PACKAGE_BY_ID.get(args.package_id)
     if package is None:
         raise RuntimeError(f"unknown package id: {args.package_id}")

--- a/tools/model_manager.py
+++ b/tools/model_manager.py
@@ -7,6 +7,7 @@ import fractions
 import io
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -142,7 +143,8 @@ class ModelPackage:
     required_files: tuple[str, ...]
     source: SnapshotSource | CompositeSnapshotSource | ConverterSource | UnsupportedSource
     description: str = ""
-    # Optional discovery overrides for ``list --json`` / tooling consumers.
+    # Optional identity fields for ``list --json`` consumers. When unset,
+    # family/tasks/standalone/gated are derived from local package metadata only.
     family: str | None = None
     standalone: bool | None = None
     parent_package_id: str | None = None
@@ -152,15 +154,10 @@ class ModelPackage:
 
 UTILITY_CONVERTER_KINDS = {"pytorch_to_safetensors"}
 POSTPROCESS_SNAPSHOT_PACKAGE_IDS = {"voxcpm2"}
+# HF repos that require accepting a license / access grant before download.
 _GATED_REPO_MARKERS = (
     "kyutai/pocket-tts",
     "stabilityai/",
-)
-_GATED_TEXT_MARKERS = (
-    "gated",
-    "requires access",
-    "accept the license",
-    "accept the conditions",
 )
 
 
@@ -225,6 +222,8 @@ CATALOG: tuple[ModelPackage, ...] = (
         target_directory="Kokoro-82M-bf16",
         source=SnapshotSource(repo_id="mlx-community/Kokoro-82M-bf16"),
         required_files=("config.json", "kokoro-v1_0.safetensors", "voices/af_heart.safetensors"),
+        family="kokoro_tts",
+        tasks=("tts",),
     ),
     ModelPackage(
         id="moss_tts_nano_100m",
@@ -796,6 +795,8 @@ CATALOG: tuple[ModelPackage, ...] = (
             "tokenizer.json",
             "tokenizer_config.json",
         ),
+        family="higgs_audio_tts",
+        tasks=("tts",),
     ),
     ModelPackage(
         id="heartmula",
@@ -1237,85 +1238,78 @@ def resolve_path(path: str) -> Path:
     return REPO_ROOT / candidate
 
 
-def _infer_family_from_package_id(package_id: str) -> str:
+_FAMILY_ID_STRIP_PATTERNS = (
+    re.compile(r"_\d+_\d+b(?:_base|_custom_voice|_voice_design)?$"),
+    re.compile(r"_\d+b(?:_base|_custom_voice|_voice_design)?$"),
+    re.compile(r"_\d+m(?:_bf16)?$"),
+    re.compile(r"_bf16$"),
+    re.compile(r"_\d+spk_v\d+$"),
+    re.compile(r"_\d+hz_\d+k_v\d+$"),
+    re.compile(r"_3_small_(?:music|sfx)$"),
+    re.compile(r"_3_medium$"),
+    re.compile(r"_v\d+(?:_\d+)?$"),
+    re.compile(r"_\d+$"),
+    re.compile(r"_model$"),
+    re.compile(r"_hf$"),
+    re.compile(r"_12hz$"),
+    re.compile(r"_(?:base|custom_voice|voice_design)$"),
+)
+
+
+def _default_family_from_package_id(package_id: str) -> str:
+    """Strip size/version suffixes from a package id. Prefer ``ModelPackage.family`` for exceptions."""
     key = str(package_id or "").strip().lower()
-    aliases = (
-        ("qwen3_forced_aligner", "qwen3_forced_aligner"),
-        ("qwen3_tts", "qwen3_tts"),
-        ("qwen3_asr", "qwen3_asr"),
-        ("vibevoice_asr", "vibevoice_asr"),
-        ("vibevoice", "vibevoice"),
-        ("moss_tts_nano", "moss_tts_nano"),
-        ("moss_tts_local", "moss_tts_local"),
-        ("higgs_audio", "higgs_audio_stt"),
-        ("irodori_tts", "irodori_tts"),
-        ("index_tts", "index_tts2"),
-        ("sortformer", "sortformer_diar"),
-        ("marblenet", "marblenet_vad"),
-        ("stable_audio", "stable_audio"),
-        ("mel_band_roformer", "mel_band_roformer"),
-        ("htdemucs", "htdemucs"),
-        ("miocodec", "miocodec"),
-        ("miotts", "miotts"),
-        ("omnivoice", "omnivoice"),
-        ("pocket_tts", "pocket_tts"),
-        ("supertonic", "supertonic"),
-        ("voxcpm2", "voxcpm2"),
-        ("chatterbox", "chatterbox"),
-        ("citrinet", "citrinet_asr"),
-        ("hviske", "hviske_asr"),
-        ("nemotron", "nemotron_asr"),
-        ("seed_vc", "seed_vc"),
-        ("vevo2", "vevo2"),
-        ("ace_step", "ace_step"),
-        ("heartmula", "heartmula"),
-        ("silero", "silero_vad"),
-        ("kokoro", "kokoro_tts"),
-        ("parakeet", "parakeet_tdt"),
-    )
-    for prefix, family in aliases:
-        if key == prefix or key.startswith(prefix + "_"):
-            return family
+    if not key:
+        return ""
+    changed = True
+    while changed and key:
+        changed = False
+        for pattern in _FAMILY_ID_STRIP_PATTERNS:
+            updated = pattern.sub("", key)
+            if updated and updated != key:
+                key = updated
+                changed = True
+                break
     return key
 
 
-def _infer_tasks_from_family(family: str) -> list[str]:
+def _default_tasks_from_family(family: str) -> list[str]:
     key = str(family or "").strip().lower()
+    if not key:
+        return []
     if "forced_aligner" in key or key.endswith("_aligner") or key.endswith("_align"):
         return ["align"]
     if key.endswith("_asr") or key.endswith("_stt") or key in {"parakeet_tdt", "whisper"}:
         return ["asr"]
     if "vad" in key:
         return ["vad"]
-    if "diar" in key or "sortformer" in key:
+    if "diar" in key:
         return ["diar"]
     if any(token in key for token in ("demucs", "roformer", "separator")):
         return ["sep"]
     if key in {"stable_audio", "ace_step", "heartmula"} or key.endswith("_gen"):
         return ["gen"]
-    if key in {"seed_vc", "vevo2"} or key.endswith("_vc"):
+    if key.endswith("_vc") or key in {"seed_vc", "vevo2"}:
         return ["vc"]
-    if key == "miocodec" or key.startswith("miocodec") or key.endswith("_codec"):
+    if key.endswith("_codec") or key == "miocodec":
         return ["codec"]
-    if any(
-        token in key
-        for token in (
-            "tts",
-            "kokoro",
-            "chatterbox",
-            "voxcpm",
-            "omnivoice",
-            "supertonic",
-            "miotts",
-            "pocket",
-            "irodori",
-            "moss_tts",
-            "index_tts",
-            "vibevoice",
-        )
-    ):
-        if key.endswith("_asr") or key.endswith("_stt"):
-            return ["asr"]
+    if key.endswith("_asr") or key.endswith("_stt"):
+        return ["asr"]
+    if "tts" in key or key in {
+        "kokoro",
+        "kokoro_tts",
+        "chatterbox",
+        "voxcpm2",
+        "omnivoice",
+        "supertonic",
+        "miotts",
+        "pocket_tts",
+        "irodori_tts",
+        "index_tts2",
+        "vibevoice",
+        "moss_tts_nano",
+        "moss_tts_local",
+    }:
         return ["tts"]
     return []
 
@@ -1335,10 +1329,7 @@ def _package_is_gated(package: ModelPackage) -> bool:
     if isinstance(package.gated, bool):
         return package.gated
     repos = [repo.lower() for repo in _collect_package_repo_ids(package)]
-    if any(any(marker in repo for marker in _GATED_REPO_MARKERS) for repo in repos):
-        return True
-    text = str(package.description or "").lower()
-    return any(marker in text for marker in _GATED_TEXT_MARKERS)
+    return any(any(marker in repo for marker in _GATED_REPO_MARKERS) for repo in repos)
 
 
 def _package_standalone_fields(package: ModelPackage) -> tuple[bool, str | None]:
@@ -1349,7 +1340,6 @@ def _package_standalone_fields(package: ModelPackage) -> tuple[bool, str | None]
     if desc.startswith("subcomponent only.") or desc.startswith("utility only.") or kind == "utility":
         parent = package.parent_package_id
         if not parent:
-            # "Use moss_tts_nano_100m for the full framework..."
             for token in desc.replace(".", " ").replace(",", " ").split():
                 if token in PACKAGE_BY_ID and token != package.id:
                     parent = token
@@ -1410,8 +1400,8 @@ def package_payload(package: ModelPackage) -> dict[str, object]:
             "reason": source.reason,
         }
         installable = False
-    family = package.family or _infer_family_from_package_id(package.id)
-    tasks = list(package.tasks) if package.tasks else _infer_tasks_from_family(family)
+    family = package.family or _default_family_from_package_id(package.id)
+    tasks = list(package.tasks) if package.tasks else _default_tasks_from_family(family)
     standalone, parent_package_id = _package_standalone_fields(package)
     return {
         "id": package.id,


### PR DESCRIPTION
## Summary

Integrators currently scrape `--list-loaders` text and infer package identity from `model_manager` metadata. This PR adds a small, versioned machine-readable discovery contract so tools can learn loaders and installable packages from the build itself.

### 1. `audiocpp_cli --list-loaders --json`

```json
{
  "schema_version": 1,
  "loaders": {
    "omnivoice": {
      "tasks": {"tts": ["offline"]},
      "api_endpoints": ["/v1/audio/speech"],
      "instructions_policy": "soft_tags"
    }
  }
}
```

- `IVoiceModelLoader::advertise*()` / `ModelRegistry::advertise_loaders()` provide a path-free catalog
- **Each loader overrides** `advertised_capabilities()` with the same task/mode contract it already uses in inspect/load (no central family-name heuristic table)
- Instruction policy defaults from advertised speech tasks (`openai_instruct` / `none`); loaders with a different contract override (`omnivoice`, `voxcpm2`, `irodori_tts`)
- API endpoints are derived from the advertised capability set
- Plain `--list-loaders` remains for humans, with task/mode summaries

### 2. Richer `model_manager.py list --json`

Each package payload includes:

- `family`, `tasks`, `modes`
- `standalone`, `parent_package_id`
- `gated`

`ModelPackage` accepts optional explicit overrides. Defaults come only from local package metadata:

- family: strip size/version suffixes from `id` (plus rare explicit overrides)
- standalone: `Subcomponent only.` / `Utility only.` / utility install kind / tokenizer|audiovae ids
- gated: known gated HF repo markers

### 3. Lazy Torch import for catalog commands

`list` / `info` no longer import Torch at module load. Install/convert paths import heavy deps on first use.

## Motivation

When a new loader or package is added, integrators should not need a parallel hardcoded catalog. The engine already knows its registered loaders and install packages — this surfaces that knowledge as a stable JSON contract.

## Test plan

- [x] `audiocpp_cli --list-loaders` prints a human-readable listing
- [x] `audiocpp_cli --list-loaders --json` returns `schema_version: 1` with non-empty tasks for all 30 registered families
- [x] Spot-check: omnivoice=`soft_tags`, voxcpm2=`text_prefix`, irodori=`caption_option`, silero_vad=`none`
- [x] `python tools/model_manager.py list --json` succeeds without Torch
- [x] Package JSON includes identity fields; Higgs TTS / Kokoro use explicit `family` overrides; tokenizers stay non-standalone; PocketTTS / Stable Audio stay gated
- [ ] Existing install/convert flows still import Torch successfully on first use
