### PR TITLE
Fix PowerShell parse errors in build_windows.ps1

### DIFF
--- a/scripts/build_windows.ps1
+++ b/scripts/build_windows.ps1
@@ -17,7 +17,7 @@ param(
 )
 
 Set-StrictMode -Version Latest
-$ErrorActionPreference = "Stop"
+$ErrorActionPreference = "Continue"  # let native command stderr (e.g. cmake warnings) flow without aborting the script
 
 function Invoke-Checked {
     param(
@@ -154,7 +154,7 @@ function Find-VsCMake {
         return $cmake
     }
     $cmd = Get-Command "cmake.exe" -ErrorAction SilentlyContinue
-    return if ($cmd) { $cmd.Source } else { "" }
+    if ($cmd) { return $cmd.Source } else { return "" }
 }
 
 function Find-VsNinja {
@@ -164,7 +164,7 @@ function Find-VsNinja {
         return $ninja
     }
     $cmd = Get-Command "ninja.exe" -ErrorAction SilentlyContinue
-    return if ($cmd) { $cmd.Source } else { "" }
+    if ($cmd) { return $cmd.Source } else { return "" }
 }
 
 function Find-WindowsKitTool {


### PR DESCRIPTION
## Problem

`scripts/build_windows.ps1` fails at **function-definition time** on every PowerShell version, before CMake configure can start. The script never reaches the `cmake` invocation, so `audiocpp_cli` / `audiocpp_server` cannot be built from source on Windows using the documented commands.

## Root cause

Two separate issues in `scripts/build_windows.ps1`:

### 1. Invalid `return if (...) {...} else {...}` syntax

`Find-VsCMake` and `Find-VsNinja` both end with:

```powershell
return if ($cmd) { $cmd.Source } else { "" }
```

PowerShell does **not** allow `return` to be followed by an `if` statement. The parser treats the bare `if` as an unknown command name, so **both functions fail to define**, and the script aborts at line 432:

```
$cmake = Find-VsCMake $vsInstall
```

with:

```
The term 'if' is not recognized as the name of a cmdlet, function,
script file, or executable program.
```

This reproduces on **both** Windows PowerShell 5.1 (`powershell.exe`, the OS default) and PowerShell 7.6.4 (`pwsh`). The README's `powershell.exe -File .\scripts\build_windows.ps1` invocation uses the default shell, so it hits this on a stock Windows install.

**Fix:** rewrite as a regular `if/return`:

```powershell
if ($cmd) { return $cmd.Source } else { return "" }
```

### 2. `$ErrorActionPreference = "Stop"` aborts on native-command stderr

Even after fixing #1, `cmake` writes normal progress/warnings (e.g. the ASM compiler dev warning, NCCL-not-found warning) to **stderr**. Under `$ErrorActionPreference = "Stop"` + `Set-StrictMode`, PowerShell 5.1 turns each native-command stderr line into a terminating error, so `Invoke-Checked` throws before `$LASTEXITCODE` is ever checked.

The script relies on `$LASTEXITCODE` for failure detection (see `Invoke-Checked`), so it is safe and correct to use `"Continue"` here.

**Fix:**

```powershell
$ErrorActionPreference = "Continue"
```

## Verification

Verified on Windows 11, RTX 4090 D (sm_89), Visual Studio Build Tools 2022 (MSVC 19.42), CUDA Toolkit 12.8.61, CMake 4.3.3, Ninja 1.13.2:

- **Parser check** — `[System.Management.Automation.Language.Parser]::ParseInput` on the patched file reports **0 errors**; after dot-sourcing, both `Find-VsCMake` and `Find-VsNinja` are defined (they fail to define on the unpatched file).
- **Configure** — `scripts\build_windows.ps1 -Preset windows-cuda-release -ConfigureOnly` now reaches `-- Configuring done`.
- **Build** — `scripts\build_windows.ps1 -Preset windows-cuda-release -Target audiocpp_cli -Jobs 16` produces `build\windows-cuda-release\bin\audiocpp_cli.exe`.
- **Smoke test** — the built CLI runs `--list-loaders` (36 loaders registered) and a CUDA `marblenet_vad` request end-to-end on the bundled model:

```
ggml_cuda_init: found 1 CUDA devices (Total VRAM: 24563 MiB)
  Device 0: NVIDIA GeForce RTX 4090 D, compute capability 8.9
session.wall_ms 57.4216
```

## Scope

Single file changed, 3 lines. No behavior change for successful builds; only unblocks the script on stock Windows PowerShell.
