### PR TITLE
Fix Windows CUDA build: don't pass /openmp:experimental to nvcc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -595,7 +595,9 @@ if (ENGINE_ENABLE_OPENMP)
         # '#pragma omp simd' directives in longformer_attention.cpp (error C7660).
         # /openmp:experimental enables the OpenMP 4.0 SIMD support; it overrides the
         # /openmp added by OpenMP::OpenMP_CXX above (harmless D9025 override notice).
-        target_compile_options(engine_runtime PRIVATE /openmp:experimental)
+        # Guard on CXX: nvcc does not forward a bare /openmp:experimental to the host
+        # compiler and instead treats it as a second input file, which is fatal.
+        target_compile_options(engine_runtime PRIVATE $<$<COMPILE_LANGUAGE:CXX>:/openmp:experimental>)
     endif()
 endif()
 


### PR DESCRIPTION
## Problem

A CUDA release build on Windows/MSVC (`scripts/build_windows.ps1 -Preset windows-cuda-release`) fails to compile the two CUDA sources in `engine_runtime`:

```
FAILED: CMakeFiles/engine_runtime.dir/src/framework/sampling/torch_random_cuda_runtime.cu.obj
nvcc fatal   : A single input file is required for a non-link phase when an outputfile is specified
FAILED: CMakeFiles/engine_runtime.dir/src/framework/audio/istft_cuda_runtime.cu.obj
nvcc fatal   : A single input file is required for a non-link phase when an outputfile is specified
```

Reproduced on latest `main` (365b4f6) with CUDA 13.3 + MSVC (VS 2022/18).

### Cause

`CMakeLists.txt` adds the MSVC OpenMP flag to `engine_runtime` unconditionally:

```cmake
target_compile_options(engine_runtime PRIVATE /openmp:experimental)
```

`engine_runtime` also compiles CUDA sources (`istft_cuda_runtime.cu`, `torch_random_cuda_runtime.cu`), so this flag is applied to their `nvcc` invocations too. The generated compile line for a `.cu` object ends with a bare `/openmp:experimental`:

```
FLAGS = -Xcompiler=/utf-8 -Xcompiler="-O2 -Ob2" -DNDEBUG -std=c++17 \
        "--generate-code=arch=compute_120a,code=[sm_120a]" -Xcompiler=-MD /openmp:experimental
```

nvcc does not recognize `/openmp:experimental` and does not forward it to the host compiler (`-forward-unknown-to-host-compiler` only forwards `-`-prefixed unknowns, not `/`-prefixed ones). It therefore parses the token as a second **input file**, and aborts because an output file is already specified — hence the `nvcc fatal` above.

Note: passing `-DOpenMP_CUDA_FLAGS=/openmp:experimental` in `build_windows.ps1` does not help, because the offending flag does not come from an `OpenMP::OpenMP_CUDA` target — it is the hard-coded `target_compile_options` line, which lands on every language in the target.

## Fix

Guard the flag on the C++ language so it never reaches nvcc:

```cmake
target_compile_options(engine_runtime PRIVATE $<$<COMPILE_LANGUAGE:CXX>:/openmp:experimental>)
```

The OpenMP 4.0 SIMD pragmas in the C++ sources (e.g. `longformer_attention.cpp`) still receive the flag; the `.cu` files no longer do.

## Verification

- Before: `engine_runtime` build fails at the two `.cu` objects with `nvcc fatal` (above).
- After: reconfigured and rebuilt `engine_runtime` on the `windows-cuda-release` preset — both CUDA objects compile and the target builds to completion (CUDA 13.3, MSVC, RTX 5090 / `sm_120a`).
