### PR TITLE
Correct OuteTTS model_specs_v1 metadata

### DIFF
--- a/docs/community_models/outetts.md
+++ b/docs/community_models/outetts.md
@@ -45,7 +45,7 @@ audiocpp_cli --task clon --family outetts \
   --max-tokens 1024 --out cloned.wav
 ```
 
-`--task tts` with the same `--voice-ref` and `--reference-text` options also enables speaker conditioning, which is useful for clients that expose one TTS route. Safetensors packages and older OuteTTS GGUFs do not contain the aligner. For those models, pass `outetts.aligner_model_path`; cloning fails clearly instead of using unreliable estimated word boundaries.
+`--task tts` with the same `--voice-ref` and `--reference-text` options also enables speaker conditioning, which is useful for clients that expose one TTS route. Safetensors packages and older OuteTTS GGUFs do not contain the aligner. For those models, pass `outetts.aligner_path`; cloning fails clearly instead of using unreliable estimated word boundaries.
 
 The installer places `DAC.speech.v1.0` and `Qwen3-ForcedAligner-0.6B` beside the OuteTTS directory. It converts the official DAC checkpoint to a safe tensor source. To do that conversion manually:
 
@@ -97,7 +97,10 @@ audiocpp_cli --task tts --family outetts \
 | `--reference-text` | text | none | Exact transcript of `--voice-ref`; required for voice cloning. |
 | `--request-option reference_language=<code>` | language code | `en` | Language used by the optional reference aligner. |
 | `--session-option outetts.weight_type=native|f32|f16|bf16|q8_0` | enum | `native` | Language-model weight storage type. For CUDA voice cloning, quantized weights remain compact in the GGUF but are expanded to F32 in VRAM to avoid generation divergence over long reference-codec prompts. Normal TTS and CPU cloning keep the selected type. |
-| `--session-option outetts.aligner_model_path=<path>` | model path | embedded aligner | Optional external Qwen3 Forced Aligner override, required only for safetensors packages and older GGUFs without the embedded aligner. |
+| `--session-option outetts.aligner_path=<path>` | model path | embedded aligner | Optional external Qwen3 Forced Aligner override, required only for safetensors packages and older GGUFs without the embedded aligner. |
+
+The legacy session keys `outetts.aligner_model_path` and
+`outetts.dac_graph_context_mb` remain accepted for backward compatibility.
 | `--session-option outetts.reference_cache_slots=<n>` | integer | `1` | LRU slots for prepared reference profiles (alignment, DAC codes, and word features). Set `0` to disable reuse. |
 | `--session-option outetts.mem_saver=true|false` | bool | `false` | Release the reusable Llama cached-step graph after each generated chunk and release the aligner runtime after preparing a reference. Model and DAC weights stay resident; later requests rebuild released state. |
 

--- a/docs/reports/outetts_validation.md
+++ b/docs/reports/outetts_validation.md
@@ -216,7 +216,7 @@ build\windows-cuda-release\bin\outetts_warm_bench.exe `
   --backend cuda --threads 8 `
   --request-file tests\outetts\warm_bench_requests.json `
   --session-option outetts.weight_type=f32 `
-  --session-option outetts.aligner_model_path=..\models\Qwen3-ForcedAligner-0.6B `
+  --session-option outetts.aligner_path=..\models\Qwen3-ForcedAligner-0.6B `
   --audio-out-dir build\reference\cpp_f32_final_explicit `
   --log-file build\reference\cpp_f32_final_explicit.log
 ```

--- a/model_specs_v1/outetts.json
+++ b/model_specs_v1/outetts.json
@@ -167,15 +167,15 @@
         "default": 1024
       },
       {
-        "name": "dac_graph_context_mb",
+        "name": "dac_graph_arena_mb",
         "type": "int",
-        "description": "DAC decoder graph context size in MiB; default 1536.",
+        "description": "DAC decoder graph arena size in MiB; default 1536.",
         "required": false,
         "min": 1,
         "default": 1536
       },
       {
-        "name": "aligner_model_path",
+        "name": "aligner_path",
         "type": "path",
         "description": "Optional Qwen3 Forced Aligner override. Cloning automatically uses the aligner embedded in a standalone OuteTTS GGUF when present.",
         "required": false

--- a/model_specs_v1/outetts.json
+++ b/model_specs_v1/outetts.json
@@ -167,15 +167,15 @@
         "default": 1024
       },
       {
-        "name": "dac_graph_arena_mb",
+        "name": "dac_graph_context_mb",
         "type": "int",
-        "description": "DAC decoder graph arena size in MiB; default 1536.",
+        "description": "DAC decoder graph context size in MiB; default 1536.",
         "required": false,
         "min": 1,
         "default": 1536
       },
       {
-        "name": "aligner_path",
+        "name": "aligner_model_path",
         "type": "path",
         "description": "Optional Qwen3 Forced Aligner override. Cloning automatically uses the aligner embedded in a standalone OuteTTS GGUF when present.",
         "required": false
@@ -272,11 +272,12 @@
       "default": true,
       "format": "gguf",
       "precision": "q8_0",
-      "target_directory": "Llama-OuteTTS-1.0-1B-GGUF",
+      "target_directory": "Llama-OuteTTS-1.0-1B_Q8",
       "files": [
         "Text to audio (TTS)/Llama-OuteTTS-1.0-1B_Q8.gguf"
       ],
       "strip_prefix": "Text to audio (TTS)",
+      "description": "Standalone Q8_0 GGUF with the IBM DAC codec and Qwen3 Forced Aligner weights, tokenizers, configs, and sidecars embedded for one-file TTS and voice cloning.",
       "download": {
         "kind": "huggingface_snapshot",
         "repo": "mirek190/audio.cpp"

--- a/src/community_models/outetts/loader.cpp
+++ b/src/community_models/outetts/loader.cpp
@@ -75,9 +75,9 @@ runtime::ModelCliInterface cli(const OuteTTSAssets &) {
        "Language-model constant tensor context size in MiB."},
       {"outetts.dac_weight_context_mb", "n",
        "DAC decoder weight context size in MiB."},
-      {"outetts.dac_graph_context_mb", "n",
-       "DAC decoder graph context size in MiB."},
-      {"outetts.aligner_model_path", "path",
+      {"outetts.dac_graph_arena_mb", "n",
+       "DAC decoder graph arena size in MiB."},
+      {"outetts.aligner_path", "path",
        "Optional Qwen3 Forced Aligner override. Cloning automatically uses "
        "the aligner embedded in a standalone OuteTTS GGUF when present."},
       {"outetts.reference_cache_slots", "n",

--- a/src/community_models/outetts/session.cpp
+++ b/src/community_models/outetts/session.cpp
@@ -438,7 +438,8 @@ resolve_aligner_assets(const runtime::SessionOptions &options,
                        const OuteTTSAssets &model_assets) {
   const auto model_path = runtime::find_option(
       options.options,
-      {"outetts.aligner_model_path", "outetts.forced_aligner_model_path"});
+      {"outetts.aligner_path", "outetts.aligner_model_path",
+       "outetts.forced_aligner_model_path"});
   if (model_path.has_value()) {
     return engine::models::qwen3_asr::load_qwen3_asr_assets(
         std::filesystem::path(*model_path), "qwen3_forced_aligner");
@@ -485,7 +486,8 @@ OuteTTSSession::OuteTTSSession(runtime::TaskSpec task,
                                          {"outetts.dac_weight_context_mb"},
                                          1024ull * 1024ull * 1024ull),
            runtime::parse_size_mb_option(options.options,
-                                         {"outetts.dac_graph_context_mb"},
+                                         {"outetts.dac_graph_arena_mb",
+                                          "outetts.dac_graph_context_mb"},
                                          1536ull * 1024ull * 1024ull),
            assets::TensorStorageType::F32),
       mem_saver_(mem_saver_from_options(options)),
@@ -582,7 +584,7 @@ OuteTTSVoiceProfile OuteTTSSession::prepare_voice_profile(
       throw std::runtime_error(
           "OuteTTS voice cloning requires a GGUF with an embedded Qwen3 "
           "Forced Aligner or --session-option "
-          "outetts.aligner_model_path=<path>");
+          "outetts.aligner_path=<path>");
     }
     aligner_session_ = std::make_unique<
         engine::models::qwen3_forced_aligner::Qwen3ForcedAlignerSession>(


### PR DESCRIPTION
## Summary

Follow-up to #63 that aligns OuteTTS with the normalized `model_specs_v1`
session-option contract and corrects its package metadata.

## Changes

- keeps the normalized session names `dac_graph_arena_mb` and `aligner_path`
- advertises their public forms as `outetts.dac_graph_arena_mb` and
  `outetts.aligner_path`
- maps those names to the existing DAC and aligner implementation
- retains `outetts.dac_graph_context_mb`,
  `outetts.aligner_model_path`, and
  `outetts.forced_aligner_model_path` as compatibility aliases
- points installation at the published/tested
  `Llama-OuteTTS-1.0-1B_Q8` directory
- documents that the standalone GGUF embeds IBM DAC and Qwen3 Forced Aligner
  resources for one-file synthesis and cloning

## Why

`model_specs_v1` is a normalized framework-facing contract. The spec should use
consistent option names; model-specific historical names are translated at the
session boundary instead of leaking into catalog clients and generated UIs.

## Impact

Both normalized and legacy session keys work. Conflicting values supplied under
multiple aliases are rejected rather than resolved ambiguously.

The existing 23-language list, tasks, capabilities, source declarations,
inference math, and model outputs are unchanged.

## Validation

- parsed `model_specs_v1/outetts.json`
- confirmed v1 `sources` exactly match `model_specs/outetts.json`
- confirmed all request and session options against the current loader
- confirmed 23 language entries
- resolved `outetts_1_0_1b_q8_0` with `model_manager_v2.py`
- verified the remote GGUF at `3,029,895,456` bytes
- built the complete `engine_runtime` CPU target
- `git diff --check`
