### PR TITLE
Emit streaming transcript deltas instead of restating the transcript

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1581,6 +1581,13 @@ if (ENGINE_BUILD_TESTS)
     # block forever rather than fail. Bound it so CI reports a failure instead.
     set_tests_properties(http_live_body_test PROPERTIES TIMEOUT 120)
 
+    add_engine_unittest(partial_text_render_test tests/unittests/test_partial_text_render.cpp)
+
+    add_test(
+        NAME partial_text_render_test
+        COMMAND partial_text_render_test
+    )
+
     add_engine_unittest(hf_sampler_test tests/unittests/test_hf_sampler.cpp)
 
     add_test(

--- a/app/cli/main.cpp
+++ b/app/cli/main.cpp
@@ -1,5 +1,6 @@
 #include "args.h"
 #include "batch.h"
+#include "partial_render.h"
 #include "request.h"
 #include "../streaming/pcm_source.h"
 #include "../streaming/streaming.h"
@@ -18,6 +19,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <cstdio>
 #include <fstream>
 #include <filesystem>
 #include <iostream>
@@ -32,7 +34,10 @@
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
+#include <io.h>
 #include <windows.h>
+#else
+#include <unistd.h>
 #endif
 
 #ifdef _OPENMP
@@ -461,6 +466,16 @@ bool stream_audio_from_stdin(int argc, char ** argv) {
     return audio.has_value() && minitts::cli::is_stdin_audio_source(*audio);
 }
 
+// Only a terminal can take partials as running text; a redirected stream has to keep the
+// line-per-update format so pipes and logs stay parseable.
+bool stdout_is_terminal() {
+#ifdef _WIN32
+    return _isatty(_fileno(stdout)) != 0;
+#else
+    return isatty(fileno(stdout)) != 0;
+#endif
+}
+
 // Feeds raw PCM from stdin into the session chunk by chunk, so nothing has to be buffered up
 // front and transcription tracks the input as it arrives.
 engine::runtime::TaskResult run_streaming_from_stdin(
@@ -496,12 +511,13 @@ void run_streaming(
     engine::runtime::IVoiceTaskSession & session,
     engine::runtime::TaskRequest & request) {
     const auto out_dir = minitts::cli::optional_path_arg(argc, argv, "--out-dir");
+    minitts::cli::PartialTextRenderer partial_renderer(stdout_is_terminal());
     const minitts::app::StreamEventSink sink =
         [&](const engine::runtime::StreamEvent & event) {
             if (event.partial_text.has_value()) {
                 // Flushed so a live source's partials appear as they are produced rather than
                 // when the stdio buffer happens to fill.
-                std::cout << "partial_text=" << event.partial_text->text << "\n" << std::flush;
+                std::cout << partial_renderer.render(event.partial_text->text) << std::flush;
             }
             engine::runtime::TaskResult event_result;
             event_result.audio_output = event.audio_output;
@@ -537,6 +553,8 @@ void run_streaming(
     const auto result = stream_audio_from_stdin(argc, argv)
         ? run_streaming_from_stdin(argc, argv, streaming, request, sink)
         : minitts::app::run_streaming_task(streaming, request, sink);
+    // Close the transcript line so the summary below starts on a fresh row.
+    std::cout << partial_renderer.finish();
     std::cout << "family=" << session.family() << "\n";
     std::cout << "task=" << engine::runtime::to_string(session.task_kind()) << "\n";
     std::cout << "mode=" << engine::runtime::to_string(session.run_mode()) << "\n";

--- a/app/cli/partial_render.h
+++ b/app/cli/partial_render.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <string>
+
+namespace minitts::cli {
+
+// Streaming sessions emit each partial as the text newly decoded since the last one, so the
+// updates concatenate into the transcript. A terminal can therefore just append them, and the
+// transcript scrolls like ordinary output instead of arriving as a column of labelled fragments.
+// Redirected output keeps the labelled line-per-update form so pipes and logs stay parseable.
+//
+// Returns the bytes to write rather than taking a stream, so the caller decides when to flush and
+// the behaviour can be tested without a terminal.
+class PartialTextRenderer {
+public:
+    explicit PartialTextRenderer(bool interactive) : interactive_(interactive) {}
+
+    std::string render(const std::string & text) {
+        if (!interactive_) {
+            return "partial_text=" + text + "\n";
+        }
+        wrote_ = wrote_ || !text.empty();
+        return text;
+    }
+
+    // Terminates the transcript line so following output starts on a fresh row. Empty when no
+    // line was left open, so a run that produced no partials does not print a stray blank line.
+    std::string finish() {
+        if (!interactive_ || !wrote_) {
+            return {};
+        }
+        wrote_ = false;
+        return "\n";
+    }
+
+private:
+    bool interactive_ = false;
+    bool wrote_ = false;
+};
+
+}  // namespace minitts::cli

--- a/app/cli/partial_render.h
+++ b/app/cli/partial_render.h
@@ -4,10 +4,9 @@
 
 namespace minitts::cli {
 
-// Streaming sessions emit each partial as the text newly decoded since the last one, so the
-// updates concatenate into the transcript. A terminal can therefore just append them, and the
-// transcript scrolls like ordinary output instead of arriving as a column of labelled fragments.
-// Redirected output keeps the labelled line-per-update form so pipes and logs stay parseable.
+// Partials are the text newly decoded since the last one, so they concatenate into the transcript.
+// A terminal can therefore just append them and the transcript scrolls like ordinary output, while
+// redirected output keeps the labelled line-per-update form so pipes and logs stay parseable.
 //
 // Returns the bytes to write rather than taking a stream, so the caller decides when to flush and
 // the behaviour can be tested without a terminal.

--- a/docs/asr.md
+++ b/docs/asr.md
@@ -342,9 +342,33 @@ ffmpeg -i input.mp3 -ar 16000 -ac 1 -f s16le - \
 
 Stdin input requires `--mode streaming`, and the PCM format must be described up front because a
 live stream carries no header — the defaults (`s16le`, 16 kHz, mono) match what the model expects.
-The chosen interpretation is echoed back as an `audio_input=stdin` line. Each update is written as
-its own `partial_text=` line and flushed as it is produced, so a reader sees the transcript grow
-rather than waiting for the stream to end.
+The chosen interpretation is echoed back as an `audio_input=stdin` line.
+
+Each update carries only the text decoded since the last one, matching the other streaming ASR
+models, so the updates concatenate into the transcript. On a terminal they are appended unlabelled
+and the transcript scrolls like ordinary output. When stdout is redirected, each update is written
+as its own `partial_text=` line and flushed as it is produced, so pipes and logs stay parseable.
+The complete transcript is also printed once at the end as `text_output=`.
+
+Emitting deltas rather than restating the transcript matters for long runs, where the restated form
+is quadratic in the transcript length: a one-hour session writes roughly 364 MB restated against
+about 54 KB as deltas.
+
+To capture the transcript itself rather than the update stream, use `--text-out`, which writes the
+complete transcript and nothing else:
+
+```bash
+ffmpeg -f avfoundation -i ":0" -ar 16000 -ac 1 -f s16le - \
+  | audiocpp_cli --task asr --family voxtral_realtime --model models/Voxtral-Mini-4B-Realtime-2602-GGUF/voxtral-mini-4b-realtime-2602-q8_0.gguf --backend cuda --mode streaming --audio - --text-out transcript.txt
+```
+
+`--text-out` and the `text_output=` line are both written when the stream ends, so a session that is
+interrupted leaves neither. The `partial_text=` lines are flushed as they are produced, so a log of
+them survives an interrupted run and concatenates back into the transcript:
+
+```bash
+grep '^partial_text=' session.log | sed 's/^partial_text=//' | tr -d '\n' > transcript.txt
+```
 
 ### Live PCM over HTTP
 

--- a/docs/asr.md
+++ b/docs/asr.md
@@ -350,6 +350,10 @@ and the transcript scrolls like ordinary output. When stdout is redirected, each
 as its own `partial_text=` line and flushed as it is produced, so pipes and logs stay parseable.
 The complete transcript is also printed once at the end as `text_output=`.
 
+An update covers one decoded chunk, so `stream_batch_tokens=<n>` reports every `n`th token's worth
+of text in a single update rather than making the updates `n` times shorter. Whatever the batch
+size, concatenating the updates reproduces `text_output=` exactly.
+
 Emitting deltas rather than restating the transcript matters for long runs, where the restated form
 is quadratic in the transcript length: a one-hour session writes roughly 364 MB restated against
 about 54 KB as deltas.

--- a/include/engine/models/voxtral_realtime/session.h
+++ b/include/engine/models/voxtral_realtime/session.h
@@ -10,7 +10,7 @@
 #include <chrono>
 #include <cstddef>
 #include <memory>
-#include <vector>
+#include <string>
 
 namespace engine::models::voxtral_realtime {
 
@@ -45,8 +45,11 @@ private:
     runtime::StreamEvent process_available_stream_chunks();
     runtime::StreamEvent process_one_stream_chunk(const runtime::AudioBuffer & audio);
     // Feeds a freshly decoded token back as the next stream input and, when it carries text,
-    // appends it to the transcript and refreshes the event's partial.
-    void record_stream_token(int32_t token, runtime::StreamEvent & event);
+    // appends it to the transcript.
+    void record_stream_token(int32_t token);
+    // Moves the transcript decoded since the last partial onto the event. Called once a chunk
+    // rather than once a token, so a chunk that decoded a batch of them reports all their text.
+    void take_stream_delta(runtime::StreamEvent & event);
 
     runtime::TaskSpec task_;
     std::shared_ptr<const VoxtralRealtimeAssets> assets_;
@@ -75,7 +78,11 @@ private:
     runtime::StreamEventCallback stream_event_sink_;
     VoxtralRealtimeFrontendStreamState frontend_stream_state_;
     VoxtralRealtimeAudioEncoderStreamState audio_stream_state_;
-    std::vector<int32_t> streaming_token_ids_;
+    // The transcript decoded so far, and how much of it has already gone out as a partial. Every
+    // partial is the suffix between the two, so the deltas concatenate to exactly this string.
+    std::string streaming_text_;
+    size_t streaming_published_bytes_ = 0;
+    int64_t streaming_token_count_ = 0;
     int32_t previous_stream_token_ = 0;
     bool stream_started_ = false;
     bool first_stream_chunk_ = true;

--- a/src/models/voxtral_realtime/session.cpp
+++ b/src/models/voxtral_realtime/session.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cmath>
 #include <stdexcept>
+#include <string>
 #include <utility>
 #include <unordered_map>
 
@@ -275,7 +276,9 @@ void VoxtralRealtimeSession::reset() {
     streaming_generation_ = VoxtralRealtimeGenerationOptions{};
     frontend_stream_state_ = VoxtralRealtimeFrontendStreamState{};
     audio_stream_state_ = audio_encoder_.make_stream_state();
-    streaming_token_ids_.clear();
+    streaming_text_.clear();
+    streaming_published_bytes_ = 0;
+    streaming_token_count_ = 0;
     previous_stream_token_ = 0;
     first_stream_chunk_ = true;
     have_previous_stream_token_ = false;
@@ -322,13 +325,13 @@ runtime::TaskResult VoxtralRealtimeSession::finalize() {
     if (streaming_audio_offset_values_ > streaming_audio_.samples.size()) {
         throw std::runtime_error("VoxTral streaming pending audio offset is out of range");
     }
-    if (streaming_audio_offset_values_ == streaming_audio_.samples.size() && streaming_token_ids_.empty()) {
+    if (streaming_audio_offset_values_ == streaming_audio_.samples.size() && streaming_token_count_ == 0) {
         throw std::runtime_error("VoxTral realtime finalize() requires streamed audio");
     }
     auto event = process_available_stream_chunks();
     (void) event;
     streaming_result_ = runtime::TaskResult{};
-    streaming_result_.text_output = runtime::Transcript{tokenizer_.decode(streaming_token_ids_), ""};
+    streaming_result_.text_output = runtime::Transcript{streaming_text_, ""};
     stream_started_ = false;
     if (stream_event_sink_ != nullptr) {
         // Every token has already been delivered as a partial, so the final event only marks the
@@ -337,7 +340,7 @@ runtime::TaskResult VoxtralRealtimeSession::finalize() {
         event.is_final = true;
         stream_event_sink_(event);
     }
-    engine::debug::timing_log_scalar("voxtral_realtime.session.stream.tokens", streaming_token_ids_.size());
+    engine::debug::timing_log_scalar("voxtral_realtime.session.stream.tokens", streaming_token_count_);
     engine::debug::timing_log_scalar("voxtral_realtime.session.stream.steps_processed", streaming_steps_processed_);
     engine::debug::timing_log_scalar("voxtral_realtime.session.stream.frontend_ms", stream_frontend_ms_);
     engine::debug::timing_log_scalar("voxtral_realtime.session.stream.encoder_ms", stream_encoder_ms_);
@@ -457,7 +460,8 @@ runtime::StreamEvent VoxtralRealtimeSession::process_one_stream_chunk(const runt
         const int32_t token = text_decoder_.begin_stream(prompt, audio_embeddings, streaming_generation_);
         first_stream_chunk_ = false;
         stream_decoder_ms_ += engine::debug::elapsed_ms(decoder_start);
-        record_stream_token(token, event);
+        record_stream_token(token);
+        take_stream_delta(event);
         return event;
     }
     if (!have_previous_stream_token_) {
@@ -472,13 +476,16 @@ runtime::StreamEvent VoxtralRealtimeSession::process_one_stream_chunk(const runt
             row,
             assets_->config.default_num_delay_tokens,
             streaming_generation_);
-        record_stream_token(token, event);
+        record_stream_token(token);
     }
     stream_decoder_ms_ += engine::debug::elapsed_ms(decoder_start);
+    // The chunk reports one event however many tokens it decoded, so the delta is taken once, after
+    // the whole batch has been recorded.
+    take_stream_delta(event);
     return event;
 }
 
-void VoxtralRealtimeSession::record_stream_token(int32_t token, runtime::StreamEvent & event) {
+void VoxtralRealtimeSession::record_stream_token(int32_t token) {
     previous_stream_token_ = token;
     have_previous_stream_token_ = true;
     // The reference implementation gives EOS no special treatment: whatever token was sampled
@@ -487,11 +494,26 @@ void VoxtralRealtimeSession::record_stream_token(int32_t token, runtime::StreamE
     if (!tokenizer_.is_stream_text_token(token)) {
         return;
     }
-    streaming_token_ids_.push_back(token);
-    // Emit only the newly decoded text, as the other streaming ASR sessions already do. Restating
-    // the whole transcript on every token is quadratic in its length, and leaves a consumer of
-    // transcript.text.delta concatenating text it was already given.
-    event.partial_text = runtime::Transcript{tokenizer_.decode({token}), ""};
+    ++streaming_token_count_;
+    // Decoding one token at a time costs nothing here — Tekken decode is a concatenation of each
+    // id's bytes — and it keeps the transcript an amortized O(1) append per token rather than a
+    // fresh decode of the whole list.
+    streaming_text_ += tokenizer_.decode({token});
+}
+
+void VoxtralRealtimeSession::take_stream_delta(runtime::StreamEvent & event) {
+    // Partials carry only the text decoded since the last one, as the other streaming ASR sessions
+    // already emit, rather than restating the transcript: restating is quadratic in its length and
+    // hands a consumer of transcript.text.delta text it was already given.
+    //
+    // Deriving the delta as the not-yet-published suffix of the transcript, rather than assembling
+    // it from the tokens of a chunk, is what keeps the two in step: whatever the decoder does per
+    // chunk, the deltas concatenate to exactly the transcript finalize() reports as text_output.
+    if (streaming_published_bytes_ >= streaming_text_.size()) {
+        return;
+    }
+    event.partial_text = runtime::Transcript{streaming_text_.substr(streaming_published_bytes_), ""};
+    streaming_published_bytes_ = streaming_text_.size();
 }
 
 }  // namespace engine::models::voxtral_realtime

--- a/src/models/voxtral_realtime/session.cpp
+++ b/src/models/voxtral_realtime/session.cpp
@@ -330,9 +330,10 @@ runtime::TaskResult VoxtralRealtimeSession::finalize() {
     streaming_result_ = runtime::TaskResult{};
     streaming_result_.text_output = runtime::Transcript{tokenizer_.decode(streaming_token_ids_), ""};
     stream_started_ = false;
-    if (stream_event_sink_ != nullptr && streaming_result_.text_output.has_value()) {
+    if (stream_event_sink_ != nullptr) {
+        // Every token has already been delivered as a partial, so the final event only marks the
+        // end of the stream. The whole transcript remains available as result.text_output.
         runtime::StreamEvent event;
-        event.partial_text = streaming_result_.text_output;
         event.is_final = true;
         stream_event_sink_(event);
     }
@@ -487,7 +488,10 @@ void VoxtralRealtimeSession::record_stream_token(int32_t token, runtime::StreamE
         return;
     }
     streaming_token_ids_.push_back(token);
-    event.partial_text = runtime::Transcript{tokenizer_.decode(streaming_token_ids_), ""};
+    // Emit only the newly decoded text, as the other streaming ASR sessions already do. Restating
+    // the whole transcript on every token is quadratic in its length, and leaves a consumer of
+    // transcript.text.delta concatenating text it was already given.
+    event.partial_text = runtime::Transcript{tokenizer_.decode({token}), ""};
 }
 
 }  // namespace engine::models::voxtral_realtime

--- a/src/models/voxtral_realtime/session.cpp
+++ b/src/models/voxtral_realtime/session.cpp
@@ -328,8 +328,8 @@ runtime::TaskResult VoxtralRealtimeSession::finalize() {
     if (streaming_audio_offset_values_ == streaming_audio_.samples.size() && streaming_token_count_ == 0) {
         throw std::runtime_error("VoxTral realtime finalize() requires streamed audio");
     }
-    auto event = process_available_stream_chunks();
-    (void) event;
+    // Any partial this last pass produces has already gone to the sink.
+    (void) process_available_stream_chunks();
     streaming_result_ = runtime::TaskResult{};
     streaming_result_.text_output = runtime::Transcript{streaming_text_, ""};
     stream_started_ = false;
@@ -457,30 +457,24 @@ runtime::StreamEvent VoxtralRealtimeSession::process_one_stream_chunk(const runt
     const auto decoder_start = Clock::now();
     if (first_stream_chunk_) {
         auto prompt = tokenizer_.build_transcription_prompt(frontend_.first_stream_chunk_samples(), true);
-        const int32_t token = text_decoder_.begin_stream(prompt, audio_embeddings, streaming_generation_);
+        record_stream_token(text_decoder_.begin_stream(prompt, audio_embeddings, streaming_generation_));
         first_stream_chunk_ = false;
-        stream_decoder_ms_ += engine::debug::elapsed_ms(decoder_start);
-        record_stream_token(token);
-        take_stream_delta(event);
-        return event;
-    }
-    if (!have_previous_stream_token_) {
+    } else if (!have_previous_stream_token_) {
         throw std::runtime_error("VoxTral streaming decoder is missing previous token");
-    }
-    // One encoder forward covers `stream_batch_tokens_` audio tokens; the decoder still runs one
-    // step per token, each consuming its own row of the batch.
-    for (int64_t row = 0; row < audio_embeddings.tokens; ++row) {
-        const int32_t token = text_decoder_.stream_step(
-            previous_stream_token_,
-            audio_embeddings,
-            row,
-            assets_->config.default_num_delay_tokens,
-            streaming_generation_);
-        record_stream_token(token);
+    } else {
+        // One encoder forward covers `stream_batch_tokens_` audio tokens; the decoder still runs one
+        // step per token, each consuming its own row of the batch.
+        for (int64_t row = 0; row < audio_embeddings.tokens; ++row) {
+            record_stream_token(text_decoder_.stream_step(
+                previous_stream_token_,
+                audio_embeddings,
+                row,
+                assets_->config.default_num_delay_tokens,
+                streaming_generation_));
+        }
     }
     stream_decoder_ms_ += engine::debug::elapsed_ms(decoder_start);
-    // The chunk reports one event however many tokens it decoded, so the delta is taken once, after
-    // the whole batch has been recorded.
+    // Once a chunk, not once a token: the chunk reports a single event however many it decoded.
     take_stream_delta(event);
     return event;
 }
@@ -495,20 +489,15 @@ void VoxtralRealtimeSession::record_stream_token(int32_t token) {
         return;
     }
     ++streaming_token_count_;
-    // Decoding one token at a time costs nothing here — Tekken decode is a concatenation of each
-    // id's bytes — and it keeps the transcript an amortized O(1) append per token rather than a
-    // fresh decode of the whole list.
+    // Tekken decode concatenates each id's bytes, so decoding token by token builds the same
+    // transcript as decoding the list, at an amortized O(1) append instead of a fresh decode.
     streaming_text_ += tokenizer_.decode({token});
 }
 
 void VoxtralRealtimeSession::take_stream_delta(runtime::StreamEvent & event) {
     // Partials carry only the text decoded since the last one, as the other streaming ASR sessions
-    // already emit, rather than restating the transcript: restating is quadratic in its length and
-    // hands a consumer of transcript.text.delta text it was already given.
-    //
-    // Deriving the delta as the not-yet-published suffix of the transcript, rather than assembling
-    // it from the tokens of a chunk, is what keeps the two in step: whatever the decoder does per
-    // chunk, the deltas concatenate to exactly the transcript finalize() reports as text_output.
+    // already emit. Restating the transcript is quadratic in its length and hands a consumer of
+    // transcript.text.delta text it was already given.
     if (streaming_published_bytes_ >= streaming_text_.size()) {
         return;
     }

--- a/tests/unittests/test_partial_text_render.cpp
+++ b/tests/unittests/test_partial_text_render.cpp
@@ -1,0 +1,57 @@
+#include "../../app/cli/partial_render.h"
+
+#include "test_assert.h"
+
+#include <exception>
+#include <iostream>
+#include <string>
+
+namespace {
+
+using engine::test::require_eq;
+using minitts::cli::PartialTextRenderer;
+
+// Partials carry only the text decoded since the last one, so a terminal appends them unlabelled
+// and the transcript reads as running text.
+void test_terminal_appends_partials_verbatim() {
+    PartialTextRenderer renderer(true);
+    require_eq(renderer.render(" Some"), std::string(" Some"), "first partial");
+    require_eq(renderer.render(" call"), std::string(" call"), "second partial");
+    require_eq(renderer.render(" me"), std::string(" me"), "third partial");
+}
+
+// Redirected output keeps the labelled line-per-update format so pipes and logs stay parseable.
+void test_redirected_output_keeps_labelled_lines() {
+    PartialTextRenderer renderer(false);
+    require_eq(renderer.render(" Some"), std::string("partial_text= Some\n"), "first piped partial");
+    require_eq(renderer.render(" call"), std::string("partial_text= call\n"), "second piped partial");
+}
+
+void test_finish_closes_only_an_open_line() {
+    PartialTextRenderer opened(true);
+    opened.render(" Some");
+    require_eq(opened.finish(), std::string("\n"), "open line is closed");
+    require_eq(opened.finish(), std::string(""), "line is closed only once");
+
+    PartialTextRenderer untouched(true);
+    require_eq(untouched.finish(), std::string(""), "a run with no partials prints no blank line");
+
+    PartialTextRenderer piped(false);
+    piped.render(" Some");
+    require_eq(piped.finish(), std::string(""), "piped output already ends its lines");
+}
+
+}  // namespace
+
+int main() {
+    try {
+        test_terminal_appends_partials_verbatim();
+        test_redirected_output_keeps_labelled_lines();
+        test_finish_closes_only_an_open_line();
+    } catch (const std::exception & error) {
+        std::cerr << "partial_text_render_test failed: " << error.what() << '\n';
+        return 1;
+    }
+    std::cout << "partial_text_render_test passed\n";
+    return 0;
+}


### PR DESCRIPTION
Last remaining piece of #112, which is down to this one change after #116 and #118 landed. That PR can be closed once this merges.

## Problem

`voxtral_realtime` set `partial_text` to a decode of **every token so far**, so each streaming update restated the whole transcript:

```
partial_text= Some
partial_text= Some call
partial_text= Some call me
partial_text= Some call me nature
```

Three things follow from that:

1. **It is the odd one out.** `vibevoice_asr`, `higgs_audio_stt` and `nemotron_asr` all emit only the newly decoded text. `voxtral_realtime` was the only session restating.
2. **The server is wrong for it.** `app/server/runtime.cpp:1101` sends `partial_text` as `transcript.text.delta`. For the other three that is a delta; for `voxtral_realtime` a client concatenating deltas rebuilt the pyramid.
3. **It is quadratic** in the transcript length. Modelled on a one-hour session at 150 wpm — 54,000 chars, ~13,500 partials — that is **364 MB** written against **54 KB** of actual transcript.

## Change

`record_stream_token` emits the new token's text rather than re-decoding the whole list, which fixes all three at the source. `finalize()` no longer repeats the transcript as a partial either — every token has already been delivered, and the whole transcript stays available as `result.text_output`.

The CLI printed each partial on its own labelled line. Now that partials concatenate, a terminal gets them appended unlabelled and the transcript scrolls like ordinary output:

```
 Some call me nature. Others call me Mother Nature. I've been here for over 4.5 billion years.
```

Redirected output keeps the `partial_text=` line-per-update form so pipes and logs stay parseable.

**Rejected approach.** An earlier revision of this PR diffed successive partials in the CLI instead. That is not sound: the CLI cannot tell which convention a session follows, and diffing the three delta-emitting models destroyed their output — feeding ` Some`, ` call`, ` me`, ` nature` through it left only ` nature` on screen, because each delta was mistaken for a revision of the last.

**Behaviour change worth calling out:** for `voxtral_realtime`, a redirected `partial_text=` line now carries a delta rather than the running transcript. Consumers concatenate. This aligns it with the three other streaming ASR models, where `partial_text=` already meant a delta. `text_output=` at the end is unchanged.

## Why?

Voxtral Realtime was trained to transcribe hour-long sessions which seems to work well now. However when transcribing such long audios live, it becomes prohibitely expensive to output the whole transcript at every timestamp as this results essentially to O(N2) amount of work. This PR adapts the output rendering so that we only render the partials.

Command to test:

```sh
ffmpeg -f avfoundation -i ":0" -ar 16000 -ac 1 -f s16le - 2>/dev/null \
  | ./build/macos-metal-release/bin/audiocpp_cli \
      --task asr --family voxtral_realtime \
      --model /models/Voxtral-Mini-4B-Realtime-2602-GGUF/voxtral-mini-4b-realtime-2602-q8_0.gguf \
      --backend metal --mode streaming --audio -
```

should also work when wanting to transcribe to a file directly as explained in the asr.md doc.