### PR TITLE
Release 0.4 webui

### DIFF
--- a/webui/README.md
+++ b/webui/README.md
@@ -101,8 +101,10 @@ Starts the Gradio web interface (`webui.py`); open **http://127.0.0.1:7860** in 
   (one model in VRAM at a time; switching models restarts it).
 - The UI lets you upload a reference voice, download uninstalled models, enter an HF token / proxy, and so on.
 - Backend is auto-detected (as above: GPU if CUDA is present, otherwise CPU); `AUDIOCPP_BACKEND=gpu|cpu` forces it.
-  In CPU mode, the ggml thread count is set automatically to cores-1 (override with `AUDIOCPP_THREADS=N`), and the
-  VRAM warning is no longer shown.
+  In CPU mode, the ggml thread count is set automatically from the **physical** core count — SMT/Hyper-Threading
+  siblings are not counted, and one core is left free above 4 — so a long run leaves the rest of the machine
+  usable. Filling every logical CPU is faster (~1.4x in a short CPU TTS run on an 8-core/16-thread 5800H); set
+  `AUDIOCPP_THREADS=N` if you want that. The VRAM warning is not shown in CPU mode.
 
 > The web interface (7860) is for humans; to use it as an **API for other programs**, start `audiocpp_server`
 > directly, or once the WebUI is up, hit the port 8080 it manages directly.

--- a/webui/README.zh.md
+++ b/webui/README.zh.md
@@ -92,7 +92,9 @@ python3 -m venv venv && ./venv/bin/pip install -r webui/requirements.txt
   起/切换底层的 `audiocpp_server`（一次一个模型在显存里，换模型即重启）。
 - 界面里可上传参考音色、下载未安装的模型、填 HF token / 代理等。
 - 后端自动检测（同上：有 CUDA 用 GPU，否则 CPU）；`AUDIOCPP_BACKEND=gpu|cpu` 可强制。
-  CPU 模式下 ggml 线程数自动设为核数-1（可用 `AUDIOCPP_THREADS=N` 覆盖），且不再显示显存警告。
+  CPU 模式下 ggml 线程数按**物理核数**自动设置（不计超线程的逻辑核，物理核多于 4 时再留一个核给系统），
+  这样长任务跑起来机器仍然可用。把逻辑核占满会更快（8 核 16 线程的 5800H 上，一次短文本 CPU TTS 快约 1.4 倍），
+  想要这个速度就设 `AUDIOCPP_THREADS=N`。CPU 模式下不显示显存警告。
 
 > 网页界面（7860）是给人用的；要给**其它程序**当 API，请直接启动 `audiocpp_server`，
 > 或让 WebUI 起来后直接打它管理的 8080 端口。

--- a/webui/configs/models_catalog.json
+++ b/webui/configs/models_catalog.json
@@ -19,6 +19,18 @@
     { "id": "moss-tts-local",         "display_name": "MOSS-TTS-Local v1.5 (tts)",              "family": "moss_tts_local",       "path": "models/MOSS-TTS-Local-Transformer-v1.5", "task": "tts",   "mode": "offline", "download_id": "moss_tts_local_v1_5",     "min_vram_gb": 8 },
     { "id": "moss-tts-nano",          "display_name": "MOSS-TTS-Nano 100M (tts)",               "family": "moss_tts_nano",        "path": "models/MOSS-TTS-Nano-100M",              "task": "tts",   "mode": "offline", "download_id": "moss_tts_nano_100m",      "min_vram_gb": 2 },
     { "id": "supertonic",             "display_name": "Supertonic 3 (tts 预置音色/多语种)",        "display_name_en": "Supertonic 3 (tts, preset voices)",      "family": "supertonic", "path": "models/supertonic-3",       "task": "tts",   "mode": "offline", "download_id": "supertonic_3",            "min_vram_gb": 2 },
