### PR TITLE
Fix/tts hang chatterbox

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -903,6 +903,21 @@ if (ENGINE_BUILD_TESTS)
         COMMAND server_multipart_test
     )
 
+    add_executable(server_busy_guard_test
+        tests/unittests/test_server_busy_guard.cpp
+    )
+    target_include_directories(server_busy_guard_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/app/server)
+    find_package(Threads REQUIRED)
+    target_link_libraries(server_busy_guard_test PRIVATE Threads::Threads)
+
+    add_test(
+        NAME server_busy_guard_test
+        COMMAND server_busy_guard_test
+    )
+    # The suite deliberately drives threads against a held lock; bound it so a
+    # regression that reintroduces unbounded queuing fails instead of hanging CI.
+    set_tests_properties(server_busy_guard_test PROPERTIES TIMEOUT 60)
+
     add_executable(server_config_test
         tests/unittests/test_server_config.cpp
         app/server/config.cpp

--- a/app/server/README.md
+++ b/app/server/README.md
@@ -74,6 +74,8 @@ Set top-level `"lazy_load": true` to register all configured model ids at startu
 > [!WARNING]
 > Lazy loading does not unload models after a request. Once a model is first used, the server keeps that model and session in memory for reuse until the server exits.
 
+Set top-level `"busy_timeout_ms"` to bound how long a request waits for a model that is already running. Each model serializes its requests on an internal lock, so a second request normally queues behind the first. A GPU call that wedges cannot be cancelled from userspace, so without a bound every subsequent request would park a worker thread forever. When the current inference has held the lock past this timeout, a new request fails fast with HTTP 503 (`server_busy`) instead of queuing; streaming requests that have already sent headers surface the same condition as a `{"type":"error"}` stream event. The value must exceed the slowest legitimate single inference (music generation can take minutes). Defaults to `300000` (5 minutes); set `0` to disable the guard and restore unbounded waiting.
+
 For streaming endpoints, configure the model with `"mode": "streaming"` and use that model id in the request. A complete example is available at `app/server/streaming_example.json`:
 
 ```json

--- a/app/server/README.md
+++ b/app/server/README.md
@@ -74,7 +74,28 @@ Set top-level `"lazy_load": true` to register all configured model ids at startu
 > [!WARNING]
 > Lazy loading does not unload models after a request. Once a model is first used, the server keeps that model and session in memory for reuse until the server exits.
 
-Set top-level `"busy_timeout_ms"` to bound how long a request waits for a model that is already running. Each model serializes its requests on an internal lock, so a second request normally queues behind the first. A GPU call that wedges cannot be cancelled from userspace, so without a bound every subsequent request would park a worker thread forever. When the current inference has held the lock past this timeout, a new request fails fast with HTTP 503 (`server_busy`) instead of queuing; streaming requests that have already sent headers surface the same condition as a `{"type":"error"}` stream event. The value must exceed the slowest legitimate single inference (music generation can take minutes). Defaults to `300000` (5 minutes); set `0` to disable the guard and restore unbounded waiting.
+Set top-level `"busy_timeout_ms"` to bound how long a request waits for a model that is already running. Each model serializes its requests on an internal lock, so a second request normally queues behind the first. A GPU call that wedges cannot be cancelled from userspace, so without a bound every subsequent request would park a worker thread forever. When the current inference has held the lock past this timeout, a new request fails fast with HTTP 503 (`server_busy`) instead of queuing; streaming requests that have already sent headers surface the same condition as a `{"type":"error"}` stream event. The value must exceed the slowest legitimate single inference (music generation can take minutes). Defaults to `300000` (5 minutes); set `0` to disable the guard and restore unbounded waiting. The `--busy-timeout-ms <ms>` command-line flag overrides the config value.
+
+The bound is resolved in three layers, since model runtimes differ by orders of magnitude (a short TTS clip versus minutes of music generation):
+
+1. **Server** — top-level `"busy_timeout_ms"` (or `--busy-timeout-ms`) sets the fleet default.
+2. **Model** — `"busy_timeout_ms"` on an entry in `"models"` overrides that default for one model, and becomes the ceiling for requests to it.
+3. **Request** — `"busy_timeout_ms"` in the request body (or as a `busy_timeout_ms` form field on multipart transcription) lets a caller bound its own wait.
+
+A request may ask for a **shorter** bound than the model's ceiling but never a longer one — `effective = min(request, ceiling)` — so a client cannot weaken the guard and reintroduce the hang it prevents. Because `0` means "unbounded", it compares as infinity on both sides: a request asking for `0` is still capped by the model ceiling, while under a ceiling of `0` a request's own bound is honored.
+
+```json
+{
+  "busy_timeout_ms": 300000,
+  "models": [
+    { "id": "tts",   "busy_timeout_ms": 30000,  "...": "..." },
+    { "id": "music", "busy_timeout_ms": 900000, "...": "..." },
+    { "id": "asr", "...": "..." }
+  ]
+}
+```
+
+Here `asr` inherits 300000, a request to `music` asking for `60000` waits 60 s, and one asking for `999999` is clamped to 900000.
 
 For streaming endpoints, configure the model with `"mode": "streaming"` and use that model id in the request. A complete example is available at `app/server/streaming_example.json`:
 

--- a/app/server/busy_guard.h
+++ b/app/server/busy_guard.h
@@ -1,0 +1,126 @@
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <mutex>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+namespace minitts::server {
+
+// Thrown when a model is occupied and the effective busy timeout has elapsed.
+// Mapped to HTTP 503 so a client can retry or fail over rather than hang.
+class ServerBusyError : public std::runtime_error {
+public:
+    using std::runtime_error::runtime_error;
+};
+
+inline std::int64_t steady_now_ms() {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+               std::chrono::steady_clock::now().time_since_epoch())
+        .count();
+}
+
+// True when a request should fail fast instead of queuing behind the model lock:
+// the current holder acquired it at busy_since_ms and has already run longer than
+// timeout_ms. busy_since_ms == 0 means the model is idle; timeout_ms <= 0 disables
+// the guard. Both times are steady-clock milliseconds.
+inline bool model_run_has_overrun(std::int64_t busy_since_ms, std::int64_t now_ms, int timeout_ms) {
+    if (timeout_ms <= 0 || busy_since_ms == 0) {
+        return false;
+    }
+    return (now_ms - busy_since_ms) > timeout_ms;
+}
+
+// Resolve the timeout for a single run. `ceiling` is server policy (the top-level
+// config value, overridden per model); `requested` is the optional per-request
+// value. A request may ask for a shorter bound than policy but never a longer one,
+// so a client cannot weaken the guard. 0 means "unbounded" and therefore compares
+// as +infinity on both sides: a request asking for unbounded is still capped by
+// policy, and under an unbounded policy a request's own bound is honored.
+inline int resolve_busy_timeout_ms(int ceiling, std::optional<int> requested) {
+    if (!requested.has_value()) {
+        return ceiling;
+    }
+    const int value = *requested;
+    if (value <= 0) {
+        return ceiling;
+    }
+    if (ceiling <= 0) {
+        return value;
+    }
+    return value < ceiling ? value : ceiling;
+}
+
+// Serializes runs on one model and bounds how long a caller waits for its turn.
+//
+// A single model runs one request at a time. If a running inference wedges the GPU
+// -- a CUDA call that never returns cannot be cancelled from userspace -- later
+// requests would otherwise block forever and every worker thread would pile up
+// behind it. With a positive timeout, a caller instead gives up and throws
+// ServerBusyError (-> HTTP 503). A timeout of 0 restores the original unbounded
+// std::mutex behavior.
+class BusyGuard {
+public:
+    // Holds the guard for the duration of a run and marks it idle again when it
+    // releases (including on exception), so the fail-fast check never sees a stale
+    // timestamp. Move-only.
+    class Lock {
+    public:
+        Lock() = default;
+        Lock(BusyGuard & guard, std::unique_lock<std::timed_mutex> lock)
+            : guard_(&guard), lock_(std::move(lock)) {}
+        Lock(Lock &&) = default;
+        Lock & operator=(Lock &&) = default;
+        Lock(const Lock &) = delete;
+        Lock & operator=(const Lock &) = delete;
+        ~Lock() {
+            if (guard_ != nullptr && lock_.owns_lock()) {
+                guard_->busy_since_ms_.store(0, std::memory_order_release);
+            }
+        }
+
+    private:
+        BusyGuard * guard_ = nullptr;
+        std::unique_lock<std::timed_mutex> lock_;
+    };
+
+    // `label` identifies the model in the error message. Throws ServerBusyError when
+    // timeout_ms is positive and either the current holder has already overrun (fail
+    // fast, no wait) or the wait itself times out.
+    Lock acquire(int timeout_ms, std::string_view label) {
+        std::unique_lock<std::timed_mutex> lock(mutex_, std::defer_lock);
+        if (timeout_ms <= 0) {
+            lock.lock();  // guard disabled: original unbounded wait
+        } else {
+            // If the current holder has already run past the timeout, treat it as
+            // wedged and fail fast rather than queue behind it -- this is what stops
+            // requests piling up on a stuck GPU.
+            const auto since = busy_since_ms_.load(std::memory_order_acquire);
+            const auto now_ms = steady_now_ms();
+            if (model_run_has_overrun(since, now_ms, timeout_ms)) {
+                throw ServerBusyError(
+                    "model '" + std::string(label) + "' is busy: current inference has run " +
+                    std::to_string(now_ms - since) + " ms (busy_timeout_ms=" +
+                    std::to_string(timeout_ms) +
+                    "); the previous request has likely wedged and cannot be cancelled");
+            }
+            if (!lock.try_lock_for(std::chrono::milliseconds(timeout_ms))) {
+                throw ServerBusyError(
+                    "model '" + std::string(label) + "' is busy: timed out after " +
+                    std::to_string(timeout_ms) + " ms waiting for the inference lock");
+            }
+        }
+        busy_since_ms_.store(steady_now_ms(), std::memory_order_release);
+        return Lock(*this, std::move(lock));
+    }
+
+private:
+    std::timed_mutex mutex_;
+    std::atomic<std::int64_t> busy_since_ms_{0};
+};
+
+}  // namespace minitts::server

--- a/app/server/config.cpp
+++ b/app/server/config.cpp
@@ -91,6 +91,14 @@ ServerConfig load_server_config(const std::filesystem::path & path) {
         model.task = engine::io::json::optional_string(item, "task", model.task);
         model.mode = engine::io::json::optional_string(item, "mode", model.mode);
         model.lazy = engine::io::json::optional_bool(item, "lazy", config.lazy_load);
+        if (item.find("busy_timeout_ms") != nullptr) {
+            const auto busy_timeout_ms = engine::io::json::optional_i32(item, "busy_timeout_ms", 0);
+            if (busy_timeout_ms < 0) {
+                throw std::runtime_error(
+                    "busy_timeout_ms for model " + model.id + " must be >= 0 (0 disables the guard)");
+            }
+            model.busy_timeout_ms = busy_timeout_ms;
+        }
         if (const auto * value = item.find("config")) {
             model.config_id = value->as_string();
         }

--- a/app/server/config.cpp
+++ b/app/server/config.cpp
@@ -62,11 +62,15 @@ ServerConfig load_server_config(const std::filesystem::path & path) {
     config.device = engine::io::json::optional_i32(root, "device", config.device);
     config.threads = engine::io::json::optional_i32(root, "threads", config.threads);
     config.lazy_load = engine::io::json::optional_bool(root, "lazy_load", config.lazy_load);
+    config.busy_timeout_ms = engine::io::json::optional_i32(root, "busy_timeout_ms", config.busy_timeout_ms);
     if (const auto * value = root.find("model_spec_override")) {
         config.model_spec_override = resolve_path(base, value->as_string());
     }
     if (config.port <= 0 || config.port > 65535) {
         throw std::runtime_error("server port must be in 1..65535");
+    }
+    if (config.busy_timeout_ms < 0) {
+        throw std::runtime_error("server busy_timeout_ms must be >= 0 (0 disables the guard)");
     }
     if (config.threads <= 0) {
         throw std::runtime_error("server threads must be positive");

--- a/app/server/config.h
+++ b/app/server/config.h
@@ -24,6 +24,11 @@ struct ServerModelConfig {
     std::string task = "tts";
     std::string mode = "offline";
     bool lazy = false;
+    // Overrides ServerConfig::busy_timeout_ms for this model, and acts as the ceiling
+    // a per-request busy_timeout_ms is clamped to. Model runtimes differ by orders of
+    // magnitude (a short TTS clip vs. minutes of music generation), so one fleet-wide
+    // bound is either too tight for the slow models or useless for the fast ones.
+    std::optional<int> busy_timeout_ms;
     std::optional<std::string> config_id;
     std::optional<std::string> weight_id;
     std::unordered_map<std::string, std::string> load_options;

--- a/app/server/config.h
+++ b/app/server/config.h
@@ -40,6 +40,14 @@ struct ServerConfig {
     int device = 0;
     int threads = 1;
     bool lazy_load = false;
+    // A single model runs one request at a time (serialized on model.mutex). If a
+    // running inference wedges the GPU -- a CUDA call that never returns cannot be
+    // cancelled from userspace -- later requests would otherwise block forever, so
+    // once the current run has held the lock this long a new request fails fast with
+    // 503 instead of parking a worker thread. Must exceed the slowest legitimate
+    // single inference (music generation can take minutes). 0 disables the guard and
+    // restores unbounded waiting.
+    int busy_timeout_ms = 300000;
     std::optional<std::filesystem::path> model_spec_override;
     std::vector<ServerModelConfig> models;
 };

--- a/app/server/http.cpp
+++ b/app/server/http.cpp
@@ -65,6 +65,8 @@ const char * status_text(int status) noexcept {
         return "Method Not Allowed";
     case 500:
         return "Internal Server Error";
+    case 503:
+        return "Service Unavailable";
     default:
         return "Error";
     }

--- a/app/server/main.cpp
+++ b/app/server/main.cpp
@@ -44,10 +44,12 @@ bool has_arg(int argc, char ** argv, const std::string & name) {
 void print_help() {
     std::cout
         << "audiocpp_server --config <server.json> [--host <ip>] [--port <port>] [--backend <backend>]\n"
-        << "                [--device <id>] [--threads <n>]\n"
+        << "                [--device <id>] [--threads <n>] [--busy-timeout-ms <ms>]\n"
         << "                [--model-spec-override <json-or-directory>]\n"
         << "                [--log] [--log-file <path>]\n"
         << "  --backend cpu|cuda|vulkan|metal  default cuda\n"
+        << "  --busy-timeout-ms <ms>           fail a request with 503 when the model has been\n"
+        << "                                   busy this long; default 300000, 0 disables\n"
         << "\n"
         << "Endpoints:\n"
         << "  GET  /health\n"
@@ -95,11 +97,17 @@ int main(int argc, char ** argv) {
         if (const auto threads = arg_value(argc, argv, "--threads")) {
             config.threads = std::stoi(*threads);
         }
+        if (const auto busy_timeout = arg_value(argc, argv, "--busy-timeout-ms")) {
+            config.busy_timeout_ms = std::stoi(*busy_timeout);
+        }
         if (const auto model_spec = arg_value(argc, argv, "--model-spec-override")) {
             config.model_spec_override = std::filesystem::path(*model_spec);
         }
         if (config.threads <= 0) {
             throw std::runtime_error("--threads must be positive");
+        }
+        if (config.busy_timeout_ms < 0) {
+            throw std::runtime_error("--busy-timeout-ms must be >= 0 (0 disables the guard)");
         }
 
         minitts::server::ServerState state(config, std::filesystem::current_path());

--- a/app/server/runtime.cpp
+++ b/app/server/runtime.cpp
@@ -30,6 +30,19 @@ using engine::io::json::Value;
 
 using Clock = std::chrono::steady_clock;
 
+// Thrown when a model is occupied and the busy_timeout has elapsed. Mapped to
+// HTTP 503 so a client can retry or fail over rather than hang.
+class ServerBusyError : public std::runtime_error {
+public:
+    using std::runtime_error::runtime_error;
+};
+
+std::int64_t steady_now_ms() {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+               Clock::now().time_since_epoch())
+        .count();
+}
+
 std::string json_quote(std::string_view value) {
     return engine::io::json::stringify_string(value);
 }
@@ -534,6 +547,7 @@ ServerState::ServerState(ServerConfig config, std::filesystem::path request_base
 }
 
 HttpResponse ServerState::handle(const HttpRequest & request) {
+  try {
     if (request.method == "GET" && request.path == "/health") {
         return json_response(
             "{\"status\":\"ok\",\"backend\":\"" +
@@ -561,6 +575,12 @@ HttpResponse ServerState::handle(const HttpRequest & request) {
         return handle_generic_stream(request.body);
     }
     return error_response(404, "unknown endpoint: " + request.path, "not_found");
+  } catch (const ServerBusyError & ex) {
+    // Non-streaming requests surface the busy state as 503 before any response is
+    // sent. (Streaming requests acquire the lock inside the stream body, after
+    // headers are sent, so there it becomes a stream error event instead.)
+    return error_response(503, ex.what(), "server_busy");
+  }
 }
 
 void ServerState::load_models() {
@@ -753,10 +773,39 @@ struct ServerState::TimedTaskResult {
     std::optional<double> ttft_ms;
 };
 
+ServerState::ModelRunLock ServerState::acquire_model_run(LoadedModel & model) {
+    std::unique_lock<std::timed_mutex> lock(model.mutex, std::defer_lock);
+    const int timeout_ms = config_.busy_timeout_ms;
+    if (timeout_ms <= 0) {
+        lock.lock();  // guard disabled: original unbounded wait
+    } else {
+        // If the current holder has already run past the timeout, treat it as wedged
+        // and fail fast rather than queue behind it -- this is what stops requests
+        // piling up on a stuck GPU.
+        const auto since = model.busy_since_ms.load(std::memory_order_acquire);
+        if (since != 0) {
+            const auto held_ms = steady_now_ms() - since;
+            if (held_ms > timeout_ms) {
+                throw ServerBusyError(
+                    "model '" + model.config.id + "' is busy: current inference has run " +
+                    std::to_string(held_ms) + " ms (busy_timeout_ms=" + std::to_string(timeout_ms) +
+                    "); the previous request has likely wedged and cannot be cancelled");
+            }
+        }
+        if (!lock.try_lock_for(std::chrono::milliseconds(timeout_ms))) {
+            throw ServerBusyError(
+                "model '" + model.config.id + "' is busy: timed out after " +
+                std::to_string(timeout_ms) + " ms waiting for the inference lock");
+        }
+    }
+    model.busy_since_ms.store(steady_now_ms(), std::memory_order_release);
+    return ModelRunLock(model, std::move(lock));
+}
+
 ServerState::TimedTaskResult ServerState::run_model(
     LoadedModel & model,
     const engine::runtime::TaskRequest & request) {
-    std::lock_guard<std::mutex> lock(model.mutex);
+    ModelRunLock lock = acquire_model_run(model);
     ensure_model_loaded_locked(model);
     if (model.offline == nullptr) {
         throw std::runtime_error("configured model does not provide offline execution: " + model.config.id);
@@ -771,7 +820,7 @@ ServerState::TimedTaskResult ServerState::run_streaming_model(
     LoadedModel & model,
     const engine::runtime::TaskRequest & request,
     const std::function<void(const engine::runtime::StreamEvent &)> & event_sink) {
-    std::lock_guard<std::mutex> lock(model.mutex);
+    ModelRunLock lock = acquire_model_run(model);
     ensure_model_loaded_locked(model);
     if (model.streaming == nullptr) {
         throw std::runtime_error("configured model does not provide streaming execution: " + model.config.id);

--- a/app/server/runtime.cpp
+++ b/app/server/runtime.cpp
@@ -30,17 +30,19 @@ using engine::io::json::Value;
 
 using Clock = std::chrono::steady_clock;
 
-// Thrown when a model is occupied and the busy_timeout has elapsed. Mapped to
-// HTTP 503 so a client can retry or fail over rather than hang.
-class ServerBusyError : public std::runtime_error {
-public:
-    using std::runtime_error::runtime_error;
-};
-
-std::int64_t steady_now_ms() {
-    return std::chrono::duration_cast<std::chrono::milliseconds>(
-               Clock::now().time_since_epoch())
-        .count();
+// Per-request override for the busy timeout. Absent means "use the model's
+// configured ceiling"; a value is clamped to that ceiling by resolve_busy_timeout_ms
+// so a client can shorten its own wait but never weaken the guard.
+std::optional<int> parse_busy_timeout_override(const Value & body) {
+    const auto * value = body.find("busy_timeout_ms");
+    if (value == nullptr) {
+        return std::nullopt;
+    }
+    const auto requested = engine::io::json::optional_i32(body, "busy_timeout_ms", 0);
+    if (requested < 0) {
+        throw std::runtime_error("busy_timeout_ms must be >= 0 (0 means no client-side bound)");
+    }
+    return requested;
 }
 
 std::string json_quote(std::string_view value) {
@@ -773,39 +775,23 @@ struct ServerState::TimedTaskResult {
     std::optional<double> ttft_ms;
 };
 
-ServerState::ModelRunLock ServerState::acquire_model_run(LoadedModel & model) {
-    std::unique_lock<std::timed_mutex> lock(model.mutex, std::defer_lock);
-    const int timeout_ms = config_.busy_timeout_ms;
-    if (timeout_ms <= 0) {
-        lock.lock();  // guard disabled: original unbounded wait
-    } else {
-        // If the current holder has already run past the timeout, treat it as wedged
-        // and fail fast rather than queue behind it -- this is what stops requests
-        // piling up on a stuck GPU.
-        const auto since = model.busy_since_ms.load(std::memory_order_acquire);
-        if (since != 0) {
-            const auto held_ms = steady_now_ms() - since;
-            if (held_ms > timeout_ms) {
-                throw ServerBusyError(
-                    "model '" + model.config.id + "' is busy: current inference has run " +
-                    std::to_string(held_ms) + " ms (busy_timeout_ms=" + std::to_string(timeout_ms) +
-                    "); the previous request has likely wedged and cannot be cancelled");
-            }
-        }
-        if (!lock.try_lock_for(std::chrono::milliseconds(timeout_ms))) {
-            throw ServerBusyError(
-                "model '" + model.config.id + "' is busy: timed out after " +
-                std::to_string(timeout_ms) + " ms waiting for the inference lock");
-        }
-    }
-    model.busy_since_ms.store(steady_now_ms(), std::memory_order_release);
-    return ModelRunLock(model, std::move(lock));
+int ServerState::model_busy_timeout_ceiling(const LoadedModel & model) const {
+    return model.config.busy_timeout_ms.value_or(config_.busy_timeout_ms);
+}
+
+BusyGuard::Lock ServerState::acquire_model_run(
+    LoadedModel & model,
+    std::optional<int> request_timeout_ms) {
+    const int timeout_ms =
+        resolve_busy_timeout_ms(model_busy_timeout_ceiling(model), request_timeout_ms);
+    return model.busy.acquire(timeout_ms, model.config.id);
 }
 
 ServerState::TimedTaskResult ServerState::run_model(
     LoadedModel & model,
-    const engine::runtime::TaskRequest & request) {
-    ModelRunLock lock = acquire_model_run(model);
+    const engine::runtime::TaskRequest & request,
+    std::optional<int> busy_timeout_ms) {
+    BusyGuard::Lock lock = acquire_model_run(model, busy_timeout_ms);
     ensure_model_loaded_locked(model);
     if (model.offline == nullptr) {
         throw std::runtime_error("configured model does not provide offline execution: " + model.config.id);
@@ -819,8 +805,9 @@ ServerState::TimedTaskResult ServerState::run_model(
 ServerState::TimedTaskResult ServerState::run_streaming_model(
     LoadedModel & model,
     const engine::runtime::TaskRequest & request,
-    const std::function<void(const engine::runtime::StreamEvent &)> & event_sink) {
-    ModelRunLock lock = acquire_model_run(model);
+    const std::function<void(const engine::runtime::StreamEvent &)> & event_sink,
+    std::optional<int> busy_timeout_ms) {
+    BusyGuard::Lock lock = acquire_model_run(model, busy_timeout_ms);
     ensure_model_loaded_locked(model);
     if (model.streaming == nullptr) {
         throw std::runtime_error("configured model does not provide streaming execution: " + model.config.id);
@@ -854,9 +841,10 @@ HttpResponse ServerState::handle_speech(const std::string & body_text) {
     if (body.find("stream_format") != nullptr || bool_field(body, "stream", false)) {
         return handle_speech_stream(model, request, body);
     }
+    const auto busy_timeout_ms = parse_busy_timeout_override(body);
     const auto timed_result = model.task.mode == engine::runtime::RunMode::Streaming
-        ? run_streaming_model(model, request)
-        : run_model(model, request);
+        ? run_streaming_model(model, request, {}, busy_timeout_ms)
+        : run_model(model, request, busy_timeout_ms);
     const auto & audio = select_audio_output(timed_result.result);
     const auto wav = encode_pcm16_wav(audio);
     const auto response_format = engine::io::json::optional_string(body, "response_format", "wav");
@@ -889,8 +877,9 @@ HttpResponse ServerState::handle_speech_stream(
         throw std::runtime_error("streaming speech stream_format must be sse or audio");
     }
 
+    const auto busy_timeout_ms = parse_busy_timeout_override(body);
     LoadedModel * model_ptr = &model;
-    auto stream_body = [this, model_ptr, request](HttpStreamWriter & writer) {
+    auto stream_body = [this, model_ptr, request, busy_timeout_ms](HttpStreamWriter & writer) {
         bool wrote_audio = false;
         const auto timed_result = run_streaming_model(
             *model_ptr,
@@ -912,7 +901,8 @@ HttpResponse ServerState::handle_speech_stream(
                             "}");
                     wrote_audio = true;
                 }
-            });
+            },
+            busy_timeout_ms);
         if (!wrote_audio) {
             throw std::runtime_error("streaming speech model produced no audio delta events");
         }
@@ -926,7 +916,7 @@ HttpResponse ServerState::handle_speech_stream(
     if (stream_format == "sse") {
         return sse_response(std::move(stream_body));
     }
-    return chunked_audio_response([this, model_ptr, request](HttpStreamWriter & writer) {
+    return chunked_audio_response([this, model_ptr, request, busy_timeout_ms](HttpStreamWriter & writer) {
         bool wrote_audio = false;
         (void)run_streaming_model(
             *model_ptr,
@@ -942,7 +932,8 @@ HttpResponse ServerState::handle_speech_stream(
                     writer.write(std::string(reinterpret_cast<const char *>(pcm.data()), pcm.size()));
                     wrote_audio = true;
                 }
-            });
+            },
+            busy_timeout_ms);
         if (!wrote_audio) {
             throw std::runtime_error("streaming speech model produced no audio delta events");
         }
@@ -964,10 +955,11 @@ HttpResponse ServerState::handle_transcription_json(const std::string & body_tex
     const auto body = engine::io::json::parse(body_text);
     auto & model = require_model(body);
     const auto request = build_openai_transcription_request(body, request_base_);
+    const auto busy_timeout_ms = parse_busy_timeout_override(body);
     if (bool_field(body, "stream", false)) {
-        return run_transcription_stream(model, request);
+        return run_transcription_stream(model, request, busy_timeout_ms);
     }
-    return run_transcription(model, request);
+    return run_transcription(model, request, busy_timeout_ms);
 }
 
 // Accepts the same multipart/form-data shape OpenAI's Whisper API (and clients built against it,
@@ -980,6 +972,7 @@ HttpResponse ServerState::handle_transcription_multipart(const std::string & bod
     const MultipartPart * file_part = nullptr;
     std::string model_id;
     std::string language;
+    std::optional<int> busy_timeout_ms;
     bool stream = false;
     for (const auto & part : parts) {
         if (part.name == "file") {
@@ -988,6 +981,15 @@ HttpResponse ServerState::handle_transcription_multipart(const std::string & bod
             model_id = part.data;
         } else if (part.name == "language") {
             language = part.data;
+        } else if (part.name == "busy_timeout_ms") {
+            try {
+                busy_timeout_ms = std::stoi(part.data);
+            } catch (const std::exception &) {
+                throw std::runtime_error("multipart busy_timeout_ms field must be an integer");
+            }
+            if (*busy_timeout_ms < 0) {
+                throw std::runtime_error("busy_timeout_ms must be >= 0 (0 means no client-side bound)");
+            }
         } else if (part.name == "stream") {
             if (part.data == "true" || part.data == "True" || part.data == "1") {
                 stream = true;
@@ -1021,15 +1023,18 @@ HttpResponse ServerState::handle_transcription_multipart(const std::string & bod
     auto & model = require_model(body);
     const auto request = build_openai_transcription_request(body, request_base_, &file_part->data);
     if (stream) {
-        return run_transcription_stream(model, request);
+        return run_transcription_stream(model, request, busy_timeout_ms);
     }
-    return run_transcription(model, request);
+    return run_transcription(model, request, busy_timeout_ms);
 }
 
-HttpResponse ServerState::run_transcription(LoadedModel & model, const engine::runtime::TaskRequest & request) {
+HttpResponse ServerState::run_transcription(
+    LoadedModel & model,
+    const engine::runtime::TaskRequest & request,
+    std::optional<int> busy_timeout_ms) {
     const auto timed_result = model.task.mode == engine::runtime::RunMode::Streaming
-        ? run_streaming_model(model, request)
-        : run_model(model, request);
+        ? run_streaming_model(model, request, {}, busy_timeout_ms)
+        : run_model(model, request, busy_timeout_ms);
     const auto & result = timed_result.result;
     if (!result.text_output.has_value()) {
         throw std::runtime_error("model result did not contain transcript text");
@@ -1044,12 +1049,13 @@ HttpResponse ServerState::run_transcription(LoadedModel & model, const engine::r
 
 HttpResponse ServerState::run_transcription_stream(
     LoadedModel & model,
-    const engine::runtime::TaskRequest & request) {
+    const engine::runtime::TaskRequest & request,
+    std::optional<int> busy_timeout_ms) {
     if (model.task.mode != engine::runtime::RunMode::Streaming) {
         throw std::runtime_error("transcription stream=true requires a model configured with mode=streaming");
     }
     LoadedModel * model_ptr = &model;
-    return sse_response([this, model_ptr, request](HttpStreamWriter & writer) {
+    return sse_response([this, model_ptr, request, busy_timeout_ms](HttpStreamWriter & writer) {
         const auto timed_result = run_streaming_model(
             *model_ptr,
             request,
@@ -1062,7 +1068,8 @@ HttpResponse ServerState::run_transcription_stream(
                     "{\"type\":\"transcript.text.delta\",\"delta\":" +
                         json_quote(event.partial_text->text) +
                         "}");
-            });
+            },
+            busy_timeout_ms);
         if (!timed_result.result.text_output.has_value()) {
             throw std::runtime_error("streaming transcription result did not contain transcript text");
         }
@@ -1084,9 +1091,10 @@ HttpResponse ServerState::handle_generic_run(const std::string & body_text) {
     const auto request = minitts::cli::build_request_from_json(
         request_json != nullptr ? *request_json : body,
         request_base_);
+    const auto busy_timeout_ms = parse_busy_timeout_override(body);
     const auto timed_result = model.task.mode == engine::runtime::RunMode::Streaming
-        ? run_streaming_model(model, request)
-        : run_model(model, request);
+        ? run_streaming_model(model, request, {}, busy_timeout_ms)
+        : run_model(model, request, busy_timeout_ms);
     return json_response(task_result_json(timed_result.result, timed_result.wall_ms));
 }
 
@@ -1103,7 +1111,8 @@ HttpResponse ServerState::handle_generic_stream(const std::string & body_text) {
         request,
         [&](const engine::runtime::StreamEvent & event) {
             events.push_back(event);
-        });
+        },
+        parse_busy_timeout_override(body));
     std::ostringstream out;
     out << "{\"events\":[";
     for (size_t i = 0; i < events.size(); ++i) {

--- a/app/server/runtime.h
+++ b/app/server/runtime.h
@@ -7,6 +7,8 @@
 #include "engine/framework/runtime/model.h"
 #include "engine/framework/runtime/session.h"
 
+#include <atomic>
+#include <cstdint>
 #include <filesystem>
 #include <functional>
 #include <memory>
@@ -38,8 +40,41 @@ private:
         engine::runtime::IStreamingVoiceTaskSession * streaming = nullptr;
         std::unordered_map<std::string, RuntimeVoicePreset> voice_presets;
         std::optional<RuntimeVoicePreset> default_voice_preset;
-        std::mutex mutex;
+        // timed_mutex so a request can bound how long it waits for the model.
+        // busy_since_ms is the steady-clock time (ms) the current holder acquired the
+        // lock, or 0 when idle; it lets a new request detect a run that has already
+        // overrun and fail fast instead of queuing behind a wedged inference.
+        std::timed_mutex mutex;
+        std::atomic<std::int64_t> busy_since_ms{0};
     };
+
+    // Holds model.mutex for the duration of a run and clears busy_since_ms when it
+    // releases (including on exception), so the fail-fast check never sees a stale
+    // timestamp. Move-only.
+    class ModelRunLock {
+    public:
+        ModelRunLock() = default;
+        ModelRunLock(LoadedModel & model, std::unique_lock<std::timed_mutex> lock)
+            : model_(&model), lock_(std::move(lock)) {}
+        ModelRunLock(ModelRunLock &&) = default;
+        ModelRunLock & operator=(ModelRunLock &&) = default;
+        ModelRunLock(const ModelRunLock &) = delete;
+        ModelRunLock & operator=(const ModelRunLock &) = delete;
+        ~ModelRunLock() {
+            if (model_ != nullptr && lock_.owns_lock()) {
+                model_->busy_since_ms.store(0, std::memory_order_release);
+            }
+        }
+
+    private:
+        LoadedModel * model_ = nullptr;
+        std::unique_lock<std::timed_mutex> lock_;
+    };
+
+    // Acquire model.mutex for a run. Throws ServerBusyError (-> HTTP 503) when the
+    // busy_timeout has elapsed, either because the current holder has already
+    // overrun (fail fast, no wait) or because the wait itself timed out.
+    ModelRunLock acquire_model_run(LoadedModel & model);
 
     void load_models();
     LoadedModel::RuntimeVoicePreset load_runtime_voice_preset(const ServerModelConfig::VoicePreset & preset) const;

--- a/app/server/runtime.h
+++ b/app/server/runtime.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "busy_guard.h"
 #include "config.h"
 #include "http.h"
 
@@ -40,41 +41,19 @@ private:
         engine::runtime::IStreamingVoiceTaskSession * streaming = nullptr;
         std::unordered_map<std::string, RuntimeVoicePreset> voice_presets;
         std::optional<RuntimeVoicePreset> default_voice_preset;
-        // timed_mutex so a request can bound how long it waits for the model.
-        // busy_since_ms is the steady-clock time (ms) the current holder acquired the
-        // lock, or 0 when idle; it lets a new request detect a run that has already
-        // overrun and fail fast instead of queuing behind a wedged inference.
-        std::timed_mutex mutex;
-        std::atomic<std::int64_t> busy_since_ms{0};
+        // Serializes runs on this model and bounds how long a caller waits for its
+        // turn; see BusyGuard.
+        BusyGuard busy;
     };
 
-    // Holds model.mutex for the duration of a run and clears busy_since_ms when it
-    // releases (including on exception), so the fail-fast check never sees a stale
-    // timestamp. Move-only.
-    class ModelRunLock {
-    public:
-        ModelRunLock() = default;
-        ModelRunLock(LoadedModel & model, std::unique_lock<std::timed_mutex> lock)
-            : model_(&model), lock_(std::move(lock)) {}
-        ModelRunLock(ModelRunLock &&) = default;
-        ModelRunLock & operator=(ModelRunLock &&) = default;
-        ModelRunLock(const ModelRunLock &) = delete;
-        ModelRunLock & operator=(const ModelRunLock &) = delete;
-        ~ModelRunLock() {
-            if (model_ != nullptr && lock_.owns_lock()) {
-                model_->busy_since_ms.store(0, std::memory_order_release);
-            }
-        }
+    // Acquire the model's run guard. `request_timeout_ms` is the caller-supplied
+    // override, clamped by this model's configured ceiling. Throws ServerBusyError
+    // (-> HTTP 503) once the effective timeout has elapsed.
+    BusyGuard::Lock acquire_model_run(LoadedModel & model, std::optional<int> request_timeout_ms);
 
-    private:
-        LoadedModel * model_ = nullptr;
-        std::unique_lock<std::timed_mutex> lock_;
-    };
-
-    // Acquire model.mutex for a run. Throws ServerBusyError (-> HTTP 503) when the
-    // busy_timeout has elapsed, either because the current holder has already
-    // overrun (fail fast, no wait) or because the wait itself timed out.
-    ModelRunLock acquire_model_run(LoadedModel & model);
+    // Server policy for this model: its own busy_timeout_ms if set, else the
+    // top-level config value.
+    int model_busy_timeout_ceiling(const LoadedModel & model) const;
 
     void load_models();
     LoadedModel::RuntimeVoicePreset load_runtime_voice_preset(const ServerModelConfig::VoicePreset & preset) const;
@@ -89,11 +68,17 @@ private:
         const LoadedModel & model,
         const engine::io::json::Value & body) const;
     struct TimedTaskResult;
-    TimedTaskResult run_model(LoadedModel & model, const engine::runtime::TaskRequest & request);
+    // `busy_timeout_ms` on each of these is the per-request override parsed from the
+    // request body; nullopt means "use the model's configured ceiling".
+    TimedTaskResult run_model(
+        LoadedModel & model,
+        const engine::runtime::TaskRequest & request,
+        std::optional<int> busy_timeout_ms = std::nullopt);
     TimedTaskResult run_streaming_model(
         LoadedModel & model,
         const engine::runtime::TaskRequest & request,
-        const std::function<void(const engine::runtime::StreamEvent &)> & event_sink = {});
+        const std::function<void(const engine::runtime::StreamEvent &)> & event_sink = {},
+        std::optional<int> busy_timeout_ms = std::nullopt);
     HttpResponse handle_speech(const std::string & body_text);
     HttpResponse handle_speech_stream(
         LoadedModel & model,
@@ -102,8 +87,14 @@ private:
     HttpResponse handle_transcription(const HttpRequest & request);
     HttpResponse handle_transcription_json(const std::string & body_text);
     HttpResponse handle_transcription_multipart(const std::string & body_text, const std::string & boundary);
-    HttpResponse run_transcription(LoadedModel & model, const engine::runtime::TaskRequest & request);
-    HttpResponse run_transcription_stream(LoadedModel & model, const engine::runtime::TaskRequest & request);
+    HttpResponse run_transcription(
+        LoadedModel & model,
+        const engine::runtime::TaskRequest & request,
+        std::optional<int> busy_timeout_ms = std::nullopt);
+    HttpResponse run_transcription_stream(
+        LoadedModel & model,
+        const engine::runtime::TaskRequest & request,
+        std::optional<int> busy_timeout_ms = std::nullopt);
     HttpResponse handle_generic_run(const std::string & body_text);
     HttpResponse handle_generic_stream(const std::string & body_text);
     HttpResponse handle_voices(const HttpRequest & request) const;

--- a/tests/unittests/test_server_busy_guard.cpp
+++ b/tests/unittests/test_server_busy_guard.cpp
@@ -1,0 +1,252 @@
+// Behavioral tests for the model busy guard.
+//
+// The central claim these tests pin down is the one the guard exists to make:
+// with the guard disabled (timeout 0) the server behaves exactly as it did before
+// -- callers queue behind a wedged inference forever and every worker thread is
+// consumed -- and with a positive timeout those same callers fail fast instead.
+// Rather than asserting on the code path, each test drives real threads against a
+// real BusyGuard whose holder never releases, which is what a wedged CUDA call
+// looks like from userspace.
+
+#include "busy_guard.h"
+
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+using namespace std::chrono_literals;
+
+void require(bool condition, const std::string & message) {
+    if (!condition) {
+        throw std::runtime_error(message);
+    }
+}
+
+// A run that never finishes, standing in for an inference wedged inside the GPU
+// driver. The holder thread parks until `release` is set, so the guard stays taken
+// for as long as the test needs.
+class WedgedRun {
+public:
+    explicit WedgedRun(minitts::server::BusyGuard & guard) {
+        thread_ = std::thread([this, &guard] {
+            auto lock = guard.acquire(0, "wedged");
+            held_.store(true);
+            while (!release_.load()) {
+                std::this_thread::sleep_for(1ms);
+            }
+        });
+        while (!held_.load()) {
+            std::this_thread::sleep_for(1ms);
+        }
+    }
+
+    // Let the wedged run finish. Tests must call this before their std::async futures
+    // go out of scope: ~future blocks until its task completes, and locals destruct in
+    // reverse declaration order, so an implicit cleanup would join the waiters while
+    // this run still holds the guard -- deadlocking the test itself.
+    void release() {
+        if (thread_.joinable()) {
+            release_.store(true);
+            thread_.join();
+        }
+    }
+
+    ~WedgedRun() { release(); }
+
+private:
+    std::thread thread_;
+    std::atomic<bool> held_{false};
+    std::atomic<bool> release_{false};
+};
+
+// Is this caller still stuck waiting after `patience`? Returns true when the future
+// has not resolved -- i.e. the thread is parked on the lock, exactly the pile-up the
+// guard is meant to prevent.
+template <typename T>
+bool still_blocked(std::future<T> & future, std::chrono::milliseconds patience) {
+    return future.wait_for(patience) == std::future_status::timeout;
+}
+
+// timeout 0 must reproduce the original std::mutex behavior exactly: a caller
+// arriving behind a wedged run waits, and keeps waiting, with no way out.
+void test_disabled_guard_queues_forever() {
+    minitts::server::BusyGuard guard;
+    WedgedRun wedged(guard);
+
+    std::atomic<bool> acquired{false};
+    auto waiter = std::async(std::launch::async, [&] {
+        auto lock = guard.acquire(0, "model");  // guard disabled
+        acquired.store(true);
+        return true;
+    });
+
+    require(
+        still_blocked(waiter, 300ms),
+        "with busy_timeout_ms=0 a caller must queue behind the wedged run (original behavior)");
+    require(!acquired.load(), "the queued caller must not have entered the model");
+
+    // The waiter is still parked at this point. Releasing the wedged run lets it
+    // through so the test can finish -- in the real server nothing performs this
+    // release, which is precisely the bug: the thread is gone until the process
+    // restarts.
+    wedged.release();
+    require(waiter.get(), "the waiter proceeds only once the wedged run releases");
+    require(acquired.load(), "the queued caller enters the model after the release");
+}
+
+// The system-stuck claim: with the guard disabled, every worker that arrives is
+// consumed, so a bounded thread pool is fully exhausted and the server stops
+// serving -- including requests for other, healthy models.
+void test_disabled_guard_exhausts_all_workers() {
+    minitts::server::BusyGuard guard;
+    WedgedRun wedged(guard);
+
+    constexpr int kWorkers = 8;
+    std::atomic<int> entered{0};
+    std::vector<std::future<void>> workers;
+    workers.reserve(kWorkers);
+    for (int i = 0; i < kWorkers; ++i) {
+        workers.push_back(std::async(std::launch::async, [&] {
+            auto lock = guard.acquire(0, "model");
+            entered.fetch_add(1);
+        }));
+    }
+
+    for (auto & worker : workers) {
+        require(
+            still_blocked(worker, 100ms),
+            "every worker must be stuck behind the wedged run when the guard is disabled");
+    }
+    require(entered.load() == 0, "no worker may enter the model while it is wedged");
+
+    wedged.release();  // drain the parked workers so the test can exit
+    for (auto & worker : workers) {
+        worker.get();
+    }
+    require(entered.load() == kWorkers, "the parked workers drain once the model frees up");
+}
+
+// With a positive timeout the same wedged run no longer captures callers: each one
+// gives up and reports busy, so the worker returns to the pool.
+void test_enabled_guard_fails_fast_instead_of_queuing() {
+    minitts::server::BusyGuard guard;
+    WedgedRun wedged(guard);
+
+    constexpr int kWorkers = 8;
+    std::atomic<int> busy_errors{0};
+    std::vector<std::future<void>> workers;
+    workers.reserve(kWorkers);
+    for (int i = 0; i < kWorkers; ++i) {
+        workers.push_back(std::async(std::launch::async, [&] {
+            try {
+                auto lock = guard.acquire(50, "model");
+                require(false, "acquire must not succeed while the model is wedged");
+            } catch (const minitts::server::ServerBusyError &) {
+                busy_errors.fetch_add(1);
+            }
+        }));
+    }
+
+    // Record the verdict before asserting: if the guard regressed, the workers are
+    // parked on the lock and their futures would block on destruction, hanging the
+    // test instead of reporting. Releasing the wedged run first frees them either way.
+    bool all_returned = true;
+    for (auto & worker : workers) {
+        if (still_blocked(worker, 2000ms)) {
+            all_returned = false;
+        }
+    }
+    wedged.release();
+    for (auto & worker : workers) {
+        worker.get();
+    }
+
+    require(all_returned, "with a positive timeout no worker may stay parked on the lock");
+    require(
+        busy_errors.load() == kWorkers,
+        "every worker must surface ServerBusyError rather than hang");
+}
+
+// Once the holder has overrun, later arrivals skip the wait entirely -- they must
+// not each burn another full timeout window before reporting busy.
+void test_overrun_holder_fails_without_waiting() {
+    minitts::server::BusyGuard guard;
+    WedgedRun wedged(guard);
+
+    // Let the holder run past a 50 ms bound.
+    std::this_thread::sleep_for(120ms);
+
+    const auto started = std::chrono::steady_clock::now();
+    bool threw = false;
+    try {
+        auto lock = guard.acquire(50, "model");
+    } catch (const minitts::server::ServerBusyError &) {
+        threw = true;
+    }
+    const auto elapsed = std::chrono::steady_clock::now() - started;
+
+    require(threw, "an already-overrun holder must be reported as busy");
+    require(
+        elapsed < 40ms,
+        "the fail-fast path must not wait out another timeout window");
+}
+
+// The guard must not leave a stale timestamp behind: after a normal run completes,
+// the next caller acquires immediately rather than inheriting the previous run's
+// elapsed time and being wrongly rejected.
+void test_guard_is_reusable_after_a_normal_run() {
+    minitts::server::BusyGuard guard;
+    {
+        auto lock = guard.acquire(50, "model");
+        std::this_thread::sleep_for(80ms);  // longer than the timeout, but legitimate
+    }
+    // A completed run -- even one that outlived the timeout -- must not poison the guard.
+    auto lock = guard.acquire(50, "model");
+}
+
+// The same must hold when a run ends by throwing.
+void test_guard_is_reusable_after_a_failed_run() {
+    minitts::server::BusyGuard guard;
+    try {
+        auto lock = guard.acquire(50, "model");
+        throw std::runtime_error("inference failed");
+    } catch (const std::runtime_error &) {
+    }
+    auto lock = guard.acquire(50, "model");
+}
+
+// An idle model must be entered without delay regardless of the bound.
+void test_idle_model_acquires_immediately() {
+    minitts::server::BusyGuard guard;
+    const auto started = std::chrono::steady_clock::now();
+    auto lock = guard.acquire(5000, "model");
+    require(
+        std::chrono::steady_clock::now() - started < 100ms,
+        "an idle model must not wait for the timeout");
+}
+
+}  // namespace
+
+int main() {
+    try {
+        test_disabled_guard_queues_forever();
+        test_disabled_guard_exhausts_all_workers();
+        test_enabled_guard_fails_fast_instead_of_queuing();
+        test_overrun_holder_fails_without_waiting();
+        test_guard_is_reusable_after_a_normal_run();
+        test_guard_is_reusable_after_a_failed_run();
+        test_idle_model_acquires_immediately();
+    } catch (const std::exception & error) {
+        std::cerr << error.what() << '\n';
+        return 1;
+    }
+    std::cout << "server_busy_guard_test passed\n";
+    return 0;
+}

--- a/tests/unittests/test_server_config.cpp
+++ b/tests/unittests/test_server_config.cpp
@@ -1,3 +1,4 @@
+#include "busy_guard.h"
 #include "config.h"
 
 #include <filesystem>
@@ -140,6 +141,130 @@ void test_missing_default_preset_name_is_rejected() {
     require(rejected, "unknown default preset name is rejected");
 }
 
+const char * const kMinimalModel = R"JSON(
+  "models": [
+    {
+      "id": "tts",
+      "family": "pocket_tts",
+      "path": "models/pocket-tts"
+    }
+  ]
+)JSON";
+
+void test_busy_timeout_defaults_and_overrides() {
+    const auto root = make_temp_root();
+
+    const auto default_path = write_config(
+        root, "busy_default.json", std::string("{") + kMinimalModel + "}");
+    require(
+        minitts::server::load_server_config(default_path).busy_timeout_ms == 300000,
+        "busy_timeout_ms defaults to 5 minutes when omitted");
+
+    const auto override_path = write_config(
+        root, "busy_override.json", std::string(R"JSON({"busy_timeout_ms": 90000,)JSON") + kMinimalModel + "}");
+    require(
+        minitts::server::load_server_config(override_path).busy_timeout_ms == 90000,
+        "busy_timeout_ms is read from the config");
+
+    const auto disabled_path = write_config(
+        root, "busy_disabled.json", std::string(R"JSON({"busy_timeout_ms": 0,)JSON") + kMinimalModel + "}");
+    require(
+        minitts::server::load_server_config(disabled_path).busy_timeout_ms == 0,
+        "busy_timeout_ms accepts 0 to disable the guard");
+}
+
+void test_negative_busy_timeout_is_rejected() {
+    const auto root = make_temp_root();
+    const auto config_path = write_config(
+        root, "busy_negative.json", std::string(R"JSON({"busy_timeout_ms": -1,)JSON") + kMinimalModel + "}");
+
+    bool rejected = false;
+    try {
+        (void) minitts::server::load_server_config(config_path);
+    } catch (const std::runtime_error & error) {
+        rejected = std::string(error.what()).find("busy_timeout_ms") != std::string::npos;
+    }
+    require(rejected, "negative busy_timeout_ms is rejected");
+}
+
+void test_per_model_busy_timeout() {
+    const auto root = make_temp_root();
+    const auto config_path = write_config(
+        root,
+        "busy_per_model.json",
+        R"JSON({
+  "busy_timeout_ms": 300000,
+  "models": [
+    {"id": "tts",   "family": "pocket_tts", "path": "models/a", "busy_timeout_ms": 30000},
+    {"id": "music", "family": "pocket_tts", "path": "models/b", "busy_timeout_ms": 900000},
+    {"id": "asr",   "family": "pocket_tts", "path": "models/c"}
+  ]
+})JSON");
+
+    const auto config = minitts::server::load_server_config(config_path);
+    require(config.models.at(0).busy_timeout_ms == 30000, "per-model busy_timeout_ms parsed");
+    require(config.models.at(1).busy_timeout_ms == 900000, "a model may exceed the top-level value");
+    require(
+        !config.models.at(2).busy_timeout_ms.has_value(),
+        "a model without the key inherits the top-level value");
+}
+
+void test_negative_per_model_busy_timeout_is_rejected() {
+    const auto root = make_temp_root();
+    const auto config_path = write_config(
+        root,
+        "busy_per_model_negative.json",
+        R"JSON({
+  "models": [
+    {"id": "tts", "family": "pocket_tts", "path": "models/a", "busy_timeout_ms": -1}
+  ]
+})JSON");
+
+    bool rejected = false;
+    try {
+        (void) minitts::server::load_server_config(config_path);
+    } catch (const std::runtime_error & error) {
+        rejected = std::string(error.what()).find("busy_timeout_ms for model tts") != std::string::npos;
+    }
+    require(rejected, "negative per-model busy_timeout_ms is rejected, naming the model");
+}
+
+// A request may shorten its own wait but must never lengthen it past server policy,
+// otherwise a client could reintroduce the unbounded hang the guard prevents.
+void test_request_timeout_is_clamped_to_policy() {
+    using minitts::server::resolve_busy_timeout_ms;
+
+    require(resolve_busy_timeout_ms(900000, std::nullopt) == 900000, "no request override uses policy");
+    require(resolve_busy_timeout_ms(900000, 60000) == 60000, "a shorter request bound is honored");
+    require(resolve_busy_timeout_ms(900000, 999999) == 900000, "a longer request bound is clamped");
+    require(resolve_busy_timeout_ms(900000, 900000) == 900000, "an equal request bound is unchanged");
+
+    // 0 means unbounded, so it must compare as +infinity rather than as a tiny value.
+    require(
+        resolve_busy_timeout_ms(900000, 0) == 900000,
+        "a request asking for unbounded is still capped by policy");
+    require(
+        resolve_busy_timeout_ms(0, 60000) == 60000,
+        "under unbounded policy a request may still bound its own wait");
+    require(
+        resolve_busy_timeout_ms(0, std::nullopt) == 0,
+        "unbounded policy with no override stays unbounded");
+    require(
+        resolve_busy_timeout_ms(0, 0) == 0,
+        "unbounded on both sides stays unbounded");
+}
+
+void test_model_run_overrun_predicate() {
+    using minitts::server::model_run_has_overrun;
+
+    require(!model_run_has_overrun(0, 10'000'000, 1000), "an idle model never counts as overrun");
+    require(!model_run_has_overrun(1000, 1500, 1000), "a run inside the timeout waits normally");
+    require(!model_run_has_overrun(1000, 2000, 1000), "a run exactly at the timeout is not yet overrun");
+    require(model_run_has_overrun(1000, 2001, 1000), "a run past the timeout fails fast");
+    require(!model_run_has_overrun(1000, 10'000'000, 0), "timeout 0 disables the guard");
+    require(!model_run_has_overrun(1000, 10'000'000, -1), "a non-positive timeout disables the guard");
+}
+
 }  // namespace
 
 int main() {
@@ -147,6 +272,12 @@ int main() {
         test_inline_default_and_named_presets();
         test_default_preset_name();
         test_missing_default_preset_name_is_rejected();
+        test_busy_timeout_defaults_and_overrides();
+        test_negative_busy_timeout_is_rejected();
+        test_per_model_busy_timeout();
+        test_negative_per_model_busy_timeout_is_rejected();
+        test_request_timeout_is_clamped_to_policy();
+        test_model_run_overrun_predicate();
     } catch (const std::exception & error) {
         std::cerr << error.what() << '\n';
         return 1;


### PR DESCRIPTION
1) timed_mutex is used, so that one failed/stuck operation on GPU will not block other threads.
2) Allow busy timeout to be configured per model and per request