### PR TITLE
Stream live audio input from stdin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -657,6 +657,7 @@ add_executable(audiocpp_cli
     app/cli/args.cpp
     app/cli/batch.cpp
     app/cli/request.cpp
+    app/streaming/pcm_source.cpp
     app/streaming/streaming.cpp
     app/workflow/execution.cpp
     app/workflow/file_sink.cpp
@@ -968,6 +969,19 @@ if (ENGINE_BUILD_TESTS)
     add_test(
         NAME backend_device_resolution_test
         COMMAND backend_device_resolution_test
+    )
+
+    add_executable(streaming_audio_input_test
+        tests/unittests/test_streaming_audio_input.cpp
+        app/streaming/pcm_source.cpp
+        app/streaming/streaming.cpp
+    )
+    target_link_libraries(streaming_audio_input_test PRIVATE engine_runtime ggml)
+    target_include_directories(streaming_audio_input_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests/unittests)
+
+    add_test(
+        NAME streaming_audio_input_test
+        COMMAND streaming_audio_input_test
     )
 
     add_engine_unittest(hf_sampler_test tests/unittests/test_hf_sampler.cpp)

--- a/app/cli/main.cpp
+++ b/app/cli/main.cpp
@@ -1,6 +1,7 @@
 #include "args.h"
 #include "batch.h"
 #include "request.h"
+#include "../streaming/pcm_source.h"
 #include "../streaming/streaming.h"
 #include "../workflow/execution.h"
 #include "../workflow/file_sink.h"
@@ -113,7 +114,10 @@ void print_task_list_help() {
         << "    --text-chunk-size <chars>\n"
         << "    --text-chunk-mode default|tag_aware|japanese|endline\n"
         << "  Inputs:\n"
-        << "    --audio <wav>\n"
+        << "    --audio <wav>  Use - to stream raw PCM from stdin (requires --mode streaming)\n"
+        << "    --input-format s16le|f32le  Raw PCM sample format for --audio -, default s16le\n"
+        << "    --input-rate <hz>  Raw PCM sample rate for --audio -, default 16000\n"
+        << "    --input-channels <n>  Raw PCM channel count for --audio -, default 1\n"
         << "    --text <text>\n"
         << "    --max-text-length <chars>  Maximum input text length for models that enforce it\n"
         << "    --language <code>\n"
@@ -452,6 +456,39 @@ void write_vad_chunks_output(
     std::cout << "vad_chunks_out=" << path.string() << "\n";
 }
 
+bool stream_audio_from_stdin(int argc, char ** argv) {
+    const auto audio = minitts::cli::find_arg(argc, argv, "--audio");
+    return audio.has_value() && minitts::cli::is_stdin_audio_source(*audio);
+}
+
+// Feeds raw PCM from stdin into the session chunk by chunk, so nothing has to be buffered up
+// front and transcription tracks the input as it arrives.
+engine::runtime::TaskResult run_streaming_from_stdin(
+    int argc,
+    char ** argv,
+    engine::runtime::IStreamingVoiceTaskSession & streaming,
+    const engine::runtime::TaskRequest & request,
+    const minitts::app::StreamEventSink & sink) {
+    // build_request_from_cli fills audio_input with the declared format and no samples, which is
+    // also what prepare() consumes as its audio contract.
+    if (!request.audio_input.has_value()) {
+        throw std::runtime_error("streaming from stdin requires an audio format contract");
+    }
+    const auto sample_format = minitts::app::parse_pcm_sample_format(
+        minitts::cli::find_arg(argc, argv, "--input-format").value_or("s16le"));
+    const minitts::app::AudioStreamFormat format{
+        request.audio_input->sample_rate,
+        request.audio_input->channels,
+    };
+    // A headerless stream cannot be checked against a header, so report how it was interpreted.
+    std::cout << "audio_input=stdin format=" << minitts::app::to_string(sample_format)
+              << " rate=" << format.sample_rate
+              << " channels=" << format.channels << "\n"
+              << std::flush;
+    const auto stream = minitts::app::make_stdin_pcm_stream(format, sample_format);
+    return minitts::app::run_streaming_task(streaming, request, sink, stream);
+}
+
 void run_streaming(
     int argc,
     char ** argv,
@@ -459,12 +496,12 @@ void run_streaming(
     engine::runtime::IVoiceTaskSession & session,
     engine::runtime::TaskRequest & request) {
     const auto out_dir = minitts::cli::optional_path_arg(argc, argv, "--out-dir");
-    const auto result = minitts::app::run_streaming_task(
-        streaming,
-        request,
+    const minitts::app::StreamEventSink sink =
         [&](const engine::runtime::StreamEvent & event) {
             if (event.partial_text.has_value()) {
-                std::cout << "partial_text=" << event.partial_text->text << "\n";
+                // Flushed so a live source's partials appear as they are produced rather than
+                // when the stdio buffer happens to fill.
+                std::cout << "partial_text=" << event.partial_text->text << "\n" << std::flush;
             }
             engine::runtime::TaskResult event_result;
             event_result.audio_output = event.audio_output;
@@ -495,7 +532,11 @@ void run_streaming(
                 }
                 std::cout << " sample=" << activity.sample << " probability=" << activity.probability << "\n";
             }
-        });
+        };
+
+    const auto result = stream_audio_from_stdin(argc, argv)
+        ? run_streaming_from_stdin(argc, argv, streaming, request, sink)
+        : minitts::app::run_streaming_task(streaming, request, sink);
     std::cout << "family=" << session.family() << "\n";
     std::cout << "task=" << engine::runtime::to_string(session.task_kind()) << "\n";
     std::cout << "mode=" << engine::runtime::to_string(session.run_mode()) << "\n";
@@ -705,6 +746,9 @@ int audiocpp_cli_main(int argc, char ** argv) {
             engine::runtime::parse_voice_task_kind(*task_name),
             engine::runtime::parse_run_mode(mode_name),
         };
+        if (stream_audio_from_stdin(argc, argv) && task_spec.mode != engine::runtime::RunMode::Streaming) {
+            throw std::runtime_error("--audio - reads live PCM and requires --mode streaming");
+        }
 
         engine::runtime::SessionOptions session_options;
         session_options.backend.type = parse_backend(find_arg(argc, argv, "--backend").value_or("cpu"));

--- a/app/cli/request.cpp
+++ b/app/cli/request.cpp
@@ -35,6 +35,10 @@ void set_option_from_json_field(
 
 }  // namespace
 
+bool is_stdin_audio_source(std::string_view audio_arg) {
+    return audio_arg == "-";
+}
+
 engine::runtime::AudioBuffer read_audio_buffer(const std::filesystem::path & path) {
     const auto wav = engine::audio::read_wav_f32(path);
     return engine::runtime::AudioBuffer{
@@ -259,7 +263,17 @@ engine::runtime::TaskRequest build_request_from_cli(int argc, char ** argv) {
         request.text_input = engine::runtime::Transcript{*text, language};
     }
     if (const auto audio_path = find_arg(argc, argv, "--audio")) {
-        request.audio_input = read_audio_buffer(std::filesystem::path(*audio_path));
+        if (is_stdin_audio_source(*audio_path)) {
+            // Live PCM arrives chunk by chunk, so only the format contract is known up front.
+            // The samples stay empty; the streaming driver pulls them from stdin instead.
+            request.audio_input = engine::runtime::AudioBuffer{
+                parse_int_arg(argc, argv, "--input-rate", 16000),
+                parse_int_arg(argc, argv, "--input-channels", 1),
+                {},
+            };
+        } else {
+            request.audio_input = read_audio_buffer(std::filesystem::path(*audio_path));
+        }
     }
     engine::runtime::VoiceCondition voice;
     bool has_voice = false;

--- a/app/cli/request.h
+++ b/app/cli/request.h
@@ -11,6 +11,8 @@
 
 namespace minitts::cli {
 
+// True when --audio selects raw PCM on stdin ("-") rather than a file path.
+bool is_stdin_audio_source(std::string_view audio_arg);
 engine::runtime::AudioBuffer read_audio_buffer(const std::filesystem::path & path);
 engine::runtime::AudioBuffer read_audio_buffer(std::istream & path);
 engine::runtime::AudioBuffer read_audio_buffer(std::string_view input);

--- a/app/streaming/pcm_source.cpp
+++ b/app/streaming/pcm_source.cpp
@@ -71,10 +71,11 @@ AudioChunkStream make_pcm_chunk_stream(
 
     const int sample_bytes = pcm_sample_format_bytes(sample_format);
     const size_t frame_bytes = static_cast<size_t>(sample_bytes) * static_cast<size_t>(format.channels);
+    const auto decode = sample_format == PcmSampleFormat::S16LE ? &decode_s16le : &decode_f32le;
 
     AudioChunkStream stream;
     stream.format = format;
-    stream.read = [source = &input, sample_format, sample_bytes, frame_bytes, bytes = std::vector<char>{}](
+    stream.read = [source = &input, decode, sample_bytes, frame_bytes, bytes = std::vector<char>{}](
         int64_t max_samples, std::vector<float> & samples) mutable {
         if (max_samples <= 0) {
             throw std::runtime_error("raw PCM read requires a positive sample count");
@@ -90,9 +91,7 @@ AudioChunkStream make_pcm_chunk_stream(
         samples.resize(count);
         const auto * raw = reinterpret_cast<const unsigned char *>(bytes.data());
         for (size_t i = 0; i < count; ++i) {
-            samples[i] = sample_format == PcmSampleFormat::S16LE
-                ? decode_s16le(raw + i * static_cast<size_t>(sample_bytes))
-                : decode_f32le(raw + i * static_cast<size_t>(sample_bytes));
+            samples[i] = decode(raw + i * static_cast<size_t>(sample_bytes));
         }
         return received == bytes.size();
     };

--- a/app/streaming/pcm_source.cpp
+++ b/app/streaming/pcm_source.cpp
@@ -1,0 +1,106 @@
+#include "pcm_source.h"
+
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <stdexcept>
+#include <vector>
+
+#ifdef _WIN32
+#include <fcntl.h>
+#include <io.h>
+#include <cstdio>
+#endif
+
+namespace minitts::app {
+namespace {
+
+// Decoded little-endian so a stream produced on one machine reads back the same on any host.
+float decode_s16le(const unsigned char * bytes) {
+    const auto raw = static_cast<uint16_t>(
+        static_cast<uint16_t>(bytes[0]) | (static_cast<uint16_t>(bytes[1]) << 8));
+    // Matches the scaling engine::audio::read_wav_f32 applies, so raw PCM and WAV input of the
+    // same audio decode to identical samples.
+    return static_cast<float>(static_cast<int16_t>(raw)) / 32768.0F;
+}
+
+float decode_f32le(const unsigned char * bytes) {
+    const auto raw = static_cast<uint32_t>(
+        static_cast<uint32_t>(bytes[0]) |
+        (static_cast<uint32_t>(bytes[1]) << 8) |
+        (static_cast<uint32_t>(bytes[2]) << 16) |
+        (static_cast<uint32_t>(bytes[3]) << 24));
+    float value = 0.0F;
+    std::memcpy(&value, &raw, sizeof(value));
+    return value;
+}
+
+}  // namespace
+
+PcmSampleFormat parse_pcm_sample_format(std::string_view name) {
+    if (name == "s16le") return PcmSampleFormat::S16LE;
+    if (name == "f32le") return PcmSampleFormat::F32LE;
+    throw std::runtime_error(
+        "unsupported raw PCM sample format '" + std::string(name) + "' (expected s16le or f32le)");
+}
+
+std::string to_string(PcmSampleFormat format) {
+    return format == PcmSampleFormat::S16LE ? "s16le" : "f32le";
+}
+
+int pcm_sample_format_bytes(PcmSampleFormat format) {
+    return format == PcmSampleFormat::S16LE ? 2 : 4;
+}
+
+AudioChunkStream make_pcm_chunk_stream(
+    std::istream & input,
+    AudioStreamFormat format,
+    PcmSampleFormat sample_format) {
+    if (format.sample_rate <= 0 || format.channels <= 0) {
+        throw std::runtime_error("raw PCM input requires a positive sample rate and channel count");
+    }
+
+    const int sample_bytes = pcm_sample_format_bytes(sample_format);
+    const size_t frame_bytes = static_cast<size_t>(sample_bytes) * static_cast<size_t>(format.channels);
+
+    AudioChunkStream stream;
+    stream.format = format;
+    stream.read = [source = &input, sample_format, sample_bytes, frame_bytes, bytes = std::vector<char>{}](
+        int64_t max_samples, std::vector<float> & samples) mutable {
+        if (max_samples <= 0) {
+            throw std::runtime_error("raw PCM read requires a positive sample count");
+        }
+        bytes.resize(static_cast<size_t>(max_samples) * static_cast<size_t>(sample_bytes));
+        source->read(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+        const auto received = static_cast<size_t>(source->gcount());
+
+        // A short read means end of input; drop a trailing partial frame, which cannot be
+        // interpreted, so the chunk always holds whole frames.
+        const size_t usable = (received / frame_bytes) * frame_bytes;
+        const size_t count = usable / static_cast<size_t>(sample_bytes);
+        samples.resize(count);
+        const auto * raw = reinterpret_cast<const unsigned char *>(bytes.data());
+        for (size_t i = 0; i < count; ++i) {
+            samples[i] = sample_format == PcmSampleFormat::S16LE
+                ? decode_s16le(raw + i * static_cast<size_t>(sample_bytes))
+                : decode_f32le(raw + i * static_cast<size_t>(sample_bytes));
+        }
+        return received == bytes.size();
+    };
+    return stream;
+}
+
+void set_stdin_binary_mode() {
+#ifdef _WIN32
+    if (_setmode(_fileno(stdin), _O_BINARY) == -1) {
+        throw std::runtime_error("failed to switch stdin to binary mode");
+    }
+#endif
+}
+
+AudioChunkStream make_stdin_pcm_stream(AudioStreamFormat format, PcmSampleFormat sample_format) {
+    set_stdin_binary_mode();
+    return make_pcm_chunk_stream(std::cin, format, sample_format);
+}
+
+}  // namespace minitts::app

--- a/app/streaming/pcm_source.cpp
+++ b/app/streaming/pcm_source.cpp
@@ -35,6 +35,19 @@ float decode_f32le(const unsigned char * bytes) {
     return value;
 }
 
+int pcm_sample_format_bytes(PcmSampleFormat format) {
+    return format == PcmSampleFormat::S16LE ? 2 : 4;
+}
+
+// Required on Windows, where stdin's default text mode mangles PCM bytes; a no-op elsewhere.
+void set_stdin_binary_mode() {
+#ifdef _WIN32
+    if (_setmode(_fileno(stdin), _O_BINARY) == -1) {
+        throw std::runtime_error("failed to switch stdin to binary mode");
+    }
+#endif
+}
+
 }  // namespace
 
 PcmSampleFormat parse_pcm_sample_format(std::string_view name) {
@@ -46,10 +59,6 @@ PcmSampleFormat parse_pcm_sample_format(std::string_view name) {
 
 std::string to_string(PcmSampleFormat format) {
     return format == PcmSampleFormat::S16LE ? "s16le" : "f32le";
-}
-
-int pcm_sample_format_bytes(PcmSampleFormat format) {
-    return format == PcmSampleFormat::S16LE ? 2 : 4;
 }
 
 AudioChunkStream make_pcm_chunk_stream(
@@ -88,14 +97,6 @@ AudioChunkStream make_pcm_chunk_stream(
         return received == bytes.size();
     };
     return stream;
-}
-
-void set_stdin_binary_mode() {
-#ifdef _WIN32
-    if (_setmode(_fileno(stdin), _O_BINARY) == -1) {
-        throw std::runtime_error("failed to switch stdin to binary mode");
-    }
-#endif
 }
 
 AudioChunkStream make_stdin_pcm_stream(AudioStreamFormat format, PcmSampleFormat sample_format) {

--- a/app/streaming/pcm_source.h
+++ b/app/streaming/pcm_source.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "streaming.h"
+
+#include <istream>
+#include <string>
+#include <string_view>
+
+namespace minitts::app {
+
+// Sample encodings accepted for raw (headerless) PCM input.
+enum class PcmSampleFormat {
+    S16LE,
+    F32LE,
+};
+
+PcmSampleFormat parse_pcm_sample_format(std::string_view name);
+std::string to_string(PcmSampleFormat format);
+int pcm_sample_format_bytes(PcmSampleFormat format);
+
+// Streams raw interleaved PCM from `input` without buffering the whole stream. Blocks until a
+// full block is available, a short block can be completed at end of input, or the stream ends.
+// `input` must outlive the returned stream.
+AudioChunkStream make_pcm_chunk_stream(
+    std::istream & input,
+    AudioStreamFormat format,
+    PcmSampleFormat sample_format);
+
+// Puts the process stdin handle into binary mode. Required on Windows, where the default text
+// mode mangles PCM bytes; a no-op elsewhere.
+void set_stdin_binary_mode();
+
+// Streams raw interleaved PCM from process stdin, switching the handle to binary mode first.
+AudioChunkStream make_stdin_pcm_stream(AudioStreamFormat format, PcmSampleFormat sample_format);
+
+}  // namespace minitts::app

--- a/app/streaming/pcm_source.h
+++ b/app/streaming/pcm_source.h
@@ -16,7 +16,6 @@ enum class PcmSampleFormat {
 
 PcmSampleFormat parse_pcm_sample_format(std::string_view name);
 std::string to_string(PcmSampleFormat format);
-int pcm_sample_format_bytes(PcmSampleFormat format);
 
 // Streams raw interleaved PCM from `input` without buffering the whole stream. Blocks until a
 // full block is available, a short block can be completed at end of input, or the stream ends.
@@ -26,11 +25,8 @@ AudioChunkStream make_pcm_chunk_stream(
     AudioStreamFormat format,
     PcmSampleFormat sample_format);
 
-// Puts the process stdin handle into binary mode. Required on Windows, where the default text
-// mode mangles PCM bytes; a no-op elsewhere.
-void set_stdin_binary_mode();
-
-// Streams raw interleaved PCM from process stdin, switching the handle to binary mode first.
+// Streams raw interleaved PCM from process stdin, switching the handle to binary mode first
+// (required on Windows, where the default text mode mangles PCM bytes).
 AudioChunkStream make_stdin_pcm_stream(AudioStreamFormat format, PcmSampleFormat sample_format);
 
 }  // namespace minitts::app

--- a/app/streaming/streaming.cpp
+++ b/app/streaming/streaming.cpp
@@ -81,6 +81,11 @@ void feed_audio_stream(
 // Replays an already materialized buffer through the same path a live source takes, so the two
 // input routes cannot drift apart. `audio` must outlive the returned stream.
 AudioChunkStream buffer_audio_stream(const engine::runtime::AudioBuffer & audio) {
+    // The whole length is known here, unlike a live source, so reject a malformed buffer before
+    // the session is touched rather than partway through it on the final short chunk.
+    if (audio.channels <= 0 || audio.samples.size() % static_cast<size_t>(audio.channels) != 0) {
+        throw std::runtime_error("streaming audio input sample count must be divisible by channels");
+    }
     AudioChunkStream stream;
     stream.format = AudioStreamFormat{audio.sample_rate, audio.channels};
     stream.read = [source = &audio, offset = size_t{0}](
@@ -119,7 +124,9 @@ engine::runtime::TaskResult run_stream(
         session.start_stream(request);
         if (policy.input == engine::runtime::StreamingInputKind::AudioChunks) {
             if (stream == nullptr) {
-                throw std::runtime_error("streaming audio input mode requires audio_input");
+                throw std::runtime_error(
+                    "streaming audio input mode requires samples in audio_input, or an "
+                    "AudioChunkStream for a live source");
             }
             feed_audio_stream(session, *stream, resolve_chunk_samples(policy, stream->format), sink);
         }
@@ -141,7 +148,10 @@ engine::runtime::TaskResult run_streaming_task(
     engine::runtime::IStreamingVoiceTaskSession & session,
     const engine::runtime::TaskRequest & request,
     const StreamEventSink & sink) {
-    if (!request.audio_input.has_value()) {
+    // A live source carries its format in audio_input but no samples, and must be supplied as an
+    // AudioChunkStream instead. Treating that as an empty buffer here would feed the session
+    // nothing and fail much later, so leave it to the null-stream check in run_stream.
+    if (!request.audio_input.has_value() || request.audio_input->samples.empty()) {
         return run_stream(session, request, sink, nullptr);
     }
     const auto stream = buffer_audio_stream(*request.audio_input);

--- a/app/streaming/streaming.cpp
+++ b/app/streaming/streaming.cpp
@@ -26,43 +26,74 @@ void emit_if_nonempty(const engine::runtime::StreamEvent & event, const StreamEv
     }
 }
 
-void feed_audio_chunks(
+int64_t resolve_chunk_samples(
+    const engine::runtime::StreamingPolicy & policy,
+    const AudioStreamFormat & format) {
+    if (policy.preferred_audio_chunk_seconds > 0.0) {
+        return static_cast<int64_t>(std::llround(
+            policy.preferred_audio_chunk_seconds * static_cast<double>(format.sample_rate))) *
+            static_cast<int64_t>(format.channels);
+    }
+    return policy.preferred_audio_chunk_samples;
+}
+
+void feed_audio_stream(
     engine::runtime::IStreamingVoiceTaskSession & session,
-    const engine::runtime::TaskRequest & request,
+    const AudioChunkStream & stream,
     int64_t chunk_samples,
     const StreamEventSink & sink) {
-    if (!request.audio_input.has_value()) {
-        throw std::runtime_error("streaming audio input mode requires audio_input");
-    }
     if (chunk_samples <= 0) {
         throw std::runtime_error("streaming audio chunk size must be positive");
     }
-    const auto & audio = *request.audio_input;
-    if (audio.sample_rate <= 0 || audio.channels <= 0) {
+    if (stream.format.sample_rate <= 0 || stream.format.channels <= 0) {
         throw std::runtime_error("streaming audio input requires positive sample rate and channels");
     }
-    if (audio.samples.size() % static_cast<size_t>(audio.channels) != 0) {
-        throw std::runtime_error("streaming audio input sample count must be divisible by channels");
+    if (!stream.read) {
+        throw std::runtime_error("streaming audio input requires a chunk reader");
     }
 
-    const size_t step = static_cast<size_t>(chunk_samples);
-    for (size_t offset = 0; offset < audio.samples.size(); offset += step) {
-        const size_t available = std::min(step, audio.samples.size() - offset);
-        std::vector<float> samples;
-        samples.reserve(available);
-        samples.insert(
-            samples.end(),
-            audio.samples.begin() + static_cast<std::ptrdiff_t>(offset),
-            audio.samples.begin() + static_cast<std::ptrdiff_t>(offset + available));
-        emit_if_nonempty(
-            session.process_audio_chunk({
-                audio.sample_rate,
-                audio.channels,
-                static_cast<int64_t>(offset),
-                std::move(samples),
-            }),
-            sink);
+    int64_t start_sample = 0;
+    std::vector<float> samples;
+    while (true) {
+        samples.clear();
+        const bool has_more = stream.read(chunk_samples, samples);
+        if (samples.size() % static_cast<size_t>(stream.format.channels) != 0) {
+            throw std::runtime_error("streaming audio input sample count must be divisible by channels");
+        }
+        if (!samples.empty()) {
+            const auto consumed = static_cast<int64_t>(samples.size());
+            emit_if_nonempty(
+                session.process_audio_chunk({
+                    stream.format.sample_rate,
+                    stream.format.channels,
+                    start_sample,
+                    std::move(samples),
+                }),
+                sink);
+            start_sample += consumed;
+        }
+        if (!has_more) {
+            break;
+        }
     }
+}
+
+// Replays an already materialized buffer through the same path a live source takes, so the two
+// input routes cannot drift apart. `audio` must outlive the returned stream.
+AudioChunkStream buffer_audio_stream(const engine::runtime::AudioBuffer & audio) {
+    AudioChunkStream stream;
+    stream.format = AudioStreamFormat{audio.sample_rate, audio.channels};
+    stream.read = [source = &audio, offset = size_t{0}](
+        int64_t max_samples, std::vector<float> & samples) mutable {
+        const size_t step = static_cast<size_t>(max_samples);
+        const size_t available = std::min(step, source->samples.size() - offset);
+        samples.assign(
+            source->samples.begin() + static_cast<std::ptrdiff_t>(offset),
+            source->samples.begin() + static_cast<std::ptrdiff_t>(offset + available));
+        offset += available;
+        return offset < source->samples.size();
+    };
+    return stream;
 }
 
 void pull_stream_events(
@@ -77,28 +108,20 @@ void pull_stream_events(
     }
 }
 
-}  // namespace
-
-engine::runtime::TaskResult run_streaming_task(
+engine::runtime::TaskResult run_stream(
     engine::runtime::IStreamingVoiceTaskSession & session,
     const engine::runtime::TaskRequest & request,
-    const StreamEventSink & sink) {
+    const StreamEventSink & sink,
+    const AudioChunkStream * stream) {
     const auto policy = session.streaming_policy();
     session.set_stream_event_sink(sink);
     try {
         session.start_stream(request);
         if (policy.input == engine::runtime::StreamingInputKind::AudioChunks) {
-            int64_t chunk_samples = policy.preferred_audio_chunk_samples;
-            if (policy.preferred_audio_chunk_seconds > 0.0) {
-                if (!request.audio_input.has_value()) {
-                    throw std::runtime_error("streaming audio input mode requires audio_input");
-                }
-                const auto & audio = *request.audio_input;
-                chunk_samples = static_cast<int64_t>(
-                    std::llround(policy.preferred_audio_chunk_seconds * static_cast<double>(audio.sample_rate))) *
-                    static_cast<int64_t>(audio.channels);
+            if (stream == nullptr) {
+                throw std::runtime_error("streaming audio input mode requires audio_input");
             }
-            feed_audio_chunks(session, request, chunk_samples, sink);
+            feed_audio_stream(session, *stream, resolve_chunk_samples(policy, stream->format), sink);
         }
         if (policy.output == engine::runtime::StreamingOutputKind::PullEvents) {
             pull_stream_events(session, sink);
@@ -110,6 +133,27 @@ engine::runtime::TaskResult run_streaming_task(
         session.set_stream_event_sink(nullptr);
         throw;
     }
+}
+
+}  // namespace
+
+engine::runtime::TaskResult run_streaming_task(
+    engine::runtime::IStreamingVoiceTaskSession & session,
+    const engine::runtime::TaskRequest & request,
+    const StreamEventSink & sink) {
+    if (!request.audio_input.has_value()) {
+        return run_stream(session, request, sink, nullptr);
+    }
+    const auto stream = buffer_audio_stream(*request.audio_input);
+    return run_stream(session, request, sink, &stream);
+}
+
+engine::runtime::TaskResult run_streaming_task(
+    engine::runtime::IStreamingVoiceTaskSession & session,
+    const engine::runtime::TaskRequest & request,
+    const StreamEventSink & sink,
+    const AudioChunkStream & stream) {
+    return run_stream(session, request, sink, &stream);
 }
 
 }  // namespace minitts::app

--- a/app/streaming/streaming.h
+++ b/app/streaming/streaming.h
@@ -2,15 +2,44 @@
 
 #include "engine/framework/runtime/session.h"
 
+#include <cstdint>
 #include <functional>
+#include <vector>
 
 namespace minitts::app {
 
 using StreamEventSink = std::function<void(const engine::runtime::StreamEvent &)>;
 
+// Format of an incrementally supplied audio stream. A live source has to declare it up front
+// because the samples themselves only arrive later.
+struct AudioStreamFormat {
+    int sample_rate = 0;
+    int channels = 1;
+};
+
+// Pulls the next block of interleaved samples into `samples`, at most `max_samples` values
+// (`channels * frames`). Returns false once the stream has ended and no further audio will
+// arrive; the final block may be short and can be returned together with either result.
+// Implementations are expected to block while waiting for a live source.
+using AudioChunkReader = std::function<bool(int64_t max_samples, std::vector<float> & samples)>;
+
+struct AudioChunkStream {
+    AudioStreamFormat format;
+    AudioChunkReader read;
+};
+
 engine::runtime::TaskResult run_streaming_task(
     engine::runtime::IStreamingVoiceTaskSession & session,
     const engine::runtime::TaskRequest & request,
     const StreamEventSink & sink);
+
+// Streams audio from `stream` rather than from `request.audio_input`, so the audio never has to
+// be fully materialized. `request` still supplies text, options and the audio format contract
+// used to prepare the session.
+engine::runtime::TaskResult run_streaming_task(
+    engine::runtime::IStreamingVoiceTaskSession & session,
+    const engine::runtime::TaskRequest & request,
+    const StreamEventSink & sink,
+    const AudioChunkStream & stream);
 
 }  // namespace minitts::app

--- a/docs/asr.md
+++ b/docs/asr.md
@@ -286,6 +286,28 @@ Streaming CLI:
 audiocpp_cli --task asr --family voxtral_realtime --model models/Voxtral-Mini-4B-Realtime-2602-GGUF/voxtral-mini-4b-realtime-2602-q8_0.gguf --backend cuda --threads 8 --mode streaming --audio assets/resources/sample.wav --text-out transcript.txt
 ```
 
+Live streaming input. `--audio -` reads raw (headerless) interleaved PCM from stdin and feeds it
+to the model chunk by chunk as it arrives, so the audio is never buffered up front and does not
+have to exist as a file. Any capture tool that can write PCM to a pipe works as the source:
+
+```bash
+# Microphone (macOS; use -f alsa on Linux or -f dshow on Windows)
+ffmpeg -f avfoundation -i ":0" -ar 16000 -ac 1 -f s16le - \
+  | audiocpp_cli --task asr --family voxtral_realtime --model models/Voxtral-Mini-4B-Realtime-2602-GGUF/voxtral-mini-4b-realtime-2602-q8_0.gguf --backend cuda --threads 8 --mode streaming --audio -
+```
+
+```bash
+# Any file or network stream, decoded to PCM on the fly
+ffmpeg -i input.mp3 -ar 16000 -ac 1 -f s16le - \
+  | audiocpp_cli --task asr --family voxtral_realtime --model models/Voxtral-Mini-4B-Realtime-2602-GGUF/voxtral-mini-4b-realtime-2602-q8_0.gguf --backend cuda --threads 8 --mode streaming --audio -
+```
+
+Stdin input requires `--mode streaming`, and the PCM format must be described up front because a
+live stream carries no header — the defaults (`s16le`, 16 kHz, mono) match what the model expects.
+The chosen interpretation is echoed back as an `audio_input=stdin` line. Each update is written as
+its own `partial_text=` line and flushed as it is produced, so a reader sees the transcript grow
+rather than waiting for the stream to end.
+
 > **Throughput.** A streaming step always advances 80 ms of audio, so a step has to cost under
 > 80 ms to keep up with a realtime source. Measured on an Apple M3 Air (Metal, q8_0):
 >
@@ -344,7 +366,10 @@ curl -N http://127.0.0.1:8080/v1/audio/transcriptions \
 
 | Option | Values | Default | Meaning |
 |---|---|---:|---|
-| `--audio` | WAV path | required | Speech input. |
+| `--audio` | WAV path or `-` | required | Speech input. `-` streams raw PCM from stdin and requires `--mode streaming`. |
+| `--input-format` | `s16le`, `f32le` | `s16le` | Sample format of raw PCM read from stdin. Ignored for file input. |
+| `--input-rate` | integer Hz | `16000` | Sample rate of raw PCM read from stdin. Ignored for file input. |
+| `--input-channels` | integer | `1` | Channel count of raw PCM read from stdin. Ignored for file input. |
 | `--mode` | `offline`, `streaming` | `offline` | Full-context or streaming session. |
 | `--request-option max_new_tokens=<n>` | integer | model-derived limit | Maximum generated transcript tokens. |
 | `--do-sample` | bool | `false` | Enable sampling instead of greedy decode. |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -25,7 +25,10 @@ audiocpp_cli --task <task> --family <family> --model <model-dir> --backend <back
 | Option | Used by | Meaning |
 |---|---|---|
 | `--text` | generation, TTS, ASR context, alignment transcript | Input text. |
-| `--audio` | generation/editing, ASR, VAD, diarization, separation, conversion, alignment | Input WAV. |
+| `--audio` | generation/editing, ASR, VAD, diarization, separation, conversion, alignment | Input WAV, or `-` to stream raw PCM from stdin (requires `--mode streaming`). |
+| `--input-format` | streaming ASR with `--audio -` | Raw PCM sample format, `s16le` or `f32le`. Default `s16le`. |
+| `--input-rate` | streaming ASR with `--audio -` | Raw PCM sample rate in Hz. Default `16000`. |
+| `--input-channels` | streaming ASR with `--audio -` | Raw PCM channel count. Default `1`. |
 | `--voice-ref` | voice clone / voice design / some VC paths | Reference voice WAV. |
 | `--language` | language-aware models | Language code. |
 | `--out` | audio-producing models | Output WAV path. |

--- a/tests/unittests/test_streaming_audio_input.cpp
+++ b/tests/unittests/test_streaming_audio_input.cpp
@@ -280,9 +280,6 @@ void test_format_parsing_and_validation() {
     require(
         minitts::app::parse_pcm_sample_format("f32le") == minitts::app::PcmSampleFormat::F32LE,
         "f32le parse");
-    require_eq(minitts::app::pcm_sample_format_bytes(minitts::app::PcmSampleFormat::S16LE), 2, "s16le width");
-    require_eq(minitts::app::pcm_sample_format_bytes(minitts::app::PcmSampleFormat::F32LE), 4, "f32le width");
-
     bool rejected = false;
     try {
         (void)minitts::app::parse_pcm_sample_format("s24le");

--- a/tests/unittests/test_streaming_audio_input.cpp
+++ b/tests/unittests/test_streaming_audio_input.cpp
@@ -89,6 +89,22 @@ engine::runtime::TaskRequest audio_request(engine::runtime::AudioBuffer audio) {
     return request;
 }
 
+// Every case here runs at 16 kHz; only the channel count and sample encoding vary.
+engine::runtime::AudioBuffer audio_format(int channels = 1) {
+    engine::runtime::AudioBuffer buffer;
+    buffer.sample_rate = 16000;
+    buffer.channels = channels;
+    return buffer;
+}
+
+minitts::app::AudioChunkStream pcm_stream(
+    std::istream & input,
+    int channels = 1,
+    minitts::app::PcmSampleFormat format = minitts::app::PcmSampleFormat::S16LE) {
+    return minitts::app::make_pcm_chunk_stream(
+        input, minitts::app::AudioStreamFormat{16000, channels}, format);
+}
+
 std::vector<float> flatten(const std::vector<RecordingSession::Chunk> & chunks) {
     std::vector<float> all;
     for (const auto & chunk : chunks) {
@@ -105,9 +121,7 @@ void test_stdin_source_matches_buffer_source() {
         pcm[i] = static_cast<int16_t>((i * 37) % 30000 - 15000);
     }
 
-    engine::runtime::AudioBuffer buffer;
-    buffer.sample_rate = 16000;
-    buffer.channels = 1;
+    auto buffer = audio_format();
     buffer.samples.reserve(pcm.size());
     for (const int16_t value : pcm) {
         buffer.samples.push_back(static_cast<float>(value) / 32768.0F);
@@ -118,10 +132,7 @@ void test_stdin_source_matches_buffer_source() {
 
     RecordingSession streamed(512);
     std::istringstream input(s16le_bytes(pcm));
-    const auto stream = minitts::app::make_pcm_chunk_stream(
-        input,
-        minitts::app::AudioStreamFormat{16000, 1},
-        minitts::app::PcmSampleFormat::S16LE);
+    const auto stream = pcm_stream(input);
     minitts::app::run_streaming_task(streamed, audio_request(buffer), nullptr, stream);
 
     require_eq(streamed.chunks.size(), buffered.chunks.size(), "chunk count");
@@ -154,15 +165,8 @@ void test_chunk_sizing_and_drain() {
 
     RecordingSession session(chunk_samples);
     std::istringstream input(s16le_bytes(pcm));
-    const auto stream = minitts::app::make_pcm_chunk_stream(
-        input,
-        minitts::app::AudioStreamFormat{16000, 1},
-        minitts::app::PcmSampleFormat::S16LE);
-
-    engine::runtime::AudioBuffer contract;
-    contract.sample_rate = 16000;
-    contract.channels = 1;
-    minitts::app::run_streaming_task(session, audio_request(contract), nullptr, stream);
+    const auto stream = pcm_stream(input);
+    minitts::app::run_streaming_task(session, audio_request(audio_format()), nullptr, stream);
 
     require_eq(session.chunks.size(), size_t{3}, "chunk count");
     require_eq(session.chunks[0].samples.size(), size_t{400}, "first chunk size");
@@ -180,10 +184,7 @@ void test_sample_format_decoding() {
     const std::string s16 = s16le_bytes({0, 32767, -32768, 1234});
     std::istringstream s16_input(s16);
     std::vector<float> decoded;
-    auto s16_stream = minitts::app::make_pcm_chunk_stream(
-        s16_input,
-        minitts::app::AudioStreamFormat{16000, 1},
-        minitts::app::PcmSampleFormat::S16LE);
+    auto s16_stream = pcm_stream(s16_input);
     s16_stream.read(4, decoded);
     require_eq(decoded.size(), size_t{4}, "s16le sample count");
     require(decoded[0] == 0.0F, "s16le zero");
@@ -194,10 +195,7 @@ void test_sample_format_decoding() {
     // 1.0f and -2.0f little-endian.
     const std::string f32("\x00\x00\x80\x3F\x00\x00\x00\xC0", 8);
     std::istringstream f32_input(f32);
-    auto f32_stream = minitts::app::make_pcm_chunk_stream(
-        f32_input,
-        minitts::app::AudioStreamFormat{16000, 1},
-        minitts::app::PcmSampleFormat::F32LE);
+    auto f32_stream = pcm_stream(f32_input, 1, minitts::app::PcmSampleFormat::F32LE);
     f32_stream.read(2, decoded);
     require_eq(decoded.size(), size_t{2}, "f32le sample count");
     require(decoded[0] == 1.0F, "f32le 1.0");
@@ -209,10 +207,7 @@ void test_sample_format_decoding() {
 void test_partial_trailing_frame_is_dropped() {
     const std::string bytes = s16le_bytes({1, 2, 3});  // 1.5 stereo frames
     std::istringstream input(bytes);
-    auto stream = minitts::app::make_pcm_chunk_stream(
-        input,
-        minitts::app::AudioStreamFormat{16000, 2},
-        minitts::app::PcmSampleFormat::S16LE);
+    auto stream = pcm_stream(input, 2);
     std::vector<float> samples;
     const bool more = stream.read(8, samples);
     require(!more, "short read should report end of stream");
@@ -222,15 +217,8 @@ void test_partial_trailing_frame_is_dropped() {
 void test_empty_stream_produces_no_chunks() {
     RecordingSession session(256);
     std::istringstream input("");
-    const auto stream = minitts::app::make_pcm_chunk_stream(
-        input,
-        minitts::app::AudioStreamFormat{16000, 1},
-        minitts::app::PcmSampleFormat::S16LE);
-
-    engine::runtime::AudioBuffer contract;
-    contract.sample_rate = 16000;
-    contract.channels = 1;
-    minitts::app::run_streaming_task(session, audio_request(contract), nullptr, stream);
+    const auto stream = pcm_stream(input);
+    minitts::app::run_streaming_task(session, audio_request(audio_format()), nullptr, stream);
 
     require(session.chunks.empty(), "empty stream must not produce chunks");
     require(session.finalized(), "empty stream must still finalize");
@@ -240,13 +228,9 @@ void test_empty_stream_produces_no_chunks() {
 // overload must not mistake that for zero-length audio and feed the session nothing.
 void test_live_format_contract_is_not_mistaken_for_empty_audio() {
     RecordingSession session(512);
-    engine::runtime::AudioBuffer contract;
-    contract.sample_rate = 16000;
-    contract.channels = 1;
-
     bool rejected = false;
     try {
-        minitts::app::run_streaming_task(session, audio_request(contract), nullptr);
+        minitts::app::run_streaming_task(session, audio_request(audio_format()), nullptr);
     } catch (const std::exception &) {
         rejected = true;
     }
@@ -258,9 +242,7 @@ void test_live_format_contract_is_not_mistaken_for_empty_audio() {
 // sees any of it rather than partway through on the final short chunk.
 void test_malformed_buffer_is_rejected_before_any_chunk() {
     RecordingSession session(400);
-    engine::runtime::AudioBuffer audio;
-    audio.sample_rate = 16000;
-    audio.channels = 2;
+    auto audio = audio_format(2);
     audio.samples.assign(1001, 0.5F);  // not a whole number of stereo frames
 
     bool rejected = false;

--- a/tests/unittests/test_streaming_audio_input.cpp
+++ b/tests/unittests/test_streaming_audio_input.cpp
@@ -1,0 +1,286 @@
+#include "../../app/streaming/pcm_source.h"
+#include "../../app/streaming/streaming.h"
+
+#include "test_assert.h"
+
+#include <cstdint>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+using engine::test::require;
+using engine::test::require_eq;
+
+// Records what the streaming driver pushes, so a live source and a materialized buffer can be
+// compared chunk for chunk.
+class RecordingSession : public engine::runtime::IStreamingVoiceTaskSession {
+public:
+    struct Chunk {
+        int sample_rate = 0;
+        int channels = 0;
+        int64_t start_sample = 0;
+        std::vector<float> samples;
+    };
+
+    explicit RecordingSession(int64_t chunk_samples) : chunk_samples_(chunk_samples) {}
+
+    std::string family() const override { return "recording"; }
+    engine::runtime::VoiceTaskKind task_kind() const override {
+        return engine::runtime::VoiceTaskKind::Asr;
+    }
+    engine::runtime::RunMode run_mode() const override {
+        return engine::runtime::RunMode::Streaming;
+    }
+    void prepare(const engine::runtime::SessionPreparationRequest &) override { prepared_ = true; }
+
+    engine::runtime::StreamingPolicy streaming_policy() const override {
+        engine::runtime::StreamingPolicy policy;
+        policy.input = engine::runtime::StreamingInputKind::AudioChunks;
+        policy.output = engine::runtime::StreamingOutputKind::FinalResult;
+        policy.preferred_audio_chunk_samples = chunk_samples_;
+        return policy;
+    }
+    void start_stream(const engine::runtime::TaskRequest &) override {
+        started_ = true;
+        chunks.clear();
+    }
+    void reset() override { chunks.clear(); }
+    engine::runtime::StreamEvent process_audio_chunk(const engine::runtime::AudioChunk & chunk) override {
+        chunks.push_back(Chunk{chunk.sample_rate, chunk.channels, chunk.start_sample, chunk.samples});
+        return {};
+    }
+    engine::runtime::TaskResult finalize() override {
+        finalized_ = true;
+        engine::runtime::TaskResult result;
+        result.text_output = engine::runtime::Transcript{"done", ""};
+        return result;
+    }
+
+    bool prepared() const { return prepared_; }
+    bool started() const { return started_; }
+    bool finalized() const { return finalized_; }
+
+    std::vector<Chunk> chunks;
+
+private:
+    int64_t chunk_samples_ = 0;
+    bool prepared_ = false;
+    bool started_ = false;
+    bool finalized_ = false;
+};
+
+std::string s16le_bytes(const std::vector<int16_t> & values) {
+    std::string bytes;
+    bytes.reserve(values.size() * 2);
+    for (const int16_t value : values) {
+        const auto raw = static_cast<uint16_t>(value);
+        bytes.push_back(static_cast<char>(raw & 0xFF));
+        bytes.push_back(static_cast<char>((raw >> 8) & 0xFF));
+    }
+    return bytes;
+}
+
+engine::runtime::TaskRequest audio_request(engine::runtime::AudioBuffer audio) {
+    engine::runtime::TaskRequest request;
+    request.audio_input = std::move(audio);
+    return request;
+}
+
+std::vector<float> flatten(const std::vector<RecordingSession::Chunk> & chunks) {
+    std::vector<float> all;
+    for (const auto & chunk : chunks) {
+        all.insert(all.end(), chunk.samples.begin(), chunk.samples.end());
+    }
+    return all;
+}
+
+// The whole point of the source abstraction: a live stdin-style source and a fully materialized
+// buffer must drive the session identically, so transcripts cannot diverge between the two.
+void test_stdin_source_matches_buffer_source() {
+    std::vector<int16_t> pcm(2500);
+    for (size_t i = 0; i < pcm.size(); ++i) {
+        pcm[i] = static_cast<int16_t>((i * 37) % 30000 - 15000);
+    }
+
+    engine::runtime::AudioBuffer buffer;
+    buffer.sample_rate = 16000;
+    buffer.channels = 1;
+    buffer.samples.reserve(pcm.size());
+    for (const int16_t value : pcm) {
+        buffer.samples.push_back(static_cast<float>(value) / 32768.0F);
+    }
+
+    RecordingSession buffered(512);
+    minitts::app::run_streaming_task(buffered, audio_request(buffer), nullptr);
+
+    RecordingSession streamed(512);
+    std::istringstream input(s16le_bytes(pcm));
+    const auto stream = minitts::app::make_pcm_chunk_stream(
+        input,
+        minitts::app::AudioStreamFormat{16000, 1},
+        minitts::app::PcmSampleFormat::S16LE);
+    minitts::app::run_streaming_task(streamed, audio_request(buffer), nullptr, stream);
+
+    require_eq(streamed.chunks.size(), buffered.chunks.size(), "chunk count");
+    for (size_t i = 0; i < buffered.chunks.size(); ++i) {
+        const auto & expected = buffered.chunks[i];
+        const auto & actual = streamed.chunks[i];
+        const std::string label = "chunk " + std::to_string(i);
+        require_eq(actual.sample_rate, expected.sample_rate, label + " sample rate");
+        require_eq(actual.channels, expected.channels, label + " channels");
+        require_eq(actual.start_sample, expected.start_sample, label + " start sample");
+        require_eq(actual.samples.size(), expected.samples.size(), label + " size");
+        for (size_t j = 0; j < expected.samples.size(); ++j) {
+            require(
+                actual.samples[j] == expected.samples[j],
+                label + " sample " + std::to_string(j) + " differs");
+        }
+    }
+    require(streamed.started(), "stream was not started");
+    require(streamed.finalized(), "stream was not finalized");
+}
+
+// The driver must honour the session's preferred chunk size and drain the source to EOF,
+// including a final short chunk.
+void test_chunk_sizing_and_drain() {
+    const int64_t chunk_samples = 400;
+    std::vector<int16_t> pcm(1000);  // 2 full chunks + a 200-sample tail
+    for (size_t i = 0; i < pcm.size(); ++i) {
+        pcm[i] = static_cast<int16_t>(i);
+    }
+
+    RecordingSession session(chunk_samples);
+    std::istringstream input(s16le_bytes(pcm));
+    const auto stream = minitts::app::make_pcm_chunk_stream(
+        input,
+        minitts::app::AudioStreamFormat{16000, 1},
+        minitts::app::PcmSampleFormat::S16LE);
+
+    engine::runtime::AudioBuffer contract;
+    contract.sample_rate = 16000;
+    contract.channels = 1;
+    minitts::app::run_streaming_task(session, audio_request(contract), nullptr, stream);
+
+    require_eq(session.chunks.size(), size_t{3}, "chunk count");
+    require_eq(session.chunks[0].samples.size(), size_t{400}, "first chunk size");
+    require_eq(session.chunks[1].samples.size(), size_t{400}, "second chunk size");
+    require_eq(session.chunks[2].samples.size(), size_t{200}, "tail chunk size");
+    require_eq(session.chunks[0].start_sample, int64_t{0}, "first start sample");
+    require_eq(session.chunks[1].start_sample, int64_t{400}, "second start sample");
+    require_eq(session.chunks[2].start_sample, int64_t{800}, "tail start sample");
+    require_eq(flatten(session.chunks).size(), pcm.size(), "total samples delivered");
+}
+
+// Decoding is explicitly little-endian so a stream captured on one machine reads back the same
+// on any host, and matches the scaling the WAV reader uses.
+void test_sample_format_decoding() {
+    const std::string s16 = s16le_bytes({0, 32767, -32768, 1234});
+    std::istringstream s16_input(s16);
+    std::vector<float> decoded;
+    auto s16_stream = minitts::app::make_pcm_chunk_stream(
+        s16_input,
+        minitts::app::AudioStreamFormat{16000, 1},
+        minitts::app::PcmSampleFormat::S16LE);
+    s16_stream.read(4, decoded);
+    require_eq(decoded.size(), size_t{4}, "s16le sample count");
+    require(decoded[0] == 0.0F, "s16le zero");
+    require(decoded[1] == 32767.0F / 32768.0F, "s16le positive full scale");
+    require(decoded[2] == -1.0F, "s16le negative full scale");
+    require(decoded[3] == 1234.0F / 32768.0F, "s16le midrange");
+
+    // 1.0f and -2.0f little-endian.
+    const std::string f32("\x00\x00\x80\x3F\x00\x00\x00\xC0", 8);
+    std::istringstream f32_input(f32);
+    auto f32_stream = minitts::app::make_pcm_chunk_stream(
+        f32_input,
+        minitts::app::AudioStreamFormat{16000, 1},
+        minitts::app::PcmSampleFormat::F32LE);
+    f32_stream.read(2, decoded);
+    require_eq(decoded.size(), size_t{2}, "f32le sample count");
+    require(decoded[0] == 1.0F, "f32le 1.0");
+    require(decoded[1] == -2.0F, "f32le -2.0");
+}
+
+// A trailing partial frame cannot be interpreted, so chunks must always hold whole frames -
+// sessions reject a chunk whose sample count is not divisible by the channel count.
+void test_partial_trailing_frame_is_dropped() {
+    const std::string bytes = s16le_bytes({1, 2, 3});  // 1.5 stereo frames
+    std::istringstream input(bytes);
+    auto stream = minitts::app::make_pcm_chunk_stream(
+        input,
+        minitts::app::AudioStreamFormat{16000, 2},
+        minitts::app::PcmSampleFormat::S16LE);
+    std::vector<float> samples;
+    const bool more = stream.read(8, samples);
+    require(!more, "short read should report end of stream");
+    require_eq(samples.size(), size_t{2}, "partial trailing frame must be dropped");
+}
+
+void test_empty_stream_produces_no_chunks() {
+    RecordingSession session(256);
+    std::istringstream input("");
+    const auto stream = minitts::app::make_pcm_chunk_stream(
+        input,
+        minitts::app::AudioStreamFormat{16000, 1},
+        minitts::app::PcmSampleFormat::S16LE);
+
+    engine::runtime::AudioBuffer contract;
+    contract.sample_rate = 16000;
+    contract.channels = 1;
+    minitts::app::run_streaming_task(session, audio_request(contract), nullptr, stream);
+
+    require(session.chunks.empty(), "empty stream must not produce chunks");
+    require(session.finalized(), "empty stream must still finalize");
+}
+
+void test_format_parsing_and_validation() {
+    require(
+        minitts::app::parse_pcm_sample_format("s16le") == minitts::app::PcmSampleFormat::S16LE,
+        "s16le parse");
+    require(
+        minitts::app::parse_pcm_sample_format("f32le") == minitts::app::PcmSampleFormat::F32LE,
+        "f32le parse");
+    require_eq(minitts::app::pcm_sample_format_bytes(minitts::app::PcmSampleFormat::S16LE), 2, "s16le width");
+    require_eq(minitts::app::pcm_sample_format_bytes(minitts::app::PcmSampleFormat::F32LE), 4, "f32le width");
+
+    bool rejected = false;
+    try {
+        (void)minitts::app::parse_pcm_sample_format("s24le");
+    } catch (const std::exception &) {
+        rejected = true;
+    }
+    require(rejected, "unsupported sample format must be rejected");
+
+    std::istringstream input("");
+    bool bad_format_rejected = false;
+    try {
+        (void)minitts::app::make_pcm_chunk_stream(
+            input,
+            minitts::app::AudioStreamFormat{0, 1},
+            minitts::app::PcmSampleFormat::S16LE);
+    } catch (const std::exception &) {
+        bad_format_rejected = true;
+    }
+    require(bad_format_rejected, "non-positive sample rate must be rejected");
+}
+
+}  // namespace
+
+int main() {
+    try {
+        test_stdin_source_matches_buffer_source();
+        test_chunk_sizing_and_drain();
+        test_sample_format_decoding();
+        test_partial_trailing_frame_is_dropped();
+        test_empty_stream_produces_no_chunks();
+        test_format_parsing_and_validation();
+    } catch (const std::exception & error) {
+        std::cerr << "streaming_audio_input_test failed: " << error.what() << '\n';
+        return 1;
+    }
+    std::cout << "streaming_audio_input_test passed\n";
+    return 0;
+}

--- a/tests/unittests/test_streaming_audio_input.cpp
+++ b/tests/unittests/test_streaming_audio_input.cpp
@@ -236,6 +236,43 @@ void test_empty_stream_produces_no_chunks() {
     require(session.finalized(), "empty stream must still finalize");
 }
 
+// A live source declares its format in audio_input and carries no samples there. The buffer
+// overload must not mistake that for zero-length audio and feed the session nothing.
+void test_live_format_contract_is_not_mistaken_for_empty_audio() {
+    RecordingSession session(512);
+    engine::runtime::AudioBuffer contract;
+    contract.sample_rate = 16000;
+    contract.channels = 1;
+
+    bool rejected = false;
+    try {
+        minitts::app::run_streaming_task(session, audio_request(contract), nullptr);
+    } catch (const std::exception &) {
+        rejected = true;
+    }
+    require(rejected, "a format-only audio_input must be rejected, not streamed as empty audio");
+    require(session.chunks.empty(), "no chunks should have been delivered");
+}
+
+// The buffer length is known up front, so a malformed buffer must be rejected before the session
+// sees any of it rather than partway through on the final short chunk.
+void test_malformed_buffer_is_rejected_before_any_chunk() {
+    RecordingSession session(400);
+    engine::runtime::AudioBuffer audio;
+    audio.sample_rate = 16000;
+    audio.channels = 2;
+    audio.samples.assign(1001, 0.5F);  // not a whole number of stereo frames
+
+    bool rejected = false;
+    try {
+        minitts::app::run_streaming_task(session, audio_request(audio), nullptr);
+    } catch (const std::exception &) {
+        rejected = true;
+    }
+    require(rejected, "a buffer that is not divisible by channels must be rejected");
+    require(session.chunks.empty(), "no chunks should have been delivered before the rejection");
+}
+
 void test_format_parsing_and_validation() {
     require(
         minitts::app::parse_pcm_sample_format("s16le") == minitts::app::PcmSampleFormat::S16LE,
@@ -276,6 +313,8 @@ int main() {
         test_sample_format_decoding();
         test_partial_trailing_frame_is_dropped();
         test_empty_stream_produces_no_chunks();
+        test_live_format_contract_is_not_mistaken_for_empty_audio();
+        test_malformed_buffer_is_rejected_before_any_chunk();
         test_format_parsing_and_validation();
     } catch (const std::exception & error) {
         std::cerr << "streaming_audio_input_test failed: " << error.what() << '\n';


### PR DESCRIPTION
Adds `--audio -` so the streaming CLI can transcribe audio as it is produced, instead of only replaying something already in memory. Carved out of #112.

```bash
 ffmpeg -f avfoundation -i ":0" -ar 16000 -ac 1 -f s16le - 2>/dev/null \
  | ./build/macos-metal-release/bin/audiocpp_cli \
      --task asr --family voxtral_realtime \
      --model /Users/patrickprivate/models/Voxtral-Mini-4B-Realtime-2602-GGUF/voxtral-mini-4b-realtime-2602-q8_0.gguf \
      --backend metal --mode streaming --audio -
```

## Why

`run_streaming_task` required a fully materialized `request.audio_input` and sliced it into chunks. On `main`, `process_audio_chunk` has exactly one call site — inside `feed_audio_chunks` — and it cannot be reached without the complete audio in hand, so no C++ path accepted audio incrementally.

That also applies to the two existing streaming paths, which is worth stating since both look like they already cover this:

- `tools/streaming/measure_asr_streaming_client.py` paces a multipart upload across several socket writes, but computes `Content-Length` from a complete file and, as its own manifest records, `"current server reads full HTTP body before invoking ASR streaming handler"`. It measures response latency; a microphone cannot produce a `Content-Length`.
- `webui/realtime_pipeline.py` does transcribe a live mic, but via Python silero-VAD segmentation with each *completed* utterance sent as an ordinary `/v1/audio/transcriptions` request. Nothing surfaces until the speaker pauses (`min_silence_ms=450`), and `_run_turn` runs STT → LLM → TTS with no early exit — it is a speech-to-speech assistant, not a transcriber.

## Approach

`AudioChunkStream` — a format declared up front plus a pull-based reader:

```cpp
using AudioChunkReader = std::function<bool(int64_t max_samples, std::vector<float> & samples)>;
```

Both input routes go through it, and the file path is expressed as a reader over the buffer (`buffer_audio_stream`), so live and buffered input run the same code and cannot drift apart — that is what makes the byte-identical result below a property of the design rather than a coincidence. The three-argument `run_streaming_task` stays as a wrapper, so `app/server/runtime.cpp` is untouched.

`--input-format` (`s16le`/`f32le`), `--input-rate` and `--input-channels` supply the format a headerless stream cannot carry. They double as the audio contract `prepare()` requires — `VoxtralRealtimeSession::prepare` throws without one — carried as an `audio_input` with rate and channels but no samples. Decoding is explicitly little-endian and reuses the WAV reader's `/32768` scaling, so raw PCM and WAV of the same audio decode identically. `partial_text=` lines are flushed as produced, otherwise a piped consumer sees nothing until the stdio buffer fills.

`app/cli/main.cpp` changes by +50/−6, with no preprocessor work; the in-place terminal rendering that made the original diff larger stays in #112, as it is orthogonal and improves file streaming on `main` today.

## Verification

- File input, `s16le` stdin and `f32le` stdin all transcribe `assets/resources/sample_16k.wav` to **byte-identical stdout** apart from the `audio_input=stdin` banner — 34 partials each, growing one token at a time.
- `--audio -` without `--mode streaming` fails with `--audio - reads live PCM and requires --mode streaming`; `--input-format s24le` fails with `unsupported raw PCM sample format 's24le' (expected s16le or f32le)`.
- `streaming_audio_input_test` (new) covers stdin/buffer equivalence, both sample formats, chunk sizing and drain, a trailing partial frame, the empty stream, format parsing, and the two cases from the second commit.
- `ctest` 29/32, matching `main`. `gguf_tensor_source_test` and `scaled_dot_product_attention_test` fail on `main` too; `asr_standalone_gguf_test` does not compile there (`test_asr_standalone_gguf.cpp` calls `load_hviske_assets`, the header declares `load_hviske_asr_assets`), as do the three `tests/moss_tts_local/codec_*_parity.cpp` targets. `audio_dsp_test` and `supertonic_vector_convnext_exp_test` are flaky rather than broken — `test_audio_dsp.cpp:38` seeds its RNG from the wall clock. None of these are touched by this branch. CI is green on all four platforms.