+    { "id": "higgs-audio-tts",        "display_name": "Higgs Audio v3 TTS 4B (tts 克隆, GGUF Q8)", "display_name_en": "Higgs Audio v3 TTS 4B (tts + clone, GGUF Q8)", "family": "higgs_audio_tts", "path": "models/Higgs-Audio-v3-TTS-4B-GGUF", "task": "tts", "mode": "offline", "download_id": "higgs_audio_v3_tts_4b", "min_vram_gb": 6,
+      "input_hint": "**Higgs Audio v3 TTS**：Q8_0 GGUF 包（权重已量化，不用再设 weight_type）；上传参考音色即声音克隆，留空用默认音色；长文本自动分段。",
+      "input_hint_en": "**Higgs Audio v3 TTS**: Q8_0 GGUF package (already quantized — no weight_type needed). Upload a reference voice to clone, or leave it empty for the default voice; long text is chunked automatically." },
+    { "id": "fish-audio-s2-pro",      "display_name": "Fish Audio S2 Pro (tts 克隆/控制标记, GGUF Q8)", "display_name_en": "Fish Audio S2 Pro (tts + clone/control tags, GGUF Q8)", "family": "fish_audio", "path": "models/Fish-Audio-S2-Pro-GGUF", "task": "tts", "mode": "offline", "download_id": "fish_audio_s2_pro", "min_vram_gb": 8,
+      "input_hint": "**Fish Audio S2 Pro**：Q8_0 GGUF 包；中英+自动语种；上传参考音色即克隆；正文里可写行内控制标记（如 (laugh)）。",
+      "input_hint_en": "**Fish Audio S2 Pro**: Q8_0 GGUF package; English/Chinese plus auto language. Upload a reference voice to clone; inline control tags such as (laugh) can be written in the text." },
+    { "id": "outetts",                "display_name": "Llama-OuteTTS 1.0 1B (tts 克隆, 社区)",     "display_name_en": "Llama-OuteTTS 1.0 1B (tts + clone, community)", "family": "outetts", "path": "models/Llama-OuteTTS-1.0-1B", "task": "tts", "mode": "offline", "download_id": "outetts_1_0_1b", "min_vram_gb": 4,
+      "input_hint": "**OuteTTS 1.0 1B**（社区模型）：23 种语言，DAC 编解码；上传参考音色即克隆。",
+      "input_hint_en": "**OuteTTS 1.0 1B** (community): 23 languages, IBM DAC codec. Upload a reference voice to clone." },
+    { "id": "vietneu-tts",            "display_name": "VieNeu-TTS v3 Turbo (tts 越南语, 社区)",    "display_name_en": "VieNeu-TTS v3 Turbo (vi tts, community)", "family": "vietneu_tts", "path": "models/VieNeu-TTS-v3-Turbo", "task": "tts", "mode": "offline", "download_id": "vietneu_tts_v3_turbo", "min_vram_gb": 4,
+      "input_hint": "**VieNeu-TTS v3 Turbo**（社区模型）：越南语 / 英语；上传参考音色即克隆。",
+      "input_hint_en": "**VieNeu-TTS v3 Turbo** (community): Vietnamese and English. Upload a reference voice to clone." },
 
     { "id": "chatterbox",             "display_name": "Chatterbox (voice clone)",              "family": "chatterbox",           "path": "models/chatterbox",                      "task": "clon",  "mode": "offline", "download_id": "chatterbox",              "min_vram_gb": 12 },
 
@@ -40,7 +52,7 @@
       "input_hint": "**Hviske ASR**：丹麦语专用；模型侧自动分段。" },
     { "id": "vibevoice-asr",          "display_name": "VibeVoice ASR (asr, 多语种+说话人分段)",   "family": "vibevoice_asr",        "path": "models/VibeVoice-ASR",                   "task": "asr",   "mode": "offline", "download_id": "vibevoice_asr",           "min_vram_gb": 20,
       "input_hint": "**VibeVoice ASR**：自动语种，可输出分段/说话人轮次；文本框可填上下文提示（如 The recording is a meeting conversation.）。权重 17.3G，8G 卡跑不动。" },
