### PR TITLE
Fix PocketTTS Mimi decoder CPU crash: restore context-tensor backing removed in d98123e

### DIFF
--- a/src/models/pocket_tts/mimi_decoder.cpp
+++ b/src/models/pocket_tts/mimi_decoder.cpp
@@ -220,6 +220,7 @@ public:
             false,
         }).build(ctx, input_, {weight, std::nullopt});
 
+        params_buffer_ = ggml_backend_alloc_ctx_tensors(ggml_ctx_, backend_);
         core::set_backend_threads(backend_, threads_);
         graph_ = ggml_new_graph_custom(ggml_ctx_, 32768, false);
         ggml_build_forward_expand(graph_, output_.tensor);
@@ -236,6 +237,9 @@ public:
     ~DepthwiseConvTranspose1dRuntime() {
         if (galloc_ != nullptr) {
             ggml_gallocr_free(galloc_);
+        }
+        if (params_buffer_ != nullptr) {
+            ggml_backend_buffer_free(params_buffer_);
         }
         if (ggml_ctx_ != nullptr) {
             ggml_free(ggml_ctx_);
@@ -259,6 +263,7 @@ private:
     int64_t kernel_size_ = 0;
     int stride_ = 1;
     ggml_context * ggml_ctx_ = nullptr;
+    ggml_backend_buffer_t params_buffer_ = nullptr;
     ggml_cgraph * graph_ = nullptr;
     ggml_gallocr_t galloc_ = nullptr;
     core::TensorValue input_;
@@ -308,6 +313,7 @@ public:
             bias.has_value(),
         }).build(ctx, input_, modules::Conv1dWeights{weight, bias});
 
+        params_buffer_ = ggml_backend_alloc_ctx_tensors(ggml_ctx_, backend_);
         core::set_backend_threads(backend_, threads_);
         graph_ = ggml_new_graph_custom(ggml_ctx_, 32768, false);
         ggml_build_forward_expand(graph_, output_.tensor);
@@ -324,6 +330,9 @@ public:
     ~Conv1dRuntime() {
         if (galloc_ != nullptr) {
             ggml_gallocr_free(galloc_);
+        }
+        if (params_buffer_ != nullptr) {
+            ggml_backend_buffer_free(params_buffer_);
         }
         if (ggml_ctx_ != nullptr) {
             ggml_free(ggml_ctx_);
@@ -349,6 +358,7 @@ private:
     int stride_ = 1;
     int dilation_ = 1;
     ggml_context * ggml_ctx_ = nullptr;
+    ggml_backend_buffer_t params_buffer_ = nullptr;
     ggml_cgraph * graph_ = nullptr;
     ggml_gallocr_t galloc_ = nullptr;
     core::TensorValue input_;
@@ -396,6 +406,7 @@ public:
             bias.has_value(),
         }).build(ctx, input_, modules::ConvTranspose1dWeights{weight, bias});
 
+        params_buffer_ = ggml_backend_alloc_ctx_tensors(ggml_ctx_, backend_);
         core::set_backend_threads(backend_, threads_);
         graph_ = ggml_new_graph_custom(ggml_ctx_, 32768, false);
         ggml_build_forward_expand(graph_, output_.tensor);
