### PR TITLE
SEP model BS-RoFormer source separation ( a voice extraction from the source )  

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Runtime tags: safetensors is the default model loading path. `GGUF 16/Q8/Q4` mea
 | Family | Task | Lang | Variants | Runtime |
 |---|---|---|---|---|
 | **ace_step** | Music, Edit | 50+ langs | ACE-Step 1.5 Turbo and Base with acestep-5Hz-lm-1.7B | GGUF 16/Q8 |
+| **bs_roformer** | Sep | lang agnostic | BS-RoFormer vocal separation checkpoints | GGUF Q8 |
 | **chatterbox** | TTS, Clone, VC| ar, da, de, el, en, es, fi, fr, hi, it, ko, ms, nl, no, pl, pt, sv, sw, tr | Chatterbox with 0.5B backbone | GGUF 16/Q8 |
 | **citrinet_asr** | ASR | en | Citrinet-256 | GGUF Q8 |
 | **fish_audio** | TTS, Clone, Ctrl | auto, en, zh | Fish Audio S2 Pro | GGUF 16/Q8 |

--- a/docs/audio_tools.md
+++ b/docs/audio_tools.md
@@ -6,6 +6,7 @@
 | Seed-VC | `seed_vc` | `vc`, `svc` | [Seed-VC](#seed-vc) |
 | VeVo2 | `vevo2` | TTS, SVC, VC, editing | [VeVo2](#vevo2) |
 | HTDemucs | `htdemucs` | `sep` | [HTDemucs](#htdemucs) |
+| BS-RoFormer | `bs_roformer` | `sep` | [BS-RoFormer](#bs-roformer) |
 | Mel-Band RoFormer | `mel_band_roformer` | `sep` | [Mel-Band RoFormer](#mel-band-roformer) |
 
 This page covers voice conversion, codec, and source-separation families. These models do not share one interface: conversion models consume source speech plus a target voice, while the separation models consume a mixture and write named stems.
@@ -89,6 +90,44 @@ audiocpp_cli --task sep --family htdemucs --model models/htdemucs --backend cuda
 | `--audio` | 44.1 kHz WAV path | required | Input music mixture. |
 | `--out-dir` | directory | required | Directory for separated stems. |
 | `--backend` | `cpu`, `cuda`, `vulkan`, `metal`, `best` | `cpu` | Compute backend. |
+
+## BS-RoFormer
+
+BS-RoFormer separates vocals from a 44.1 kHz music mixture using explicit,
+non-overlapping frequency bands. The native implementation accepts either the
+converted SafeTensors package or a standalone GGUF with the package spec and
+`config.json` embedded.
+
+| Field | Value |
+|---|---|
+| Family | `bs_roformer` |
+| Task | `sep` |
+| Modes | `offline` |
+| Input | 44.1 kHz mono or stereo WAV through `--audio` |
+| Output | `vocals.wav` and derived `instrumental.wav` under `--out-dir` |
+| Weight types | `native`, `f32`, `f16`, `bf16`, `q8_0` |
+
+Standalone GGUF:
+
+```bash
+audiocpp_cli --task sep --model models/BS-RoFormer-ep368_Q8/BS-RoFormer-ep368_Q8.gguf --backend cuda --audio song_44k.wav --out-dir stems
+```
+
+Converted SafeTensors package:
+
+```bash
+audiocpp_cli --task sep --family bs_roformer --model models/BS-RoFormer-ep368 --backend cuda --audio song_44k.wav --out-dir stems
+```
+
+The conversion helper preserves the checkpoint's fused QKV weights, explicit
+`freqs_per_bands` layout, global final RMSNorm, and mask-estimator depth:
+
+```bash
+python tests/bs_roformer/convert_reference_ckpt.py \
+  --ckpt model_bs_roformer.ckpt \
+  --config-path model_bs_roformer.yaml \
+  --output-dir models/BS-RoFormer
+```
 
 ## Mel-Band RoFormer
 

--- a/docs/audio_tools.md
+++ b/docs/audio_tools.md
@@ -119,6 +119,21 @@ Converted SafeTensors package:
 audiocpp_cli --task sep --family bs_roformer --model models/BS-RoFormer-ep368 --backend cuda --audio song_44k.wav --out-dir stems
 ```
 
+CUDA uses F32-accumulating Flash Attention while CPU and other backends keep
+the explicit attention path. The packaged overlap count remains the
+quality-oriented default. Lower overlap is an opt-in speed/quality tradeoff:
+
+| Session option | Default | Notes |
+|---|---:|---|
+| `bs_roformer.num_overlap` | package `num_overlap` (`4` for ep368) | Set to `2` or `1` for fewer model passes. This is faster but changes boundary blending and can reduce separation quality. |
+| `bs_roformer.weight_type` | `native` on device backends | Optional storage override such as `f16` or `f32`; measure it on the target backend because converting Q8 weights to F16 is not necessarily faster. |
+
+Fast single-pass example:
+
+```bash
+audiocpp_cli --task sep --model models/BS-RoFormer-ep368_Q8/BS-RoFormer-ep368_Q8.gguf --backend cuda --audio song_44k.wav --out-dir stems-fast --session-option bs_roformer.num_overlap=1
+```
+
 The conversion helper preserves the checkpoint's fused QKV weights, explicit
 `freqs_per_bands` layout, global final RMSNorm, and mask-estimator depth:
 

--- a/docs/gguf.md
+++ b/docs/gguf.md
@@ -57,6 +57,7 @@ Status labels:
 | Family | Package-spec refactor | Safetensors tested after refactor | `orig` GGUF tested | 16-bit GGUF tested | `q8_0` GGUF tested |
 |---|---|---|---|---|---|
 | `ace_step` | Done | Pass | --- | Pass (drift) | Pass (drift) |
+| `bs_roformer` | Done | Pass | --- | --- | Pass |
 | `chatterbox` | Done | Pass | --- | Pass (ASR match, drift) | Pass (ASR match, drift) |
 | `citrinet_asr` | Done | Pass | --- | --- | Pass |
 | `fish_audio` | Done | Pass | --- | Pass | Pass |

--- a/include/engine/models/roformer/assets.h
+++ b/include/engine/models/roformer/assets.h
@@ -38,6 +38,7 @@ struct RoformerArchitectureConfig {
     int win_length = 0;
     bool stft_normalized = false;
     int mask_estimator_depth = 0;
+    int mask_estimator_linear_layers = 0;
     int mlp_expansion_factor = 4;
     bool skip_connection = false;
     bool has_final_norm = false;

--- a/include/engine/models/roformer/assets.h
+++ b/include/engine/models/roformer/assets.h
@@ -13,8 +13,10 @@
 namespace engine::models::roformer {
 
 inline constexpr std::string_view kMelBandRoformerFamily = "mel_band_roformer";
+inline constexpr std::string_view kBsRoformerFamily = "bs_roformer";
 
 struct RoformerArchitectureConfig {
+    std::string family;
     int sample_rate = 0;
     int channels = 0;
     int chunk_size = 0;
@@ -39,6 +41,8 @@ struct RoformerArchitectureConfig {
     int mlp_expansion_factor = 4;
     bool skip_connection = false;
     bool has_final_norm = false;
+    bool fused_qkv = false;
+    bool transformer_output_norm = true;
     int stft_freq_bins = 0;
     int chunk_frames = 0;
     int total_band_input_dim = 0;
@@ -59,5 +63,10 @@ struct RoformerAssets {
 void validate_roformer_weight_storage_type(assets::TensorStorageType storage_type);
 std::shared_ptr<const RoformerAssets> load_mel_band_roformer_assets(
     const runtime::ModelLoadRequest & request);
+std::shared_ptr<const RoformerAssets> load_bs_roformer_assets(
+    const runtime::ModelLoadRequest & request);
+std::shared_ptr<const RoformerAssets> load_roformer_assets(
+    const runtime::ModelLoadRequest & request,
+    std::string_view family);
 
 }  // namespace engine::models::roformer

--- a/include/engine/models/roformer/loader.h
+++ b/include/engine/models/roformer/loader.h
@@ -27,7 +27,9 @@ private:
 };
 
 std::unique_ptr<runtime::ILoadedVoiceModel> load_roformer_model(
-    const runtime::ModelLoadRequest & request);
+    const runtime::ModelLoadRequest & request,
+    std::string_view family);
 std::shared_ptr<runtime::IVoiceModelLoader> make_mel_band_roformer_loader();
+std::shared_ptr<runtime::IVoiceModelLoader> make_bs_roformer_loader();
 
 }  // namespace engine::models::roformer

--- a/include/engine/models/roformer/session.h
+++ b/include/engine/models/roformer/session.h
@@ -35,6 +35,9 @@ private:
     int64_t fade_size_ = 0;
     int64_t border_ = 0;
     std::vector<float> chunk_window_;
+    std::vector<float> first_chunk_window_;
+    std::vector<float> last_chunk_window_;
+    std::vector<float> only_chunk_window_;
     std::vector<float> chunk_planar_work_;
     std::vector<float> result_work_;
     std::vector<float> counter_work_;

--- a/model_specs/bs_roformer.json
+++ b/model_specs/bs_roformer.json
@@ -1,0 +1,33 @@
+{
+  "family": "bs_roformer",
+  "sources": [
+    {
+      "format": "gguf",
+      "roots": {
+        "model": ".",
+        "weights": "$gguf"
+      },
+      "files": {
+        "config": "model:config.json"
+      },
+      "tensors": {
+        "weights": {
+          "source": "weights:",
+          "prefix": "weights"
+        }
+      }
+    },
+    {
+      "format": "safetensors",
+      "roots": {
+        "model": "."
+      },
+      "files": {
+        "config": "model:config.json"
+      },
+      "tensors": {
+        "weights": "model:model.safetensors"
+      }
+    }
+  ]
+}

--- a/model_specs_v1/bs_roformer.json
+++ b/model_specs_v1/bs_roformer.json
@@ -1,0 +1,98 @@
+{
+  "family": "bs_roformer",
+  "display_name": "BS-RoFormer",
+  "description": "Band-Split RoFormer music source-separation model that estimates vocals from explicit non-overlapping frequency bands and derives accompaniment from the input mixture.",
+  "category": "audio_tools",
+  "status": "supported",
+  "tasks": [
+    "sep"
+  ],
+  "modes": [
+    "offline"
+  ],
+  "languages": [
+    "language_agnostic"
+  ],
+  "capabilities": {
+    "sep": [
+      "stems"
+    ]
+  },
+  "options": {
+    "request": [],
+    "session": [
+      {
+        "name": "weight_type",
+        "type": "enum",
+        "description": "RoFormer weight storage type. Defaults to f32 when the backend requires a host graph plan, otherwise native.",
+        "preset": "weight_type_full",
+        "required": false
+      },
+      {
+        "name": "num_overlap",
+        "type": "int",
+        "description": "Number of overlapping inference windows; defaults to the package configuration. Lower values improve throughput but can reduce boundary quality.",
+        "required": false,
+        "min": 1
+      }
+    ],
+    "load": []
+  },
+  "runtime": {
+    "tags": [
+      "gguf"
+    ]
+  },
+  "sources": [
+    {
+      "format": "gguf",
+      "roots": {
+        "model": ".",
+        "weights": "$gguf"
+      },
+      "files": {
+        "config": "model:config.json"
+      },
+      "tensors": {
+        "weights": {
+          "source": "weights:",
+          "prefix": "weights"
+        }
+      }
+    },
+    {
+      "format": "safetensors",
+      "roots": {
+        "model": "."
+      },
+      "files": {
+        "config": "model:config.json"
+      },
+      "tensors": {
+        "weights": "model:model.safetensors"
+      }
+    }
+  ],
+  "package_defaults": {
+    "download": {
+      "kind": "huggingface_snapshot",
+      "repo": "mirek190/audio.cpp",
+      "revision": "main",
+      "gated": false
+    }
+  },
+  "packages": [
+    {
+      "id": "bs_roformer_q8_0",
+      "display_name": "BS-RoFormer ep368 Q8_0 GGUF",
+      "default": true,
+      "format": "gguf",
+      "precision": "q8_0",
+      "target_directory": "BS-RoFormer-ep368_Q8",
+      "files": [
+        "vocal separation models/BS-RoFormer-ep368_Q8.gguf"
+      ],
+      "strip_prefix": "vocal separation models"
+    }
+  ]
+}

--- a/src/framework/runtime/registry.cpp
+++ b/src/framework/runtime/registry.cpp
@@ -244,6 +244,7 @@ ModelRegistry make_default_registry(const std::optional<std::filesystem::path> &
         engine::models::ace_step::make_ace_step_loader(),
         engine::models::demucs::make_htdemucs_loader(),
         engine::models::roformer::make_mel_band_roformer_loader(),
+        engine::models::roformer::make_bs_roformer_loader(),
         engine::models::omnivoice::make_omnivoice_loader(),
         engine::models::glm_tts::make_glm_tts_loader(),
         engine::models::outetts::make_outetts_loader(),

--- a/src/models/roformer/assets.cpp
+++ b/src/models/roformer/assets.cpp
@@ -20,24 +20,27 @@ void validate_roformer_weight_storage_type(assets::TensorStorageType storage_typ
         return;
     default:
         throw std::runtime_error(
-            "mel_band_roformer weight_type currently supports only native, f32, f16, bf16, and q8_0");
+            "RoFormer weight_type currently supports only native, f32, f16, bf16, and q8_0");
     }
 }
 
 namespace {
 
-void validate_config(const json::Value & value) {
+void validate_config(const json::Value & value, std::string_view family) {
     const auto model_type = json::require_string(value, "model_type");
-    if (model_type != std::string(kMelBandRoformerFamily)) {
+    if (model_type != family) {
         throw std::runtime_error(
-            "mel_band_roformer config model_type mismatch: expected mel_band_roformer, got " + model_type);
+            std::string(family) + " config model_type mismatch: expected " +
+            std::string(family) + ", got " + model_type);
     }
 }
 
-assets::ResourceBundle load_resources(const runtime::ModelLoadRequest & request) {
+assets::ResourceBundle load_resources(
+    const runtime::ModelLoadRequest & request,
+    std::string_view family) {
     return engine::model_spec::load_resource_bundle(
         request.model_path,
-        engine::model_spec::default_spec_path(std::string(kMelBandRoformerFamily)));
+        engine::model_spec::default_spec_path(std::string(family)));
 }
 
 void fill_mel_band_layout(
@@ -101,25 +104,72 @@ void fill_mel_band_layout(
     }
 }
 
-RoformerArchitectureConfig parse_config(const json::Value & parsed) {
-    if (!parsed.is_object()) {
-        throw std::runtime_error("mel_band_roformer config root must be an object");
+void fill_bs_band_layout(
+    RoformerArchitectureConfig & config,
+    const std::vector<int64_t> & freqs_per_band) {
+    if (freqs_per_band.size() < 2) {
+        throw std::runtime_error("bs_roformer requires at least two frequency bands");
     }
-    validate_config(parsed);
+    int64_t total_freqs = 0;
+    for (const int64_t count : freqs_per_band) {
+        if (count <= 0) {
+            throw std::runtime_error("bs_roformer freqs_per_bands values must be positive");
+        }
+        total_freqs += count;
+    }
+    if (total_freqs != config.stft_freq_bins) {
+        throw std::runtime_error(
+            "bs_roformer freqs_per_bands sum mismatch: expected " +
+            std::to_string(config.stft_freq_bins) + ", got " +
+            std::to_string(total_freqs));
+    }
+
+    config.num_bands = static_cast<int>(freqs_per_band.size());
+    config.total_band_input_dim = 0;
+    config.band_input_dims.reserve(freqs_per_band.size());
+    config.merged_freq_indices.reserve(
+        static_cast<size_t>(config.stft_freq_bins * config.channels));
+    int64_t freq = 0;
+    for (const int64_t count : freqs_per_band) {
+        const int64_t dim = 2 * count * config.channels;
+        config.band_input_dims.push_back(dim);
+        config.total_band_input_dim += static_cast<int>(dim);
+        for (int64_t local = 0; local < count; ++local, ++freq) {
+            for (int channel = 0; channel < config.channels; ++channel) {
+                config.merged_freq_indices.push_back(freq * config.channels + channel);
+            }
+        }
+    }
+    config.merged_band_counts.assign(
+        static_cast<size_t>(config.stft_freq_bins * config.channels), 1);
+}
+
+RoformerArchitectureConfig parse_config(
+    const json::Value & parsed,
+    std::string_view family) {
+    if (!parsed.is_object()) {
+        throw std::runtime_error(std::string(family) + " config root must be an object");
+    }
+    validate_config(parsed, family);
     RoformerArchitectureConfig config;
+    config.family = std::string(family);
     config.sample_rate = json::require_i32(parsed, "sample_rate");
-    config.channels = 2;
-    config.stereo = true;
+    config.stereo = json::optional_bool(parsed, "stereo", true);
+    config.channels = config.stereo ? 2 : 1;
     config.chunk_size = json::require_i32(parsed, "chunk_size");
-    config.inference_batch_size = 1;
+    config.inference_batch_size = json::optional_i32(parsed, "batch_size", 1);
     config.inference_num_overlap = json::require_i32(parsed, "num_overlap");
-    config.inference_normalize = false;
+    config.inference_normalize = json::optional_bool(parsed, "normalize", false);
     config.dim = json::require_i32(parsed, "dim");
     config.depth = json::require_i32(parsed, "depth");
-    config.num_bands = json::require_i32(parsed, "num_bands");
     config.num_stems = json::require_i32(parsed, "num_stems");
     config.time_transformer_depth = json::optional_i32(parsed, "time_transformer_depth", 1);
     config.freq_transformer_depth = json::optional_i32(parsed, "freq_transformer_depth", 1);
+    config.linear_transformer_depth = json::optional_i32(parsed, "linear_transformer_depth", 0);
+    if (config.linear_transformer_depth != 0) {
+        throw std::runtime_error(
+            std::string(family) + " native runtime does not yet support linear_transformer_depth");
+    }
     config.dim_head = json::require_i32(parsed, "dim_head");
     config.heads = json::require_i32(parsed, "heads");
     config.n_fft = json::require_i32(parsed, "n_fft");
@@ -127,14 +177,32 @@ RoformerArchitectureConfig parse_config(const json::Value & parsed) {
     config.win_length = json::require_i32(parsed, "win_length");
     config.stft_normalized = json::optional_bool(parsed, "stft_normalized", false);
     config.mask_estimator_depth = json::require_i32(parsed, "mask_estimator_depth");
+    if (config.mask_estimator_depth <= 0) {
+        throw std::runtime_error(
+            std::string(family) + " mask_estimator_depth must be positive");
+    }
     config.mlp_expansion_factor = json::optional_i32(parsed, "mlp_expansion_factor", 4);
-    config.skip_connection = false;
+    config.skip_connection = json::optional_bool(parsed, "skip_connection", false);
+    if (config.skip_connection) {
+        throw std::runtime_error(
+            std::string(family) + " native runtime does not yet support skip_connection");
+    }
     config.stft_freq_bins = config.n_fft / 2 + 1;
     config.chunk_frames = 1 + config.chunk_size / config.hop_length;
     config.instruments = {"vocals"};
     config.target_instrument = std::string("vocals");
-    config.has_final_norm = json::optional_bool(parsed, "has_final_norm", false);
-    fill_mel_band_layout(config, config.num_bands);
+    if (family == kBsRoformerFamily) {
+        config.fused_qkv = true;
+        config.transformer_output_norm = false;
+        config.has_final_norm = true;
+        fill_bs_band_layout(config, json::require_i64_array(parsed, "freqs_per_bands"));
+    } else {
+        config.num_bands = json::require_i32(parsed, "num_bands");
+        config.fused_qkv = false;
+        config.transformer_output_norm = true;
+        config.has_final_norm = json::optional_bool(parsed, "has_final_norm", false);
+        fill_mel_band_layout(config, config.num_bands);
+    }
     return config;
 }
 
@@ -142,11 +210,22 @@ RoformerArchitectureConfig parse_config(const json::Value & parsed) {
 
 std::shared_ptr<const RoformerAssets> load_mel_band_roformer_assets(
     const runtime::ModelLoadRequest & request) {
+    return load_roformer_assets(request, kMelBandRoformerFamily);
+}
+
+std::shared_ptr<const RoformerAssets> load_bs_roformer_assets(
+    const runtime::ModelLoadRequest & request) {
+    return load_roformer_assets(request, kBsRoformerFamily);
+}
+
+std::shared_ptr<const RoformerAssets> load_roformer_assets(
+    const runtime::ModelLoadRequest & request,
+    std::string_view family) {
     auto assets = std::make_shared<RoformerAssets>();
-    assets->resources = load_resources(request);
+    assets->resources = load_resources(request, family);
     assets->tensor_source = assets->resources.open_tensor_source("weights");
     const auto parsed = assets->resources.parse_json("config");
-    assets->config = parse_config(parsed);
+    assets->config = parse_config(parsed, family);
     return assets;
 }
 

--- a/src/models/roformer/assets.cpp
+++ b/src/models/roformer/assets.cpp
@@ -181,6 +181,12 @@ RoformerArchitectureConfig parse_config(
         throw std::runtime_error(
             std::string(family) + " mask_estimator_depth must be positive");
     }
+    // The two upstream implementations use the same config field with
+    // different semantics. BS-RoFormer counts every linear layer, including
+    // its output projection. Mel-Band RoFormer counts only the hidden
+    // Linear+Tanh blocks and appends a separate output projection.
+    config.mask_estimator_linear_layers =
+        config.mask_estimator_depth + (family == kMelBandRoformerFamily ? 1 : 0);
     config.mlp_expansion_factor = json::optional_i32(parsed, "mlp_expansion_factor", 4);
     config.skip_connection = json::optional_bool(parsed, "skip_connection", false);
     if (config.skip_connection) {

--- a/src/models/roformer/loader.cpp
+++ b/src/models/roformer/loader.cpp
@@ -11,9 +11,11 @@ namespace {
 
 runtime::ModelMetadata metadata(const RoformerAssets & assets) {
     runtime::ModelMetadata out;
-    out.family = std::string(kMelBandRoformerFamily);
+    out.family = assets.config.family;
     out.variant = assets.resources.model_root().filename().string();
-    out.description = "Mel-band RoFormer music source separation model.";
+    out.description = assets.config.family == kBsRoformerFamily
+        ? "Band-Split RoFormer music source separation model."
+        : "Mel-band RoFormer music source separation model.";
     return out;
 }
 
@@ -25,11 +27,11 @@ runtime::CapabilitySet capabilities(const RoformerAssets &) {
     return out;
 }
 
-runtime::ModelCliInterface cli(const RoformerAssets &) {
+runtime::ModelCliInterface cli(const RoformerAssets & assets) {
     runtime::ModelCliInterface out;
     out.session_options = {
         {
-            std::string(kMelBandRoformerFamily) + ".weight_type",
+            assets.config.family + ".weight_type",
             "native|f32|f16|bf16|q8_0",
             "RoFormer weight storage type.",
         },
@@ -37,9 +39,12 @@ runtime::ModelCliInterface cli(const RoformerAssets &) {
     return out;
 }
 
-runtime::ModelInspection inspect_model(const runtime::ModelLoadRequest & request) {
-    const auto assets = load_mel_band_roformer_assets(request);
-    const auto package_spec = engine::model_spec::default_spec_path(std::string(kMelBandRoformerFamily));
+runtime::ModelInspection inspect_model(
+    const runtime::ModelLoadRequest & request,
+    std::string_view family) {
+    const auto assets = load_roformer_assets(request, family);
+    const auto package_spec =
+        engine::model_spec::default_spec_path(std::string(family));
     runtime::ModelInspection inspection;
     inspection.model_root = assets->resources.model_root();
     inspection.metadata = metadata(*assets);
@@ -58,8 +63,11 @@ runtime::ModelInspection inspect_model(const runtime::ModelLoadRequest & request
 
 class RoformerLoader final : public runtime::IVoiceModelLoader {
 public:
+    explicit RoformerLoader(std::string family)
+        : family_(std::move(family)) {}
+
     std::string family() const override {
-        return std::string(kMelBandRoformerFamily);
+        return family_;
     }
 
     runtime::CapabilitySet advertised_capabilities() const override {
@@ -75,7 +83,7 @@ public:
             return false;
         }
         try {
-            (void) load_mel_band_roformer_assets(request);
+            (void) load_roformer_assets(request, family_);
             return true;
         } catch (...) {
             if (request.family_hint.has_value() && *request.family_hint == family()) {
@@ -86,12 +94,15 @@ public:
     }
 
     runtime::ModelInspection inspect(const runtime::ModelLoadRequest & request) const override {
-        return inspect_model(request);
+        return inspect_model(request, family_);
     }
 
     std::unique_ptr<runtime::ILoadedVoiceModel> load(const runtime::ModelLoadRequest & request) const override {
-        return load_roformer_model(request);
+        return load_roformer_model(request, family_);
     }
+
+private:
+    std::string family_;
 };
 
 }  // namespace
@@ -123,8 +134,9 @@ std::unique_ptr<runtime::IVoiceTaskSession> RoformerLoadedModel::create_task_ses
 }
 
 std::unique_ptr<runtime::ILoadedVoiceModel> load_roformer_model(
-    const runtime::ModelLoadRequest & request) {
-    auto assets = load_mel_band_roformer_assets(request);
+    const runtime::ModelLoadRequest & request,
+    std::string_view family) {
+    auto assets = load_roformer_assets(request, family);
     return std::make_unique<RoformerLoadedModel>(
         metadata(*assets),
         capabilities(*assets),
@@ -132,7 +144,13 @@ std::unique_ptr<runtime::ILoadedVoiceModel> load_roformer_model(
 }
 
 std::shared_ptr<runtime::IVoiceModelLoader> make_mel_band_roformer_loader() {
-    return std::make_shared<RoformerLoader>();
+    return std::make_shared<RoformerLoader>(
+        std::string(kMelBandRoformerFamily));
+}
+
+std::shared_ptr<runtime::IVoiceModelLoader> make_bs_roformer_loader() {
+    return std::make_shared<RoformerLoader>(
+        std::string(kBsRoformerFamily));
 }
 
 }  // namespace engine::models::roformer

--- a/src/models/roformer/runtime.cpp
+++ b/src/models/roformer/runtime.cpp
@@ -192,10 +192,10 @@ MelBandWeights load_mel_band_weights(
     for (size_t band = 0; band < config.band_input_dims.size(); ++band) {
         const std::string prefix = "mask_estimators.0.to_freqs." + std::to_string(band) + ".0";
         MaskBandWeights band_weights;
-        band_weights.layers.reserve(static_cast<size_t>(config.mask_estimator_depth));
-        for (int layer = 0; layer < config.mask_estimator_depth; ++layer) {
+        band_weights.layers.reserve(static_cast<size_t>(config.mask_estimator_linear_layers));
+        for (int layer = 0; layer < config.mask_estimator_linear_layers; ++layer) {
             const int64_t in_dim = layer == 0 ? config.dim : hidden_dim;
-            const int64_t out_dim = layer + 1 == config.mask_estimator_depth
+            const int64_t out_dim = layer + 1 == config.mask_estimator_linear_layers
                 ? config.band_input_dims[band] * 2
                 : hidden_dim;
             band_weights.layers.push_back(binding::linear_from_source(

--- a/src/models/roformer/runtime.cpp
+++ b/src/models/roformer/runtime.cpp
@@ -7,6 +7,7 @@
 #include "engine/framework/core/backend_weight_store.h"
 #include "engine/framework/debug/profiler.h"
 #include "engine/framework/modules/activation_modules.h"
+#include "engine/framework/modules/attention/scaled_dot_product_attention.h"
 #include "engine/framework/modules/linear_module.h"
 #include "engine/framework/modules/norm_modules.h"
 #include "engine/framework/modules/positional_modules.h"
@@ -274,6 +275,15 @@ core::TensorValue attention_from_heads(
     const core::TensorValue & k_heads,
     const core::TensorValue & v_heads,
     int64_t dim) {
+    if (ctx.backend_type == core::BackendType::Cuda) {
+        return modules::ScaledDotProductAttentionModule({
+            dim,
+            modules::ScaledDotProductAttentionLowering::FlashPreserveViews,
+            GGML_PREC_F32,
+            modules::AttentionCausality::NonCausal,
+        }).build(ctx, q_heads, k_heads, v_heads);
+    }
+
     auto scores = matmul_f32(
         ctx,
         q_heads,
@@ -284,7 +294,8 @@ core::TensorValue attention_from_heads(
         GGML_TYPE_F32);
     scores = ensure_contiguous(ctx, scores);
     auto attn = modules::SoftmaxModule{}.build(ctx, scores);
-    return matmul_f32(ctx, attn, v_heads);
+    auto context = matmul_f32(ctx, attn, v_heads);
+    return modules::TransposeModule({{0, 2, 1, 3}, context.shape.rank}).build(ctx, context);
 }
 
 core::TensorValue build_attention(
@@ -332,7 +343,6 @@ core::TensorValue build_attention(
     auto k_heads = modules::TransposeModule({{0, 2, 1, 3}, k.shape.rank}).build(ctx, k);
     auto v_heads = modules::TransposeModule({{0, 2, 1, 3}, v.shape.rank}).build(ctx, v);
     auto attn = attention_from_heads(ctx, q_heads, k_heads, v_heads, config.dim_head);
-    attn = modules::TransposeModule({{0, 2, 1, 3}, attn.shape.rank}).build(ctx, attn);
     attn = ensure_contiguous(ctx, attn);
 
     auto gates_sigmoid = modules::SigmoidModule{}.build(ctx, gates);
@@ -340,9 +350,10 @@ core::TensorValue build_attention(
         ctx,
         ensure_contiguous(ctx, gates_sigmoid),
         core::TensorShape::from_dims({input.shape.dims[0], input.shape.dims[1], config.heads, 1}));
-    gates_sigmoid = ensure_contiguous(ctx, gates_sigmoid);
-    gates_sigmoid = modules::RepeatModule({attn.shape}).build(ctx, gates_sigmoid);
-    attn = modules::MulModule{}.build(ctx, attn, gates_sigmoid);
+    attn = core::wrap_tensor(
+        ggml_mul(ctx.ggml, attn.tensor, gates_sigmoid.tensor),
+        attn.shape,
+        GGML_TYPE_F32);
     attn = core::reshape_tensor(
         ctx,
         ensure_contiguous(ctx, attn),

--- a/src/models/roformer/runtime.cpp
+++ b/src/models/roformer/runtime.cpp
@@ -48,6 +48,7 @@ struct FeedForwardWeights {
 
 struct AttentionWeights {
     core::TensorValue norm;
+    LinearWeights qkv;
     LinearWeights q;
     LinearWeights k;
     LinearWeights v;
@@ -76,9 +77,7 @@ struct BandSplitWeights {
 };
 
 struct MaskBandWeights {
-    LinearWeights fc0;
-    LinearWeights fc1;
-    LinearWeights fc2;
+    std::vector<LinearWeights> layers;
 };
 
 struct MelBandWeights {
@@ -86,6 +85,7 @@ struct MelBandWeights {
     std::vector<BandSplitWeights> band_split;
     std::vector<AxialTransformerWeights> layers;
     std::vector<MaskBandWeights> mask_bands;
+    core::TensorValue final_norm;
 };
 
 MelBandWeights load_mel_band_weights(
@@ -96,7 +96,8 @@ MelBandWeights load_mel_band_weights(
     validate_roformer_weight_storage_type(storage_type);
     const auto & config = assets.config;
     if (config.num_stems != 1) {
-        throw std::runtime_error("mel_band_roformer native runtime currently supports only single-stem checkpoints");
+        throw std::runtime_error(
+            config.family + " native runtime currently supports only single-stem checkpoints");
     }
     const auto & source = *assets.tensor_source;
 
@@ -104,7 +105,7 @@ MelBandWeights load_mel_band_weights(
     weights.store = std::make_shared<core::BackendWeightStore>(
         backend,
         backend_type,
-        "mel_band_roformer.weights",
+        config.family + ".weights",
         768ull * 1024ull * 1024ull);
 
     weights.band_split.reserve(static_cast<size_t>(config.band_input_dims.size()));
@@ -139,9 +140,20 @@ MelBandWeights load_mel_band_weights(
 
                 TransformerLayerWeights block;
                 block.attention.norm = weights.store->load_f32_tensor(source, attn_prefix + ".norm.gamma", {config.dim});
-                block.attention.q = binding::linear_from_source(*weights.store, source, attn_prefix + ".to_q", storage_type, config.heads * config.dim_head, config.dim, false);
-                block.attention.k = binding::linear_from_source(*weights.store, source, attn_prefix + ".to_k", storage_type, config.heads * config.dim_head, config.dim, false);
-                block.attention.v = binding::linear_from_source(*weights.store, source, attn_prefix + ".to_v", storage_type, config.heads * config.dim_head, config.dim, false);
+                if (config.fused_qkv) {
+                    block.attention.qkv = binding::linear_from_source(
+                        *weights.store,
+                        source,
+                        attn_prefix + ".to_qkv",
+                        storage_type,
+                        3 * config.heads * config.dim_head,
+                        config.dim,
+                        false);
+                } else {
+                    block.attention.q = binding::linear_from_source(*weights.store, source, attn_prefix + ".to_q", storage_type, config.heads * config.dim_head, config.dim, false);
+                    block.attention.k = binding::linear_from_source(*weights.store, source, attn_prefix + ".to_k", storage_type, config.heads * config.dim_head, config.dim, false);
+                    block.attention.v = binding::linear_from_source(*weights.store, source, attn_prefix + ".to_v", storage_type, config.heads * config.dim_head, config.dim, false);
+                }
                 block.attention.gates = binding::linear_from_source(*weights.store, source, attn_prefix + ".to_gates", storage_type, config.heads, config.dim, true);
                 block.attention.out = binding::linear_from_source(*weights.store, source, attn_prefix + ".to_out.0", storage_type, config.dim, config.heads * config.dim_head, false);
 
@@ -164,10 +176,12 @@ MelBandWeights load_mel_band_weights(
                     true);
                 branch_weights.layers.push_back(std::move(block));
             }
-            branch_weights.norm = weights.store->load_f32_tensor(
-                source,
-                "layers." + std::to_string(layer) + "." + std::to_string(branch) + ".norm.gamma",
-                {config.dim});
+            if (config.transformer_output_norm) {
+                branch_weights.norm = weights.store->load_f32_tensor(
+                    source,
+                    "layers." + std::to_string(layer) + "." + std::to_string(branch) + ".norm.gamma",
+                    {config.dim});
+            }
         }
         weights.layers.push_back(std::move(axial));
     }
@@ -177,12 +191,28 @@ MelBandWeights load_mel_band_weights(
     for (size_t band = 0; band < config.band_input_dims.size(); ++band) {
         const std::string prefix = "mask_estimators.0.to_freqs." + std::to_string(band) + ".0";
         MaskBandWeights band_weights;
-        band_weights.fc0 = binding::linear_from_source(*weights.store, source, prefix + ".0", storage_type, hidden_dim, config.dim, true);
-        band_weights.fc1 = binding::linear_from_source(*weights.store, source, prefix + ".2", storage_type, hidden_dim, hidden_dim, true);
-        band_weights.fc2 = binding::linear_from_source(*weights.store, source, prefix + ".4", storage_type, config.band_input_dims[band] * 2, hidden_dim, true);
+        band_weights.layers.reserve(static_cast<size_t>(config.mask_estimator_depth));
+        for (int layer = 0; layer < config.mask_estimator_depth; ++layer) {
+            const int64_t in_dim = layer == 0 ? config.dim : hidden_dim;
+            const int64_t out_dim = layer + 1 == config.mask_estimator_depth
+                ? config.band_input_dims[band] * 2
+                : hidden_dim;
+            band_weights.layers.push_back(binding::linear_from_source(
+                *weights.store,
+                source,
+                prefix + "." + std::to_string(2 * layer),
+                storage_type,
+                out_dim,
+                in_dim,
+                true));
+        }
         weights.mask_bands.push_back(std::move(band_weights));
     }
 
+    if (config.has_final_norm) {
+        weights.final_norm =
+            weights.store->load_f32_tensor(source, "final_norm.gamma", {config.dim});
+    }
     weights.store->upload();
     return weights;
 }
@@ -270,9 +300,26 @@ core::TensorValue build_attention(
     const modules::LinearModule out_proj(binding::linear_config(config.heads * config.dim_head, config.dim, false));
 
     auto x = build_reference_rms_norm(ctx, input, config.dim, weights.norm);
-    auto q = q_proj.build(ctx, x, binding::linear_data(ctx, weights.q.weight, weights.q.bias));
-    auto k = k_proj.build(ctx, x, binding::linear_data(ctx, weights.k.weight, weights.k.bias));
-    auto v = v_proj.build(ctx, x, binding::linear_data(ctx, weights.v.weight, weights.v.bias));
+    core::TensorValue q;
+    core::TensorValue k;
+    core::TensorValue v;
+    if (config.fused_qkv) {
+        const int64_t inner = config.heads * config.dim_head;
+        const modules::LinearModule qkv_proj(
+            binding::linear_config(config.dim, 3 * inner, false));
+        auto qkv = qkv_proj.build(
+            ctx,
+            x,
+            binding::linear_data(
+                ctx, weights.qkv.weight, weights.qkv.bias));
+        q = modules::SliceModule({2, 0, inner}).build(ctx, qkv);
+        k = modules::SliceModule({2, inner, inner}).build(ctx, qkv);
+        v = modules::SliceModule({2, 2 * inner, inner}).build(ctx, qkv);
+    } else {
+        q = q_proj.build(ctx, x, binding::linear_data(ctx, weights.q.weight, weights.q.bias));
+        k = k_proj.build(ctx, x, binding::linear_data(ctx, weights.k.weight, weights.k.bias));
+        v = v_proj.build(ctx, x, binding::linear_data(ctx, weights.v.weight, weights.v.bias));
+    }
     auto gates = gate_proj.build(ctx, x, binding::linear_data(ctx, weights.gates.weight, weights.gates.bias));
 
     q = reshape_heads(ctx, q, config.heads, config.dim_head);
@@ -330,7 +377,10 @@ core::TensorValue build_transformer_branch(
         x = modules::AddModule{}.build(ctx, x, build_attention(ctx, x, positions, layer.attention, config));
         x = modules::AddModule{}.build(ctx, x, build_feed_forward(ctx, x, layer.feed_forward, config));
     }
-    return build_reference_rms_norm(ctx, x, config.dim, weights.norm);
+    if (config.transformer_output_norm) {
+        return build_reference_rms_norm(ctx, x, config.dim, weights.norm);
+    }
+    return x;
 }
 
 core::TensorValue build_band_split(
@@ -384,20 +434,27 @@ core::TensorValue build_mask_output(
             ensure_contiguous(ctx, band_input),
             core::TensorShape::from_dims({input.shape.dims[0], input.shape.dims[1], config.dim}));
         const auto & band_weights = weights.mask_bands[band];
-        auto hidden = modules::LinearModule(binding::linear_config(config.dim, config.dim * config.mlp_expansion_factor, true))
-                          .build(ctx, band_input, binding::linear_data(ctx, band_weights.fc0.weight, band_weights.fc0.bias));
-        hidden = modules::TanhModule{}.build(ctx, hidden);
-        hidden = modules::LinearModule(binding::linear_config(
-                                           config.dim * config.mlp_expansion_factor,
-                                           config.dim * config.mlp_expansion_factor,
-                                           true))
-                     .build(ctx, hidden, binding::linear_data(ctx, band_weights.fc1.weight, band_weights.fc1.bias));
-        hidden = modules::TanhModule{}.build(ctx, hidden);
-        hidden = modules::LinearModule(binding::linear_config(
-                                           config.dim * config.mlp_expansion_factor,
-                                           config.band_input_dims[band] * 2,
-                                           true))
-                     .build(ctx, hidden, binding::linear_data(ctx, band_weights.fc2.weight, band_weights.fc2.bias));
+        auto hidden = band_input;
+        int64_t in_dim = config.dim;
+        for (size_t layer = 0; layer < band_weights.layers.size(); ++layer) {
+            const bool last = layer + 1 == band_weights.layers.size();
+            const int64_t out_dim = last
+                ? config.band_input_dims[band] * 2
+                : config.dim * config.mlp_expansion_factor;
+            hidden = modules::LinearModule(
+                         binding::linear_config(in_dim, out_dim, true))
+                         .build(
+                             ctx,
+                             hidden,
+                             binding::linear_data(
+                                 ctx,
+                                 band_weights.layers[layer].weight,
+                                 band_weights.layers[layer].bias));
+            if (!last) {
+                hidden = modules::TanhModule{}.build(ctx, hidden);
+            }
+            in_dim = out_dim;
+        }
         hidden = modules::GLUModule{}.build(ctx, hidden);
         outputs.push_back(hidden);
     }
@@ -446,9 +503,13 @@ struct GgmlContextDeleter {
 
 class FixedShapeGraph {
 public:
-    FixedShapeGraph(ggml_backend_t backend, int compute_threads)
+    FixedShapeGraph(
+        ggml_backend_t backend,
+        int compute_threads,
+        std::string log_prefix)
         : backend_(backend),
-          compute_threads_(compute_threads) {
+          compute_threads_(compute_threads),
+          log_prefix_(std::move(log_prefix)) {
     }
 
     virtual ~FixedShapeGraph() {
@@ -466,19 +527,25 @@ public:
         }
         const auto upload_start = Clock::now();
         ggml_backend_tensor_set(input_, input_values.data(), 0, input_values.size() * sizeof(float));
-        engine::debug::timing_log_scalar("mel_band_roformer.graph.input_upload_ms", engine::debug::elapsed_ms(upload_start));
+        engine::debug::timing_log_scalar(
+            log_prefix_ + ".graph.input_upload_ms",
+            engine::debug::elapsed_ms(upload_start));
         core::set_backend_threads(backend_, compute_threads_);
         const auto compute_start = Clock::now();
         const ggml_status status = engine::core::compute_backend_graph(backend_, graph_);
         ggml_backend_synchronize(backend_);
-        engine::debug::timing_log_scalar("mel_band_roformer.graph.compute_ms", engine::debug::elapsed_ms(compute_start));
+        engine::debug::timing_log_scalar(
+            log_prefix_ + ".graph.compute_ms",
+            engine::debug::elapsed_ms(compute_start));
         if (status != GGML_STATUS_SUCCESS) {
             throw std::runtime_error("roformer graph compute failed");
         }
         const auto read_start = Clock::now();
         output_host_.resize(static_cast<size_t>(output_shape_.num_elements()));
         ggml_backend_tensor_get(output_, output_host_.data(), 0, output_host_.size() * sizeof(float));
-        engine::debug::timing_log_scalar("mel_band_roformer.graph.output_read_ms", engine::debug::elapsed_ms(read_start));
+        engine::debug::timing_log_scalar(
+            log_prefix_ + ".graph.output_read_ms",
+            engine::debug::elapsed_ms(read_start));
         return output_host_;
     }
 
@@ -518,6 +585,7 @@ protected:
     ggml_cgraph * graph_ = nullptr;
     ggml_gallocr_t gallocr_ = nullptr;
     std::vector<float> output_host_;
+    std::string log_prefix_;
 };
 
 class MelBandGraph final : public FixedShapeGraph {
@@ -526,9 +594,12 @@ public:
         std::shared_ptr<const RoformerAssets> assets,
         core::ExecutionContext & execution_context,
         assets_ns::TensorStorageType weight_storage_type)
-        : FixedShapeGraph(execution_context.backend(), std::max(1, execution_context.config().threads)) {
+        : FixedShapeGraph(
+              execution_context.backend(),
+              std::max(1, execution_context.config().threads),
+              assets != nullptr ? assets->config.family : std::string("roformer")) {
         if (assets == nullptr) {
-            throw std::runtime_error("mel_band_roformer graph requires assets");
+            throw std::runtime_error("RoFormer graph requires assets");
         }
         const auto build_start = Clock::now();
         const auto & config = assets->config;
@@ -538,9 +609,9 @@ public:
         constants_ = std::make_unique<core::ConstantTensorCache>(
             backend_,
             compute_threads_,
-            "mel_band_roformer.constants",
+            config.family + ".constants",
             4ull * 1024ull * 1024ull);
-        auto build_ctx = make_build_context(execution_context, "mel_band_roformer");
+        auto build_ctx = make_build_context(execution_context, config.family.c_str());
         constants_->begin_graph();
         input_shape_ = core::TensorShape::from_dims({1, config.chunk_frames, config.total_band_input_dim});
         output_shape_ = core::TensorShape::from_dims({1, config.chunk_frames, config.total_band_input_dim});
@@ -589,6 +660,10 @@ public:
             x = ensure_contiguous(build_ctx, x);
         }
 
+        if (config.has_final_norm) {
+            x = build_reference_rms_norm(
+                build_ctx, x, config.dim, weights_.final_norm);
+        }
         auto output = build_mask_output(build_ctx, x, weights_, config);
         output = ensure_contiguous(build_ctx, output);
         output_ = output.tensor;
@@ -596,8 +671,12 @@ public:
         constants_->finish_graph();
         constants_->ensure_uploaded();
         finalize_graph(131072);
-        engine::debug::timing_log_scalar("mel_band_roformer.graph.build_ms", engine::debug::elapsed_ms(build_start));
-        engine::debug::timing_log_scalar("mel_band_roformer.graph.rebuilt", true);
+        engine::debug::timing_log_scalar(
+            config.family + ".graph.build_ms",
+            engine::debug::elapsed_ms(build_start));
+        engine::debug::timing_log_scalar(
+            config.family + ".graph.rebuilt",
+            true);
     }
 
 private:
@@ -892,6 +971,7 @@ void separate_runtime_chunk(
     const RoformerArchitectureConfig & config,
     size_t fft_threads,
     std::vector<float> & output_planar) {
+    const std::string log_prefix = config.family + ".";
     const engine::audio::STFTConfig stft_config{
         config.n_fft,
         config.hop_length,
@@ -909,16 +989,24 @@ void separate_runtime_chunk(
         config.chunk_size,
         stft_config,
         fft_threads);
-    engine::debug::timing_log_scalar("mel_band_roformer.stft_ms", engine::debug::elapsed_ms(stft_start));
+    engine::debug::timing_log_scalar(
+        log_prefix + "stft_ms",
+        engine::debug::elapsed_ms(stft_start));
     const auto feature_start = Clock::now();
     auto features = build_band_features(stft, config);
-    engine::debug::timing_log_scalar("mel_band_roformer.feature_build_ms", engine::debug::elapsed_ms(feature_start));
+    engine::debug::timing_log_scalar(
+        log_prefix + "feature_build_ms",
+        engine::debug::elapsed_ms(feature_start));
     const auto graph_start = Clock::now();
     const auto & raw_masks = graph.run(features);
-    engine::debug::timing_log_scalar("mel_band_roformer.graph.total_ms", engine::debug::elapsed_ms(graph_start));
+    engine::debug::timing_log_scalar(
+        log_prefix + "graph.total_ms",
+        engine::debug::elapsed_ms(graph_start));
     const auto mask_start = Clock::now();
     auto masked = apply_masks_to_stft(raw_masks, stft, config);
-    engine::debug::timing_log_scalar("mel_band_roformer.mask_apply_ms", engine::debug::elapsed_ms(mask_start));
+    engine::debug::timing_log_scalar(
+        log_prefix + "mask_apply_ms",
+        engine::debug::elapsed_ms(mask_start));
     const auto istft_start = Clock::now();
     auto vocals = compute_roformer_istft(
         masked,
@@ -929,7 +1017,9 @@ void separate_runtime_chunk(
         config.chunk_size,
         stft_config,
         fft_threads);
-    engine::debug::timing_log_scalar("mel_band_roformer.istft_ms", engine::debug::elapsed_ms(istft_start));
+    engine::debug::timing_log_scalar(
+        log_prefix + "istft_ms",
+        engine::debug::elapsed_ms(istft_start));
     if (vocals.shape.size() != 2 || vocals.shape[0] != config.channels || vocals.shape[1] != config.chunk_size) {
         throw std::runtime_error("RoFormer ISTFT returned an unexpected waveform shape");
     }

--- a/src/models/roformer/session.cpp
+++ b/src/models/roformer/session.cpp
@@ -72,7 +72,7 @@ RoformerSession::RoformerSession(
             : assets::TensorStorageType::Native;
     weight_storage_type_ = option_weight_type(
         RuntimeSessionBase::options(),
-        std::string(kMelBandRoformerFamily) + ".weight_type",
+        assets_->config.family + ".weight_type",
         default_weight_storage);
     runtime_ = std::make_unique<RoformerRuntime>(assets_, execution_context(), weight_storage_type_);
     const auto & config = runtime_->config();
@@ -98,7 +98,7 @@ RoformerSession::RoformerSession(
 RoformerSession::~RoformerSession() = default;
 
 std::string RoformerSession::family() const {
-    return std::string(kMelBandRoformerFamily);
+    return assets_->config.family;
 }
 
 runtime::VoiceTaskKind RoformerSession::task_kind() const {
@@ -137,17 +137,18 @@ runtime::TaskResult RoformerSession::run(const runtime::TaskRequest & request) {
     const auto total_start = Clock::now();
 
     const auto & config = runtime_->config();
+    const std::string log_prefix = config.family + ".session.";
     const auto & request_audio = *request.audio_input;
     const bool original_mono = config.channels == 2 && request_audio.channels == 1;
     if (request_audio.sample_rate != config.sample_rate ||
         (request_audio.channels != config.channels && !original_mono)) {
         throw std::runtime_error("RoFormer run() audio_input does not match prepared audio contract");
     }
-    engine::debug::trace_log_scalar("mel_band_roformer.session.sample_rate", config.sample_rate);
-    engine::debug::trace_log_scalar("mel_band_roformer.session.channels", config.channels);
-    engine::debug::trace_log_scalar("mel_band_roformer.session.chunk_size", chunk_size_);
-    engine::debug::trace_log_scalar("mel_band_roformer.session.step", step_);
-    engine::debug::trace_log_scalar("mel_band_roformer.session.original_mono", original_mono);
+    engine::debug::trace_log_scalar(log_prefix + "sample_rate", config.sample_rate);
+    engine::debug::trace_log_scalar(log_prefix + "channels", config.channels);
+    engine::debug::trace_log_scalar(log_prefix + "chunk_size", chunk_size_);
+    engine::debug::trace_log_scalar(log_prefix + "step", step_);
+    engine::debug::trace_log_scalar(log_prefix + "original_mono", original_mono);
 
     const auto prepare_start = Clock::now();
     const auto audio = original_mono
@@ -186,9 +187,11 @@ runtime::TaskResult RoformerSession::run(const runtime::TaskRequest & request) {
         total_length += 2 * border_;
         padded_borders = true;
     }
-    engine::debug::trace_log_scalar("mel_band_roformer.session.frames", total_length);
-    engine::debug::trace_log_scalar("mel_band_roformer.session.padded_borders", padded_borders);
-    engine::debug::timing_log_scalar("mel_band_roformer.session.audio_prepare_ms", engine::debug::elapsed_ms(prepare_start));
+    engine::debug::trace_log_scalar(log_prefix + "frames", total_length);
+    engine::debug::trace_log_scalar(log_prefix + "padded_borders", padded_borders);
+    engine::debug::timing_log_scalar(
+        log_prefix + "audio_prepare_ms",
+        engine::debug::elapsed_ms(prepare_start));
 
     result_work_.assign(static_cast<size_t>(audio.channels * total_length), 0.0f);
     counter_work_.assign(static_cast<size_t>(audio.channels * total_length), 0.0f);
@@ -227,7 +230,9 @@ runtime::TaskResult RoformerSession::run(const runtime::TaskRequest & request) {
             chunk_window,
             engine::audio::AudioChunkCounterMode::PerLane);
     }
-    engine::debug::timing_log_scalar("mel_band_roformer.session.chunk_loop_ms", engine::debug::elapsed_ms(chunk_loop_start));
+    engine::debug::timing_log_scalar(
+        log_prefix + "chunk_loop_ms",
+        engine::debug::elapsed_ms(chunk_loop_start));
 
     const auto assemble_start = Clock::now();
     vocals_planar_work_ = result_work_;
@@ -271,7 +276,9 @@ runtime::TaskResult RoformerSession::run(const runtime::TaskRequest & request) {
     runtime::TaskResult result_task;
     result_task.named_audio_outputs.push_back({"vocals", std::move(vocals_audio), {}});
     result_task.named_audio_outputs.push_back({"instrumental", std::move(instrumental_audio), {{"derived", "mixture_minus_vocals"}}});
-    engine::debug::timing_log_scalar("mel_band_roformer.session.assemble_ms", engine::debug::elapsed_ms(assemble_start));
+    engine::debug::timing_log_scalar(
+        log_prefix + "assemble_ms",
+        engine::debug::elapsed_ms(assemble_start));
     engine::debug::timing_log_scalar("session.wall_ms", engine::debug::elapsed_ms(total_start));
     return result_task;
 }

--- a/src/models/roformer/session.cpp
+++ b/src/models/roformer/session.cpp
@@ -4,6 +4,7 @@
 #include "engine/framework/audio/conversion.h"
 #include "engine/framework/core/backend.h"
 #include "engine/framework/debug/profiler.h"
+#include "engine/framework/runtime/options.h"
 
 #include <algorithm>
 #include <chrono>
@@ -83,7 +84,13 @@ RoformerSession::RoformerSession(
         throw std::runtime_error("RoFormer config num_overlap must be positive");
     }
     chunk_size_ = config.chunk_size;
-    const int64_t overlap = config.inference_num_overlap;
+    const int64_t overlap = runtime::parse_positive_i64_option(
+        RuntimeSessionBase::options().options,
+        {config.family + ".num_overlap"},
+        config.inference_num_overlap);
+    if (overlap > chunk_size_) {
+        throw std::runtime_error(config.family + ".num_overlap must not exceed chunk_size");
+    }
     step_ = chunk_size_ / overlap;
     fade_size_ = chunk_size_ / 10;
     border_ = chunk_size_ - step_;
@@ -91,6 +98,12 @@ RoformerSession::RoformerSession(
         throw std::runtime_error("RoFormer chunk step must be positive");
     }
     chunk_window_ = engine::audio::make_linear_fade_window(chunk_size_, fade_size_);
+    first_chunk_window_ = chunk_window_;
+    std::fill(first_chunk_window_.begin(), first_chunk_window_.begin() + fade_size_, 1.0f);
+    last_chunk_window_ = chunk_window_;
+    std::fill(last_chunk_window_.end() - fade_size_, last_chunk_window_.end(), 1.0f);
+    only_chunk_window_ = first_chunk_window_;
+    std::fill(only_chunk_window_.end() - fade_size_, only_chunk_window_.end(), 1.0f);
     chunk_planar_work_.resize(static_cast<size_t>(config.channels * chunk_size_));
     assets_->tensor_source->release_storage();
 }
@@ -204,7 +217,8 @@ runtime::TaskResult RoformerSession::run(const runtime::TaskRequest & request) {
         chunk_size_ / 2 + 2,
     };
     const auto chunk_loop_start = Clock::now();
-    for (const auto & chunk : engine::audio::plan_audio_chunks(total_length, chunk_spec)) {
+    const auto chunk_plan = engine::audio::plan_audio_chunks(total_length, chunk_spec);
+    for (const auto & chunk : chunk_plan) {
         engine::audio::copy_planar_chunk(
             chunk_planar_work_,
             planar,
@@ -213,13 +227,13 @@ runtime::TaskResult RoformerSession::run(const runtime::TaskRequest & request) {
             chunk,
             chunk_spec);
         const auto & vocals_planar = runtime_->separate_chunk(chunk_planar_work_);
-        std::vector<float> chunk_window = chunk_window_;
-        if (chunk.output_start_sample == 0) {
-            std::fill(chunk_window.begin(), chunk_window.begin() + fade_size_, 1.0f);
-        } else if (chunk.output_start_sample + chunk_size_ >= total_length) {
-            std::fill(chunk_window.end() - fade_size_, chunk_window.end(), 1.0f);
-        }
-
+        const bool first_chunk = chunk.output_start_sample == 0;
+        const bool last_chunk = chunk.output_start_sample + chunk_size_ >= total_length;
+        const auto & chunk_window = chunk_plan.size() == 1
+            ? only_chunk_window_
+            : (first_chunk
+                   ? first_chunk_window_
+                   : (last_chunk ? last_chunk_window_ : chunk_window_));
         engine::audio::overlap_add_planar_chunk(
             result_work_,
             counter_work_,

--- a/tests/bs_roformer/README.md
+++ b/tests/bs_roformer/README.md
@@ -1,0 +1,104 @@
+# BS-RoFormer validation
+
+The native `bs_roformer` family was validated with
+`model_bs_roformer_ep_368_sdr_12.9628.ckpt` and its matching YAML config from
+audio-separator.
+
+## Convert the reference checkpoint
+
+```powershell
+python tests\bs_roformer\convert_reference_ckpt.py `
+  --ckpt model_bs_roformer_ep_368_sdr_12.9628.ckpt `
+  --config-path model_bs_roformer_ep_368_sdr_12.9628.yaml `
+  --output-dir models\BS-RoFormer-ep368
+```
+
+## Run the Python reference
+
+```powershell
+python tests\bs_roformer\run_python_reference.py `
+  --audio-separator-root path\to\python-audio-separator `
+  --ckpt model_bs_roformer_ep_368_sdr_12.9628.ckpt `
+  --config-path model_bs_roformer_ep_368_sdr_12.9628.yaml `
+  --audio input_8s.wav `
+  --out outputs\python\vocals.wav `
+  --device cuda
+```
+
+## Run audio.cpp
+
+SafeTensors:
+
+```powershell
+audiocpp_cli.exe --task sep --family bs_roformer `
+  --model models\BS-RoFormer-ep368 --backend cuda `
+  --audio input_44k.wav --out-dir outputs\cpp-f32
+```
+
+Standalone Q8 GGUF:
+
+```powershell
+audiocpp_cli.exe --task sep `
+  --model models\BS-RoFormer-ep368_Q8\BS-RoFormer-ep368_Q8.gguf `
+  --backend cuda --audio input_44k.wav --out-dir outputs\cpp-q8
+```
+
+## Local validation result
+
+Backend: CUDA, NVIDIA GeForce RTX 3090. Input: stereo, 44.1 kHz, 20 seconds.
+
+| Comparison | Waveform cosine |
+|---|---:|
+| audio.cpp Q8 vs audio.cpp F32 | 0.999985368 |
+| audio.cpp F32 vs audio-separator Python | 0.996474981 |
+| audio.cpp Q8 vs audio-separator Python | 0.996387362 |
+
+An exact-frame 8-second test produced 352,800 frames from both runtimes. Its
+F32 Python comparison measured waveform cosine `0.989149342` and log-mel
+cosine `0.998817655`; the lower waveform metric reflects the different
+edge/chunk overlap policies used by the complete runtime paths.
+
+For the same exact-frame input, Q8 versus F32 measured:
+
+| Metric | Result |
+|---|---:|
+| Output frames | 352,800 / 352,800 |
+| Waveform cosine | 0.999994784 |
+| Log-mel cosine | 0.999898629 |
+| Mean absolute sample error | 0.0002294 |
+| Maximum absolute sample error | 0.0044556 |
+
+This makes the tested Q8 output perceptually and numerically nearly identical
+to the native F32 path while reducing the weight file from about 639 MB to
+about 173 MB.
+
+## Server and WebUI validation
+
+The CUDA server was built with:
+
+```powershell
+.\scripts\build_windows.ps1 -Target audiocpp_server -Jobs 16
+```
+
+An offline `sep` model entry pointing directly at
+`models\BS-RoFormer-ep368_Q8\BS-RoFormer-ep368_Q8.gguf` was exercised through
+`POST /v1/tasks/run` with:
+
+```json
+{
+  "model": "bs-roformer-q8",
+  "request": {
+    "audio": "E:\\path\\to\\input_8s.wav"
+  }
+}
+```
+
+The request returned `vocals` and `instrumental` named audio outputs in
+3,032.1 ms including HTTP, lazy loading, base64 response serialization, and
+file decoding. Both returned WAV files were byte-identical to the CLI outputs.
+
+The WebUI was launched with the CUDA backend, selected `bs-roformer` beside
+HTDemucs and Mel-Band RoFormer in the Source separation tab, uploaded the same
+8-second WAV, and ran the visible Separate action. It loaded the standalone
+GGUF in 0.5 seconds and displayed two playable/downloadable tracks after a
+2.7-second separation run.

--- a/tests/bs_roformer/README.md
+++ b/tests/bs_roformer/README.md
@@ -72,6 +72,35 @@ This makes the tested Q8 output perceptually and numerically nearly identical
 to the native F32 path while reducing the weight file from about 639 MB to
 about 173 MB.
 
+## CUDA optimization validation
+
+The CUDA graph now lowers non-causal axial attention through the framework's
+view-preserving Flash Attention path with F32 accumulation. Gate values are
+broadcast directly instead of materializing a repeated gate tensor. CPU and
+other backends retain the explicit attention implementation.
+
+RTX 3090 results for the same 8-second, 44.1 kHz stereo input:
+
+| Route | `session.wall_ms` | Speed vs audio duration |
+|---|---:|---:|
+| Pre-change Q8, overlap 4 | 2,643.1 | 3.03x real time |
+| Optimized Q8, overlap 4 | 1,440.4 | 5.55x real time |
+| Optimized F32, overlap 4 | 1,874.3 | 4.27x real time |
+| Optimized Q8, overlap 2 | 734.3 | 10.89x real time |
+| Optimized Q8, overlap 1 | 384.0 | 20.84x real time |
+
+The default remains overlap 4. Lower overlap is available through
+`--session-option bs_roformer.num_overlap=2` or `=1`, but is deliberately
+opt-in because it changes boundary blending. Overlap 1 versus the default
+measured waveform cosine `0.989162147` and log-mel cosine `0.999110937`.
+
+Default optimized Q8 versus the saved pre-change Q8 output measured waveform
+cosine `0.999996424` and log-mel cosine `0.999937057`. Optimized Q8 versus the
+current F32 output measured `0.999993563` and `0.999881983`, respectively.
+The explicit CPU fallback also completed successfully; with overlap 1 its
+output versus CUDA measured `0.999995887` waveform cosine and `0.999922335`
+log-mel cosine.
+
 ## Server and WebUI validation
 
 The CUDA server was built with:
@@ -93,9 +122,11 @@ An offline `sep` model entry pointing directly at
 }
 ```
 
-The request returned `vocals` and `instrumental` named audio outputs in
-3,032.1 ms including HTTP, lazy loading, base64 response serialization, and
-file decoding. Both returned WAV files were byte-identical to the CLI outputs.
+The optimized resident server returned `vocals` and `instrumental` named audio
+outputs with internal `session.wall_ms` values of 1,731.0 ms on the first
+request and 1,401.1 / 1,422.0 ms on the next two. Corresponding end-to-end HTTP
+times were 2,235.7 / 1,496.0 / 1,520.0 ms, including JSON and base64 response
+serialization. Both returned WAV files were byte-identical to the CLI outputs.
 
 The WebUI was launched with the CUDA backend, selected `bs-roformer` beside
 HTDemucs and Mel-Band RoFormer in the Source separation tab, uploaded the same

--- a/tests/bs_roformer/convert_reference_ckpt.py
+++ b/tests/bs_roformer/convert_reference_ckpt.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import torch
+import yaml
+from safetensors.torch import save_file
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Convert an audio-separator BS-RoFormer checkpoint for audio.cpp."
+    )
+    parser.add_argument("--ckpt", required=True)
+    parser.add_argument("--config-path", required=True)
+    parser.add_argument("--output-dir", required=True)
+    return parser.parse_args()
+
+
+def load_config(path: Path) -> dict[str, Any]:
+    payload = yaml.load(path.read_text(encoding="utf-8"), Loader=yaml.FullLoader)
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"invalid BS-RoFormer config payload: {path}")
+    return payload
+
+
+def export_config_json(config: dict[str, Any]) -> dict[str, Any]:
+    audio = dict(config["audio"])
+    model = dict(config["model"])
+    inference = dict(config["inference"])
+    return {
+        "model_type": "bs_roformer",
+        "sample_rate": int(audio["sample_rate"]),
+        "stereo": bool(model["stereo"]),
+        "chunk_size": int(audio["chunk_size"]),
+        "batch_size": int(inference.get("batch_size", 1)),
+        "num_overlap": int(inference["num_overlap"]),
+        "normalize": False,
+        "dim": int(model["dim"]),
+        "depth": int(model["depth"]),
+        "num_stems": int(model["num_stems"]),
+        "time_transformer_depth": int(model["time_transformer_depth"]),
+        "freq_transformer_depth": int(model["freq_transformer_depth"]),
+        "linear_transformer_depth": int(model.get("linear_transformer_depth", 0)),
+        "freqs_per_bands": [int(value) for value in model["freqs_per_bands"]],
+        "dim_head": int(model["dim_head"]),
+        "heads": int(model["heads"]),
+        "n_fft": int(model["stft_n_fft"]),
+        "hop_length": int(model["stft_hop_length"]),
+        "win_length": int(model["stft_win_length"]),
+        "stft_normalized": bool(model["stft_normalized"]),
+        "mask_estimator_depth": int(model["mask_estimator_depth"]),
+        "mlp_expansion_factor": int(model.get("mlp_expansion_factor", 4)),
+        "skip_connection": bool(model.get("skip_connection", False)),
+    }
+
+
+def extract_state(payload: Any) -> dict[str, torch.Tensor]:
+    if isinstance(payload, dict):
+        for key in ("state_dict", "model", "model_state_dict"):
+            nested = payload.get(key)
+            if isinstance(nested, dict) and nested:
+                payload = nested
+                break
+    if not isinstance(payload, dict) or not payload:
+        raise RuntimeError(f"unexpected checkpoint payload type: {type(payload)}")
+
+    converted: dict[str, torch.Tensor] = {}
+    for name, tensor in payload.items():
+        if not isinstance(tensor, torch.Tensor):
+            continue
+        if name.endswith(".rotary_embed.freqs"):
+            continue
+        converted[name] = tensor.detach().cpu().contiguous()
+    if not converted:
+        raise RuntimeError("checkpoint contains no tensors")
+    return converted
+
+
+def main() -> int:
+    args = parse_args()
+    ckpt_path = Path(args.ckpt).resolve()
+    config_path = Path(args.config_path).resolve()
+    output_dir = Path(args.output_dir).resolve()
+
+    payload = torch.load(
+        ckpt_path,
+        map_location=torch.device("cpu"),
+        weights_only=True,
+    )
+    state = extract_state(payload)
+    config = load_config(config_path)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    save_file(state, str(output_dir / "model.safetensors"))
+    (output_dir / "config.json").write_text(
+        json.dumps(export_config_json(config), indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    print(f"converted_ckpt={ckpt_path}")
+    print(f"output_dir={output_dir}")
+    print(f"tensor_count={len(state)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/bs_roformer/run_python_reference.py
+++ b/tests/bs_roformer/run_python_reference.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+import soundfile as sf
+import torch
+import yaml
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run the audio-separator BS-RoFormer Python reference."
+    )
+    parser.add_argument("--audio-separator-root", required=True)
+    parser.add_argument("--ckpt", required=True)
+    parser.add_argument("--config-path", required=True)
+    parser.add_argument("--audio", required=True)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--device", default="cuda")
+    parser.add_argument(
+        "--no-flash-attn",
+        action="store_true",
+        help="Use the reference's explicit matmul/softmax attention path.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    separator_root = Path(args.audio_separator_root).resolve()
+    sys.path.insert(0, str(separator_root))
+
+    from audio_separator.separator.uvr_lib_v5.roformer.bs_roformer import BSRoformer
+
+    config = yaml.load(
+        Path(args.config_path).read_text(encoding="utf-8"),
+        Loader=yaml.FullLoader,
+    )
+    model_config = dict(config["model"])
+    if args.no_flash_attn:
+        model_config["flash_attn"] = False
+    model = BSRoformer(**model_config)
+    state = torch.load(
+        Path(args.ckpt),
+        map_location=torch.device("cpu"),
+        weights_only=True,
+    )
+    model.load_state_dict(state, strict=True)
+    device = torch.device(args.device)
+    model.to(device).eval()
+
+    audio, sample_rate = sf.read(args.audio, dtype="float32", always_2d=True)
+    expected_rate = int(config["audio"]["sample_rate"])
+    if sample_rate != expected_rate:
+        raise RuntimeError(f"sample-rate mismatch: expected {expected_rate}, got {sample_rate}")
+    expected_channels = 2 if bool(config["model"]["stereo"]) else 1
+    if audio.shape[1] != expected_channels:
+        raise RuntimeError(
+            f"channel mismatch: expected {expected_channels}, got {audio.shape[1]}"
+        )
+
+    tensor = torch.from_numpy(audio.T.copy()).unsqueeze(0).to(device)
+    with torch.inference_mode():
+        separated = model(tensor)[0].detach().cpu().numpy().T
+
+    output_path = Path(args.out).resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    sf.write(output_path, separated, sample_rate, subtype="FLOAT")
+    print(f"audio_out={output_path}")
+    print(f"frames={separated.shape[0]}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/webui/README.md
+++ b/webui/README.md
@@ -247,6 +247,7 @@ and a reference voice longer than ~10s is auto-truncated (an 8G VRAM limit).
 - **Audio analysis (VAD/separation/alignment):** WAV input is auto-converted to 16 kHz mono before going to the model,
   and result timelines are computed at 16 kHz. Qwen3 forced alignment caps a single audio at ~115 seconds.
 - **Source separation:** HTDemucs outputs four tracks — drums/bass/other/vocals (long audio takes a while);
+  BS-RoFormer outputs vocals + accompaniment;
   Mel-Band RoFormer outputs a vocals track + an accompaniment track (mixture − vocals).
 - **IndexTTS2** (new in 0.3): Chinese/English voice cloning; a reference voice is **required**. Emotion control is in the
   advanced parameters: `emotion_text` holds an emotion description (setting it auto-enables `use_emotion_text`) +

--- a/webui/README.zh.md
+++ b/webui/README.zh.md
@@ -214,7 +214,7 @@ singing 路线默认开，style_converted_vc / editing 默认关。
 - **音频分析（VAD/分离/对齐）**：WAV 输入自动转 16 kHz 单声道后送模型，结果时间轴按 16 kHz 换算。
   Qwen3 强制对齐单次音频上限约 115 秒。
 - **音源分离**：HTDemucs 输出 drums/bass/other/vocals 四轨（长音频耗时较长）；
-  Mel-Band RoFormer 输出人声轨 + 伴奏轨（mixture − vocals）。
+  BS-RoFormer 和 Mel-Band RoFormer 输出人声轨 + 伴奏轨（mixture − vocals）。
 - **IndexTTS2**（0.3 新增）：中/英声音克隆，**必须**提供参考音色。情感控制在高级参数：
   `emotion_text` 填情感描述（填了会自动开启 `use_emotion_text`）+ `emotion_alpha` 调强度；
   或勾 `use_emotion_text` 从朗读文本自动推断；`emotion_vector`（8 个浮点）走 JSON 兜底框。

--- a/webui/configs/models_catalog.json
+++ b/webui/configs/models_catalog.json
@@ -71,6 +71,7 @@
     { "id": "miocodec",               "display_name": "MioCodec (vc; codec dependency)",       "family": "miocodec",             "path": "models/MioCodec-25Hz-44.1kHz-v2",        "task": "vc",    "mode": "offline", "download_id": "miocodec_25hz_44k_v2",    "min_vram_gb": 3 },
 
     { "id": "htdemucs",               "display_name": "HTDemucs (sep 音源分离)",                "family": "htdemucs",             "path": "models/htdemucs",                        "task": "sep",   "mode": "offline", "download_id": "htdemucs",                "min_vram_gb": 3 },
+    { "id": "bs-roformer",             "display_name": "BS-RoFormer (sep 人声分离)",             "family": "bs_roformer",           "path": "models/BS-RoFormer-ep368_Q8/BS-RoFormer-ep368_Q8.gguf", "task": "sep", "mode": "offline",                                      "min_vram_gb": 3 },
     { "id": "mel-band-roformer",      "display_name": "Mel-Band RoFormer (sep 人声分离)",       "family": "mel_band_roformer",    "path": "models/mel-roformer-mlx",                "task": "sep",   "mode": "offline", "download_id": "mel_band_roformer",       "min_vram_gb": 3 },
 
     { "id": "silero-vad",             "display_name": "Silero VAD (vad, bundled)",             "family": "silero_vad",           "path": "assets/framework/models/silero_vad",     "task": "vad",   "mode": "offline", "min_vram_gb": 1 },

--- a/webui/configs/required_files.json
+++ b/webui/configs/required_files.json
@@ -370,6 +370,10 @@
     "config.json",
     "model.safetensors"
   ],
+  "bs_roformer": [
+    "config.json",
+    "model.safetensors"
+  ],
   "vevo2": [
     "acoustic_modeling/fm_emilia101k_singnet7k_repa/config.json",
     "acoustic_modeling/fm_emilia101k_singnet7k_repa/model.safetensors",

--- a/webui/webui.py
+++ b/webui/webui.py
@@ -628,6 +628,9 @@ MODEL_PROFILES = {
     "mel_band_roformer": {
         "input_hint": "**Mel-Band RoFormer**：输出人声轨 + 伴奏轨。",
     },
+    "bs_roformer": {
+        "input_hint": "**BS-RoFormer**：输出人声轨 + 伴奏轨。",
+    },
     "nemotron_asr": {
         "input_hint": ("**Nemotron ASR**：100+ 语种；支持⚡流式转写"
                        "（勾选后边转边出字，长音频不用干等）。"),
@@ -720,6 +723,7 @@ MODEL_HINTS_EN = {
     "miocodec": "**MioCodec** reconstructs source content with the reference voice.",
     "htdemucs": "**HTDemucs** outputs drums, bass, other and vocals.",
     "mel_band_roformer": "**Mel-Band RoFormer** outputs vocals and accompaniment.",
+    "bs_roformer": "**BS-RoFormer** outputs vocals and accompaniment.",
     "nemotron_asr": "**Nemotron ASR** supports 100+ languages and streaming transcription.",
     "higgs_audio_stt": "**Higgs Audio STT** supports streaming transcription.",
     "vibevoice_asr": "**VibeVoice-ASR** uses offline transcription with automatic language and speaker segmentation.",
@@ -4499,9 +4503,6 @@ with gr.Blocks(title="audio.cpp WebUI") as demo:
 
         _wire_model_manager(sep_mm, SEP_TASKS, sep_hint)
         sep_btn.click(
-            lambda: (*(gr.update(value=None, visible=False)
-                       for _ in range(MAX_SEP_STEMS)), None, ""),
-            None, [*sep_stems, sep_files, sep_msg]).then(
             do_sep, [sep_model, sep_audio], [*sep_stems, sep_files, sep_msg])
 
     # ---------------- 音频分析 (vad / diar / align) ----------------


### PR DESCRIPTION
## Summary

Model  BS_roformer
https://github.com/lucidrains/BS-RoFormer

Adds native BS-RoFormer vocal source separation beside the existing
`htdemucs` and `mel_band_roformer` families. ( in my opinion BS-RoFormer  is doing the best work to separate a voice  from my experience ) 

The tested checkpoint is Viperx
`model_bs_roformer_ep_368_sdr_12.9628.ckpt`. It follows the Band-Split
RoFormer architecture from ByteDance AI Labs as implemented by
`lucidrains/BS-RoFormer`; `audio-separator` was used as the executable Python
parity reference.

## Implementation

- registers a new `bs_roformer` offline `sep` family immediately beside
  HTDemucs and Mel-Band RoFormer in the framework registry
- reuses the shared RoFormer STFT/ISTFT, chunking, attention, and transformer
  infrastructure while adding BS-specific:
  - explicit non-overlapping `freqs_per_bands`
  - fused QKV projection
  - checkpoint-compatible transformer/final RMSNorm placement
  - arbitrary mask-estimator depth
- returns named `vocals` and `instrumental` stems; instrumental is derived as
  mixture minus vocals
- adds package-spec loading for converted SafeTensors and standalone GGUF
- embeds the package spec and `config.json` in a standalone GGUF
- adds checkpoint conversion and Python reference helpers under
  `tests/bs_roformer`
- adds BS-RoFormer to the WebUI Source separation model list directly between
  HTDemucs and Mel-Band RoFormer
- points the WebUI catalog at the standalone named GGUF file and wires the
  visible Separate action directly to the separation handler, avoiding a
  stalled two-stage Gradio callback chain
- updates the main model table, audio-tools guide, GGUF status table, and
  English/Chinese WebUI documentation

## Reproduction

### Reference checkpoint conversion

```powershell
python tests\bs_roformer\convert_reference_ckpt.py `
  --ckpt model_bs_roformer_ep_368_sdr_12.9628.ckpt `
  --config-path model_bs_roformer_ep_368_sdr_12.9628.yaml `
  --output-dir models\BS-RoFormer-ep368
```

### Q8 GGUF conversion

```powershell
build\windows-cuda-release\bin\audiocpp_gguf.exe `
  --input models\BS-RoFormer-ep368\model.safetensors `
  --output models\BS-RoFormer-ep368_Q8\BS-RoFormer-ep368_Q8.gguf `
  --type q8_0 `
  --family bs_roformer `
  --model-spec model_specs\bs_roformer.json `
  --root models\BS-RoFormer-ep368
```

Generated local artifacts:

- `models\BS-RoFormer-ep368\model.safetensors`: 639,103,376 bytes
- `models\BS-RoFormer-ep368_Q8\BS-RoFormer-ep368_Q8.gguf`: 172,532,256 bytes
- CLI/server/WebUI outputs: `vocals.wav` and `instrumental.wav`

### Windows CUDA build

```powershell
$cuda = "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.4"
$env:CMAKE_CUDA_COMPILER = "$cuda\bin\nvcc.exe"
$env:CUDACXX = $env:CMAKE_CUDA_COMPILER
$env:CUDA_PATH = $cuda
$env:CUDAToolkit_ROOT = $cuda
$env:NVCC_PREPEND_FLAGS = "-allow-unsupported-compiler"
.\scripts\build_windows.ps1 -Target audiocpp_cli -Jobs 16
.\scripts\build_windows.ps1 -Target audiocpp_server -Jobs 16
```

### CLI

```powershell
build\windows-cuda-release\bin\audiocpp_cli.exe `
  --task sep `
  --model models\BS-RoFormer-ep368_Q8\BS-RoFormer-ep368_Q8.gguf `
  --backend cuda `
  --audio input_8s.wav `
  --out-dir outputs\bs-roformer-q8
```

The converted SafeTensors package was also tested:

```powershell
build\windows-cuda-release\bin\audiocpp_cli.exe `
  --task sep `
  --family bs_roformer `
  --model models\BS-RoFormer-ep368 `
  --backend cuda `
  --audio input_8s.wav `
  --out-dir outputs\bs-roformer-f32
```

### Server

The server was started with a CUDA/offline `sep` model entry whose path was
`models\BS-RoFormer-ep368_Q8\BS-RoFormer-ep368_Q8.gguf`, then exercised with:

```json
{
  "model": "bs-roformer-q8",
  "request": {
    "audio": "E:\\path\\to\\input_8s.wav"
  }
}
```

against `POST /v1/tasks/run`. It returned both named stems. Their SHA-256
hashes were exactly equal to the CLI-generated WAVs.

### WebUI

```powershell
$env:AUDIOCPP_BUNDLE = $PWD
$env:AUDIOCPP_BACKEND = "gpu"
venv\Scripts\python.exe webui\webui.py
```

The browser test selected **Source separation → bs-roformer**, uploaded the
same 8-second WAV, and used the visible **Separate** action. The WebUI-managed
server loaded the standalone GGUF and displayed two playable/downloadable
tracks. A full-page result screenshot was retained locally as
`outputs\bs_roformer_webui_test.png`.

## Parity and performance

Test system:

- Windows, CUDA 12.4
- NVIDIA GeForce RTX 3090, 24 GB
- stereo 44.1 kHz inputs

### 20-second test

| Comparison | Waveform cosine |
|---|---:|
| audio.cpp Q8 vs audio.cpp F32 | 0.999985368 |
| audio.cpp F32 vs audio-separator Python | 0.996474981 |
| audio.cpp Q8 vs audio-separator Python | 0.996387362 |

### Exact-frame 8-second test

Both paths produced exactly 352,800 frames.

| Comparison/metric | Result |
|---|---:|
| Q8 vs F32 waveform cosine | **0.999994784** |
| Q8 vs F32 log-mel cosine | **0.999898629** |
| Q8 vs F32 mean absolute sample error | 0.0002294 |
| Q8 vs F32 maximum absolute sample error | 0.0044556 |
| F32 vs Python waveform cosine | 0.989149342 |
| F32 vs Python log-mel cosine | 0.998817655 |

The Q8 result is therefore numerically and perceptually nearly identical to
the native F32 result for the tested checkpoint while reducing the weight
file to about 27% of its original size.

The lower short-input Python waveform cosine comes from the different
edge/chunk-overlap policy of the complete `audio-separator` inference path;
the exact frame count and high log-mel similarity provide the more useful
parity evidence for this test.

### Request timings

| Path | Input | Result |
|---|---:|---:|
| Native server HTTP, including lazy load/base64/file decode | 8.0 s | 3,032.1 ms |
| WebUI visible action (`session.wall_ms`) | 8.0 s | 2,676.2 ms |
| WebUI reported end-to-end separation | 8.0 s | 2.7 s |
| WebUI standalone-GGUF model load | — | 0.5 s |

RSS and peak VRAM were not instrumented for this run.

## Known limitations

- The validated checkpoint is a one-target vocals model. It produces vocals
  directly and derives instrumental from the mixture.
- Native CLI/server input is WAV; this checkpoint expects 44.1 kHz audio.
  The WebUI normalizes supported uploads before sending them to the server.
- CUDA on RTX 3090 is the validated backend. CPU, Vulkan, and Metal were not
  performance-tested in this contribution.
- Other BS-RoFormer checkpoints may use additional architectural variants and
  should be parity-tested before being declared compatible.


The GGUF model is here

https://huggingface.co/mirek190/audio.cpp/tree/main/vocal%20separation%20models