-    { "id": "voxtral-realtime",       "display_name": "Voxtral Mini 4B Realtime (asr, 自动语种+流式)", "display_name_en": "Voxtral Mini 4B Realtime (asr, auto + streaming)", "family": "voxtral_realtime", "path": "models/Voxtral-Mini-4B-Realtime-2602", "task": "asr", "mode": "offline", "download_id": "voxtral_realtime", "session_options": { "voxtral_realtime.weight_type": "q8_0" }, "min_vram_gb": 8 },
+    { "id": "voxtral-realtime",       "display_name": "Voxtral Mini 4B Realtime (asr, 自动语种+流式)", "display_name_en": "Voxtral Mini 4B Realtime (asr, auto + streaming)", "family": "voxtral_realtime", "path": "models/Voxtral-Mini-4B-Realtime-2602-GGUF", "task": "asr", "mode": "offline", "download_id": "voxtral_realtime", "min_vram_gb": 8 },
 
     { "id": "chatterbox-vc",           "display_name": "Chatterbox (vc 声音转换)",                "display_name_en": "Chatterbox (voice conversion)", "family": "chatterbox", "path": "models/chatterbox", "task": "vc", "mode": "offline", "download_id": "chatterbox", "min_vram_gb": 12,
       "input_hint": "**Chatterbox VC**：上传源语音和目标音色参考；模型保留源语音内容，将说话人音色转换为目标音色，输出 24kHz 单声道。",
@@ -59,7 +71,7 @@
     { "id": "mel-band-roformer",      "display_name": "Mel-Band RoFormer (sep 人声分离)",       "family": "mel_band_roformer",    "path": "models/mel-roformer-mlx",                "task": "sep",   "mode": "offline", "download_id": "mel_band_roformer",       "min_vram_gb": 3 },
 
     { "id": "silero-vad",             "display_name": "Silero VAD (vad, bundled)",             "family": "silero_vad",           "path": "assets/framework/models/silero_vad",     "task": "vad",   "mode": "offline", "min_vram_gb": 1 },
-    { "id": "marblenet-vad",          "display_name": "MarbleNet VAD (vad)",                   "family": "marblenet_vad",        "path": "models/marblenet_vad",                   "task": "vad",   "mode": "offline", "download_id": "marblenet_vad",           "min_vram_gb": 1 },
+    { "id": "marblenet-vad",          "display_name": "MarbleNet VAD (vad, bundled)",          "family": "marblenet_vad",        "path": "assets/framework/models/marblenet_vad",  "task": "vad",   "mode": "offline", "min_vram_gb": 1 },
     { "id": "sortformer-diar",        "display_name": "Sortformer Diarization 4spk (diar)",    "family": "sortformer_diar",      "path": "models/diar_sortformer_4spk-v1",         "task": "diar",  "mode": "offline", "download_id": "sortformer_diar_4spk_v1", "min_vram_gb": 2 },
     { "id": "qwen3-forced-aligner",   "display_name": "Qwen3 Forced Aligner (align)",          "family": "qwen3_forced_aligner", "path": "models/Qwen3-ForcedAligner-0.6B",        "task": "align", "mode": "offline", "download_id": "qwen3_forced_aligner_0_6b", "min_vram_gb": 3 },
 

--- a/webui/configs/required_files.json
+++ b/webui/configs/required_files.json
@@ -9,11 +9,6 @@
     "acestep-v15-turbo/silence_latent.safetensors",
     "vae/diffusion_pytorch_model.safetensors"
   ],