@@ -412,6 +423,9 @@ public:
     ~ConvTranspose1dRuntime() {
         if (galloc_ != nullptr) {
             ggml_gallocr_free(galloc_);
+        }
+        if (params_buffer_ != nullptr) {
+            ggml_backend_buffer_free(params_buffer_);
         }
         if (ggml_ctx_ != nullptr) {
             ggml_free(ggml_ctx_);
@@ -436,6 +450,7 @@ private:
     int64_t kernel_size_ = 0;
     int stride_ = 1;
     ggml_context * ggml_ctx_ = nullptr;
+    ggml_backend_buffer_t params_buffer_ = nullptr;
     ggml_cgraph * graph_ = nullptr;
     ggml_gallocr_t galloc_ = nullptr;
     core::TensorValue input_;
@@ -636,6 +651,7 @@ public:
         }
         output_ = modules::SliceModule({2, 0, output_full.shape.dims[2] - trim_frames}).build(ctx, output_full);
 
+        params_buffer_ = ggml_backend_alloc_ctx_tensors(ggml_ctx_, backend_);
         core::set_backend_threads(backend_, threads_);
         graph_ = ggml_new_graph_custom(ggml_ctx_, 32768, false);
         ggml_build_forward_expand(graph_, output_.tensor);
@@ -679,6 +695,9 @@ public:
         if (galloc_ != nullptr) {
             ggml_gallocr_free(galloc_);
         }
+        if (params_buffer_ != nullptr) {
+            ggml_backend_buffer_free(params_buffer_);
+        }
         if (ggml_ctx_ != nullptr) {
             ggml_free(ggml_ctx_);
         }
@@ -703,6 +722,7 @@ private:
     int64_t cache_steps_ = 0;
     int64_t head_dim_ = 0;
     ggml_context * ggml_ctx_ = nullptr;
+    ggml_backend_buffer_t params_buffer_ = nullptr;
     ggml_cgraph * graph_ = nullptr;
     ggml_gallocr_t galloc_ = nullptr;
     ggml_backend_graph_plan_t plan_ = nullptr;
@@ -822,6 +842,7 @@ public:
         output_bct_ = modules::TransposeModule({{0, 2, 1, 3}, 3}).build(ctx, x);
         build_transfer_views();
 
+        params_buffer_ = ggml_backend_alloc_ctx_tensors(ggml_ctx_, backend_);
         core::set_backend_threads(backend_, threads_);
         graph_ = ggml_new_graph_custom(ggml_ctx_, 32768, false);
         ggml_build_forward_expand(graph_, output_bct_.tensor);
@@ -854,6 +875,9 @@ public:
     ~MimiTransformerRuntime() {
         if (galloc_ != nullptr) {
             ggml_gallocr_free(galloc_);
+        }
+        if (params_buffer_ != nullptr) {
+            ggml_backend_buffer_free(params_buffer_);
         }
         if (ggml_ctx_ != nullptr) {
             ggml_free(ggml_ctx_);
@@ -996,6 +1020,7 @@ private:
     int64_t cache_steps_ = 0;
     int64_t head_dim_ = 0;
     ggml_context * ggml_ctx_ = nullptr;
+    ggml_backend_buffer_t params_buffer_ = nullptr;
     ggml_cgraph * graph_ = nullptr;
     ggml_gallocr_t galloc_ = nullptr;
     core::TensorValue input_bct_;

--- a/src/models/pocket_tts/mimi_decoder.cpp
+++ b/src/models/pocket_tts/mimi_decoder.cpp
@@ -220,7 +220,9 @@ public:
             false,
         }).build(ctx, input_, {weight, std::nullopt});
 
-        params_buffer_ = ggml_backend_alloc_ctx_tensors(ggml_ctx_, backend_);
+        if (core::is_host_backend(backend_)) {
+            params_buffer_ = ggml_backend_alloc_ctx_tensors(ggml_ctx_, backend_);
+        }
         core::set_backend_threads(backend_, threads_);
         graph_ = ggml_new_graph_custom(ggml_ctx_, 32768, false);
         ggml_build_forward_expand(graph_, output_.tensor);
@@ -313,7 +315,9 @@ public:
             bias.has_value(),
         }).build(ctx, input_, modules::Conv1dWeights{weight, bias});
 
-        params_buffer_ = ggml_backend_alloc_ctx_tensors(ggml_ctx_, backend_);
+        if (core::is_host_backend(backend_)) {
+            params_buffer_ = ggml_backend_alloc_ctx_tensors(ggml_ctx_, backend_);
+        }
         core::set_backend_threads(backend_, threads_);
         graph_ = ggml_new_graph_custom(ggml_ctx_, 32768, false);
         ggml_build_forward_expand(graph_, output_.tensor);
@@ -406,7 +410,9 @@ public:
             bias.has_value(),
         }).build(ctx, input_, modules::ConvTranspose1dWeights{weight, bias});
 
-        params_buffer_ = ggml_backend_alloc_ctx_tensors(ggml_ctx_, backend_);
+        if (core::is_host_backend(backend_)) {
+            params_buffer_ = ggml_backend_alloc_ctx_tensors(ggml_ctx_, backend_);
+        }
         core::set_backend_threads(backend_, threads_);
         graph_ = ggml_new_graph_custom(ggml_ctx_, 32768, false);
         ggml_build_forward_expand(graph_, output_.tensor);
@@ -651,7 +657,9 @@ public:
         }
         output_ = modules::SliceModule({2, 0, output_full.shape.dims[2] - trim_frames}).build(ctx, output_full);
 
-        params_buffer_ = ggml_backend_alloc_ctx_tensors(ggml_ctx_, backend_);
+        if (core::is_host_backend(backend_)) {
+            params_buffer_ = ggml_backend_alloc_ctx_tensors(ggml_ctx_, backend_);
+        }
         core::set_backend_threads(backend_, threads_);
         graph_ = ggml_new_graph_custom(ggml_ctx_, 32768, false);
         ggml_build_forward_expand(graph_, output_.tensor);
@@ -842,7 +850,9 @@ public:
         output_bct_ = modules::TransposeModule({{0, 2, 1, 3}, 3}).build(ctx, x);
         build_transfer_views();
 
