### PR TITLE
fix(server): ignore SIGPIPE so a client disconnect can't take down the server

### DIFF
--- a/app/server/main.cpp
+++ b/app/server/main.cpp
@@ -80,6 +80,14 @@ int main(int argc, char ** argv) {
         });
         std::signal(SIGINT, request_shutdown);
         std::signal(SIGTERM, request_shutdown);
+#ifdef SIGPIPE
+        // Writing to a socket whose peer has already disconnected (for example a
+        // client that closed an SSE/chunked stream early) would otherwise deliver
+        // SIGPIPE and terminate the whole server. Ignore it so the failed send
+        // surfaces as an EPIPE error on that single request thread, which
+        // handle_client already unwinds cleanly, instead of taking the process down.
+        std::signal(SIGPIPE, SIG_IGN);
+#endif
 
         auto config = minitts::server::load_server_config(*config_path);
         if (const auto host = arg_value(argc, argv, "--host")) {


### PR DESCRIPTION
## What

`audiocpp_server` uses a custom socket HTTP implementation and installs signal handlers only for `SIGINT`/`SIGTERM`. Writing to a socket whose peer has already disconnected — for example a client that closes an SSE/chunked transcription stream early — delivers `SIGPIPE`, whose default disposition **terminates the whole server process**, before `handle_client`'s existing exception handling can run.

This change ignores `SIGPIPE` at startup (guarded by `#ifdef SIGPIPE`; Windows sockets don't raise it). The failed `send()` now returns an error instead of signalling the process, so `send_all` throws, and only that single detached request thread unwinds — which `handle_client` already handles cleanly. The server stays up.

Complements the request-level busy guard from #72/#73/#75: that keeps one stuck model from hanging later requests; this keeps one disconnecting client from killing the whole server.

## Scope

- Server behavior only — a single 8-line change in `app/server/main.cpp`.
- **No change to request outputs, performance, or memory.** Pure robustness.

## Build

```bash
# macOS / Metal
bash scripts/build_metal.sh --target audiocpp_server
# Linux
scripts/build_linux.sh --backend cpu --target audiocpp_server
```

## Reproduce (before this change)

Configure any streaming ASR model (`"mode": "streaming"`) and close the SSE stream early:

```bash
curl -sN http://127.0.0.1:8088/v1/audio/transcriptions \
  -F model=nemotron-asr -F stream=true \
  -F file=@assets/resources/sample_16k.wav | head -12
```

The client disconnect mid-stream causes the server's next `send()` to raise `SIGPIPE`; the whole process exits and every subsequent request fails (connection refused).

## After (verified)

Backend: **Metal**, macOS on Apple M2 Max. Same early-disconnect command:

- `GET /health` → `{"status":"ok","backend":"metal","models":4}` — **server survived**.
- A fresh `POST /v1/audio/transcriptions` still returns a correct transcript.

Also confirmed a normal full SSE stream is unaffected (`transcript.text.delta` × N → `transcript.text.done` → `data: [DONE]`).

## Known limitations

- On an early disconnect, the aborted request thread logs one benign `failed to send ...` line to stderr and the streaming error-event write is a no-op (the socket is already gone). Expected and harmless.
- Verified on the Metal backend; the change is platform-agnostic POSIX signal handling and touches no backend or model path.