-  "kokoro_82m_bf16": [
-    "config.json",
-    "kokoro-v1_0.safetensors",
-    "voices/af_heart.safetensors"
-  ],
   "moss_tts_nano_100m": [
     "config.json",
     "model.safetensors",
@@ -82,12 +77,10 @@
     "tokenizer.json"
   ],
   "voxtral_realtime": [
-    "config.json",
-    "generation_config.json",
-    "model.safetensors",
-    "params.json",
-    "processor_config.json",
-    "tekken.json"
+    "voxtral-mini-4b-realtime-2602-q8_0.gguf"
+  ],
+  "fish_audio_s2_pro": [
+    "fish-audio-s2-pro-q8_0.gguf"
   ],
   "higgs_audio_stt": [
     "config.json",
@@ -130,6 +123,14 @@
     "tokenizer_config.json",
     "vocab.json",
     "merges.txt"
+  ],
+  "vietneu_tts_v3_turbo": [
+    "config.json",
+    "model.gguf",
+    "speech_tokenizer/config.json",
+    "tokenizer_config.json",
+    "tokenizer.json",
+    "special_tokens_map.json"
   ],
   "qwen3_tts_1_7b_base": [
     "config.json",
@@ -180,12 +181,6 @@
     "config.json",
     "model.safetensors",
     "processor_config.json"
-  ],
-  "parakeet_tdt_0_6b_v3": [
-    "config.json",
-    "model.safetensors",
-    "processor_config.json",
-    "tokenizer.json"
   ],
   "pocket_tts": [
     "languages/english/model.safetensors",
@@ -255,12 +250,7 @@
     "merges.txt"
   ],
   "higgs_audio_v3_tts_4b": [
-    "chat_template.jinja",
-    "config.json",
-    "model.safetensors.index.json",
-    "model.safetensors",
-    "tokenizer.json",
-    "tokenizer_config.json"
+    "higgs-audio-v3-tts-4b-q8_0.gguf"
   ],
   "heartmula": [
     "tokenizer.json",
@@ -287,6 +277,23 @@
     "model_config.json",
     "../llm-jp-3-150m/tokenizer.json",
     "../Semantic-DACVAE-Japanese-32dim/weights.safetensors"
+  ],
+  "outetts_1_0_1b": [
+    "config.json",
+    "generation_config.json",
+    "model.safetensors",
+    "special_tokens_map.json",
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "../DAC.speech.v1.0/config.json",
+    "../DAC.speech.v1.0/model.safetensors",
+    "../Qwen3-ForcedAligner-0.6B/config.json",
+    "../Qwen3-ForcedAligner-0.6B/generation_config.json",
+    "../Qwen3-ForcedAligner-0.6B/model.safetensors",
+    "../Qwen3-ForcedAligner-0.6B/preprocessor_config.json",
+    "../Qwen3-ForcedAligner-0.6B/tokenizer_config.json",
+    "../Qwen3-ForcedAligner-0.6B/vocab.json",
+    "../Qwen3-ForcedAligner-0.6B/merges.txt"
   ],
   "stable_audio_3_small_music": [
     "model_config.json",
@@ -409,11 +416,6 @@
     "citrinet_256_config.json",
     "citrinet_256_tokenizer.model",
     "citrinet_256_vocab.txt"
-  ],
-  "marblenet_vad": [
-    "marblenet_vad.safetensors",
-    "marblenet_vad_config.json",
-    "marblenet_vad_labels.txt"
   ],
   "voxcpm2": [
     "config.json",

--- a/webui/test_catalog_sync.py
+++ b/webui/test_catalog_sync.py
@@ -1,0 +1,122 @@
+"""The WebUI catalog must stay in step with the repo it ships next to.
+
+configs/models_catalog.json and configs/required_files.json are hand-maintained
+copies of facts that live in tools/model_manager.py (package ids, install
+directories, post-install file lists) and src/framework/runtime/registry.cpp
+(which families the server can actually load). Nothing fails loudly when they
+drift: a renamed install directory just makes an installed model read as "not
+installed", a dropped package makes the Download button run a package id that no
+longer exists, and a new family is simply invisible in the UI. Release 0.4 did
+all three at once, which is why these are tests.
+"""
+import json
+import os
+import re
+import sys
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.dirname(HERE)
+if os.path.join(REPO_ROOT, "tools") not in sys.path:
+    sys.path.insert(0, os.path.join(REPO_ROOT, "tools"))
+
+import model_manager  # noqa: E402
+
+try:
+    from webui import webui as app
+except ImportError:
+    import webui as app
+
+CATALOG_PATH = os.path.join(HERE, "configs", "models_catalog.json")
+REQUIRED_FILES_PATH = os.path.join(HERE, "configs", "required_files.json")
+REGISTRY_PATH = os.path.join(REPO_ROOT, "src", "framework", "runtime", "registry.cpp")
+
+_LOADER_CALL_RE = re.compile(r"\bmake_([a-z0-9_]+)_loader\s*\(\s*\)")
+
+# Families the server registers but the WebUI deliberately does not surface,
+# with the reason. Keep this empty unless there is one.
+UNLISTED_FAMILIES: dict[str, str] = {}
+
+
+def _packages():
+    catalog = model_manager.CATALOG
+    values = catalog.values() if isinstance(catalog, dict) else catalog
+    return {p.id: p for p in values}
+
+
+def _load(path):
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+class CatalogSyncTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.packages = _packages()
+        cls.entries = _load(CATALOG_PATH)["models"]
+        cls.required = _load(REQUIRED_FILES_PATH)
+
+    def test_every_download_id_is_a_model_manager_package(self):
+        for entry in self.entries:
+            download_id = entry.get("download_id")
+            if download_id is None:
+                continue
+            self.assertIn(download_id, self.packages,
+                          f"catalog entry {entry['id']} downloads {download_id!r}, "
+                          "which tools/model_manager.py no longer offers")
+
+    def test_install_directory_matches_the_package_target(self):
+        for entry in self.entries:
+            download_id = entry.get("download_id")
+            if download_id not in self.packages:
+                continue
+            target = self.packages[download_id].target_directory
+            self.assertEqual(os.path.basename(entry["path"]), target,
+                             f"catalog entry {entry['id']} looks in {entry['path']!r}, "
+                             f"but {download_id} installs into {target!r}")
+
+    def test_entries_without_a_download_id_ship_with_the_repo(self):
+        # No download_id means the weights are committed (bundled assets); the
+        # path has to exist in a checkout or the model is simply unreachable.
+        for entry in self.entries:
+            if entry.get("download_id"):
+                continue
+            self.assertTrue(os.path.isdir(os.path.join(REPO_ROOT, entry["path"])),
+                            f"catalog entry {entry['id']} has no download_id, so "
+                            f"{entry['path']!r} must be a bundled directory in the repo")
+
+    def test_required_files_mirrors_the_package_specs(self):
+        expected = {pkg_id: list(p.required_files)
+                    for pkg_id, p in self.packages.items() if p.required_files}
+        actual = {k: v for k, v in self.required.items() if k != "_comment"}
+        self.assertEqual(actual, expected,
+                         "configs/required_files.json is stale; regenerate it from "
+                         "tools/model_manager.py CATALOG (see its _comment)")
+
+    def test_gguf_families_come_from_the_package_specs(self):
+        specs = {os.path.splitext(f)[0]
+                 for f in os.listdir(os.path.join(REPO_ROOT, "model_specs"))
+                 if f.endswith(".json")}
+        self.assertEqual(app.GGUF_NATIVE_FAMILIES, specs,
+                         "GGUF_NATIVE_FAMILIES should be read from model_specs/")
+        # The no-model_specs fallback may lag behind, but it must never claim
+        # GGUF support for a family the runtime has no package spec for.
+        self.assertLessEqual(app.GGUF_NATIVE_FAMILIES_FALLBACK, specs)
+        self.assertLessEqual(app.GGUF_WEBUI_CONVERTIBLE_FAMILIES, specs)
+
+    def test_every_registered_family_is_reachable_from_the_ui(self):
+        with open(REGISTRY_PATH, "r", encoding="utf-8") as f:
+            registry = f.read()
+        registered = {m.group(1) for line in registry.splitlines()
+                      for m in [_LOADER_CALL_RE.search(line.strip())]
+                      if m and not line.strip().startswith("//")}
+        listed = {e.get("family") for e in self.entries}
+        missing = sorted(registered - listed - set(UNLISTED_FAMILIES))
+        self.assertFalse(missing,
+                         "families the server can load but the WebUI never offers: "
+                         f"{missing}. Add a catalog entry, or record why not in "
+                         "UNLISTED_FAMILIES.")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/webui/webui.py
+++ b/webui/webui.py
@@ -18,7 +18,8 @@ Env overrides:
                                  (default: auto — gpu when an NVIDIA driver and the
                                  gpu server build are both present, else cpu)
     AUDIOCPP_THREADS=N           ggml compute threads (default 1; cpu backend
-                                 defaults to all cores minus one)
+                                 defaults to the physical core count, minus one
+                                 above 4 cores — SMT siblings are not counted)
     AUDIOCPP_SERVER=http://...   talk to an already-running server instead of managing one
     AUDIOCPP_LOAD_TIMEOUT=300    seconds to wait for a model to finish loading
     AUDIOCPP_NO_BROWSER=1        don't open a browser tab