-        params_buffer_ = ggml_backend_alloc_ctx_tensors(ggml_ctx_, backend_);
+        if (core::is_host_backend(backend_)) {
+            params_buffer_ = ggml_backend_alloc_ctx_tensors(ggml_ctx_, backend_);
+        }
         core::set_backend_threads(backend_, threads_);
         graph_ = ggml_new_graph_custom(ggml_ctx_, 32768, false);
         ggml_build_forward_expand(graph_, output_bct_.tensor);

--- a/src/models/pocket_tts/mimi_decoder.cpp
+++ b/src/models/pocket_tts/mimi_decoder.cpp
@@ -75,10 +75,15 @@ class MimiTransformerRuntime;
 
 void release_partial_graph_runtime(
     ggml_gallocr_t & gallocr,
+    ggml_backend_buffer_t & params_buffer,
     ggml_context *& context) {
     if (gallocr != nullptr) {
         ggml_gallocr_free(gallocr);
         gallocr = nullptr;
+    }
+    if (params_buffer != nullptr) {
+        ggml_backend_buffer_free(params_buffer);
+        params_buffer = nullptr;
     }
     if (context != nullptr) {
         ggml_free(context);
@@ -222,6 +227,10 @@ public:
 
         if (core::is_host_backend(backend_)) {
             params_buffer_ = ggml_backend_alloc_ctx_tensors(ggml_ctx_, backend_);
+            if (params_buffer_ == nullptr) {
+                release_partial_graph_runtime(galloc_, params_buffer_, ggml_ctx_);
+                throw std::runtime_error("Mimi depthwise conv transpose context tensor allocation failed");
+            }
         }
         core::set_backend_threads(backend_, threads_);
         graph_ = ggml_new_graph_custom(ggml_ctx_, 32768, false);
@@ -230,7 +239,7 @@ public:
         if (galloc_ == nullptr ||
             !ggml_gallocr_reserve(galloc_, graph_) ||
             !ggml_gallocr_alloc_graph(galloc_, graph_)) {
-            release_partial_graph_runtime(galloc_, ggml_ctx_);
+            release_partial_graph_runtime(galloc_, params_buffer_, ggml_ctx_);
             throw std::runtime_error("Mimi depthwise conv transpose graph allocation failed");
         }
         core::write_tensor_f32(input_, std::vector<float>(static_cast<size_t>(channels_ * frames_), 0.0F));
@@ -317,6 +326,10 @@ public:
 
         if (core::is_host_backend(backend_)) {
             params_buffer_ = ggml_backend_alloc_ctx_tensors(ggml_ctx_, backend_);
+            if (params_buffer_ == nullptr) {
+                release_partial_graph_runtime(galloc_, params_buffer_, ggml_ctx_);
+                throw std::runtime_error("Mimi conv1d context tensor allocation failed");
+            }
         }
         core::set_backend_threads(backend_, threads_);
         graph_ = ggml_new_graph_custom(ggml_ctx_, 32768, false);
@@ -325,7 +338,7 @@ public:
         if (galloc_ == nullptr ||
             !ggml_gallocr_reserve(galloc_, graph_) ||
             !ggml_gallocr_alloc_graph(galloc_, graph_)) {
-            release_partial_graph_runtime(galloc_, ggml_ctx_);
+            release_partial_graph_runtime(galloc_, params_buffer_, ggml_ctx_);
             throw std::runtime_error("Mimi conv1d graph allocation failed");
         }
         core::write_tensor_f32(input_, std::vector<float>(static_cast<size_t>(in_channels_ * frames_), 0.0F));
@@ -412,6 +425,10 @@ public:
 
         if (core::is_host_backend(backend_)) {
             params_buffer_ = ggml_backend_alloc_ctx_tensors(ggml_ctx_, backend_);
+            if (params_buffer_ == nullptr) {
+                release_partial_graph_runtime(galloc_, params_buffer_, ggml_ctx_);
+                throw std::runtime_error("Mimi conv transpose context tensor allocation failed");
+            }
         }
         core::set_backend_threads(backend_, threads_);
         graph_ = ggml_new_graph_custom(ggml_ctx_, 32768, false);
@@ -420,7 +437,7 @@ public:
         if (galloc_ == nullptr ||
             !ggml_gallocr_reserve(galloc_, graph_) ||
             !ggml_gallocr_alloc_graph(galloc_, graph_)) {
-            release_partial_graph_runtime(galloc_, ggml_ctx_);
+            release_partial_graph_runtime(galloc_, params_buffer_, ggml_ctx_);
             throw std::runtime_error("Mimi conv transpose graph allocation failed");
         }
         core::write_tensor_f32(input_, std::vector<float>(static_cast<size_t>(in_channels_ * frames_), 0.0F));
@@ -659,6 +676,10 @@ public:
 
         if (core::is_host_backend(backend_)) {
             params_buffer_ = ggml_backend_alloc_ctx_tensors(ggml_ctx_, backend_);
+            if (params_buffer_ == nullptr) {
+                release_partial_graph_runtime(galloc_, params_buffer_, ggml_ctx_);
+                throw std::runtime_error("Mimi full decoder context tensor allocation failed");
+            }
         }
         core::set_backend_threads(backend_, threads_);
         graph_ = ggml_new_graph_custom(ggml_ctx_, 32768, false);
@@ -667,7 +688,7 @@ public:
         if (galloc_ == nullptr ||
             !ggml_gallocr_reserve(galloc_, graph_) ||
             !ggml_gallocr_alloc_graph(galloc_, graph_)) {
-            release_partial_graph_runtime(galloc_, ggml_ctx_);
+            release_partial_graph_runtime(galloc_, params_buffer_, ggml_ctx_);
             throw std::runtime_error("Mimi full decoder graph allocation failed");
         }
         core::write_tensor_f32(latents_bct_, std::vector<float>(static_cast<size_t>(config_.latent_size * steps_), 0.0F));
@@ -852,6 +873,10 @@ public:
 
         if (core::is_host_backend(backend_)) {
             params_buffer_ = ggml_backend_alloc_ctx_tensors(ggml_ctx_, backend_);
+            if (params_buffer_ == nullptr) {
+                release_partial_graph_runtime(galloc_, params_buffer_, ggml_ctx_);
+                throw std::runtime_error("Mimi transformer context tensor allocation failed");
+            }
         }
         core::set_backend_threads(backend_, threads_);
         graph_ = ggml_new_graph_custom(ggml_ctx_, 32768, false);
@@ -860,7 +885,7 @@ public:
         if (galloc_ == nullptr ||
             !ggml_gallocr_reserve(galloc_, graph_) ||
             !ggml_gallocr_alloc_graph(galloc_, graph_)) {
-            release_partial_graph_runtime(galloc_, ggml_ctx_);
+            release_partial_graph_runtime(galloc_, params_buffer_, ggml_ctx_);
             throw std::runtime_error("Mimi transformer graph allocation failed");
         }
         core::write_tensor_f32(input_bct_, std::vector<float>(static_cast<size_t>(config_.hidden_size * frames_), 0.0F));


### PR DESCRIPTION
## Problem
On `--backend cpu`, every PocketTTS synthesis aborts with:

```
ggml-backend.cpp:327: GGML_ASSERT(buf != NULL && "tensor buffer not set") failed
```

The flow-LM stage runs fine; the crash is on entry to the Mimi codec decoder, deterministically, in both the server and the CLI. CUDA is unaffected.

### Repro
```sh
scripts/build_linux.sh --backend cpu --target audiocpp_cli
audiocpp_cli --task tts --family pocket_tts --model <pocket-tts> --backend cpu \
  --load-option language=english --voice-id alba --text "hi" --out out.wav
# -> GGML_ASSERT abort on main; valid 24 kHz WAV with this PR
```

## Cause
d98123e ("Harden PocketTTS Mimi decoder graph allocation") removed every `ggml_backend_alloc_ctx_tensors(ggml_ctx_, backend_)` call in mimi_decoder.cpp, leaving allocation to `ggml_gallocr_alloc_graph` alone. That call gave the decoder's context tensors (graph inputs plus persistent state: KV-cache prefixes, positions, attention mask, latents) stable lifetime-long backend buffers. The CPU path uses a persistent graph plan and repeated `run()` writes into those tensors; gallocr's graph-scoped allocation leaves them unbacked, so on CPU they hit `buffer == NULL`. CUDA's path kept them backed, hiding the regression.

## Fix
Restore `ggml_backend_alloc_ctx_tensors` (buffer member + destructor free) in the 5 runtime constructors, while keeping d98123e's gallocr null-checks and `release_partial_graph_runtime` helper. +25/-0, no deletions.

## Verification
CPU build; PocketTTS-100M english; `--backend cpu`, 4 threads on an Intel N100: valid 24 kHz mono WAV via both CLI and the OpenAI-compatible server (`POST /v1/audio/speech`), 3 back-to-back requests, no crash, RTF ~0.7.

---

**UPDATE:**

- a590f43: gated the restored `ggml_backend_alloc_ctx_tensors` behind `core::is_host_backend(backend_)` in all 5 runtime constructors, per review. CUDA/Metal/Vulkan keep the gallocr-only allocation from d98123e, so the #55 VRAM reduction is preserved; only the CPU path (which uses the persistent graph plan) gets the context-tensor backing. Rebuilt and re-verified on CPU.
- c215af6: failure-path hardening on top: `ggml_backend_alloc_ctx_tensors` result is now null-checked (immediate `runtime_error` instead of a later `GGML_ASSERT` abort), and `release_partial_graph_runtime` also frees the params buffer so a constructor throw after gallocr failure no longer leaks it.
