### PR TITLE
Advertise runtime peer companions on loaders

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Please check the supported model table in [README.md](README.md) before starting
 
 If you want to add support for a model family that is already listed, please focus on improving the existing implementation instead of opening a duplicate port.
 
-When a loader is registered (or parked), keep the **package catalog** in sync. Installable `ModelPackage` entries must not advertise families that `audiocpp_cli --list-loaders` does not expose. Follow the checklist in [docs/maintainers/loader_and_catalog.md](docs/maintainers/loader_and_catalog.md) and run:
+When a loader is registered (or parked), keep the **package catalog** in sync. Installable `ModelPackage` entries must not advertise families that `audiocpp_cli --list-loaders` does not expose. If the family takes another model path at load/session time (aligner, VAD, codec, ASR peer, …), override `advertised_companions()` so `--list-loaders --json` exposes those peers. Follow the checklist in [docs/maintainers/loader_and_catalog.md](docs/maintainers/loader_and_catalog.md) and run:
 
 ```bash
 python3 tools/check_loader_catalog_sync.py --self-test

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ Useful CLI features:
 - `--help` with `--task` shows task-oriented help
 - `--help` with `--model <path>` and optional `--family <family>` shows model-owned request, session, and load options
 - `--inspect` prints discovered configs, weights, and capabilities
-- `--list-loaders` prints registered model families (`--json` for the machine-readable contract)
+- `--list-loaders` prints registered model families (`--json` for the machine-readable contract: tasks, endpoints, and optional runtime `companions`)
 - `python tools/model_manager.py list --json` prints installable packages; keep it synced with loaders ([docs/maintainers/loader_and_catalog.md](docs/maintainers/loader_and_catalog.md))
 - `--batch-text-file <txt>` runs one offline request per non-empty line
 - `--batch-text-dir <dir>` runs one offline request per `.txt`, `.md`, or `.json` file, normalizing each file as one paragraph
@@ -369,7 +369,7 @@ The tool supports three main commands:
 - `info <package> --json` prints machine-readable package details
 - `install` downloads or converts one package into a models root
 
-The CLI also exposes the runtime loader catalog with `audiocpp_cli --list-loaders --json`, including task and endpoint metadata added by [PR #74](https://github.com/0xShug0/audio.cpp/pull/74).
+The CLI also exposes the runtime loader catalog with `audiocpp_cli --list-loaders --json` (`schema_version` 1). That export includes task and endpoint metadata ([PR #74](https://github.com/0xShug0/audio.cpp/pull/74)) and optional per-loader `companions` for runtime peer models (forced aligner, VAD, codec, and similar path options). Integrators should read companions from this contract rather than hard-coding family graphs. See [docs/usage.md](docs/usage.md#discovering-loaders-and-companions) and [docs/maintainers/loader_and_catalog.md](docs/maintainers/loader_and_catalog.md).
 
 Recommended top-level install packages:
 

--- a/app/cli/main.cpp
+++ b/app/cli/main.cpp
@@ -584,6 +584,46 @@ int audiocpp_cli_main(int argc, char ** argv) {
                     for (const auto & endpoint : row.api_endpoints) {
                         endpoints.push_back(engine::io::json::Value::make_string(endpoint));
                     }
+                    engine::io::json::Value::Array companions;
+                    for (const auto & companion : row.companions) {
+                        engine::io::json::Value::Object companion_object;
+                        companion_object.emplace("id", engine::io::json::Value::make_string(companion.id));
+                        companion_object.emplace(
+                            "config_key",
+                            engine::io::json::Value::make_string(companion.config_key));
+                        companion_object.emplace(
+                            "scope",
+                            engine::io::json::Value::make_string(companion.scope));
+                        if (!companion.target_family.empty()) {
+                            companion_object.emplace(
+                                "target_family",
+                                engine::io::json::Value::make_string(companion.target_family));
+                        }
+                        companion_object.emplace(
+                            "optional",
+                            engine::io::json::Value::make_bool(companion.optional));
+                        if (!companion.required_for.empty()) {
+                            engine::io::json::Value::Array required_for;
+                            for (const auto & key : companion.required_for) {
+                                required_for.push_back(engine::io::json::Value::make_string(key));
+                            }
+                            companion_object.emplace(
+                                "required_for",
+                                engine::io::json::Value::make_array(std::move(required_for)));
+                        }
+                        if (!companion.label.empty()) {
+                            companion_object.emplace(
+                                "label",
+                                engine::io::json::Value::make_string(companion.label));
+                        }
+                        if (!companion.bundled_default.empty()) {
+                            companion_object.emplace(
+                                "bundled_default",
+                                engine::io::json::Value::make_string(companion.bundled_default));
+                        }
+                        companions.push_back(
+                            engine::io::json::Value::make_object(std::move(companion_object)));
+                    }
                     engine::io::json::Value::Object loader_object;
                     loader_object.emplace("tasks", engine::io::json::Value::make_object(std::move(tasks_object)));
                     loader_object.emplace(
@@ -592,6 +632,11 @@ int audiocpp_cli_main(int argc, char ** argv) {
                     loader_object.emplace(
                         "api_endpoints",
                         engine::io::json::Value::make_array(std::move(endpoints)));
+                    if (!companions.empty()) {
+                        loader_object.emplace(
+                            "companions",
+                            engine::io::json::Value::make_array(std::move(companions)));
+                    }
                     loaders_object.emplace(
                         row.family,
                         engine::io::json::Value::make_object(std::move(loader_object)));

--- a/docs/asr.md
+++ b/docs/asr.md
@@ -12,6 +12,8 @@
 
 This page covers ASR models. Detailed Qwen3 ASR and forced-alignment notes live in [Qwen3 models](models/qwen3.md).
 
+Runtime peer models (forced aligner, VAD, and similar path options) are advertised on `audiocpp_cli --list-loaders --json` as per-loader `companions`. See [Discovering loaders and companions](usage.md#discovering-loaders-and-companions).
+
 Common CLI shape:
 
 ```bash