@@ -1327,6 +1328,60 @@ def _msg_from_error(e):
     return getattr(e, "message", None) or str(e) or _t("未知错误", "Unknown error")
 
 
+def _physical_core_count():
+    """Physical cores, SMT siblings collapsed; None when it can't be determined."""
+    try:                                  # Linux: distinct (physical id, core id)
+        pairs, pkg, core = set(), None, None
+        with open("/proc/cpuinfo", "r", encoding="utf-8", errors="replace") as f:
+            for line in f:
+                key, _, val = line.partition(":")
+                key, val = key.strip(), val.strip()
+                if key == "physical id":
+                    pkg = val
+                elif key == "core id":
+                    core = val
+                    pairs.add((pkg, core))
+        if pairs:
+            return len(pairs)
+    except OSError:
+        pass
+    if sys.platform == "darwin":
+        try:
+            out = subprocess.run(["sysctl", "-n", "hw.physicalcpu"],
+                                 capture_output=True, text=True, timeout=5)
+            if out.returncode == 0 and out.stdout.strip().isdigit():
+                return int(out.stdout.strip())
+        except (OSError, subprocess.SubprocessError):
+            pass
+    return None
+
+
+def _default_cpu_threads():
+    """ggml compute threads for the cpu backend when nothing was configured.
+
+    One thread per physical core, bounded by the CPUs we are actually allowed to
+    run on (taskset/cgroup), with one left free above 4 cores.
+
+    This is deliberately not the fastest setting: filling every SMT sibling as
+    well is measurably quicker (on a 5800H, 8 cores / 16 threads, a short CPU TTS
+    run took 163s at 15 threads vs 233s at 7). But the WebUI runs on the machine
+    someone is using, and a server that pins every logical CPU for minutes makes
+    the rest of the desktop crawl. Trade the ~40% for a usable box; anyone who
+    wants the throughput sets AUDIOCPP_THREADS.
+
+    Where the physical count is unknown (Windows) assume SMT and halve, which is
+    right on every consumer CPU that ships it."""
+    try:
+        allowed = len(os.sched_getaffinity(0))
+    except (AttributeError, OSError):
+        allowed = os.cpu_count() or 4
+    cores = _physical_core_count()
+    if cores is None:
+        cores = max(1, allowed // 2) if allowed > 2 else allowed
+    cores = max(1, min(cores, allowed))
+    return cores - 1 if cores > 4 else cores
+
+
 # Fallback catalog if models_catalog.json is missing/unreadable.
 DEFAULT_CATALOG = {
     "host": "127.0.0.1", "port": 8080, "device": 0, "threads": 1,
@@ -1392,8 +1447,8 @@ DEVICE = int(CATALOG.get("device", 0))
 THREADS = int(os.environ.get("AUDIOCPP_THREADS") or CATALOG.get("threads", 1))
 if BACKEND == "cpu" and THREADS <= 1:
     # catalog 里的 threads=1 是按 CUDA 调的（GPU 路径不吃这个值）；CPU 后端的
-    # ggml 计算线程数就是它，单线程没法用 —— 默认全核减一，留一个核给 UI/系统。
-    THREADS = max(1, (os.cpu_count() or 4) - 1)
+    # ggml 计算线程数就是它，单线程没法用 —— 默认按物理核数（见 _default_cpu_threads）。
+    THREADS = _default_cpu_threads()
 
 # If the user points us at an existing server, keep everything consistent with it.
 _ENV_SERVER = os.environ.get("AUDIOCPP_SERVER")

--- a/webui/webui.py
+++ b/webui/webui.py
@@ -338,9 +338,13 @@ LOAD_TIMEOUT = int(os.environ.get("AUDIOCPP_LOAD_TIMEOUT", "300"))
 GGUF_TYPES = ("orig", "f16", "bf16", "q8_0", "q2_k", "q3_k", "q4_k", "q5_k", "q6_k")
 
 # Only families with a model package spec can load the runtime GGUF produced by
-# audiocpp_gguf.  Keep this aligned with model_specs/*.json; a safetensors file
-# by itself is not evidence that the corresponding C++ loader supports GGUF.
-GGUF_NATIVE_FAMILIES = frozenset({
+# audiocpp_gguf; a safetensors file by itself is not evidence that the
+# corresponding C++ loader supports GGUF. model_specs/<family>.json is the
+# runtime's own list, so read it rather than tracking it by hand — the set grew
+# from 15 to 33 families between 0.3 and 0.4 and a hand-copy just goes stale,
+# telling users a supported model "does not support GGUF". The literal below is
+# the 0.3-era fallback for bundles that ship no model_specs/ directory.
+GGUF_NATIVE_FAMILIES_FALLBACK = frozenset({
     "citrinet_asr",
     "higgs_audio_stt",
     "hviske_asr",
@@ -356,6 +360,31 @@ GGUF_NATIVE_FAMILIES = frozenset({
     "supertonic",
     "vibevoice_asr",
 })
+
+
+def _spec_families():
+    """Families with a package spec on disk, or the fallback set if there is none."""
+    for root in (PROJECT_ROOT, BUNDLE_ROOT):
+        spec_dir = os.path.join(root, "model_specs")
+        if not os.path.isdir(spec_dir):
+            continue
+        families = set()
+        for name in os.listdir(spec_dir):
+            if not name.endswith(".json"):
+                continue
+            path = os.path.join(spec_dir, name)
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    family = json.load(f).get("family")
+            except (OSError, ValueError):
+                family = None
+            families.add(family or os.path.splitext(name)[0])
+        if families:
+            return frozenset(families)
+    return GGUF_NATIVE_FAMILIES_FALLBACK
+
+
+GGUF_NATIVE_FAMILIES = _spec_families()
 
 # These families have input layouts the WebUI can assemble without guessing.
 # Other native-GGUF composite packages remain available through the converter


### PR DESCRIPTION
 webui: resync the model catalog with release 0.4

    The WebUI catalog is a hand-maintained copy of facts that live in
    tools/model_manager.py, model_specs/ and registry.cpp, and 0.4 moved all
    three under it. Nothing failed loudly: a renamed install directory just
    makes an installed model read as "not installed", and a dropped package
    makes the Download button run a package id that no longer exists.

    - marblenet_vad is no longer an installable package; the weights ship in
      assets/framework/models/marblenet_vad. Point at them and drop the
      download_id, as silero_vad already does. Verified: VAD runs from the
      bundled path (2 segments on a 2.2s clip).
    - voxtral_realtime is now a standalone Q8_0 GGUF package installed into
      Voxtral-Mini-4B-Realtime-2602-GGUF. Follow the rename and drop the
      weight_type=q8_0 session option, which was quantizing an already-Q8
      package.
    - required_files.json: regenerated. kokoro/parakeet/marblenet are gone,
      voxtral and higgs_audio_v3_tts_4b are single .gguf files now, and
      fish_audio_s2_pro / vietneu_tts_v3_turbo / outetts_1_0_1b were missing
      entirely, so their installs were never integrity-checked.
    - Add the four families 0.4 registered that the UI never offered:
      higgs_audio_tts, fish_audio, outetts, vietneu_tts. VRAM estimates come
      from the Q8 peaks in docs/reports/gguf_q8_performance.md. Untested
      locally — the weights are not on this machine.
    - GGUF_NATIVE_FAMILIES: read model_specs/*.json instead of restating it.
      The literal listed 15 of the 33 families that now have specs, so the
      UI told users that e.g. Chatterbox "does not support native GGUF".
      The old literal stays as the fallback for bundles without model_specs/.

    test_catalog_sync.py pins all of it: package ids exist, install
    directories match, no-download_id entries are really bundled, the
    required-files map mirrors model_manager, and every registered family is
    reachable from the UI. Four of its six tests fail on the 0.4 tree.