### PR TITLE
docs: point flake input to upstream repository and add flake.lock

### DIFF
--- a/docs/nixos.md
+++ b/docs/nixos.md
@@ -86,7 +86,7 @@ In your `flake.nix`, add it to your `inputs`, making sure to use `follows` to av
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     
-    audiocpp.url = "github:fedeizzo/audio.cpp";
+    audiocpp.url = "github:0xShug0/audio.cpp";
     audiocpp.inputs.nixpkgs.follows = "nixpkgs";
   };
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1784497964,
+        "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "241313f4e8e508cb9b13278c2b0fa25b9ca27163",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -9,10 +9,10 @@
     let
       supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
-      nixpkgsFor = forAllSystems (system: import nixpkgs { 
+      pkgs = forAllSystems (system: import nixpkgs { 
         inherit system; 
       });
-      nixpkgsCudaFor = forAllSystems (system: import nixpkgs { 
+      pkgsCuda = forAllSystems (system: import nixpkgs { 
         inherit system; 
         config.cudaSupport = true;
         config.allowUnfreePredicate = p:
@@ -30,7 +30,6 @@
     {
       packages = forAllSystems (system:
         let
-          pkgs = nixpkgsFor.${system};
           # A function to build audio.cpp with any set of features
           mkAudioCpp = { pkgs, cudaSupport ? false, vulkanSupport ? false, metalSupport ? pkgs.stdenv.isDarwin }: 
             let
@@ -104,25 +103,25 @@
         in
         {
           # Expose specific backend variants
-          cpu = mkAudioCpp { pkgs = nixpkgsFor.${system}; cudaSupport = false; vulkanSupport = false; metalSupport = false; };
-          vulkan = mkAudioCpp { pkgs = nixpkgsFor.${system}; vulkanSupport = true; cudaSupport = false; metalSupport = false; };
-        } // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
-          cuda = mkAudioCpp { pkgs = nixpkgsCudaFor.${system}; cudaSupport = true; vulkanSupport = false; metalSupport = false; };
-        } // pkgs.lib.optionalAttrs pkgs.stdenv.isDarwin {
-          metal = mkAudioCpp { pkgs = nixpkgsFor.${system}; metalSupport = true; cudaSupport = false; vulkanSupport = false; };
+          cpu = mkAudioCpp { pkgs = pkgs.${system}; cudaSupport = false; vulkanSupport = false; metalSupport = false; };
+          vulkan = mkAudioCpp { pkgs = pkgs.${system}; vulkanSupport = true; cudaSupport = false; metalSupport = false; };
+        } // pkgs.${system}.lib.optionalAttrs pkgs.${system}.stdenv.isLinux {
+          cuda = mkAudioCpp { pkgs = pkgsCuda.${system}; cudaSupport = true; vulkanSupport = false; metalSupport = false; };
+        } // pkgs.${system}.lib.optionalAttrs pkgs.${system}.stdenv.isDarwin {
+          metal = mkAudioCpp { pkgs = pkgs.${system}; metalSupport = true; cudaSupport = false; vulkanSupport = false; };
         } // {
           # Automatically select best default for the current platform
-          default = if nixpkgsFor.${system}.stdenv.isDarwin then self.packages.${system}.metal else self.packages.${system}.vulkan;
+          default = if pkgs.${system}.stdenv.isDarwin then self.packages.${system}.metal else self.packages.${system}.vulkan;
         }
       );
 
       devShells = forAllSystems (system:
         {
-          default = nixpkgsFor.${system}.mkShell {
+          default = pkgs.${system}.mkShell {
             inputsFrom = [ self.packages.${system}.default ];
           };
-        } // nixpkgsFor.${system}.lib.optionalAttrs nixpkgsFor.${system}.stdenv.isLinux {
-          cuda = nixpkgsCudaFor.${system}.mkShell {
+        } // pkgs.${system}.lib.optionalAttrs pkgs.${system}.stdenv.isLinux {
+          cuda = pkgsCuda.${system}.mkShell {
             inputsFrom = [ self.packages.${system}.cuda ];
           };
         }

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,6 @@
       nixpkgsFor = forAllSystems (system: import nixpkgs { 
         inherit system; 
         config.allowUnfree = true;
-        config.cudaSupport = true;
       });
     in
     {
@@ -38,11 +37,9 @@
                 cmake
                 ninja
                 pkg-config
-                makeWrapper
               ] ++ pkgs.lib.optional cudaSupport pkgs.cudaPackages.cuda_nvcc;
 
               buildInputs = with pkgs; [
-                libunwind
                 myPython
               ] ++ pkgs.lib.optionals vulkanSupport [
                 vulkan-headers
@@ -72,8 +69,8 @@
 
                 mkdir -p $out/bin
                 
-                # Find and copy the built C++ executables
-                find . -type f -executable \( -name "audiocpp_cli" -o -name "audiocpp_server" -o -name "audiocpp_gguf" \) -exec cp {} $out/bin/ \;
+                # Copy the built C++ executables directly from the bin directory
+                cp bin/audiocpp_cli bin/audiocpp_server bin/audiocpp_gguf $out/bin/
 
                 # Install the python model manager script
                 cp $src/tools/model_manager.py $out/bin/audiocpp_model_manager

--- a/flake.nix
+++ b/flake.nix
@@ -9,18 +9,14 @@
     let
       supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
-      nixpkgsFreeFor = forAllSystems (system: import nixpkgs { 
+      nixpkgsFor = forAllSystems (system: import nixpkgs { 
         inherit system; 
-      });
-      nixpkgsUnfreeFor = forAllSystems (system: import nixpkgs { 
-        inherit system; 
-        config.allowUnfree = true;
       });
     in
     {
       packages = forAllSystems (system:
         let
-          pkgs = nixpkgsFreeFor.${system};
+          pkgs = nixpkgsFor.${system};
           # A function to build audio.cpp with any set of features
           mkAudioCpp = { pkgs, cudaSupport ? false, vulkanSupport ? false, metalSupport ? pkgs.stdenv.isDarwin }: 
             let
@@ -94,25 +90,25 @@
         in
         {
           # Expose specific backend variants
-          cpu = mkAudioCpp { pkgs = nixpkgsFreeFor.${system}; cudaSupport = false; vulkanSupport = false; metalSupport = false; };
-          vulkan = mkAudioCpp { pkgs = nixpkgsFreeFor.${system}; vulkanSupport = true; cudaSupport = false; metalSupport = false; };
+          cpu = mkAudioCpp { pkgs = nixpkgsFor.${system}; cudaSupport = false; vulkanSupport = false; metalSupport = false; };
+          vulkan = mkAudioCpp { pkgs = nixpkgsFor.${system}; vulkanSupport = true; cudaSupport = false; metalSupport = false; };
         } // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
-          cuda = mkAudioCpp { pkgs = nixpkgsUnfreeFor.${system}; cudaSupport = true; vulkanSupport = false; metalSupport = false; };
+          cuda = mkAudioCpp { pkgs = nixpkgsFor.${system}; cudaSupport = true; vulkanSupport = false; metalSupport = false; };
         } // pkgs.lib.optionalAttrs pkgs.stdenv.isDarwin {
-          metal = mkAudioCpp { pkgs = nixpkgsFreeFor.${system}; metalSupport = true; cudaSupport = false; vulkanSupport = false; };
+          metal = mkAudioCpp { pkgs = nixpkgsFor.${system}; metalSupport = true; cudaSupport = false; vulkanSupport = false; };
         } // {
           # Automatically select best default for the current platform
-          default = if nixpkgsFreeFor.${system}.stdenv.isDarwin then self.packages.${system}.metal else self.packages.${system}.vulkan;
+          default = if nixpkgsFor.${system}.stdenv.isDarwin then self.packages.${system}.metal else self.packages.${system}.vulkan;
         }
       );
 
       devShells = forAllSystems (system:
         {
-          default = nixpkgsFreeFor.${system}.mkShell {
+          default = nixpkgsFor.${system}.mkShell {
             inputsFrom = [ self.packages.${system}.default ];
           };
-        } // nixpkgsFreeFor.${system}.lib.optionalAttrs nixpkgsFreeFor.${system}.stdenv.isLinux {
-          cuda = nixpkgsUnfreeFor.${system}.mkShell {
+        } // nixpkgsFor.${system}.lib.optionalAttrs nixpkgsFor.${system}.stdenv.isLinux {
+          cuda = nixpkgsFor.${system}.mkShell {
             inputsFrom = [ self.packages.${system}.cuda ];
           };
         }

--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,7 @@
     {
       packages = forAllSystems (system:
         let
+          pkgs = nixpkgsFreeFor.${system};
           # A function to build audio.cpp with any set of features
           mkAudioCpp = { pkgs, cudaSupport ? false, vulkanSupport ? false, metalSupport ? pkgs.stdenv.isDarwin }: 
             let
@@ -53,10 +54,7 @@
               ] ++ pkgs.lib.optionals cudaSupport [
                 pkgs.cudaPackages.cudatoolkit
               ] ++ pkgs.lib.optionals metalSupport [
-                darwin.apple_sdk.frameworks.Metal
-                darwin.apple_sdk.frameworks.Foundation
-                darwin.apple_sdk.frameworks.MetalPerformanceShaders
-                darwin.apple_sdk.frameworks.Accelerate
+                pkgs.apple-sdk_14
               ];
 
               cmakeFlags = [
@@ -98,9 +96,11 @@
           # Expose specific backend variants
           cpu = mkAudioCpp { pkgs = nixpkgsFreeFor.${system}; cudaSupport = false; vulkanSupport = false; metalSupport = false; };
           vulkan = mkAudioCpp { pkgs = nixpkgsFreeFor.${system}; vulkanSupport = true; cudaSupport = false; metalSupport = false; };
+        } // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
           cuda = mkAudioCpp { pkgs = nixpkgsUnfreeFor.${system}; cudaSupport = true; vulkanSupport = false; metalSupport = false; };
+        } // pkgs.lib.optionalAttrs pkgs.stdenv.isDarwin {
           metal = mkAudioCpp { pkgs = nixpkgsFreeFor.${system}; metalSupport = true; cudaSupport = false; vulkanSupport = false; };
-
+        } // {
           # Automatically select best default for the current platform
           default = if nixpkgsFreeFor.${system}.stdenv.isDarwin then self.packages.${system}.metal else self.packages.${system}.vulkan;
         }
@@ -111,6 +111,7 @@
           default = nixpkgsFreeFor.${system}.mkShell {
             inputsFrom = [ self.packages.${system}.default ];
           };
+        } // nixpkgsFreeFor.${system}.lib.optionalAttrs nixpkgsFreeFor.${system}.stdenv.isLinux {
           cuda = nixpkgsUnfreeFor.${system}.mkShell {
             inputsFrom = [ self.packages.${system}.cuda ];
           };

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,20 @@
       nixpkgsFor = forAllSystems (system: import nixpkgs { 
         inherit system; 
       });
+      nixpkgsCudaFor = forAllSystems (system: import nixpkgs { 
+        inherit system; 
+        config.cudaSupport = true;
+        config.allowUnfreePredicate = p:
+          builtins.all (
+            license:
+            license.free
+            || builtins.elem license.shortName [
+              "CUDA EULA"
+              "cuDNN EULA"
+              "cuSPARSELt EULA"
+            ]
+          ) (p.meta.licenses or (nixpkgs.lib.toList (p.meta.license or [])));
+      });
     in
     {
       packages = forAllSystems (system:
@@ -93,7 +107,7 @@
           cpu = mkAudioCpp { pkgs = nixpkgsFor.${system}; cudaSupport = false; vulkanSupport = false; metalSupport = false; };
           vulkan = mkAudioCpp { pkgs = nixpkgsFor.${system}; vulkanSupport = true; cudaSupport = false; metalSupport = false; };
         } // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
-          cuda = mkAudioCpp { pkgs = nixpkgsFor.${system}; cudaSupport = true; vulkanSupport = false; metalSupport = false; };
+          cuda = mkAudioCpp { pkgs = nixpkgsCudaFor.${system}; cudaSupport = true; vulkanSupport = false; metalSupport = false; };
         } // pkgs.lib.optionalAttrs pkgs.stdenv.isDarwin {
           metal = mkAudioCpp { pkgs = nixpkgsFor.${system}; metalSupport = true; cudaSupport = false; vulkanSupport = false; };
         } // {
@@ -108,7 +122,7 @@
             inputsFrom = [ self.packages.${system}.default ];
           };
         } // nixpkgsFor.${system}.lib.optionalAttrs nixpkgsFor.${system}.stdenv.isLinux {
