### PR TITLE
build: add cross-platform Nix flake and documentation

### DIFF
--- a/docs/nixos.md
+++ b/docs/nixos.md
@@ -1,0 +1,111 @@
+# Running audio.cpp on NixOS (and Nix)
+
+## Prerequisites
+
+- The [Nix package manager](https://nixos.org/download) must be installed.
+- [Flakes](https://nixos.wiki/wiki/Flakes) must be enabled in your Nix configuration.
+
+## Packages
+
+The `flake.nix` provides multiple platform and hardware-specific builds. 
+The following backends are available:
+- **`vulkan`**: Hardware-accelerated build using Vulkan. (Default on Linux)
+- **`cuda`**: Hardware-accelerated build using NVIDIA CUDA.
+- **`metal`**: Hardware-accelerated build using Apple Metal. (Default on macOS)
+- **`cpu`**: Portable CPU-only build.
+
+All packages include the main tools: ***audiocpp_cli***, ***audiocpp_server***, ***audiocpp_gguf***, and the Python-based ***audiocpp_model_manager***.
+
+## Build the package
+
+### Default (Auto-detected OS)
+
+Build the default package for your operating system:
+
+```bash
+nix build .
+```
+
+### Specific Backends
+
+Build explicitly for a desired backend:
+
+```bash
+nix build .#vulkan
+nix build .#cuda
+nix build .#metal
+nix build .#cpu
+```
+
+## Usage
+
+After building, the compiled binaries will be available in the `result/bin/` directory.
+
+### Running the CLI
+
+You can execute the CLI directly via `nix run` (which uses `audiocpp_cli` as the main program):
+
+```bash
+nix run .#vulkan -- <arguments...>
+```
+
+### Running the Server
+
+To run the server, use `nix shell` or execute from the build result:
+
+```bash
+nix shell .#vulkan -c audiocpp_server <arguments...>
+# or
+./result/bin/audiocpp_server <arguments...>
+```
+
+### Downloading Models (Model Manager)
+
+The flake seamlessly bundles the `model_manager.py` Python script along with all its required dependencies (PyTorch, Safetensors, etc.) as `audiocpp_model_manager`.
+
+```bash
+nix shell .#vulkan -c audiocpp_model_manager install supertonic_3
+```
+
+## Development Shell
+
+If you want to work on `audio.cpp` and need a development environment with `cmake`, `ninja`, and all the necessary C++ and Python dependencies pre-configured, simply run:
+
+```bash
+nix develop
+```
+
+## Using in a NixOS Configuration
+
+You can easily include `audio.cpp` as a flake input in your own NixOS configuration or other Nix projects.
+
+In your `flake.nix`, add it to your `inputs`, making sure to use `follows` to avoid duplicating `nixpkgs` versions:
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    
+    audiocpp.url = "github:fedeizzo/audio.cpp";
+    audiocpp.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = { self, nixpkgs, audiocpp, ... }: {
+    nixosConfigurations.my-machine = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        ({ pkgs, ... }: {
+          environment.systemPackages = [
+            # Add the default package (auto-detects Metal/Vulkan based on OS)
+            audiocpp.packages.x86_64-linux.default
+            
+            # Or explicitly select a backend flavor:
+            # audiocpp.packages.x86_64-linux.vulkan
+            # audiocpp.packages.x86_64-linux.cuda
+          ];
+        })
+      ];
+    };
+  };
+}
+```

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,120 @@
+{
+  description = "audio.cpp - High-performance C++ audio inference framework";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+      nixpkgsFor = forAllSystems (system: import nixpkgs { 
+        inherit system; 
+        config.allowUnfree = true;
+        config.cudaSupport = true;
+      });
+    in
+    {
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgsFor.${system};
+          # Python environment for model_manager.py
+          myPython = pkgs.python3.withPackages (ps: with ps; [
+            torch
+            safetensors
+            pyyaml
+          ]);
+
+          # A function to build audio.cpp with any set of features
+          mkAudioCpp = { cudaSupport ? false, vulkanSupport ? false, metalSupport ? pkgs.stdenv.isDarwin }: 
+            pkgs.stdenv.mkDerivation {
+              pname = "audio.cpp";
+              version = self.shortRev or self.dirtyShortRev or "dirty";
+
+              src = ./.;
+
+              nativeBuildInputs = with pkgs; [
+                cmake
+                ninja
+                pkg-config
+                makeWrapper
+              ] ++ pkgs.lib.optional cudaSupport pkgs.cudaPackages.cuda_nvcc;
+
+              buildInputs = with pkgs; [
+                libunwind
+                myPython
+              ] ++ pkgs.lib.optionals vulkanSupport [
+                vulkan-headers
+                vulkan-loader
+                vulkan-tools
+                glslang
+                shaderc
+              ] ++ pkgs.lib.optionals cudaSupport [
+                pkgs.cudaPackages.cudatoolkit
+              ] ++ pkgs.lib.optionals metalSupport [
+                darwin.apple_sdk.frameworks.Metal
+                darwin.apple_sdk.frameworks.Foundation
+                darwin.apple_sdk.frameworks.MetalPerformanceShaders
+                darwin.apple_sdk.frameworks.Accelerate
+              ];
+
+              cmakeFlags = [
+                "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+                "-DENGINE_ENABLE_NATIVE_CPU=ON"
+                "-DENGINE_ENABLE_LLAMAFILE=ON"
+              ] ++ pkgs.lib.optional vulkanSupport "-DENGINE_ENABLE_VULKAN=ON"
+                ++ pkgs.lib.optional cudaSupport "-DENGINE_ENABLE_CUDA=ON"
+                ++ pkgs.lib.optional metalSupport "-DENGINE_ENABLE_METAL=ON";
+
+              installPhase = ''
+                runHook preInstall
+
+                mkdir -p $out/bin
+                
+                # Find and copy the built C++ executables
+                find . -type f -executable \( -name "audiocpp_cli" -o -name "audiocpp_server" -o -name "audiocpp_gguf" \) -exec cp {} $out/bin/ \;
+
+                # Install the python model manager script
+                cp $src/tools/model_manager.py $out/bin/audiocpp_model_manager
+                chmod +x $out/bin/audiocpp_model_manager
+
+                # Patch the shebang to use our python environment with torch/safetensors/pyyaml
+                patchShebangs $out/bin/audiocpp_model_manager
+
+                runHook postInstall
+              '';
+
+              meta = with pkgs.lib; {
+                description = "A high-performance C++ audio inference framework";
+                homepage = "https://github.com/0xShug0/audio.cpp";
+                license = licenses.mit;
+                platforms = platforms.unix;
+                mainProgram = "audiocpp_cli";
+              };
+            };
+        in
+        {
+          # Expose specific backend variants
+          cpu = mkAudioCpp { cudaSupport = false; vulkanSupport = false; metalSupport = false; };
+          vulkan = mkAudioCpp { vulkanSupport = true; cudaSupport = false; metalSupport = false; };
+          cuda = mkAudioCpp { cudaSupport = true; vulkanSupport = false; metalSupport = false; };
+          metal = mkAudioCpp { metalSupport = true; cudaSupport = false; vulkanSupport = false; };
+
+          # Automatically select best default for the current platform
+          default = if pkgs.stdenv.isDarwin then self.packages.${system}.metal else self.packages.${system}.vulkan;
+        }
+      );
+
+      devShells = forAllSystems (system:
+        let
+          pkgs = nixpkgsFor.${system};
+        in
+        {
+          default = pkgs.mkShell {
+            inputsFrom = [ self.packages.${system}.default ];
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION
### Summary
This PR adds a `flake.nix` to provide deterministic, cross-platform builds via the Nix package manager, addressing the "cross-platform build and packaging polish" priority area in `CONTRIBUTING.md`.

It allows users to build and run `audio.cpp` entirely isolated from their host system dependencies, while natively supporting hardware acceleration.

### Changes Made
- **Added `flake.nix`:** Exposes dynamic packages for different backends (`vulkan`, `cuda`, `metal`, `cpu`), ensuring all CMake flags and dependencies (e.g., `cudatoolkit`, `darwin.apple_sdk`) are automatically handled.
- **Python Integration:** Bundles `tools/model_manager.py` directly into the build output (as `audiocpp_model_manager`) wrapped with its own isolated Python environment (containing `torch`, `safetensors`, and `pyyaml`).
- **Added `docs/nixos.md`:** Included user-facing documentation mimicking the style of `Docker.md`, covering usage, development shells, and how to consume this flake as an input in a NixOS configuration.

### Impact & Validation
- **Affects:** Only docs and build wiring. No changes were made to internal model routing, behavior, or runtime memory/performance.
- **Tested Backends:** Built and verified against Vulkan (Linux/Framework desktop) and CPU configurations.
- **Commands Checked:**
  - `nix build .#vulkan`
  - `nix shell .#vulkan -c audiocpp_model_manager install supertonic_3`
  - `nix develop` (verifying the dev environment assembles CMake/Ninja correctly)