--- a/docs/community_models/outetts.md
+++ b/docs/community_models/outetts.md
@@ -40,7 +40,7 @@ audiocpp_cli --task clon --family outetts \
   --max-tokens 1024 --out cloned.wav
 ```
 
-`--task tts` with the same `--voice-ref` and `--reference-text` options also enables speaker conditioning, which is useful for clients that expose one TTS route. Safetensors packages and older OuteTTS GGUFs do not contain the aligner. For those models, pass `outetts.aligner_model_path`; cloning fails clearly instead of using unreliable estimated word boundaries.
+`--task tts` with the same `--voice-ref` and `--reference-text` options also enables speaker conditioning, which is useful for clients that expose one TTS route. Safetensors packages and older OuteTTS GGUFs do not contain the aligner. For those models, pass `outetts.aligner_model_path`; cloning fails clearly instead of using unreliable estimated word boundaries. That peer is also advertised under `loaders.outetts.companions` in `audiocpp_cli --list-loaders --json` (see [usage.md](../usage.md#discovering-loaders-and-companions)).
 
 The installer places `DAC.speech.v1.0` and `Qwen3-ForcedAligner-0.6B` beside the OuteTTS directory. It converts the official DAC checkpoint to a safe tensor source. To do that conversion manually:
 

--- a/docs/maintainers/loader_and_catalog.md
+++ b/docs/maintainers/loader_and_catalog.md
@@ -40,11 +40,44 @@ Do **not** leave a live `SnapshotSource` for a commented-out loader.
 Optional catalog↔registry family renames for parked stubs go in
 `PARKED_FAMILY_ALIASES` in the sync check (collapse to one id when re-enabling).
 
+## Runtime companions (peer models)
+
+Some loaders take **another model path** at load/session time (forced aligner,
+VAD, codec, ASR for best-of-N, etc.). Integrators need a machine-readable way to
+discover those peers — not by hard-coding family graphs in UIs.
+
+Advertise them from the loader via `advertised_companions()`. They appear under
+each loader in `audiocpp_cli --list-loaders --json` as an optional `companions`
+array (`schema_version` stays **1**; additive fields only).
+
+| Field | Meaning |
+|---|---|
+| `id` | Stable integrator id (e.g. `forced_aligner`) |
+| `config_key` | Option key that receives the peer path |
+| `scope` | `session`, `load`, or `request` |
+| `target_family` | Registered loader family to install/select; omit/empty for external dirs |
+| `optional` | Whether the primary can run without the peer |
+| `required_for` | Capability/feature keys that need this peer |
+| `label` | Short UI label |
+| `bundled_default` | Optional in-tree default path (e.g. Silero under `assets/`) |
+
+Rules:
+
+1. Prefer a real `target_family` when the peer is an audio.cpp loader.
+2. Non-empty `target_family` must be an **active** registry family (or a bundled
+   loader such as `silero_vad`).
+3. Use empty `target_family` + a clear `label` only for external/non-loader peers
+   (e.g. Vevo2 Whisper directory).
+4. Do **not** invent companions for catalog `parent_package_id` install deps —
+   those stay install-time only.
+5. Keep companions in the loader that owns the path option; do not duplicate a
+   Studio-owned seed graph.
+
 ## Checklist: adding a model family
 
 1. Implement `include/engine/models/<family>/` (or `community_models/`) with a
    loader that overrides `advertised_capabilities()` so tasks/endpoints are
-   explicit.
+   explicit. Override `advertised_companions()` when the family takes peer paths.
 2. Register it in `src/framework/runtime/registry.cpp` (include +
    `available_loaders` entry). Prefer the factory name
    `make_<family>_loader()` so the id matches the advertised family.
@@ -66,7 +99,8 @@ python3 tools/model_manager.py list --json
 ```
 
 Confirm the new family appears in `--list-loaders` and that installable packages
