### PR TITLE
Fix WebUI model download: list_hf_files now returns 3-tuples

### DIFF
--- a/webui/model_manager_webui.py
+++ b/webui/model_manager_webui.py
@@ -209,7 +209,7 @@ def install_snapshot_into_dir(
     validate: bool = True,
 ) -> None:
     files = mm.list_hf_files(source)
-    for relative, expected_size in files:
+    for relative, _local_snapshot_path, expected_size in files:
         destination = destination_root / relative
         destination.parent.mkdir(parents=True, exist_ok=True)
         download_hf_file(source, relative, destination_root, expected_size)


### PR DESCRIPTION
## Summary

- `tools/model_manager.py`'s `list_hf_files()` returns `(path, local_snapshot_path, size)` 3-tuples, but the WebUI's own copy in `webui/model_manager_webui.py` (`install_snapshot_into_dir`) still unpacked them as `(relative, expected_size)` 2-tuples.
- This raised `ValueError: too many values to unpack (expected 2)` for every plain-snapshot model download started from the WebUI (Download button), while `tools/model_manager.py install` on its own worked fine.

## Fix

Unpack the third tuple element (`local_snapshot_path`) into an ignored variable, matching the current `list_hf_files` signature.

## Test plan

- [x] Built `audiocpp_server` from source (`windows-cuda-release`) and ran the WebUI locally.
- [x] Reproduced the bug: clicking Download for a plain-snapshot model (e.g. Qwen3-TTS 0.6B) failed immediately with `too many values to unpack (expected 2)`.
- [x] Applied the one-line fix; re-ran the same download end-to-end (13 files, ~3.8GB) to completion.
- [x] Loaded the downloaded model in the WebUI (`backend=gpu`) and generated speech successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)