### PR TITLE
Fix: Remove #ifdef GGML_USE_CUDA from CUDA probe in torch_random.cpp

### DIFF
--- a/src/framework/sampling/torch_random.cpp
+++ b/src/framework/sampling/torch_random.cpp
@@ -312,7 +312,7 @@ TorchCudaSamplingPolicy resolve_torch_cuda_sampling_policy(
         log_default_policy(log_category, "backend is not CUDA");
         return policy;
     }
-#ifdef GGML_USE_CUDA
+    // CUDA runtime probe via dynamic library (works with both static and GGML_BACKEND_DL builds)
     const engine::io::DynamicLibraryHandle driver = engine::io::open_dynamic_library(
         {"libcuda.so.1", "libcuda.so", "libcuda.dylib", "nvcuda.dll"});
     if (driver == nullptr) {
@@ -366,14 +366,6 @@ TorchCudaSamplingPolicy resolve_torch_cuda_sampling_policy(
     policy.cuda_fast_path = true;
     policy.cuda_device_index = device_index;
     return policy;
-#else
-    (void) device_index;
-    if (failure_mode == TorchCudaSamplingPolicyFailureMode::FallbackToDefault) {
-        log_default_policy(log_category, "build does not include CUDA support");
-        return policy;
-    }
-    throw std::runtime_error(std::string(model_name) + " generation requires a build with CUDA support");
-#endif
 }
 
 uint64_t torch_cuda_tensor_iterator_offset_blocks(


### PR DESCRIPTION
## Summary 
When ENGINE_ENABLE_CPU_ALL_VARIANTS=ON (Docker builds), ggml's CMake sets GGML_BACKEND_DL=ON, which prevents GGML_USE_CUDA from being defined as a compile-time macro. The #ifdef GGML_USE_CUDA in resolve_torch_cuda_sampling_policy() then took the #else branch and threw, even though CUDA is fully available at runtime.

The probe code already uses dynamic library loading (open_dynamic_library / dynamic_library_symbol) to query libcuda.so at runtime, so there is no compile-time dependency on CUDA. Removing the #ifdef guards allows the probe to work correctly in both static-link and GGML_BACKEND_DL builds.

Fixes Qwen3 TTS failing with 'requires a build with CUDA support' in CUDA Docker images.

See #84 where ENGINE_ENABLE_CPU_ALL_VARIANTS was introduced
See [#107](https://github.com/0xShug0/audio.cpp/pull/107#issuecomment-5078272077) where this issue was noticed