-          cuda = nixpkgsFor.${system}.mkShell {
+          cuda = nixpkgsCudaFor.${system}.mkShell {
             inputsFrom = [ self.packages.${system}.cuda ];
           };
         }

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,10 @@
     let
       supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
-      nixpkgsFor = forAllSystems (system: import nixpkgs { 
+      nixpkgsFreeFor = forAllSystems (system: import nixpkgs { 
+        inherit system; 
+      });
+      nixpkgsUnfreeFor = forAllSystems (system: import nixpkgs { 
         inherit system; 
         config.allowUnfree = true;
       });
@@ -17,16 +20,16 @@
     {
       packages = forAllSystems (system:
         let
-          pkgs = nixpkgsFor.${system};
-          # Python environment for model_manager.py
-          myPython = pkgs.python3.withPackages (ps: with ps; [
-            torch
-            safetensors
-            pyyaml
-          ]);
-
           # A function to build audio.cpp with any set of features
-          mkAudioCpp = { cudaSupport ? false, vulkanSupport ? false, metalSupport ? pkgs.stdenv.isDarwin }: 
+          mkAudioCpp = { pkgs, cudaSupport ? false, vulkanSupport ? false, metalSupport ? pkgs.stdenv.isDarwin }: 
+            let
+              # Python environment for model_manager.py
+              myPython = pkgs.python3.withPackages (ps: with ps; [
+                (if cudaSupport then ps.torchWithCuda else if vulkanSupport then ps.torchWithVulkan else ps.torch)
+                ps.safetensors
+                ps.pyyaml
+              ]);
+            in
             pkgs.stdenv.mkDerivation {
               pname = "audio.cpp";
               version = self.shortRev or self.dirtyShortRev or "dirty";
@@ -93,23 +96,23 @@
         in
         {
           # Expose specific backend variants
-          cpu = mkAudioCpp { cudaSupport = false; vulkanSupport = false; metalSupport = false; };
-          vulkan = mkAudioCpp { vulkanSupport = true; cudaSupport = false; metalSupport = false; };
-          cuda = mkAudioCpp { cudaSupport = true; vulkanSupport = false; metalSupport = false; };
-          metal = mkAudioCpp { metalSupport = true; cudaSupport = false; vulkanSupport = false; };
+          cpu = mkAudioCpp { pkgs = nixpkgsFreeFor.${system}; cudaSupport = false; vulkanSupport = false; metalSupport = false; };
+          vulkan = mkAudioCpp { pkgs = nixpkgsFreeFor.${system}; vulkanSupport = true; cudaSupport = false; metalSupport = false; };
+          cuda = mkAudioCpp { pkgs = nixpkgsUnfreeFor.${system}; cudaSupport = true; vulkanSupport = false; metalSupport = false; };
+          metal = mkAudioCpp { pkgs = nixpkgsFreeFor.${system}; metalSupport = true; cudaSupport = false; vulkanSupport = false; };
 
           # Automatically select best default for the current platform
-          default = if pkgs.stdenv.isDarwin then self.packages.${system}.metal else self.packages.${system}.vulkan;
+          default = if nixpkgsFreeFor.${system}.stdenv.isDarwin then self.packages.${system}.metal else self.packages.${system}.vulkan;
         }
       );
 
       devShells = forAllSystems (system:
-        let
-          pkgs = nixpkgsFor.${system};
-        in
         {
-          default = pkgs.mkShell {
+          default = nixpkgsFreeFor.${system}.mkShell {
             inputsFrom = [ self.packages.${system}.default ];
+          };
+          cuda = nixpkgsUnfreeFor.${system}.mkShell {
+            inputsFrom = [ self.packages.${system}.cuda ];
           };
         }
       );


### PR DESCRIPTION
Summary
---

https://github.com/0xShug0/audio.cpp/pull/82#issuecomment-5023686049

Last famous words :smile: I forgot to add the flake.lock file in the repo. My bad.

The lock file acts similarly to the `package-lock.json` for js/ts


Testing
---
```sh
$ nix build
$ ./result/bin/audiocpp_cli
audiocpp_cli failed: missing required --model argument
```