-for that family set `"family"` to the same string.
+for that family set `"family"` to the same string. Confirm any `companions[].target_family`
+values resolve to registered loaders.
 
 ## Checklist: parking or removing a family
 
@@ -98,6 +132,8 @@ builds. It:
 - Parses active vs commented `make_*_loader()` calls in `registry.cpp`
 - Compares them to installable standalone packages from `model_manager.py`
 - Cross-checks the README recommended package table
+- Parses `advertised_companions()` initializers in `**/loader.cpp` and ensures
+  non-empty `target_family` values are active registry families
 - Does **not** require a compiled binary
 
 ```bash

--- a/docs/models/qwen3.md
+++ b/docs/models/qwen3.md
@@ -105,6 +105,10 @@ the forced aligner model path. Long audio is split inside the model session
 before ASR inference; word timestamps are shifted back onto the original audio
 timeline.
 
+Integrators can discover the aligner and VAD peers from
+`audiocpp_cli --list-loaders --json` under `loaders.qwen3_asr.companions`
+(see [usage.md](../usage.md#discovering-loaders-and-companions)).
+
 `audio_chunk_mode=auto` is the default. For transcript-only ASR, Qwen3 ASR uses
 fixed chunks. When word timestamps are requested, it uses bundled Silero VAD
 internally to choose speech-aware chunks before running ASR and alignment.

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -87,7 +87,7 @@ audiocpp_cli --task vc --family chatterbox --model models/chatterbox --backend c
 
 ## MioTTS
 
-MioTTS is a 1.7B voice-clone TTS path that uses MioCodec for acoustic decoding. It requires a reference voice.
+MioTTS is a 1.7B voice-clone TTS path that uses MioCodec for acoustic decoding. It requires a reference voice. MioCodec and optional best-of-N ASR peers are advertised under `loaders.miotts.companions` in `audiocpp_cli --list-loaders --json` (see [usage.md](usage.md#discovering-loaders-and-companions)).
 
 | Field | Value |
 |---|---|

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -69,6 +69,53 @@ Omit these unless you need explicit control. If `--seed` is omitted, models that
 
 `--batch-text-dir` reads `.txt` and `.md` files as plain text. For `.json`, use either a JSON string root or an object with a string `input` or `text` field.
 
+## Discovering loaders and companions
+
+List registered families:
+
+```bash
+audiocpp_cli --list-loaders
+audiocpp_cli --list-loaders --json
+```
+
+`--list-loaders --json` is the machine-readable runtime contract (`schema_version` 1). Each loader entry includes:
+
+| Field | Meaning |
+|---|---|
+| `tasks` | Supported tasks and run modes |
+| `instructions_policy` | How instruction / style text is handled |
+| `api_endpoints` | Usual HTTP surfaces for those capabilities |
+| `companions` | Optional runtime peer models (omitted when empty) |
+
+Use `companions` when a family needs another model path at load or session time (for example Qwen3 ASR + forced aligner, MioTTS + MioCodec). Do not invent a separate UI graph of peer families — read this export.
+
+Example companion object:
+
+```json
+{
+  "id": "forced_aligner",
+  "config_key": "qwen3_asr.forced_aligner_model_path",
+  "scope": "session",
+  "target_family": "qwen3_forced_aligner",
+  "optional": true,
+  "required_for": ["return_timestamps"],
+  "label": "Forced aligner"
+}
+```
+
+| Companion field | Meaning |
+|---|---|
+| `id` | Stable integrator id |
+| `config_key` | Option key that receives the peer path (`--session-option` / load option) |
+| `scope` | `session`, `load`, or `request` |
+| `target_family` | Registered loader family to install or select; omitted for external dirs |
+| `optional` | Whether the primary can run without the peer |
+| `required_for` | Feature keys that need this peer |
+| `label` | Short UI label |
+| `bundled_default` | Optional in-tree default path (for example Silero under `assets/`) |
+
+Install-time package dependencies (`parent_package_id` in `model_manager`) are separate from runtime companions. Maintainer rules: [maintainers/loader_and_catalog.md](maintainers/loader_and_catalog.md).
+
 ## Model Docs
 
 | Need | Doc |

--- a/include/engine/framework/runtime/model.h
+++ b/include/engine/framework/runtime/model.h
@@ -105,11 +105,32 @@ public:
         const SessionOptions & options) const = 0;
 };
 
+struct LoaderCompanion {
+    /** Stable id for integrators (e.g. forced_aligner). */
+    std::string id;
+    /** Session/load/request option key that receives the peer path. */
+    std::string config_key;
+    /** One of: session, load, request. */
+    std::string scope = "session";
+    /**
+     * Registered loader family to install/select, when the peer is an audio.cpp
+     * family. Empty when the peer is only a bundled/external directory.
+     */
+    std::string target_family;
+    bool optional = true;
+    /** Request/session capability keys that need this peer (e.g. return_timestamps). */
+    std::vector<std::string> required_for;
+    std::string label;
+    /** Optional default path for bundled assets (e.g. Silero under assets/). */
+    std::string bundled_default;
+};
+
 struct LoaderAdvertisement {
     std::string family;
     CapabilitySet capabilities;
     std::string instructions_policy;
     std::vector<std::string> api_endpoints;
+    std::vector<LoaderCompanion> companions;
 };
 
 /** Map advertised capabilities to the HTTP surfaces they normally use. */
@@ -127,10 +148,13 @@ public:
     /**
      * Path-free loader catalog for ``--list-loaders --json``.
      * Override ``advertised_capabilities`` (and policy when non-default) on each loader.
+     * Override ``advertised_companions`` when the family loads another family or
+     * bundled peer at runtime via a path option.
      */
     virtual CapabilitySet advertised_capabilities() const;
     virtual std::string advertised_instructions_policy() const;
     virtual std::vector<std::string> advertised_api_endpoints() const;
+    virtual std::vector<LoaderCompanion> advertised_companions() const;
     LoaderAdvertisement advertise() const;
 };
 

--- a/src/community_models/outetts/loader.cpp
+++ b/src/community_models/outetts/loader.cpp
@@ -94,6 +94,30 @@ class OuteTTSLoader final : public runtime::IVoiceModelLoader {
 public:
   std::string family() const override { return "outetts"; }
 
+  runtime::CapabilitySet advertised_capabilities() const override {
+    runtime::CapabilitySet out;
+    out.supported_tasks = {
+        {runtime::VoiceTaskKind::Tts, {runtime::RunMode::Offline}},
+    };
+    out.supports_speaker_reference = true;
+    return out;
+  }
+
+  std::vector<runtime::LoaderCompanion> advertised_companions() const override {
+    return {
+        {
+            "forced_aligner",
+            "outetts.aligner_model_path",
+            "session",
+            "qwen3_forced_aligner",
+            true,
+            {"speaker_reference"},
+            "Forced aligner (voice cloning)",
+            "",
+        },
+    };
+  }
+
   bool can_load(const runtime::ModelLoadRequest &request) const override {
     try {
       const auto package_spec =

--- a/src/framework/runtime/model.cpp
+++ b/src/framework/runtime/model.cpp
@@ -148,12 +148,17 @@ std::vector<std::string> IVoiceModelLoader::advertised_api_endpoints() const {
     return default_api_endpoints_for_capabilities(advertised_capabilities());
 }
 
+std::vector<LoaderCompanion> IVoiceModelLoader::advertised_companions() const {
+    return {};
+}
+
 LoaderAdvertisement IVoiceModelLoader::advertise() const {
     LoaderAdvertisement row;
     row.family = family();
     row.capabilities = advertised_capabilities();
     row.instructions_policy = advertised_instructions_policy();
     row.api_endpoints = advertised_api_endpoints();
+    row.companions = advertised_companions();
     return row;
 }
 

--- a/src/models/miotts/loader.cpp
+++ b/src/models/miotts/loader.cpp
@@ -43,6 +43,31 @@ public:
         return out;
     }
 
+    std::vector<runtime::LoaderCompanion> advertised_companions() const override {
+        return {
+            {
+                "codec",
+                "codec_model",
+                "session",
+                "miocodec",
+                false,
+                {},
+                "MioCodec",
+                "",
+            },
+            {
+                "best_of_n_asr",
+                "best_of_n_asr_model",
+                "session",
+                "qwen3_asr",
+                true,
+                {"best_of_n"},
+                "ASR for best-of-N scoring",
+                "",
+            },
+        };
+    }
+
     bool can_load(const runtime::ModelLoadRequest & request) const override {
         if (request.family_hint.has_value() && *request.family_hint != family()) {
             return false;

--- a/src/models/qwen3_asr/loader.cpp
+++ b/src/models/qwen3_asr/loader.cpp
@@ -43,6 +43,31 @@ public:
         return out;
     }
 
+    std::vector<runtime::LoaderCompanion> advertised_companions() const override {
+        return {
+            {
+                "forced_aligner",
+                "qwen3_asr.forced_aligner_model_path",
+                "session",
+                "qwen3_forced_aligner",
+                true,
+                {"return_timestamps"},
+                "Forced aligner",
+                "",
+            },
+            {
+                "vad",
+                "qwen3_asr.vad_model_path",
+                "session",
+                "silero_vad",
+                true,
+                {"return_timestamps"},
+                "VAD (long-audio timestamps)",
+                "assets/framework/models/silero_vad",
+            },
+        };
+    }
+
     bool can_load(const runtime::ModelLoadRequest & request) const override {
         try {
             const auto package_spec = engine::assets::default_model_package_spec_path(family());

--- a/src/models/vevo2/loader.cpp
+++ b/src/models/vevo2/loader.cpp
@@ -159,6 +159,21 @@ public:
         return out;
     }
 
+    std::vector<runtime::LoaderCompanion> advertised_companions() const override {
+        return {
+            {
+                "whisper",
+                "vevo2.whisper_model_path",
+                "load",
+                "",
+                true,
+                {"speech_to_speech", "svc"},
+                "External Whisper encoder directory (not an audio.cpp loader family)",
+                "",
+            },
+        };
+    }
+
     bool can_load(const runtime::ModelLoadRequest & request) const override {
         if (request.family_hint.has_value() && *request.family_hint != family()) {
             return false;

--- a/src/models/vibevoice_asr/loader.cpp
+++ b/src/models/vibevoice_asr/loader.cpp
@@ -69,6 +69,21 @@ public:
         return out;
     }
 
+    std::vector<runtime::LoaderCompanion> advertised_companions() const override {
+        return {
+            {
+                "vad",
+                "vibevoice_asr.vad_model_path",
+                "session",
+                "silero_vad",
+                true,
+                {"audio_chunk_mode=vad"},
+                "VAD (vad chunking)",
+                "assets/framework/models/silero_vad",
+            },
+        };
+    }
+
     bool can_load(const runtime::ModelLoadRequest & request) const override {
         try {
             const auto package_spec = engine::assets::default_model_package_spec_path(family());

--- a/tools/check_loader_catalog_sync.py
+++ b/tools/check_loader_catalog_sync.py
@@ -33,6 +33,11 @@ BUNDLED_LOADERS_WITHOUT_PACKAGE: set[str] = {
     "silero_vad",
 }
 
+# Matches LoaderCompanion brace inits: scope string, then target_family, then optional.
+_COMPANION_TARGET_RE = re.compile(
+    r'"(?:session|load|request)"\s*,\s*"([a-z0-9_]*)"\s*,\s*(?:true|false)\b'
+)
+
 
 def parse_registry_loaders(registry_text: str) -> tuple[set[str], set[str]]:
     """Return (active_families, commented_families) from registry.cpp."""
@@ -185,6 +190,57 @@ def check_catalog(
     return errors, warnings
 
 
+def iter_loader_sources(repo_root: Path) -> list[Path]:
+    roots = [
+        repo_root / "src" / "models",
+        repo_root / "src" / "community_models",
+    ]
+    out: list[Path] = []
+    for root in roots:
+        if not root.is_dir():
+            continue
+        out.extend(sorted(root.rglob("loader.cpp")))
+    return out
+
+
+def parse_companion_target_families(loader_text: str) -> list[str]:
+    """Extract non-empty target_family strings from advertised_companions inits."""
+    if "advertised_companions" not in loader_text:
+        return []
+    return [
+        match.group(1)
+        for match in _COMPANION_TARGET_RE.finditer(loader_text)
+        if match.group(1)
+    ]
+
+
+def check_companions(
+    *,
+    active: set[str],
+    loader_sources: list[Path],
+) -> tuple[list[str], list[str]]:
+    errors: list[str] = []
+    warnings: list[str] = []
+    for path in loader_sources:
+        text = path.read_text(encoding="utf-8")
+        if "advertised_companions" not in text:
+            continue
+        rel = path.as_posix()
+        targets = parse_companion_target_families(text)
+        if not targets and '""' not in text:
+            warnings.append(
+                f"{rel}: advertised_companions present but no target_family "
+                "strings matched (check brace-init order: scope, target_family, optional)"
+            )
+        for family in targets:
+            if family not in active:
+                errors.append(
+                    f"{rel}: companion target_family '{family}' is not an active "
+                    "registry loader"
+                )
+    return errors, warnings
+
+
 def check_readme(
     *,
     readme_text: str,
@@ -242,6 +298,39 @@ class _SyncCheckSelfTests(unittest.TestCase):
         active, commented = parse_registry_loaders(text)
         self.assertEqual(active, {"family_b", "family_c"})
         self.assertEqual(commented, {"family_a"})
+
+    def test_parse_companion_targets(self) -> None:
+        text = """
+        std::vector<runtime::LoaderCompanion> advertised_companions() const override {
+            return {
+                {"forced_aligner", "qwen3_asr.forced_aligner_model_path", "session",
+                 "qwen3_forced_aligner", true, {"return_timestamps"}, "Forced aligner", ""},
+                {"whisper", "vevo2.whisper_model_path", "load", "", true, {}, "External", ""},
+            };
+        }
+        """
+        self.assertEqual(
+            parse_companion_target_families(text),
+            ["qwen3_forced_aligner"],
+        )
+
+    def test_companion_unknown_family_errors(self) -> None:
+        errors, _ = check_companions(
+            active={"qwen3_asr"},
+            loader_sources=[],
+        )
+        self.assertEqual(errors, [])
+        # Inline parse path covered via fake file content in check helper usage.
+        bad = parse_companion_target_families(
+            'advertised_companions() { return {{"x","k","session","missing_family",true,{},"",""}}; }'
+        )
+        self.assertEqual(bad, ["missing_family"])
+        errors = [
+            f"loader.cpp: companion target_family '{family}' is not an active registry loader"
+            for family in bad
+            if family not in {"qwen3_asr"}
+        ]
+        self.assertTrue(any("missing_family" in e for e in errors))
 
     def test_parked_alias_blocks_installable(self) -> None:
         class Pkg:
@@ -319,6 +408,13 @@ def main() -> int:
         default_family_from_package_id=mm._default_family_from_package_id,
     )
 
+    companion_errors, companion_warnings = check_companions(
+        active=active,
+        loader_sources=iter_loader_sources(REPO_ROOT),
+    )
+    errors.extend(companion_errors)
+    warnings.extend(companion_warnings)
+
     if not args.skip_readme:
         if not README_PATH.is_file():
             errors.append(f"README.md not found: {README_PATH}")
@@ -349,7 +445,7 @@ def main() -> int:
         )
         return 1
 
-    print("ok: installable catalog families match registered loaders")
+    print("ok: installable catalog families and companion targets match registered loaders")
     return 0
 
 


### PR DESCRIPTION
## Summary

After the machine-readable loader catalog (#74 / #86), integrators can discover **which families exist** and **which packages install**. They still cannot discover **which peers a family needs at runtime** (aligner, VAD, codec, best-of-N ASR, external Whisper, …) without reading C++ session code or hard-coding a UI graph.

This PR makes those peers part of the same contract: each loader can advertise a `companions[]` array on `audiocpp_cli --list-loaders --json`. Integrators should consume that export instead of owning a seed table of family→peer edges.

`schema_version` stays **1** (additive fields only).

### Why this belongs in audio.cpp

- The path option keys and peer families are owned by the loaders today.
- An external companion graph would drift whenever a loader adds/renames an option.
- Catalog `parent_package_id` covers **install-time** deps; companions cover **runtime** peers wired via load/session options.

### Schema (per companion)

| Field | Meaning |
|---|---|
| `id` | Stable integrator id (e.g. `forced_aligner`) |
| `config_key` | Option key that receives the peer path |
| `scope` | `session`, `load`, or `request` |
| `target_family` | Registered loader family to install/select; omitted when external |
| `optional` | Whether the primary can run without the peer |
| `required_for` | Feature keys that need this peer |
| `label` | Short UI label |
| `bundled_default` | Optional in-tree default (e.g. Silero under `assets/`) |

### Seeded families

| Primary | Companions |
|---|---|
| `qwen3_asr` | `qwen3_forced_aligner`, `silero_vad` (for timestamps) |
| `vibevoice_asr` | `silero_vad` (for `audio_chunk_mode=vad`) |
| `outetts` | `qwen3_forced_aligner` (voice cloning / `outetts.aligner_model_path`) |
| `miotts` | `miocodec` (required), `qwen3_asr` (optional best-of-N) |
| `vevo2` | external Whisper dir (`vevo2.whisper_model_path`; empty `target_family`) |

Also fills in missing `advertised_capabilities()` on `outetts` so the list-loaders row has tasks.

### Docs / CI

- Extends `docs/maintainers/loader_and_catalog.md` with companion rules + checklist.
- Extends `tools/check_loader_catalog_sync.py` so non-empty companion `target_family` values must be active registry families (no binary required).

## Test plan

- [x] `python3 tools/check_loader_catalog_sync.py --self-test`
- [x] `python3 tools/check_loader_catalog_sync.py`
- [x] Build `audiocpp_cli` and confirm `companions` appear for the families above in `--list-loaders --json`
- [ ] Review that `config_key` / `required_for` match the intended UI wiring for each family