### PR TITLE
Follow upstream PocketTTS default temperature (0.3 for English models)

### DIFF
--- a/include/engine/models/pocket_tts/assets.h
+++ b/include/engine/models/pocket_tts/assets.h
@@ -25,6 +25,7 @@ struct TransformerKVState;
 namespace engine::models::pocket_tts {
 
 struct PocketTTSModelConfig {
+    float default_temperature = 0.7F;
     int sample_rate = 24000;
     float frame_rate = 12.5F;
     float mimi_frame_rate = 12.5F;

--- a/src/models/pocket_tts/assets.cpp
+++ b/src/models/pocket_tts/assets.cpp
@@ -22,6 +22,7 @@ namespace {
 namespace binding = engine::modules::binding;
 
 struct PocketTTSDescriptor {
+    float default_temperature = 0.7F;
     bool pad_with_spaces_for_short_inputs = false;
     bool remove_semicolons = false;
     bool insert_bos_before_voice = false;
@@ -119,6 +120,8 @@ int64_t read_voice_state_i64_scalar(
 
 PocketTTSDescriptor descriptor_from_yaml(const io::yaml::FlattenedDocument & parsed) {
     PocketTTSDescriptor descriptor;
+    descriptor.default_temperature =
+        io::yaml::optional_float(parsed, "default_temperature").value_or(descriptor.default_temperature);
     const auto pad_it = parsed.scalars.find("pad_with_spaces_for_short_inputs");
     descriptor.pad_with_spaces_for_short_inputs = io::yaml::parse_bool_scalar(
         pad_it != parsed.scalars.end() ? pad_it->second : "false",
@@ -166,6 +169,11 @@ PocketTTSDescriptor descriptor_from_yaml(const io::yaml::FlattenedDocument & par
 
 PocketTTSDescriptor descriptor_from_builtin_defaults(const std::string & language) {
     PocketTTSDescriptor descriptor;
+    // Upstream pocket-tts defaults the english and english_2026-04 models to
+    // temperature 0.3 (human evals preferred it at equal WER/similarity).
+    if (language == "english" || language == "english_2026-04") {
+        descriptor.default_temperature = 0.3F;
+    }
     descriptor.pad_with_spaces_for_short_inputs = (language == "english_2026-01");
     descriptor.insert_bos_before_voice = (language != "english_2026-01");
     if (language.find("french_24l") != std::string::npos) {
@@ -188,6 +196,7 @@ PocketTTSDescriptor resolve_descriptor(
 
 PocketTTSModelConfig make_model_config(const PocketTTSDescriptor & descriptor) {
     PocketTTSModelConfig config;
+    config.default_temperature = descriptor.default_temperature;
     config.sample_rate = descriptor.sample_rate;
     config.frame_rate = descriptor.frame_rate;
     config.mimi_frame_rate = descriptor.frame_rate;

--- a/src/models/pocket_tts/session.cpp
+++ b/src/models/pocket_tts/session.cpp
@@ -119,13 +119,13 @@ void apply_voice_condition(const std::optional<runtime::VoiceCondition> & voice,
 void apply_generation_options(
     const std::unordered_map<std::string, std::string> & options,
     GenerationRequest & generation_request) {
-    if (const auto embedding_path = runtime::find_option(options, {"voice_embedding_path"})) {
+    if (const auto embedding_path = runtime::find_option(options, {"voice_embedding_path", "pocket_tts.voice_embedding_path"})) {
         generation_request.voice.embedding_path = *embedding_path;
     }
-    if (const auto clone_text = runtime::find_option(options, {"voice_clone_text"})) {
+    if (const auto clone_text = runtime::find_option(options, {"voice_clone_text", "pocket_tts.voice_clone_text"})) {
         generation_request.voice.clone_prompt_text = *clone_text;
     }
-    if (const auto truncate = runtime::find_option(options, {"truncate_clone_audio"})) {
+    if (const auto truncate = runtime::find_option(options, {"truncate_clone_audio", "pocket_tts.truncate_clone_audio"})) {
         generation_request.voice.truncate_clone_audio = runtime::parse_bool_option(*truncate, "truncate_clone_audio");
     }
 }
@@ -134,28 +134,28 @@ void apply_session_generation_options(
     const std::unordered_map<std::string, std::string> & options,
     GenerationRequest & generation_request) {
     apply_generation_options(options, generation_request);
-    if (const auto max_steps = runtime::parse_int_option(options, {"max_steps"})) {
+    if (const auto max_steps = runtime::parse_int_option(options, {"max_steps", "pocket_tts.max_steps"})) {
         generation_request.max_steps = *max_steps;
     }
     if (const auto max_tokens = runtime::parse_int_option(
             options,
-            {"max_tokens"})) {
+            {"max_tokens", "pocket_tts.max_tokens"})) {
         generation_request.max_tokens = *max_tokens;
     }
     generation_request.text_chunk_size =
         engine::text::parse_text_chunk_size_override(options).value_or(kDefaultTextChunkSize);
-    if (const auto temperature = runtime::parse_float_option(options, {"temperature"})) {
+    if (const auto temperature = runtime::parse_float_option(options, {"temperature", "pocket_tts.temperature"})) {
         generation_request.temperature = *temperature;
     }
-    if (const auto noise_clamp = runtime::parse_float_option(options, {"noise_clamp"})) {
+    if (const auto noise_clamp = runtime::parse_float_option(options, {"noise_clamp", "pocket_tts.noise_clamp"})) {
         generation_request.noise_clamp = *noise_clamp;
     }
-    if (const auto eos_threshold = runtime::parse_float_option(options, {"eos_threshold"})) {
+    if (const auto eos_threshold = runtime::parse_float_option(options, {"eos_threshold", "pocket_tts.eos_threshold"})) {
         generation_request.eos_threshold = *eos_threshold;
     }
-    generation_request.seed = runtime::parse_u32_option(options, {"seed"})
+    generation_request.seed = runtime::parse_u32_option(options, {"seed", "pocket_tts.seed"})
         .value_or(runtime::random_u32_seed());
-    if (const auto noise_file = runtime::find_option(options, {"noise_file"})) {
+    if (const auto noise_file = runtime::find_option(options, {"noise_file", "pocket_tts.noise_file"})) {
         generation_request.noise_schedule_path = *noise_file;
     }
 }
@@ -165,35 +165,39 @@ void apply_request_generation_options(
     GenerationRequest & generation_request) {
     if (const auto frames_after_eos = runtime::parse_int_option(
             options,
-            {"frames_after_eos"})) {
+            {"frames_after_eos", "pocket_tts.frames_after_eos"})) {
         generation_request.frames_after_eos = *frames_after_eos;
     }
     if (const auto max_tokens = runtime::parse_int_option(
             options,
-            {"max_tokens"})) {
+            {"max_tokens", "pocket_tts.max_tokens"})) {
         generation_request.max_tokens = *max_tokens;
     }
     generation_request.text_chunk_size =
         engine::text::parse_text_chunk_size_override(options).value_or(kDefaultTextChunkSize);
 }
 
-GenerationRequest build_generation_request(const runtime::TaskRequest & request) {
+GenerationRequest build_generation_request(const runtime::TaskRequest & request, float default_temperature) {
     if (!request.text_input.has_value()) {
         throw std::runtime_error("PocketTTS run requires text_input");
     }
     validate_supported_style(request.voice);
 
     GenerationRequest generation_request;
+    generation_request.temperature = default_temperature;
     generation_request.text = request.text_input->text;
     apply_voice_condition(request.voice, generation_request.voice);
     apply_request_generation_options(request.options, generation_request);
     return generation_request;
 }
 
-GenerationRequest build_preparation_generation_request(const runtime::SessionPreparationRequest & request) {
+GenerationRequest build_preparation_generation_request(
+    const runtime::SessionPreparationRequest & request,
+    float default_temperature) {
     validate_supported_style(request.voice);
 
     GenerationRequest generation_request;
+    generation_request.temperature = default_temperature;
     if (request.text.has_value()) {
         generation_request.text = request.text->text;
     }
@@ -737,7 +741,8 @@ runtime::RunMode PocketTTSSession::run_mode() const {
 }
 
 void PocketTTSSession::prepare(const runtime::SessionPreparationRequest & request) {
-    prepared_session_request_ = build_preparation_generation_request(request);
+    prepared_session_request_ =
+        build_preparation_generation_request(request, manifest_->model_config.default_temperature);
     if (!has_voice_selection(prepared_session_request_.voice)) {
         throw std::runtime_error(
             "PocketTTS session prepare() requires a session voice via --voice-id or --voice-ref");
@@ -755,7 +760,8 @@ runtime::TaskResult PocketTTSSession::run(const runtime::TaskRequest & request) 
     require_prepared("PocketTTS run()");
     runtime::TaskRequest effective_request = request;
     effective_request.voice.reset();
-    GenerationRequest generation_request = build_generation_request(effective_request);
+    GenerationRequest generation_request =
+        build_generation_request(effective_request, manifest_->model_config.default_temperature);
     generation_request.max_steps = prepared_session_request_.max_steps;
     generation_request.max_tokens = prepared_session_request_.max_tokens;
     generation_request.temperature = prepared_session_request_.temperature;


### PR DESCRIPTION
## Motivation

Upstream pocket-tts changed the English models' default temperature from 0.7 to 0.3 in [kyutai-labs/pocket-tts@d108410](https://github.com/kyutai-labs/pocket-tts/commit/d108410d23eef7e01db282f9442891162dbc3db6) ("Human evaluations consistently prefer the English model at temperature 0.3 over the current default 0.7"). audio.cpp hardcodes 0.7 for all languages and ignores the new `default_temperature` yaml key, so English output at default settings no longer matches reference quality.

## Changes

- `PocketTTSModelConfig` gains `default_temperature` (fallback 0.7, matching upstream's `Config.default_temperature` schema default for custom yamls)
- Config yaml path reads upstream's `default_temperature` key when present
- Builtin defaults use 0.3 for `english` and `english_2026-04`, mirroring the two configs upstream changed; other languages stay at 0.7
- Session request builders seed the request from the model default before option parsing, so an explicit `temperature=` option still overrides
- Generation options now also accept `pocket_tts.`-prefixed spellings (following the existing `omnivoice.mem_saver`/`mem_saver` alias pattern): the warm bench passes namespaced keys the session never read, so its generation options (including parity seed and noise file) were silently ignored - masked until now because the harness default equaled the hardcoded 0.7

## Verification

```sh
scripts/build_metal.sh --target audiocpp_cli   # compiles clean
```

With `language=english` and no temperature option, generation runs at 0.3; `temperature=0.7` (either spelling) reproduces the previous output. Non-English languages unchanged.
