### PR TITLE
Speed up GGUF loading on Windows

### DIFF
--- a/include/engine/framework/assets/resource_bundle.h
+++ b/include/engine/framework/assets/resource_bundle.h
@@ -60,6 +60,7 @@ private:
     std::unordered_map<std::string, std::filesystem::path> files_;
     std::unordered_map<std::string, TensorResource> tensor_resources_;
     mutable std::unordered_map<std::string, std::shared_ptr<const TensorSource>> tensor_sources_;
+    mutable std::unordered_map<std::string, std::shared_ptr<const TensorSource>> tensor_sources_by_path_;
 };
 
 }  // namespace engine::assets

--- a/include/engine/framework/assets/tensor_source.h
+++ b/include/engine/framework/assets/tensor_source.h
@@ -155,6 +155,9 @@ std::shared_ptr<const TensorSource> open_tensor_source(const std::filesystem::pa
 std::shared_ptr<const TensorSource> open_tensor_source(
     const std::filesystem::path & path,
     std::string_view tensor_prefix);
+std::shared_ptr<const TensorSource> make_prefixed_tensor_source(
+    std::shared_ptr<const TensorSource> source,
+    std::string_view tensor_prefix);
 struct TensorSourceInput {
     std::filesystem::path path;
     std::string tensor_prefix;

--- a/src/framework/assets/resource_bundle.cpp
+++ b/src/framework/assets/resource_bundle.cpp
@@ -135,9 +135,19 @@ std::shared_ptr<const TensorSource> ResourceBundle::open_tensor_source(std::stri
         return it->second;
     }
     const auto resource = tensor_resources_.find(key);
+    const auto path = resource == tensor_resources_.end()
+        ? require_file(id)
+        : resource->second.path;
+    const auto path_key = std::filesystem::weakly_canonical(path).generic_string();
+    auto base = tensor_sources_by_path_.find(path_key);
+    if (base == tensor_sources_by_path_.end()) {
+        base = tensor_sources_by_path_.emplace(
+            path_key, engine::assets::open_tensor_source(path)).first;
+    }
     auto source = resource == tensor_resources_.end()
-        ? engine::assets::open_tensor_source(require_file(id))
-        : engine::assets::open_tensor_source(resource->second.path, resource->second.prefix);
+        ? base->second
+        : engine::assets::make_prefixed_tensor_source(
+              base->second, resource->second.prefix);
     tensor_sources_.emplace(key, source);
     return source;
 }

--- a/src/framework/assets/tensor_source.cpp
+++ b/src/framework/assets/tensor_source.cpp
@@ -1343,8 +1343,18 @@ std::shared_ptr<const TensorSource> open_tensor_source(
     const std::filesystem::path & path,
     std::string_view tensor_prefix) {
     auto source = open_tensor_source(path);
+    return make_prefixed_tensor_source(std::move(source), tensor_prefix);
+}
+
+std::shared_ptr<const TensorSource> make_prefixed_tensor_source(
+    std::shared_ptr<const TensorSource> source,
+    std::string_view tensor_prefix) {
+    if (source == nullptr) {
+        throw std::runtime_error("prefixed tensor source requires a source");
+    }
     if (tensor_prefix.empty()) return source;
-    return std::make_shared<PrefixedTensorSourceView>(std::move(source), std::string(tensor_prefix));
+    return std::make_shared<PrefixedTensorSourceView>(
+        std::move(source), std::string(tensor_prefix));
 }
 
 namespace {

--- a/src/framework/io/binary.cpp
+++ b/src/framework/io/binary.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cstring>
 #include <fstream>
+#include <limits>
 #include <stdexcept>
 
 #if defined(__unix__) || defined(__APPLE__)
@@ -10,6 +11,11 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#elif defined(_WIN32)
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
 #endif
 
 namespace engine::io {
@@ -117,6 +123,12 @@ void BinaryBlob::reset() noexcept {
         mapped_ = nullptr;
         size_ = 0;
     }
+#elif defined(_WIN32)
+    if (mapped_ != nullptr) {
+        UnmapViewOfFile(mapped_);
+        mapped_ = nullptr;
+        size_ = 0;
+    }
 #else
     mapped_ = nullptr;
     size_ = 0;
@@ -143,6 +155,45 @@ BinaryBlob read_binary_blob(const std::filesystem::path & path) {
             }
         } else {
             close(fd);
+        }
+    }
+#elif defined(_WIN32)
+    const HANDLE file = CreateFileW(
+        path.c_str(),
+        GENERIC_READ,
+        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+        nullptr,
+        OPEN_EXISTING,
+        FILE_ATTRIBUTE_NORMAL,
+        nullptr);
+    if (file != INVALID_HANDLE_VALUE) {
+        LARGE_INTEGER file_size {};
+        if (GetFileSizeEx(file, &file_size) != 0 &&
+            file_size.QuadPart >= 0 &&
+            static_cast<unsigned long long>(file_size.QuadPart) <=
+                static_cast<unsigned long long>(
+                    std::numeric_limits<size_t>::max())) {
+            const size_t size = static_cast<size_t>(file_size.QuadPart);
+            if (size == 0) {
+                CloseHandle(file);
+                return BinaryBlob();
+            }
+            const HANDLE mapping = CreateFileMappingW(
+                file, nullptr, PAGE_READONLY, 0, 0, nullptr);
+            if (mapping != nullptr) {
+                const void * mapped = MapViewOfFile(
+                    mapping, FILE_MAP_READ, 0, 0, 0);
+                CloseHandle(mapping);
+                CloseHandle(file);
+                if (mapped != nullptr) {
+                    return BinaryBlob(
+                        static_cast<const std::byte *>(mapped), size);
+                }
+            } else {
+                CloseHandle(file);
+            }
+        } else {
+            CloseHandle(file);
         }
     }
 #endif


### PR DESCRIPTION
## Summary

Speed up large GGUF and SafeTensors loading on Windows by:

- memory-mapping binary model files with `CreateFileMappingW` / `MapViewOfFile`;
- sharing one physical tensor source when a package spec exposes multiple namespaced resources from the same file;
- constructing lightweight prefixed views over that shared source.

This is a framework fix and is not specific to any model

## Problem

`BinaryBlob` used `mmap` on Linux and macOS, but Windows fell back to reading the complete model file into an owned byte vector.

Packed GGUF models made this substantially worse. `ResourceBundle` cached tensor sources by resource ID only. When five named components referred to five namespaces in the same packed GGUF, the runtime opened the same physical file five times. On Windows, each open eagerly read the complete file.

For the 5.14 GB mixed-precision GLM-TTS GGUF used to reproduce the issue:

```text
llama_weights --------\
speech_tokenizer ------\
flow_weights ------------> same 5.14 GB GGUF opened independently
hift_weights -----------/
campplus_weights ------/
```

That produced approximately 25.7 GB of redundant model-file reads before inference and a long delay before the first runtime trace or CUDA upload.

## Implementation

The updated loading flow is:

```text
package resource IDs
        |
        v
canonical physical path cache
        |
        v
one GgufTensorSource / BinaryBlob
        |
        +--> prefixed view: llama_weights/
        +--> prefixed view: speech_tokenizer_weights/
        +--> prefixed view: flow_weights/
        +--> prefixed view: hift_weights/
        `--> prefixed view: campplus_weights/
```

On Windows, `BinaryBlob` now creates a read-only file mapping and unmaps it during destruction. If mapping is unavailable, the existing buffered-read fallback remains in place. Linux and macOS behavior is unchanged.

The physical-path cache also applies to other tensor formats loaded through `ResourceBundle`, including SafeTensors resources that share a file.

## Measured impact

Tested on Windows 11, CUDA 12.4, NVIDIA RTX 3090 using a 5,143,813,728-byte standalone GLM-TTS GGUF.

The same CLI request, seed, model, reference audio, and output text were used before and after the change:

| Measurement | Before | After |
|---|---:|---:|
| Time before inference session | 28.34 s | 2.09 s |
| Complete CLI process | 31.73 s | 6.17-6.22 s |
| Startup speedup | 1.0x | 13.5x |
| Overall process speedup | 1.0x | 5.1x |

Two optimized runs measured 6.215 s and 6.168 s process wall time.

## Output parity

The before/after generated WAV files are byte-identical:

- generated speech tokens: 131 / 131;
- sample rate: 24,000 Hz;
- frames: 125,760 / 125,760;
- maximum absolute sample difference: `0`;
- waveform cosine: `1.0`;
- SHA-256: `DF8ACFDCD308EA10FDBEF37D03581DAA4E2222922E2DC54A3DD417EEF0263450`.

## Validation

- Windows CUDA Release build:
  - `audiocpp_cli`
  - `audiocpp_server`
  - `audiocpp_gguf`
- Clean Windows CPU Release build from this isolated branch:
  - `audiocpp_cli`
  - `audiocpp_server`
  - `audiocpp_gguf`
  - `gguf_tensor_source_test`
- `git diff --check`
- Repeated end-to-end CUDA generation and byte-level output comparison

The existing `gguf_tensor_source_test` executable builds and runs its GGUF round-trip, packed multi-source, rank-0, and embedded-spec cases, but the current `main` test ends on its final unrelated package-spec error-message expectation (`resource error did not name the selected spec and source`). This PR does not modify that error path.

## User impact

Single-component models avoid the eager Windows full-file copy. Multi-component packed GGUFs additionally avoid reopening and rereading the same physical file once per namespace. CUDA still needs to upload required tensors into VRAM, but the redundant host-side model reads are removed.
