### PR TITLE
[Backend selection] Fix metal backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -939,6 +939,14 @@ if (ENGINE_BUILD_TESTS)
         COMMAND torch_random_test
     )
 
+    add_engine_unittest(backend_device_resolution_test tests/unittests/test_backend_device_resolution.cpp)
+    target_include_directories(backend_device_resolution_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests/unittests)
+
+    add_test(
+        NAME backend_device_resolution_test
+        COMMAND backend_device_resolution_test
+    )
+
     add_engine_unittest(hf_sampler_test tests/unittests/test_hf_sampler.cpp)
 
     add_test(

--- a/src/framework/core/backend.cpp
+++ b/src/framework/core/backend.cpp
@@ -17,65 +17,158 @@ void ensure_backends_loaded() {
     }
 }
 
-static bool backend_has_reg_name(ggml_backend_t backend, const char * name) {
+// A backend is identified by the name of the ggml registry that owns it. The device type
+// (GPU/IGPU/ACCEL) deliberately plays no part in that: Metal reports GPU rather than ACCEL,
+// Vulkan reports IGPU on integrated GPUs, and those values are free to change upstream.
+//
+// The CUDA registry name depends on how ggml was built - GGML_CUDA_NAME is "ROCm" under HIP
+// and "MUSA" under MUSA - so every alias has to be accepted. The names are spelled out here
+// instead of pulled from ggml-cuda.h/ggml-vulkan.h because those headers resolve against the
+// backend's own build flags, which are not visible from this translation unit.
+struct BackendRegNames {
+    BackendType  type;
+    const char * names[3];  // unused entries are nullptr
+};
+
+constexpr BackendRegNames k_backend_reg_names[] = {
+    {BackendType::Cuda,   {"CUDA", "ROCm", "MUSA"}},
+    {BackendType::Vulkan, {"Vulkan", nullptr, nullptr}},
+    {BackendType::Metal,  {"MTL", nullptr, nullptr}},
+};
+
+bool reg_name_matches(BackendType type, const char * reg_name) {
+    if (reg_name == nullptr) {
+        return false;
+    }
+    for (const BackendRegNames & entry : k_backend_reg_names) {
+        if (entry.type != type) {
+            continue;
+        }
+        for (const char * name : entry.names) {
+            if (name != nullptr && std::strcmp(reg_name, name) == 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+    return false;
+}
+
+bool backend_handle_matches(ggml_backend_t backend, BackendType type) {
     if (backend == nullptr) return false;
     ggml_backend_dev_t device = ggml_backend_get_device(backend);
     if (device == nullptr) return false;
     ggml_backend_reg_t reg = ggml_backend_dev_backend_reg(device);
-    return reg != nullptr && std::strcmp(ggml_backend_reg_name(reg), name) == 0;
+    return reg != nullptr && reg_name_matches(type, ggml_backend_reg_name(reg));
 }
 
 bool is_cuda_backend_handle(ggml_backend_t backend) {
-    return backend_has_reg_name(backend, "CUDA");
+    return backend_handle_matches(backend, BackendType::Cuda);
 }
 
 bool is_vulkan_backend_handle(ggml_backend_t backend) {
-    return backend_has_reg_name(backend, "Vulkan");
+    return backend_handle_matches(backend, BackendType::Vulkan);
 }
 
 bool is_metal_backend_handle(ggml_backend_t backend) {
-    return backend_has_reg_name(backend, "MTL");
+    return backend_handle_matches(backend, BackendType::Metal);
 }
 
+ggml_backend_reg_t find_reg_by_backend_type(BackendType type) {
+    for (size_t i = 0; i < ggml_backend_reg_count(); ++i) {
+        ggml_backend_reg_t reg = ggml_backend_reg_get(i);
+        if (reg != nullptr && reg_name_matches(type, ggml_backend_reg_name(reg))) {
+            return reg;
+        }
+    }
+    return nullptr;
+}
+
+// Device indices are relative to the owning registry, matching how ggml itself numbers the
+// devices of a backend.
 ggml_backend_dev_t find_device_by_backend_type(BackendType type, int device_index) {
     if (device_index < 0) {
         return nullptr;
     }
+    ggml_backend_reg_t reg = find_reg_by_backend_type(type);
+    if (reg == nullptr) {
+        return nullptr;
+    }
+    if (static_cast<size_t>(device_index) >= ggml_backend_reg_dev_count(reg)) {
+        return nullptr;
+    }
+    return ggml_backend_reg_dev_get(reg, static_cast<size_t>(device_index));
+}
 
-    std::string reg_name;
-    enum ggml_backend_dev_type dev_type = GGML_BACKEND_DEVICE_TYPE_CPU;
+const char * backend_dev_type_label(enum ggml_backend_dev_type type) {
     switch (type) {
-        case BackendType::Cuda:
-            reg_name = "CUDA";
-            dev_type = GGML_BACKEND_DEVICE_TYPE_GPU;
-            break;
-        case BackendType::Vulkan:
-            reg_name = "Vulkan";
-            dev_type = GGML_BACKEND_DEVICE_TYPE_GPU;
-            break;
-        case BackendType::Metal:
-            reg_name = "MTL";
-            dev_type = GGML_BACKEND_DEVICE_TYPE_ACCEL;
-            break;
-        default:
-            return nullptr;
+        case GGML_BACKEND_DEVICE_TYPE_CPU:   return "CPU";
+        case GGML_BACKEND_DEVICE_TYPE_GPU:   return "GPU";
+        case GGML_BACKEND_DEVICE_TYPE_IGPU:  return "IGPU";
+        case GGML_BACKEND_DEVICE_TYPE_ACCEL: return "ACCEL";
+        case GGML_BACKEND_DEVICE_TYPE_META:  return "META";
     }
+    return "UNKNOWN";
+}
 
-    size_t found = 0;
-    for (size_t i = 0; i < ggml_backend_dev_count(); ++i) {
-        ggml_backend_dev_t dev = ggml_backend_dev_get(i);
-        if (ggml_backend_dev_type(dev) != dev_type) {
+std::string describe_available_devices() {
+    std::string description;
+    for (size_t i = 0; i < ggml_backend_reg_count(); ++i) {
+        ggml_backend_reg_t reg = ggml_backend_reg_get(i);
+        if (reg == nullptr) {
             continue;
         }
-        ggml_backend_reg_t reg = ggml_backend_dev_backend_reg(dev);
-        if (reg == nullptr || ggml_backend_reg_name(reg) != reg_name) {
-            continue;
-        }
-        if (found++ == static_cast<size_t>(device_index)) {
-            return dev;
+        const char * reg_name = ggml_backend_reg_name(reg);
+        for (size_t j = 0; j < ggml_backend_reg_dev_count(reg); ++j) {
+            ggml_backend_dev_t dev = ggml_backend_reg_dev_get(reg, j);
+            if (dev == nullptr) {
+                continue;
+            }
+            if (!description.empty()) {
+                description += ", ";
+            }
+            description += (reg_name != nullptr ? reg_name : "<unnamed>");
+            description += ":" + std::to_string(j);
+            const char * dev_name = ggml_backend_dev_name(dev);
+            if (dev_name != nullptr) {
+                description += " \"" + std::string(dev_name) + "\"";
+            }
+            description += " [";
+            description += backend_dev_type_label(ggml_backend_dev_type(dev));
+            description += "]";
         }
     }
-    return nullptr;
+    return description.empty() ? "none" : description;
+}
+
+std::string describe_missing_device(BackendType type, const char * label, int device_index) {
+    ggml_backend_reg_t reg = find_reg_by_backend_type(type);
+    std::string message = std::string(label) + " backend requested but ";
+    if (reg == nullptr) {
+        message += "it is not registered in this build";
+    } else {
+        message += "registry '" + std::string(ggml_backend_reg_name(reg)) +
+            "' has no device " + std::to_string(device_index);
+    }
+    return message + " (available: " + describe_available_devices() + ")";
+}
+
+ggml_backend_t init_device_backend(BackendType type, const char * label, const BackendConfig & config) {
+    if (config.device < 0) {
+        throw std::runtime_error(
+            std::string(label) + " backend requested with negative device index");
+    }
+    ggml_backend_dev_t device = find_device_by_backend_type(type, config.device);
+    if (device == nullptr) {
+        throw std::runtime_error(describe_missing_device(type, label, config.device));
+    }
+    ggml_backend_t backend = ggml_backend_dev_init(device, nullptr);
+    if (backend == nullptr) {
+        throw std::runtime_error(
+            "Failed to initialize " + std::string(label) + " backend on device " +
+            std::to_string(config.device));
+    }
+    return backend;
 }
 
 
@@ -101,36 +194,12 @@ ggml_backend_t init_backend(const BackendConfig & config) {
             }
             return backend;
         }
-        case BackendType::Cuda: {
-            if (config.device < 0) {
-                throw std::runtime_error("CUDA backend requested with negative device index");
-            }
-            ggml_backend_dev_t device = find_device_by_backend_type(BackendType::Cuda, config.device);
-            if (device == nullptr) {
-                throw std::runtime_error("CUDA backend requested but no CUDA device found");
-            }
-            return ggml_backend_dev_init(device, nullptr);
-        }
-        case BackendType::Vulkan: {
-            if (config.device < 0) {
-                throw std::runtime_error("Vulkan backend requested with negative device index");
-            }
-            ggml_backend_dev_t device = find_device_by_backend_type(BackendType::Vulkan, config.device);
-            if (device == nullptr) {
-                throw std::runtime_error("Vulkan backend requested but no Vulkan device found");
-            }
-            return ggml_backend_dev_init(device, nullptr);
-        }
-        case BackendType::Metal: {
-            if (config.device < 0) {
-                throw std::runtime_error("Metal backend requested with negative device index");
-            }
-            ggml_backend_dev_t device = find_device_by_backend_type(BackendType::Metal, config.device);
-            if (device == nullptr) {
-                throw std::runtime_error("Metal backend requested but no Metal device found");
-            }
-            return ggml_backend_dev_init(device, nullptr);
-        }
+        case BackendType::Cuda:
+            return init_device_backend(BackendType::Cuda, "CUDA", config);
+        case BackendType::Vulkan:
+            return init_device_backend(BackendType::Vulkan, "Vulkan", config);
+        case BackendType::Metal:
+            return init_device_backend(BackendType::Metal, "Metal", config);
         case BackendType::BestAvailable: {
             ggml_backend_t backend = ggml_backend_init_best();
             if (backend == nullptr) {

--- a/tests/unittests/test_backend_device_resolution.cpp
+++ b/tests/unittests/test_backend_device_resolution.cpp
@@ -1,0 +1,224 @@
+#include "engine/framework/core/backend.h"
+
+#include "test_assert.h"
+
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace {
+
+using engine::core::BackendConfig;
+using engine::core::BackendType;
+using engine::test::require;
+using engine::test::require_eq;
+
+struct BackendHandle {
+    ggml_backend_t handle = nullptr;
+
+    explicit BackendHandle(ggml_backend_t backend) : handle(backend) {}
+    BackendHandle(const BackendHandle &) = delete;
+    BackendHandle & operator=(const BackendHandle &) = delete;
+    ~BackendHandle() {
+        if (handle != nullptr) {
+            ggml_backend_free(handle);
+        }
+    }
+};
+
+const char * backend_label(BackendType type) {
+    switch (type) {
+        case BackendType::Cpu:           return "cpu";
+        case BackendType::Cuda:          return "cuda";
+        case BackendType::Vulkan:        return "vulkan";
+        case BackendType::Metal:         return "metal";
+        case BackendType::BestAvailable: return "best";
+    }
+    return "unknown";
+}
+
+// Mirrors the registry-name mapping in src/framework/core/backend.cpp. Duplicated on purpose:
+// the test pins the contract rather than reusing the implementation's table.
+std::optional<BackendType> backend_type_for_reg_name(const char * reg_name) {
+    if (reg_name == nullptr) {
+        return std::nullopt;
+    }
+    // CUDA's registry name follows the ggml build: "ROCm" under HIP, "MUSA" under MUSA.
+    if (std::strcmp(reg_name, "CUDA") == 0 ||
+        std::strcmp(reg_name, "ROCm") == 0 ||
+        std::strcmp(reg_name, "MUSA") == 0) {
+        return BackendType::Cuda;
+    }
+    if (std::strcmp(reg_name, "Vulkan") == 0) {
+        return BackendType::Vulkan;
+    }
+    if (std::strcmp(reg_name, "MTL") == 0) {
+        return BackendType::Metal;
+    }
+    return std::nullopt;
+}
+
+void ensure_backends_loaded() {
+    if (ggml_backend_reg_count() == 0) {
+        ggml_backend_load_all();
+    }
+}
+
+std::string init_backend_error(const BackendConfig & config) {
+    try {
+        BackendHandle backend(engine::core::init_backend(config));
+        return {};
+    } catch (const std::exception & error) {
+        return error.what();
+    }
+}
+
+// Every device ggml enumerates for an accelerator registry must be selectable by index, and
+// the resulting handle must classify back to the requested backend. This is the regression
+// guard for identifying backends by device type (Metal reports GPU, not ACCEL; Vulkan reports
+// IGPU on integrated GPUs) or by a single CUDA registry name (ROCm/MUSA builds differ).
+void test_every_enumerated_device_resolves() {
+    ensure_backends_loaded();
+
+    size_t checked_registries = 0;
+    for (size_t i = 0; i < ggml_backend_reg_count(); ++i) {
+        ggml_backend_reg_t reg = ggml_backend_reg_get(i);
+        require(reg != nullptr, "registry " + std::to_string(i) + " is null");
+
+        const char * reg_name = ggml_backend_reg_name(reg);
+        const auto type = backend_type_for_reg_name(reg_name);
+        if (!type.has_value()) {
+            continue;
+        }
+
+        const size_t dev_count = ggml_backend_reg_dev_count(reg);
+        const std::string label = std::string(reg_name) + "/" + backend_label(*type);
+        require(dev_count > 0, label + " registry exposes no devices");
+        ++checked_registries;
+
+        for (size_t device = 0; device < dev_count; ++device) {
+            BackendConfig config;
+            config.type = *type;
+            config.device = static_cast<int>(device);
+
+            BackendHandle backend(engine::core::init_backend(config));
+            require(
+                backend.handle != nullptr,
+                label + " device " + std::to_string(device) + " returned a null backend");
+            require_eq(
+                static_cast<int>(engine::core::backend_type(backend.handle)),
+                static_cast<int>(*type),
+                label + " device " + std::to_string(device) + " backend_type round trip");
+            require(
+                !engine::core::is_host_backend(backend.handle),
+                label + " device " + std::to_string(device) + " must not be a host backend");
+            require(
+                !engine::core::uses_host_graph_plan(backend.handle),
+                label + " device " + std::to_string(device) + " must not use a host graph plan");
+
+            // Shares the device lookup with init_backend, so it must agree that the device exists.
+            // Drivers are free to not report memory, but a reported snapshot must be consistent.
+            const auto memory = engine::core::query_backend_memory(config);
+            if (memory.available) {
+                require_eq(
+                    memory.used_bytes,
+                    memory.total_bytes - memory.free_bytes,
+                    label + " device " + std::to_string(device) + " memory snapshot");
+            }
+        }
+
+        BackendConfig out_of_range;
+        out_of_range.type = *type;
+        out_of_range.device = static_cast<int>(dev_count);
+        const std::string out_of_range_error = init_backend_error(out_of_range);
+        require(
+            !out_of_range_error.empty(),
+            label + " accepted out-of-range device index " + std::to_string(dev_count));
+        require(
+            out_of_range_error.find("available:") != std::string::npos,
+            label + " out-of-range error must list the available devices, got: " + out_of_range_error);
+
+        BackendConfig negative;
+        negative.type = *type;
+        negative.device = -1;
+        require(
+            !init_backend_error(negative).empty(),
+            label + " accepted a negative device index");
+    }
+
+    std::cout << "  checked " << checked_registries << " accelerator registr"
+              << (checked_registries == 1 ? "y" : "ies") << '\n';
+}
+
+// A backend must never be satisfied by a device from a registry it does not own, so requesting
+// one that is not registered in this build has to fail rather than pick up a stray device.
+void test_unregistered_backends_are_rejected() {
+    ensure_backends_loaded();
+
+    for (const BackendType type : {BackendType::Cuda, BackendType::Vulkan, BackendType::Metal}) {
+        bool registered = false;
+        for (size_t i = 0; i < ggml_backend_reg_count(); ++i) {
+            ggml_backend_reg_t reg = ggml_backend_reg_get(i);
+            if (reg == nullptr) {
+                continue;
+            }
+            const auto reg_type = backend_type_for_reg_name(ggml_backend_reg_name(reg));
+            if (reg_type.has_value() && *reg_type == type) {
+                registered = true;
+                break;
+            }
+        }
+        if (registered) {
+            continue;
+        }
+
+        BackendConfig config;
+        config.type = type;
+        const std::string error = init_backend_error(config);
+        require(
+            !error.empty(),
+            std::string(backend_label(type)) + " is not registered but init_backend succeeded");
+        require(
+            error.find("not registered in this build") != std::string::npos,
+            std::string(backend_label(type)) +
+                " should report that it is not registered, got: " + error);
+    }
+}
+
+void test_host_and_best_backends_still_resolve() {
+    BackendConfig cpu;
+    cpu.type = BackendType::Cpu;
+    BackendHandle cpu_backend(engine::core::init_backend(cpu));
+    require(cpu_backend.handle != nullptr, "cpu backend is null");
+    require_eq(
+        static_cast<int>(engine::core::backend_type(cpu_backend.handle)),
+        static_cast<int>(BackendType::Cpu),
+        "cpu backend_type round trip");
+    require(engine::core::is_host_backend(cpu_backend.handle), "cpu backend must be a host backend");
+    require(
+        engine::core::uses_host_graph_plan(cpu_backend.handle),
+        "cpu backend must use a host graph plan");
+
+    BackendConfig best;
+    best.type = BackendType::BestAvailable;
+    BackendHandle best_backend(engine::core::init_backend(best));
+    require(best_backend.handle != nullptr, "best backend is null");
+}
+
+}  // namespace
+
+int main() {
+    try {
+        test_every_enumerated_device_resolves();
+        test_unregistered_backends_are_rejected();
+        test_host_and_best_backends_still_resolve();
+    } catch (const std::exception & error) {
+        std::cerr << "backend_device_resolution_test failed: " << error.what() << '\n';
+        return 1;
+    }
+    std::cout << "backend_device_resolution_test passed\n";
+    return 0;
+}


### PR DESCRIPTION
## Problem

`--backend metal` has never worked. Backend selection rejects the Metal device immediately
after ggml has brought it up successfully.

## Repro (before this PR)

```
audiocpp_cli --task asr --family voxtral_realtime \
  --model voxtral-mini-4b-realtime-2602-q8_0.gguf \
  --backend metal --audio speech.wav --text-out transcript.txt
```

```
ggml_metal_device_init: GPU name:   MTL0 (Apple M3)
ggml_metal_device_init: GPU family: MTLGPUFamilyApple9  (1009)
ggml_metal_device_init: has unified memory    = true
...
audiocpp_cli failed: Metal backend requested but no Metal device found
```

Any model and any task reproduces it — the failure is in `init_backend()`, before the model
is touched.

## Root cause

`find_device_by_backend_type()` identified a backend by matching both the ggml **registry
name** and a hardcoded **`ggml_backend_dev_type`**. Device type is not a stable per-backend
property, so that second condition silently excluded valid devices:

| `--backend` | Code expected | ggml reports | Result |
| --- | --- | --- | --- |
| `metal` | `ACCEL` | `GPU`, unconditionally (`ggml-metal.cpp`) | never worked |
| `vulkan` | `GPU` | `IGPU` on integrated GPUs (`ggml-vulkan.cpp`) | broken on APUs / iGPUs |
| `cuda` | reg name `"CUDA"` | `GGML_CUDA_NAME` is `"ROCm"` under HIP, `"MUSA"` under MUSA | broken on those builds |

`ACCEL` is what **BLAS** registers as, which is the giveaway.

The CUDA alias gap also reached `backend_type()`: `is_cuda_backend_handle()` compared against
`"CUDA"` only, so a ROCm/MUSA handle classified as `BackendType::BestAvailable`. That is
load-bearing — ~20 sites across `src/models/**`, `src/framework/modules/**` and
`release_backend_graph_resources()` branch on it, so those builds silently lost every CUDA
fast path and the CUDA graph cleanup.

## Fix

- Backend identity now comes from the owning ggml registry alone; the device-type filter is
  gone. Device lookup is `ggml_backend_reg_get` → `ggml_backend_reg_dev_get`.
- One alias table (`k_backend_reg_names`) is shared by the device lookup and the
  `is_*_backend_handle()` classifiers, so selection and classification cannot drift apart.
  CUDA accepts `CUDA` / `ROCm` / `MUSA`.
- The three near-identical CUDA/Vulkan/Metal branches in `init_backend()` collapse into one
  helper, which also adds a missing null check on `ggml_backend_dev_init()` — previously only
  the CPU branch checked, so the GPU branches could hand back a null backend.
- Errors now enumerate what ggml actually found:
  ```
  Metal backend requested but registry 'MTL' has no device 99
    (available: MTL:0 "MTL0" [GPU], BLAS:0 "BLAS" [ACCEL], CPU:0 "CPU" [CPU])
  ```

`query_backend_memory(const BackendConfig &)` shares the same lookup and is fixed with it.

**Behaviour note:** `--device <n>` now indexes devices within the selected backend's registry,
matching ggml's own numbering. Previously, on a Vulkan host with a discrete *and* an
integrated GPU, the iGPU was unreachable and indices silently skipped it.

## Test

`tests/unittests/test_backend_device_resolution.cpp` derives its expectations from ggml's
registry list rather than hardcoding a device class, so it passes on CPU-only CI and
exercises the real accelerator wherever one exists. It asserts that:

- every enumerated device of an accelerator registry is selectable by index;
- `backend_type()` round-trips the requested backend (the ROCm/MUSA guard);
- out-of-range and negative device indices are rejected;
- an unregistered backend never picks up a stray device from another registry.

## Verification

On Apple M3, `scripts/build_metal.sh --with-tests`:

- the repro command above now transcribes correctly on `--backend metal`; `cpu` and `best`
  produce the same transcript;
- `--device 99 --backend metal` fails with the enumerated message;
- `ctest`: 24/24 pass.

Left alone: four targets already broken on `main` and unrelated to backend selection
(`test_asr_standalone_gguf.cpp` and `tests/moss_tts_local/codec_*_parity.cpp` reference
renamed APIs and don't compile; `scaled_dot_product_attention_test` hardcodes CUDA with no
availability guard; `gguf_tensor_source_test` fails a model-spec message assertion). All
confirmed failing identically with this change stashed.
