### PR TITLE
Advertise BS-RoFormer overlap option

### DIFF
--- a/src/models/roformer/loader.cpp
+++ b/src/models/roformer/loader.cpp
@@ -36,6 +36,15 @@ runtime::ModelCliInterface cli(const RoformerAssets & assets) {
             "RoFormer weight storage type.",
         },
     };
+    if (assets.config.family == kBsRoformerFamily) {
+        out.session_options.push_back({
+            assets.config.family + ".num_overlap",
+            "n",
+            "Number of overlapping inference windows; defaults to the package "
+            "configuration. Lower values improve throughput but can reduce "
+            "boundary quality.",
+        });
+    }
     return out;
 }
 


### PR DESCRIPTION
## What changed

- Advertise `bs_roformer.num_overlap` in BS-RoFormer loader inspection metadata.
- Keep Mel-Band RoFormer metadata unchanged because its v1 spec does not expose this option.

## Why

PR #114 added `num_overlap` to `model_specs_v1/bs_roformer.json` and the BS-RoFormer session already consumes `bs_roformer.num_overlap`, but the runtime loader metadata advertised only `weight_type`. As a result, CLI model help and inspection-driven clients such as server/WebUI discovery could not discover the supported overlap control.

## User impact

Inspection clients now see the same BS-RoFormer session option that is documented and accepted at runtime. Lower overlap counts can be selected for higher throughput with the existing quality tradeoff.

## Validation

- `git diff --check`
- Windows native CPU Release build: `scripts/build_windows.ps1 -Preset windows-cpu-release -Target audiocpp_cli -Jobs 8`
- Real standalone BS-RoFormer Q8 GGUF inspection: confirmed `bs_roformer.num_overlap <n>` is listed.
- Real standalone Mel-Band RoFormer Q8 GGUF inspection: confirmed only `mel_band_roformer.weight_type` is listed, so no unrelated interface expansion occurred.