### PR TITLE
Add composite model build selection

### DIFF
--- a/.devops/cpu.Dockerfile
+++ b/.devops/cpu.Dockerfile
@@ -38,6 +38,7 @@ RUN if [ "$TARGETARCH" = "amd64" ] || [ "$TARGETARCH" = "arm64" ]; then \
 # Configure and build
 RUN cmake -S . -B build \
         -DCMAKE_BUILD_TYPE=Release \
+        -DAUDIOCPP_MODEL_SET=full \
         -DENGINE_ENABLE_CPU_ALL_VARIANTS=ON \
         -DENGINE_ENABLE_CUDA=OFF \
         -DENGINE_ENABLE_VULKAN=OFF \

--- a/.devops/cuda.Dockerfile
+++ b/.devops/cuda.Dockerfile
@@ -33,6 +33,7 @@ COPY . .
 # Configure and build
 RUN cmake -S . -B build \
         -DCMAKE_BUILD_TYPE=Release \
+        -DAUDIOCPP_MODEL_SET=full \
         -DENGINE_ENABLE_CPU_ALL_VARIANTS=ON \
         -DENGINE_ENABLE_CUDA=ON \
         -DENGINE_ENABLE_CUDA_GRAPHS=ON \

--- a/.dockerignore
+++ b/.dockerignore
@@ -7,4 +7,5 @@ docs/
 tools/
 !tools/gguf_convert.cpp
 build/
+model_specs_v1/
 *.md

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,14 @@ add_compile_options(
 set(AUDIOCPP_MODEL_SET "full" CACHE STRING "Model composite to build: full, core, or custom")
 set_property(CACHE AUDIOCPP_MODEL_SET PROPERTY STRINGS full core custom)
 set(AUDIOCPP_MODELS "" CACHE STRING "Comma or semicolon separated model targets for AUDIOCPP_MODEL_SET=custom")
+set(AUDIOCPP_LIBYAML_COMPILE_DEFINITIONS
+    _POSIX_C_SOURCE=200809L
+    YAML_DECLARE_STATIC=1
+    YAML_VERSION_MAJOR=0
+    YAML_VERSION_MINOR=2
+    YAML_VERSION_PATCH=5
+    YAML_VERSION_STRING=\"0.2.5\"
+)
 
 function(audiocpp_configure_runtime_object target_name)
     target_include_directories(${target_name} PUBLIC
@@ -171,6 +179,7 @@ function(audiocpp_configure_runtime_object target_name)
         ${CMAKE_CURRENT_SOURCE_DIR}/external/cJSON
         ${CMAKE_CURRENT_SOURCE_DIR}/external/libyaml/include
     )
+    target_compile_definitions(${target_name} PRIVATE ${AUDIOCPP_LIBYAML_COMPILE_DEFINITIONS})
     target_link_libraries(${target_name} PRIVATE ggml sentencepiece)
     if (ENGINE_ENABLE_OPENMP)
         target_link_libraries(${target_name} PRIVATE OpenMP::OpenMP_CXX)
@@ -181,12 +190,13 @@ function(audiocpp_configure_runtime_object target_name)
 endfunction()
 
 function(audiocpp_add_model target_name)
-    cmake_parse_arguments(ARG "" "" "SOURCES;INCLUDES;LOADERS;ALIASES" ${ARGN})
+    cmake_parse_arguments(ARG "" "" "SOURCES;INCLUDES;LOADERS;ALIASES;DEPENDS" ${ARGN})
     add_library(engine_model_${target_name} OBJECT ${ARG_SOURCES})
     audiocpp_configure_runtime_object(engine_model_${target_name})
     set(AUDIOCPP_MODEL_TARGETS ${AUDIOCPP_MODEL_TARGETS} ${target_name} PARENT_SCOPE)
     set(AUDIOCPP_MODEL_${target_name}_INCLUDES "${ARG_INCLUDES}" PARENT_SCOPE)
     set(AUDIOCPP_MODEL_${target_name}_LOADERS "${ARG_LOADERS}" PARENT_SCOPE)
+    set(AUDIOCPP_MODEL_${target_name}_DEPENDS "${ARG_DEPENDS}" PARENT_SCOPE)
     set(AUDIOCPP_MODEL_ALIAS_${target_name} ${target_name} PARENT_SCOPE)
     foreach(alias IN LISTS ARG_ALIASES)
         set(AUDIOCPP_MODEL_ALIAS_${alias} ${target_name} PARENT_SCOPE)
@@ -388,6 +398,8 @@ audiocpp_add_model(glm_tts
         engine/community_models/glm_tts/loader.h
     LOADERS
         engine::models::glm_tts::make_glm_tts_loader
+    DEPENDS
+        outetts
 )
 
 audiocpp_add_model(outetts
@@ -402,6 +414,9 @@ audiocpp_add_model(outetts
         engine/community_models/outetts/loader.h
     LOADERS
         engine::models::outetts::make_outetts_loader
+    DEPENDS
+        qwen3_asr
+        qwen3_forced_aligner
 )
 
 audiocpp_add_model(pocket_tts
@@ -450,6 +465,9 @@ audiocpp_add_model(miotts
         engine/models/miotts/loader.h
     LOADERS
         engine::models::miotts::make_miotts_loader
+    DEPENDS
+        miocodec
+        qwen3_asr
 )
 
 audiocpp_add_model(moss
@@ -756,6 +774,8 @@ audiocpp_add_model(vietneu_tts
         engine/community_models/vietneu_tts/loader.h
     LOADERS
         engine::models::vietneu_tts::make_vietneu_tts_loader
+    DEPENDS
+        moss
 )
 
 audiocpp_add_model(qwen3_asr
@@ -773,6 +793,8 @@ audiocpp_add_model(qwen3_asr
         engine/models/qwen3_asr/loader.h
     LOADERS
         engine::models::qwen3_asr::make_qwen3_asr_loader
+    DEPENDS
+        qwen3_forced_aligner
 )
 
 audiocpp_add_model(qwen3_forced_aligner
@@ -784,6 +806,8 @@ audiocpp_add_model(qwen3_forced_aligner
         engine/models/qwen3_forced_aligner/loader.h
     LOADERS
         engine::models::qwen3_forced_aligner::make_qwen3_forced_aligner_loader
+    DEPENDS
+        qwen3_asr
 )
 
 audiocpp_add_model(sortformer_diar
@@ -888,6 +912,7 @@ audiocpp_add_model(rvc
         src/models/rvc/assets.cpp
         src/models/rvc/hubert.cpp
         src/models/rvc/native_pipeline.cpp
+        src/models/rvc/rmvpe.cpp
         src/models/rvc/retrieval_index.cpp
         src/models/rvc/session.cpp
         src/models/rvc/synthesizer.cpp
@@ -984,6 +1009,23 @@ foreach(model_name IN LISTS AUDIOCPP_ENABLED_MODELS)
         string(APPEND AUDIOCPP_REGISTRY_LOADER_CONTENT "        ${loader_name}(),\n")
     endforeach()
 endforeach()
+
+set(AUDIOCPP_LINKED_MODELS ${AUDIOCPP_ENABLED_MODELS})
+set(AUDIOCPP_DEPENDENCY_SCAN_INDEX 0)
+list(LENGTH AUDIOCPP_LINKED_MODELS AUDIOCPP_LINKED_MODEL_COUNT)
+while(AUDIOCPP_DEPENDENCY_SCAN_INDEX LESS AUDIOCPP_LINKED_MODEL_COUNT)
+    list(GET AUDIOCPP_LINKED_MODELS ${AUDIOCPP_DEPENDENCY_SCAN_INDEX} model_name)
+    foreach(dependency IN LISTS AUDIOCPP_MODEL_${model_name}_DEPENDS)
+        if (NOT dependency IN_LIST AUDIOCPP_MODEL_TARGETS)
+            message(FATAL_ERROR "Unknown composite dependency for ${model_name}: ${dependency}")
+        endif()
+        if (NOT dependency IN_LIST AUDIOCPP_LINKED_MODELS)
+            list(APPEND AUDIOCPP_LINKED_MODELS ${dependency})
+        endif()
+    endforeach()
+    math(EXPR AUDIOCPP_DEPENDENCY_SCAN_INDEX "${AUDIOCPP_DEPENDENCY_SCAN_INDEX} + 1")
+    list(LENGTH AUDIOCPP_LINKED_MODELS AUDIOCPP_LINKED_MODEL_COUNT)
+endwhile()
 file(GENERATE
     OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/generated/model_registry_includes.inc"
     CONTENT "${AUDIOCPP_REGISTRY_INCLUDE_CONTENT}")
@@ -996,11 +1038,11 @@ set(AUDIOCPP_RUNTIME_OBJECTS
     $<TARGET_OBJECTS:engine_model_silero_vad>
     $<TARGET_OBJECTS:engine_model_marblenet_vad>
 )
-foreach(model_name IN LISTS AUDIOCPP_ENABLED_MODELS)
+foreach(model_name IN LISTS AUDIOCPP_LINKED_MODELS)
     list(APPEND AUDIOCPP_RUNTIME_OBJECTS $<TARGET_OBJECTS:engine_model_${model_name}>)
 endforeach()
 
-message(STATUS "audio.cpp model composite: ${AUDIOCPP_MODEL_SET} [${AUDIOCPP_ENABLED_MODELS}]")
+message(STATUS "audio.cpp model composite: ${AUDIOCPP_MODEL_SET} selected [${AUDIOCPP_ENABLED_MODELS}] linked [${AUDIOCPP_LINKED_MODELS}]")
 add_library(engine_runtime STATIC
     src/framework/runtime/registry.cpp
     ${AUDIOCPP_RUNTIME_OBJECTS}
@@ -1026,14 +1068,7 @@ target_include_directories(yaml_vendor PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/external/libyaml/include
 )
 
-target_compile_definitions(yaml_vendor PUBLIC
-    _POSIX_C_SOURCE=200809L
-    YAML_DECLARE_STATIC=1
-    YAML_VERSION_MAJOR=0
-    YAML_VERSION_MINOR=2
-    YAML_VERSION_PATCH=5
-    YAML_VERSION_STRING=\"0.2.5\"
-)
+target_compile_definitions(yaml_vendor PUBLIC ${AUDIOCPP_LIBYAML_COMPILE_DEFINITIONS})
 
 target_include_directories(engine_runtime PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,7 +156,44 @@ add_compile_options(
     $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/permissive->
 )
 
-add_library(engine_runtime STATIC
+set(AUDIOCPP_MODEL_SET "full" CACHE STRING "Model composite to build: full, core, or custom")
+set_property(CACHE AUDIOCPP_MODEL_SET PROPERTY STRINGS full core custom)
+set(AUDIOCPP_MODELS "" CACHE STRING "Comma or semicolon separated model targets for AUDIOCPP_MODEL_SET=custom")
+
+function(audiocpp_configure_runtime_object target_name)
+    target_include_directories(${target_name} PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+    target_include_directories(${target_name} PRIVATE
+        ${CMAKE_CURRENT_BINARY_DIR}/generated
+        ${CMAKE_CURRENT_SOURCE_DIR}/external/sentencepiece/src
+        ${CMAKE_CURRENT_SOURCE_DIR}/external/llama_tokenizer
+        ${CMAKE_CURRENT_SOURCE_DIR}/external/cJSON
+        ${CMAKE_CURRENT_SOURCE_DIR}/external/libyaml/include
+    )
+    target_link_libraries(${target_name} PRIVATE ggml sentencepiece)
+    if (ENGINE_ENABLE_OPENMP)
+        target_link_libraries(${target_name} PRIVATE OpenMP::OpenMP_CXX)
+        if (MSVC)
+            target_compile_options(${target_name} PRIVATE $<$<COMPILE_LANGUAGE:CXX>:/openmp:experimental>)
+        endif()
+    endif()
+endfunction()
+
+function(audiocpp_add_model target_name)
+    cmake_parse_arguments(ARG "" "" "SOURCES;INCLUDES;LOADERS;ALIASES" ${ARGN})
+    add_library(engine_model_${target_name} OBJECT ${ARG_SOURCES})
+    audiocpp_configure_runtime_object(engine_model_${target_name})
+    set(AUDIOCPP_MODEL_TARGETS ${AUDIOCPP_MODEL_TARGETS} ${target_name} PARENT_SCOPE)
+    set(AUDIOCPP_MODEL_${target_name}_INCLUDES "${ARG_INCLUDES}" PARENT_SCOPE)
+    set(AUDIOCPP_MODEL_${target_name}_LOADERS "${ARG_LOADERS}" PARENT_SCOPE)
+    set(AUDIOCPP_MODEL_ALIAS_${target_name} ${target_name} PARENT_SCOPE)
+    foreach(alias IN LISTS ARG_ALIASES)
+        set(AUDIOCPP_MODEL_ALIAS_${alias} ${target_name} PARENT_SCOPE)
+    endforeach()
+endfunction()
+
+add_library(engine_core OBJECT
     src/framework/assets/resource_bundle.cpp
     src/framework/model_spec/package.cpp
     src/framework/model_spec/options.cpp
@@ -168,7 +205,6 @@ add_library(engine_runtime STATIC
     src/framework/core/deferred_tensor_writer.cpp
     src/framework/core/execution_context.cpp
     src/framework/core/host_memory.cpp
-    src/framework/runtime/registry.cpp
     src/framework/runtime/model.cpp
     src/framework/model_spec/metadata.cpp
     src/framework/runtime/session.cpp
@@ -271,339 +307,703 @@ add_library(engine_runtime STATIC
     src/framework/sampling/hf_sampler.cpp
     src/framework/sampling/noise.cpp
     src/framework/sampling/torch_random.cpp
-    src/models/roformer/assets.cpp
-    src/models/roformer/loader.cpp
-    src/models/roformer/runtime.cpp
-    src/models/roformer/session.cpp
-    src/models/demucs/assets.cpp
-    src/models/demucs/frontend.cpp
-    src/models/demucs/pipeline.cpp
-    src/models/demucs/postprocess.cpp
-    src/models/demucs/loader.cpp
-    src/models/demucs/session.cpp
-    src/models/omnivoice/assets.cpp
-    src/models/omnivoice/tokenizer_text.cpp
-    src/models/omnivoice/audio_tokenizer.cpp
-    src/community_models/glm_tts/assets.cpp
-    src/community_models/glm_tts/flow.cpp
-    src/community_models/glm_tts/frontend.cpp
-    src/community_models/glm_tts/loader.cpp
-    src/community_models/glm_tts/llama.cpp
-    src/community_models/glm_tts/session.cpp
-    src/community_models/glm_tts/prompt.cpp
-    src/community_models/glm_tts/speech_tokenizer.cpp
-    src/community_models/glm_tts/tokenizer_text.cpp
-    src/community_models/outetts/assets.cpp
-    src/community_models/outetts/dac.cpp
-    src/community_models/outetts/llama.cpp
-    src/community_models/outetts/loader.cpp
-    src/community_models/outetts/session.cpp
-    src/community_models/outetts/tokenizer.cpp
-    src/models/omnivoice/prompt_builder.cpp
-    src/models/omnivoice/generator.cpp
-    src/models/omnivoice/postprocess.cpp
-    src/models/omnivoice/session.cpp
-    src/models/omnivoice/loader.cpp
-    src/models/pocket_tts/assets.cpp
-    src/models/pocket_tts/backend_weights.cpp
-    src/models/pocket_tts/acoustic_model.cpp
-    src/models/pocket_tts/audio_decoder.cpp
-    src/models/pocket_tts/flow_lm.cpp
-    src/models/pocket_tts/mimi_decoder.cpp
-    src/models/pocket_tts/mimi_encoder.cpp
-    src/models/pocket_tts/text_conditioner.cpp
-    src/models/pocket_tts/voice_state_assets.cpp
-    src/models/pocket_tts/voice_conditioner.cpp
-    src/models/pocket_tts/loader.cpp
-    src/models/pocket_tts/session.cpp
-    src/models/miocodec/assets.cpp
-    src/models/miocodec/weights.cpp
-    src/models/miocodec/audio_pipeline.cpp
-    src/models/miocodec/graph_ops.cpp
-    src/models/miocodec/graphs.cpp
-    src/models/miocodec/session.cpp
-    src/models/miocodec/loader.cpp
-    src/models/miotts/assets.cpp
-    src/models/miotts/tokenizer.cpp
-    src/models/miotts/causal_lm.cpp
-    src/models/miotts/session.cpp
-    src/models/miotts/loader.cpp
-    src/models/moss/moss_tts_local/assets.cpp
-    src/models/moss/moss_tts_local/backbone.cpp
-    src/models/moss/moss_tts_nano/assets.cpp
-    src/models/moss/moss_tts_nano/generator.cpp
-    src/models/moss/moss_tts_nano/global_transformer.cpp
-    src/models/moss/moss_tts_nano/local_frame_decoder.cpp
-    src/models/moss/moss_tts_nano/loader.cpp
-    src/models/moss/moss_tts_nano/prompt_builder.cpp
-    src/models/moss/moss_tts_nano/session.cpp
-    src/models/moss/moss_tts_nano/tokenizer_text.cpp
-    src/models/moss/shared/audio_tokenizer_decoder.cpp
-    src/models/moss/shared/audio_tokenizer_encoder.cpp
-    src/models/moss/shared/audio_tokenizer_config.cpp
-    src/models/moss/shared/audio_tokenizer_quantizer.cpp
-    src/models/moss/shared/sampling.cpp
-    src/models/moss/shared/token_rows.cpp
-    src/models/moss/moss_tts_local/depth_transformer.cpp
-    src/models/moss/moss_tts_local/generator.cpp
-    src/models/moss/moss_tts_local/loader.cpp
-    src/models/moss/moss_tts_local/tokenizer_text.cpp
-    src/models/moss/moss_tts_local/session.cpp
-    src/models/voxcpm2/assets.cpp
-    src/models/voxcpm2/audiovae.cpp
-    src/models/voxcpm2/generator.cpp
-    src/models/voxcpm2/loader.cpp
-    src/models/voxcpm2/minicpm.cpp
-    src/models/voxcpm2/session.cpp
-    src/models/voxcpm2/tokenizer_text.cpp
-    src/models/vibevoice/assets.cpp
-    src/models/vibevoice/connector.cpp
-    src/models/vibevoice/decoder.cpp
-    src/models/vibevoice/diffusion_head.cpp
-    src/models/vibevoice/diffusion_sampler.cpp
-    src/models/vibevoice/generator.cpp
-    src/models/vibevoice/loader.cpp
-    src/models/vibevoice/lora.cpp
-    src/models/vibevoice/scheduler.cpp
-    src/models/vibevoice/session.cpp
-    src/models/vibevoice/tokenizer_audio.cpp
-    src/models/vibevoice/tokenizer_text.cpp
-    src/models/vibevoice_asr/assets.cpp
-    src/models/vibevoice_asr/connector.cpp
-    src/models/vibevoice_asr/frontend.cpp
-    src/models/vibevoice_asr/loader.cpp
-    src/models/vibevoice_asr/postprocess.cpp
-    src/models/vibevoice_asr/session.cpp
-    src/models/vibevoice_asr/speech_encoder.cpp
-    src/models/vibevoice_asr/speech_tokenizer.cpp
-    src/models/vibevoice_asr/text_decoder.cpp
-    src/models/vibevoice_asr/tokenizer_text.cpp
-    src/models/voxtral_realtime/assets.cpp
-    src/models/voxtral_realtime/tokenizer_text.cpp
-    src/models/voxtral_realtime/frontend.cpp
-    src/models/voxtral_realtime/audio_encoder.cpp
-    src/models/voxtral_realtime/text_decoder.cpp
-    src/models/voxtral_realtime/session.cpp
-    src/models/voxtral_realtime/loader.cpp
-    src/models/fish_audio/ar.cpp
-    src/models/fish_audio/assets.cpp
-    src/models/fish_audio/codec.cpp
-    src/models/fish_audio/generator.cpp
-    src/models/fish_audio/loader.cpp
-    src/models/fish_audio/prompt_builder.cpp
-    src/models/fish_audio/session.cpp
-    src/models/fish_audio/tokenizer_text.cpp
-    src/models/confucius4_tts/assets.cpp
-    src/models/confucius4_tts/audio_features.cpp
-    src/models/confucius4_tts/request.cpp
-    src/models/confucius4_tts/s2a.cpp
-    src/models/confucius4_tts/semantic_encoder.cpp
-    src/models/confucius4_tts/session.cpp
-    src/models/confucius4_tts/style_encoder.cpp
-    src/models/confucius4_tts/t2s.cpp
-    src/models/confucius4_tts/tokenizer_text.cpp
-    src/models/confucius4_tts/vocoder.cpp
-    src/models/dramabox/assets.cpp
-    src/models/dramabox/audio_vae.cpp
-    src/models/dramabox/dit.cpp
-    src/models/dramabox/gemma_tokenizer.cpp
-    src/models/dramabox/gemma3_encoder.cpp
-    src/models/dramabox/latent_state.cpp
-    src/models/dramabox/loader.cpp
-    src/models/dramabox/prompt_connector.cpp
-    src/models/dramabox/session.cpp
-    src/models/dramabox/vocoder.cpp
-    src/models/heartmula/assets.cpp
-    src/models/heartmula/codec.cpp
-    src/models/heartmula/generator.cpp
-    src/models/heartmula/loader.cpp
-    src/models/heartmula/mula.cpp
-    src/models/heartmula/session.cpp
-    src/models/heartmula/tokenizer_text.cpp
-    src/models/hviske_asr/assets.cpp
-    src/models/hviske_asr/frontend.cpp
-    src/models/hviske_asr/encoder.cpp
-    src/models/hviske_asr/decoder.cpp
-    src/models/hviske_asr/session.cpp
-    src/models/hviske_asr/loader.cpp
-    src/models/hviske_asr/weights.cpp
-    src/models/higgs_audio_stt/assets.cpp
-    src/models/higgs_audio_stt/tokenizer_text.cpp
-    src/models/higgs_audio_stt/frontend_whisper.cpp
-    src/models/higgs_audio_stt/audio_encoder.cpp
-    src/models/higgs_audio_stt/text_decoder.cpp
-    src/models/higgs_audio_stt/prompt_asr.cpp
-    src/models/higgs_audio_stt/postprocess.cpp
-    src/models/higgs_audio_stt/session.cpp
-    src/models/higgs_audio_stt/loader.cpp
-    src/models/higgs_audio_tts/ar.cpp
-    src/models/higgs_audio_tts/assets.cpp
-    src/models/higgs_audio_tts/codec.cpp
-    src/models/higgs_audio_tts/codebooks.cpp
-    src/models/higgs_audio_tts/generator.cpp
-    src/models/higgs_audio_tts/loader.cpp
-    src/models/higgs_audio_tts/sampler.cpp
-    src/models/higgs_audio_tts/session.cpp
-    src/models/higgs_audio_tts/tokenizer_text.cpp
-    src/models/irodori_tts/assets.cpp
-    src/models/irodori_tts/codec.cpp
-    src/models/irodori_tts/condition_encoder.cpp
-    src/models/irodori_tts/duration.cpp
-    src/models/irodori_tts/loader.cpp
-    src/models/irodori_tts/rf_dit.cpp
-    src/models/irodori_tts/session.cpp
-    src/models/irodori_tts/tokenizer_text.cpp
-    src/models/index_tts2/assets.cpp
-    src/models/index_tts2/audio_features.cpp
-    src/models/index_tts2/gpt.cpp
-    src/models/index_tts2/loader.cpp
-    src/models/index_tts2/qwen_emotion.cpp
-    src/models/index_tts2/request.cpp
-    src/models/index_tts2/s2mel.cpp
-    src/models/index_tts2/semantic_codec.cpp
-    src/models/index_tts2/semantic_encoder.cpp
-    src/models/index_tts2/session.cpp
-    src/models/index_tts2/style_encoder.cpp
-    src/models/index_tts2/tokenizer_text.cpp
-    src/models/index_tts2/vocoder.cpp
-    src/models/nemotron_asr/assets.cpp
-    src/models/nemotron_asr/frontend.cpp
-    src/models/nemotron_asr/encoder.cpp
-    src/models/nemotron_asr/decoder.cpp
-    src/models/nemotron_asr/session.cpp
-    src/models/nemotron_asr/loader.cpp
-    src/models/nemotron_asr/weights.cpp
-    src/models/qwen3_tts/assets.cpp
-    src/models/qwen3_tts/tokenizer_text.cpp
-    src/models/qwen3_tts/tokenizer_speech_encoder.cpp
-    src/models/qwen3_tts/tokenizer_speech_decoder.cpp
-    src/models/qwen3_tts/speaker_encoder.cpp
-    src/models/qwen3_tts/talker.cpp
-    src/models/qwen3_tts/prompt_tts_voice_clone.cpp
-    src/models/qwen3_tts/prompt_tts_voice_design.cpp
-    src/models/qwen3_tts/prompt_tts_custom_voice.cpp
-    src/models/qwen3_tts/session.cpp
-    src/models/qwen3_tts/loader.cpp
-    src/community_models/vietneu_tts/assets.cpp
-    src/community_models/vietneu_tts/tokenizer_text.cpp
-    src/community_models/vietneu_tts/tokenizer_speech_encoder.cpp
-    src/community_models/vietneu_tts/tokenizer_speech_decoder.cpp
-    src/community_models/vietneu_tts/speaker_encoder.cpp
-    src/community_models/vietneu_tts/talker.cpp
-    src/community_models/vietneu_tts/prompt_tts_voice_clone.cpp
-    src/community_models/vietneu_tts/session.cpp
-    src/community_models/vietneu_tts/loader.cpp
-    src/models/qwen3_asr/assets.cpp
-    src/models/qwen3_asr/tokenizer_text.cpp
-    src/models/qwen3_asr/frontend_whisper.cpp
-    src/models/qwen3_asr/audio_encoder.cpp
-    src/models/qwen3_asr/thinker.cpp
-    src/models/qwen3_asr/prompt_asr.cpp
-    src/models/qwen3_asr/postprocess.cpp
-    src/models/qwen3_asr/session.cpp
-    src/models/qwen3_asr/loader.cpp
-    src/models/vevo2/ar.cpp
-    src/models/vevo2/assets.cpp
-    src/models/vevo2/components.cpp
-    src/models/vevo2/fm.cpp
-    src/models/vevo2/prompt_builder.cpp
-    src/models/vevo2/session.cpp
-    src/models/vevo2/tokenizer_ar.cpp
-    src/models/vevo2/vocoder.cpp
-    src/models/vevo2/loader.cpp
-    src/models/seed_vc/assets.cpp
-    src/models/seed_vc/audio_features.cpp
-    src/models/seed_vc/length_regulator.cpp
-    src/models/seed_vc/astral_quantizer.cpp
-    src/models/seed_vc/content_features.cpp
-    src/models/seed_vc/rmvpe.cpp
-    src/models/seed_vc/whisper_content.cpp
-    src/models/seed_vc/v1_cfm.cpp
-    src/models/seed_vc/v2_cfm.cpp
-    src/models/seed_vc/session.cpp
-    src/models/seed_vc/loader.cpp
-    src/models/rvc/assets.cpp
-    src/models/rvc/hubert.cpp
-    src/models/rvc/native_pipeline.cpp
-    src/models/rvc/retrieval_index.cpp
-    src/models/rvc/session.cpp
-    src/models/rvc/synthesizer.cpp
-    src/models/rvc/voice_model.cpp
-    src/models/rvc/loader.cpp
-    src/models/chatterbox/assets.cpp
-    src/models/chatterbox/campplus_encoder_impl.cpp
-    src/models/chatterbox/audio_features.cpp
-    src/models/chatterbox/audio_processing.cpp
-    src/models/chatterbox/component_weights.cpp
-    src/models/chatterbox/conditionals.cpp
-    src/models/chatterbox/hift_vocoder_impl.cpp
-    src/models/chatterbox/loader.cpp
-    src/models/chatterbox/s3_tokenizer_impl.cpp
-    src/models/chatterbox/s3gen_flow.cpp
-    src/models/chatterbox/s3gen_inference.cpp
-    src/models/chatterbox/session.cpp
-    src/models/chatterbox/t3_component.cpp
-    src/models/chatterbox/t3_weights.cpp
-    src/models/chatterbox/text_tokenizer.cpp
-    src/models/chatterbox/tts.cpp
-    src/models/chatterbox/vc.cpp
-    src/models/chatterbox/voice_encoder_impl.cpp
-    src/models/qwen3_forced_aligner/processor.cpp
-    src/models/qwen3_forced_aligner/session.cpp
-    src/models/qwen3_forced_aligner/loader.cpp
-    src/models/ace_step/assets.cpp
-    src/models/ace_step/condition_encoder.cpp
-    src/models/ace_step/cover_tokenizer.cpp
-    src/models/ace_step/detokenizer.cpp
-    src/models/ace_step/diffusion.cpp
-    src/models/ace_step/dit_weights_runtime.cpp
-    src/models/ace_step/loader.cpp
-    src/models/ace_step/planner.cpp
-    src/models/ace_step/pre_dit.cpp
-    src/models/ace_step/prompt_builder.cpp
-    src/models/ace_step/repaint.cpp
-    src/models/ace_step/request_parser.cpp
-    src/models/ace_step/session.cpp
-    src/models/ace_step/task_route.cpp
-    src/models/ace_step/text_encoder.cpp
-    src/models/ace_step/tokenizer_text.cpp
-    src/models/ace_step/vae_decoder.cpp
-    src/models/ace_step/vae_encoder.cpp
-    src/models/stable_audio/assets.cpp
-    src/models/stable_audio/conditioner.cpp
-    src/models/stable_audio/conditioner_runtime.cpp
-    src/models/stable_audio/foundation/conditioner.cpp
-    src/models/stable_audio/foundation/oobleck_autoencoder.cpp
-    src/models/stable_audio/foundation/rf_dit.cpp
-    src/models/stable_audio/foundation/session.cpp
-    src/models/stable_audio/loader.cpp
-    src/models/stable_audio/request.cpp
-    src/models/stable_audio/rf_dit.cpp
-    src/models/stable_audio/same_autoencoder.cpp
-    src/models/stable_audio/sampler.cpp
-    src/models/stable_audio/session.cpp
-    src/models/stable_audio/t5gemma.cpp
-    src/models/supertonic/assets.cpp
-    src/models/supertonic/loader.cpp
-    src/models/supertonic/runtime.cpp
-    src/models/supertonic/session.cpp
-    src/models/supertonic/tokenizer_text.cpp
-    src/models/sortformer_diar/assets.cpp
-    src/models/sortformer_diar/frontend.cpp
-    src/models/sortformer_diar/graph.cpp
-    src/models/sortformer_diar/modules.cpp
-    src/models/sortformer_diar/postprocess.cpp
-    src/models/sortformer_diar/loader.cpp
-    src/models/sortformer_diar/session.cpp
+)
+audiocpp_configure_runtime_object(engine_core)
+
+# These two small built-in model paths are kept outside the selectable composite list for now.
+add_library(engine_model_silero_vad OBJECT
     src/models/silero_vad/assets.cpp
     src/models/silero_vad/runtime.cpp
     src/models/silero_vad/session.cpp
-    src/models/citrinet_asr/assets.cpp
-    src/models/citrinet_asr/runtime.cpp
-    src/models/citrinet_asr/session.cpp
+)
+audiocpp_configure_runtime_object(engine_model_silero_vad)
+
+add_library(engine_model_marblenet_vad OBJECT
     src/models/marblenet_vad/assets.cpp
     src/models/marblenet_vad/runtime.cpp
     src/models/marblenet_vad/session.cpp
+)
+audiocpp_configure_runtime_object(engine_model_marblenet_vad)
+
+audiocpp_add_model(roformer
+    SOURCES
+        src/models/roformer/assets.cpp
+        src/models/roformer/loader.cpp
+        src/models/roformer/runtime.cpp
+        src/models/roformer/session.cpp
+    INCLUDES
+        engine/models/roformer/loader.h
+    LOADERS
+        engine::models::roformer::make_mel_band_roformer_loader
+        engine::models::roformer::make_bs_roformer_loader
+    ALIASES
+        mel_band_roformer
+        bs_roformer
+)
+
+audiocpp_add_model(demucs
+    SOURCES
+        src/models/demucs/assets.cpp
+        src/models/demucs/frontend.cpp
+        src/models/demucs/pipeline.cpp
+        src/models/demucs/postprocess.cpp
+        src/models/demucs/loader.cpp
+        src/models/demucs/session.cpp
+    INCLUDES
+        engine/models/demucs/loader.h
+    LOADERS
+        engine::models::demucs::make_htdemucs_loader
+    ALIASES
+        htdemucs
+)
+
+audiocpp_add_model(omnivoice
+    SOURCES
+        src/models/omnivoice/assets.cpp
+        src/models/omnivoice/tokenizer_text.cpp
+        src/models/omnivoice/audio_tokenizer.cpp
+        src/models/omnivoice/prompt_builder.cpp
+        src/models/omnivoice/generator.cpp
+        src/models/omnivoice/postprocess.cpp
+        src/models/omnivoice/session.cpp
+        src/models/omnivoice/loader.cpp
+    INCLUDES
+        engine/models/omnivoice/loader.h
+    LOADERS
+        engine::models::omnivoice::make_omnivoice_loader
+)
+
+audiocpp_add_model(glm_tts
+    SOURCES
+        src/community_models/glm_tts/assets.cpp
+        src/community_models/glm_tts/flow.cpp
+        src/community_models/glm_tts/frontend.cpp
+        src/community_models/glm_tts/loader.cpp
+        src/community_models/glm_tts/llama.cpp
+        src/community_models/glm_tts/session.cpp
+        src/community_models/glm_tts/prompt.cpp
+        src/community_models/glm_tts/speech_tokenizer.cpp
+        src/community_models/glm_tts/tokenizer_text.cpp
+    INCLUDES
+        engine/community_models/glm_tts/loader.h
+    LOADERS
+        engine::models::glm_tts::make_glm_tts_loader
+)
+
+audiocpp_add_model(outetts
+    SOURCES
+        src/community_models/outetts/assets.cpp
+        src/community_models/outetts/dac.cpp
+        src/community_models/outetts/llama.cpp
+        src/community_models/outetts/loader.cpp
+        src/community_models/outetts/session.cpp
+        src/community_models/outetts/tokenizer.cpp
+    INCLUDES
+        engine/community_models/outetts/loader.h
+    LOADERS
+        engine::models::outetts::make_outetts_loader
+)
+
+audiocpp_add_model(pocket_tts
+    SOURCES
+        src/models/pocket_tts/assets.cpp
+        src/models/pocket_tts/backend_weights.cpp
+        src/models/pocket_tts/acoustic_model.cpp
+        src/models/pocket_tts/audio_decoder.cpp
+        src/models/pocket_tts/flow_lm.cpp
+        src/models/pocket_tts/mimi_decoder.cpp
+        src/models/pocket_tts/mimi_encoder.cpp
+        src/models/pocket_tts/text_conditioner.cpp
+        src/models/pocket_tts/voice_state_assets.cpp
+        src/models/pocket_tts/voice_conditioner.cpp
+        src/models/pocket_tts/loader.cpp
+        src/models/pocket_tts/session.cpp
+    INCLUDES
+        engine/models/pocket_tts/loader.h
+    LOADERS
+        engine::models::pocket_tts::make_pocket_tts_loader
+)
+
+audiocpp_add_model(miocodec
+    SOURCES
+        src/models/miocodec/assets.cpp
+        src/models/miocodec/weights.cpp
+        src/models/miocodec/audio_pipeline.cpp
+        src/models/miocodec/graph_ops.cpp
+        src/models/miocodec/graphs.cpp
+        src/models/miocodec/session.cpp
+        src/models/miocodec/loader.cpp
+    INCLUDES
+        engine/models/miocodec/loader.h
+    LOADERS
+        engine::models::miocodec::make_miocodec_loader
+)
+
+audiocpp_add_model(miotts
+    SOURCES
+        src/models/miotts/assets.cpp
+        src/models/miotts/tokenizer.cpp
+        src/models/miotts/causal_lm.cpp
+        src/models/miotts/session.cpp
+        src/models/miotts/loader.cpp
+    INCLUDES
+        engine/models/miotts/loader.h
+    LOADERS
+        engine::models::miotts::make_miotts_loader
+)
+
+audiocpp_add_model(moss
+    SOURCES
+        src/models/moss/moss_tts_local/assets.cpp
+        src/models/moss/moss_tts_local/backbone.cpp
+        src/models/moss/moss_tts_nano/assets.cpp
+        src/models/moss/moss_tts_nano/generator.cpp
+        src/models/moss/moss_tts_nano/global_transformer.cpp
+        src/models/moss/moss_tts_nano/local_frame_decoder.cpp
+        src/models/moss/moss_tts_nano/loader.cpp
+        src/models/moss/moss_tts_nano/prompt_builder.cpp
+        src/models/moss/moss_tts_nano/session.cpp
+        src/models/moss/moss_tts_nano/tokenizer_text.cpp
+        src/models/moss/shared/audio_tokenizer_decoder.cpp
+        src/models/moss/shared/audio_tokenizer_encoder.cpp
+        src/models/moss/shared/audio_tokenizer_config.cpp
+        src/models/moss/shared/audio_tokenizer_quantizer.cpp
+        src/models/moss/shared/sampling.cpp
+        src/models/moss/shared/token_rows.cpp
+        src/models/moss/moss_tts_local/depth_transformer.cpp
+        src/models/moss/moss_tts_local/generator.cpp
+        src/models/moss/moss_tts_local/loader.cpp
+        src/models/moss/moss_tts_local/tokenizer_text.cpp
+        src/models/moss/moss_tts_local/session.cpp
+    INCLUDES
+        engine/models/moss/moss_tts_local/loader.h
+        engine/models/moss/moss_tts_nano/loader.h
+    LOADERS
+        engine::models::moss_tts_local::make_moss_tts_local_loader
+        engine::models::moss_tts_nano::make_moss_tts_nano_loader
+    ALIASES
+        moss_tts_local
+        moss_tts_nano
+)
+
+audiocpp_add_model(voxcpm2
+    SOURCES
+        src/models/voxcpm2/assets.cpp
+        src/models/voxcpm2/audiovae.cpp
+        src/models/voxcpm2/generator.cpp
+        src/models/voxcpm2/loader.cpp
+        src/models/voxcpm2/minicpm.cpp
+        src/models/voxcpm2/session.cpp
+        src/models/voxcpm2/tokenizer_text.cpp
+    INCLUDES
+        engine/models/voxcpm2/loader.h
+    LOADERS
+        engine::models::voxcpm2::make_voxcpm2_loader
+)
+
+audiocpp_add_model(vibevoice
+    SOURCES
+        src/models/vibevoice/assets.cpp
+        src/models/vibevoice/connector.cpp
+        src/models/vibevoice/decoder.cpp
+        src/models/vibevoice/diffusion_head.cpp
+        src/models/vibevoice/diffusion_sampler.cpp
+        src/models/vibevoice/generator.cpp
+        src/models/vibevoice/loader.cpp
+        src/models/vibevoice/lora.cpp
+        src/models/vibevoice/scheduler.cpp
+        src/models/vibevoice/session.cpp
+        src/models/vibevoice/tokenizer_audio.cpp
+        src/models/vibevoice/tokenizer_text.cpp
+    INCLUDES
+        engine/models/vibevoice/loader.h
+    LOADERS
+        engine::models::vibevoice::make_vibevoice_loader
+)
+
+audiocpp_add_model(vibevoice_asr
+    SOURCES
+        src/models/vibevoice_asr/assets.cpp
+        src/models/vibevoice_asr/connector.cpp
+        src/models/vibevoice_asr/frontend.cpp
+        src/models/vibevoice_asr/loader.cpp
+        src/models/vibevoice_asr/postprocess.cpp
+        src/models/vibevoice_asr/session.cpp
+        src/models/vibevoice_asr/speech_encoder.cpp
+        src/models/vibevoice_asr/speech_tokenizer.cpp
+        src/models/vibevoice_asr/text_decoder.cpp
+        src/models/vibevoice_asr/tokenizer_text.cpp
+    INCLUDES
+        engine/models/vibevoice_asr/loader.h
+    LOADERS
+        engine::models::vibevoice_asr::make_vibevoice_asr_loader
+)
+
+audiocpp_add_model(voxtral_realtime
+    SOURCES
+        src/models/voxtral_realtime/assets.cpp
+        src/models/voxtral_realtime/tokenizer_text.cpp
+        src/models/voxtral_realtime/frontend.cpp
+        src/models/voxtral_realtime/audio_encoder.cpp
+        src/models/voxtral_realtime/text_decoder.cpp
+        src/models/voxtral_realtime/session.cpp
+        src/models/voxtral_realtime/loader.cpp
+    INCLUDES
+        engine/models/voxtral_realtime/loader.h
+    LOADERS
+        engine::models::voxtral_realtime::make_voxtral_realtime_loader
+)
+
+audiocpp_add_model(fish_audio
+    SOURCES
+        src/models/fish_audio/ar.cpp
+        src/models/fish_audio/assets.cpp
+        src/models/fish_audio/codec.cpp
+        src/models/fish_audio/generator.cpp
+        src/models/fish_audio/loader.cpp
+        src/models/fish_audio/prompt_builder.cpp
+        src/models/fish_audio/session.cpp
+        src/models/fish_audio/tokenizer_text.cpp
+    INCLUDES
+        engine/models/fish_audio/loader.h
+    LOADERS
+        engine::models::fish_audio::make_fish_audio_loader
+)
+
+audiocpp_add_model(confucius4_tts
+    SOURCES
+        src/models/confucius4_tts/assets.cpp
+        src/models/confucius4_tts/audio_features.cpp
+        src/models/confucius4_tts/request.cpp
+        src/models/confucius4_tts/s2a.cpp
+        src/models/confucius4_tts/semantic_encoder.cpp
+        src/models/confucius4_tts/session.cpp
+        src/models/confucius4_tts/style_encoder.cpp
+        src/models/confucius4_tts/t2s.cpp
+        src/models/confucius4_tts/tokenizer_text.cpp
+        src/models/confucius4_tts/vocoder.cpp
+    INCLUDES
+        engine/models/confucius4_tts/session.h
+    LOADERS
+        engine::models::confucius4_tts::make_confucius4_tts_loader
+)
+
+audiocpp_add_model(dramabox
+    SOURCES
+        src/models/dramabox/assets.cpp
+        src/models/dramabox/audio_vae.cpp
+        src/models/dramabox/dit.cpp
+        src/models/dramabox/gemma_tokenizer.cpp
+        src/models/dramabox/gemma3_encoder.cpp
+        src/models/dramabox/latent_state.cpp
+        src/models/dramabox/loader.cpp
+        src/models/dramabox/prompt_connector.cpp
+        src/models/dramabox/session.cpp
+        src/models/dramabox/vocoder.cpp
+    INCLUDES
+        engine/models/dramabox/loader.h
+    LOADERS
+        engine::models::dramabox::make_dramabox_loader
+)
+
+audiocpp_add_model(heartmula
+    SOURCES
+        src/models/heartmula/assets.cpp
+        src/models/heartmula/codec.cpp
+        src/models/heartmula/generator.cpp
+        src/models/heartmula/loader.cpp
+        src/models/heartmula/mula.cpp
+        src/models/heartmula/session.cpp
+        src/models/heartmula/tokenizer_text.cpp
+    INCLUDES
+        engine/models/heartmula/loader.h
+    LOADERS
+        engine::models::heartmula::make_heartmula_loader
+)
+
+audiocpp_add_model(higgs_audio_stt
+    SOURCES
+        src/models/higgs_audio_stt/assets.cpp
+        src/models/higgs_audio_stt/tokenizer_text.cpp
+        src/models/higgs_audio_stt/frontend_whisper.cpp
+        src/models/higgs_audio_stt/audio_encoder.cpp
+        src/models/higgs_audio_stt/text_decoder.cpp
+        src/models/higgs_audio_stt/prompt_asr.cpp
+        src/models/higgs_audio_stt/postprocess.cpp
+        src/models/higgs_audio_stt/session.cpp
+        src/models/higgs_audio_stt/loader.cpp
+    INCLUDES
+        engine/models/higgs_audio_stt/loader.h
+    LOADERS
+        engine::models::higgs_audio_stt::make_higgs_audio_stt_loader
+)
+
+audiocpp_add_model(higgs_audio_tts
+    SOURCES
+        src/models/higgs_audio_tts/ar.cpp
+        src/models/higgs_audio_tts/assets.cpp
+        src/models/higgs_audio_tts/codec.cpp
+        src/models/higgs_audio_tts/codebooks.cpp
+        src/models/higgs_audio_tts/generator.cpp
+        src/models/higgs_audio_tts/loader.cpp
+        src/models/higgs_audio_tts/sampler.cpp
+        src/models/higgs_audio_tts/session.cpp
+        src/models/higgs_audio_tts/tokenizer_text.cpp
+    INCLUDES
+        engine/models/higgs_audio_tts/loader.h
+    LOADERS
+        engine::models::higgs_audio_tts::make_higgs_audio_tts_loader
+)
+
+audiocpp_add_model(hviske_asr
+    SOURCES
+        src/models/hviske_asr/assets.cpp
+        src/models/hviske_asr/frontend.cpp
+        src/models/hviske_asr/encoder.cpp
+        src/models/hviske_asr/decoder.cpp
+        src/models/hviske_asr/session.cpp
+        src/models/hviske_asr/loader.cpp
+        src/models/hviske_asr/weights.cpp
+    INCLUDES
+        engine/models/hviske_asr/loader.h
+    LOADERS
+        engine::models::hviske_asr::make_hviske_asr_loader
+)
+
+audiocpp_add_model(irodori_tts
+    SOURCES
+        src/models/irodori_tts/assets.cpp
+        src/models/irodori_tts/codec.cpp
+        src/models/irodori_tts/condition_encoder.cpp
+        src/models/irodori_tts/duration.cpp
+        src/models/irodori_tts/loader.cpp
+        src/models/irodori_tts/rf_dit.cpp
+        src/models/irodori_tts/session.cpp
+        src/models/irodori_tts/tokenizer_text.cpp
+    INCLUDES
+        engine/models/irodori_tts/loader.h
+    LOADERS
+        engine::models::irodori_tts::make_irodori_tts_loader
+)
+
+audiocpp_add_model(index_tts2
+    SOURCES
+        src/models/index_tts2/assets.cpp
+        src/models/index_tts2/audio_features.cpp
+        src/models/index_tts2/gpt.cpp
+        src/models/index_tts2/loader.cpp
+        src/models/index_tts2/qwen_emotion.cpp
+        src/models/index_tts2/request.cpp
+        src/models/index_tts2/s2mel.cpp
+        src/models/index_tts2/semantic_codec.cpp
+        src/models/index_tts2/semantic_encoder.cpp
+        src/models/index_tts2/session.cpp
+        src/models/index_tts2/style_encoder.cpp
+        src/models/index_tts2/tokenizer_text.cpp
+        src/models/index_tts2/vocoder.cpp
+    INCLUDES
+        engine/models/index_tts2/loader.h
+    LOADERS
+        engine::models::index_tts2::make_index_tts2_loader
+)
+
+audiocpp_add_model(nemotron_asr
+    SOURCES
+        src/models/nemotron_asr/assets.cpp
+        src/models/nemotron_asr/frontend.cpp
+        src/models/nemotron_asr/encoder.cpp
+        src/models/nemotron_asr/decoder.cpp
+        src/models/nemotron_asr/session.cpp
+        src/models/nemotron_asr/loader.cpp
+        src/models/nemotron_asr/weights.cpp
+    INCLUDES
+        engine/models/nemotron_asr/loader.h
+    LOADERS
+        engine::models::nemotron_asr::make_nemotron_asr_loader
+)
+
+audiocpp_add_model(qwen3_tts
+    SOURCES
+        src/models/qwen3_tts/assets.cpp
+        src/models/qwen3_tts/tokenizer_text.cpp
+        src/models/qwen3_tts/tokenizer_speech_encoder.cpp
+        src/models/qwen3_tts/tokenizer_speech_decoder.cpp
+        src/models/qwen3_tts/speaker_encoder.cpp
+        src/models/qwen3_tts/talker.cpp
+        src/models/qwen3_tts/prompt_tts_voice_clone.cpp
+        src/models/qwen3_tts/prompt_tts_voice_design.cpp
+        src/models/qwen3_tts/prompt_tts_custom_voice.cpp
+        src/models/qwen3_tts/session.cpp
+        src/models/qwen3_tts/loader.cpp
+    INCLUDES
+        engine/models/qwen3_tts/loader.h
+    LOADERS
+        engine::models::qwen3_tts::make_qwen3_tts_loader
+)
+
+audiocpp_add_model(vietneu_tts
+    SOURCES
+        src/community_models/vietneu_tts/assets.cpp
+        src/community_models/vietneu_tts/tokenizer_text.cpp
+        src/community_models/vietneu_tts/tokenizer_speech_encoder.cpp
+        src/community_models/vietneu_tts/tokenizer_speech_decoder.cpp
+        src/community_models/vietneu_tts/speaker_encoder.cpp
+        src/community_models/vietneu_tts/talker.cpp
+        src/community_models/vietneu_tts/prompt_tts_voice_clone.cpp
+        src/community_models/vietneu_tts/session.cpp
+        src/community_models/vietneu_tts/loader.cpp
+    INCLUDES
+        engine/community_models/vietneu_tts/loader.h
+    LOADERS
+        engine::models::vietneu_tts::make_vietneu_tts_loader
+)
+
+audiocpp_add_model(qwen3_asr
+    SOURCES
+        src/models/qwen3_asr/assets.cpp
+        src/models/qwen3_asr/tokenizer_text.cpp
+        src/models/qwen3_asr/frontend_whisper.cpp
+        src/models/qwen3_asr/audio_encoder.cpp
+        src/models/qwen3_asr/thinker.cpp
+        src/models/qwen3_asr/prompt_asr.cpp
+        src/models/qwen3_asr/postprocess.cpp
+        src/models/qwen3_asr/session.cpp
+        src/models/qwen3_asr/loader.cpp
+    INCLUDES
+        engine/models/qwen3_asr/loader.h
+    LOADERS
+        engine::models::qwen3_asr::make_qwen3_asr_loader
+)
+
+audiocpp_add_model(qwen3_forced_aligner
+    SOURCES
+        src/models/qwen3_forced_aligner/processor.cpp
+        src/models/qwen3_forced_aligner/session.cpp
+        src/models/qwen3_forced_aligner/loader.cpp
+    INCLUDES
+        engine/models/qwen3_forced_aligner/loader.h
+    LOADERS
+        engine::models::qwen3_forced_aligner::make_qwen3_forced_aligner_loader
+)
+
+audiocpp_add_model(sortformer_diar
+    SOURCES
+        src/models/sortformer_diar/assets.cpp
+        src/models/sortformer_diar/frontend.cpp
+        src/models/sortformer_diar/graph.cpp
+        src/models/sortformer_diar/modules.cpp
+        src/models/sortformer_diar/postprocess.cpp
+        src/models/sortformer_diar/loader.cpp
+        src/models/sortformer_diar/session.cpp
+    INCLUDES
+        engine/models/sortformer_diar/loader.h
+    LOADERS
+        engine::models::sortformer_diar::make_sortformer_diar_loader
+)
+
+audiocpp_add_model(stable_audio
+    SOURCES
+        src/models/stable_audio/assets.cpp
+        src/models/stable_audio/conditioner.cpp
+        src/models/stable_audio/conditioner_runtime.cpp
+        src/models/stable_audio/foundation/conditioner.cpp
+        src/models/stable_audio/foundation/oobleck_autoencoder.cpp
+        src/models/stable_audio/foundation/rf_dit.cpp
+        src/models/stable_audio/foundation/session.cpp
+        src/models/stable_audio/loader.cpp
+        src/models/stable_audio/request.cpp
+        src/models/stable_audio/rf_dit.cpp
+        src/models/stable_audio/same_autoencoder.cpp
+        src/models/stable_audio/sampler.cpp
+        src/models/stable_audio/session.cpp
+        src/models/stable_audio/t5gemma.cpp
+    INCLUDES
+        engine/models/stable_audio/loader.h
+    LOADERS
+        engine::models::stable_audio::make_stable_audio_loader
+)
+
+audiocpp_add_model(supertonic
+    SOURCES
+        src/models/supertonic/assets.cpp
+        src/models/supertonic/loader.cpp
+        src/models/supertonic/runtime.cpp
+        src/models/supertonic/session.cpp
+        src/models/supertonic/tokenizer_text.cpp
+    INCLUDES
+        engine/models/supertonic/loader.h
+    LOADERS
+        engine::models::supertonic::make_supertonic_loader
+)
+
+audiocpp_add_model(citrinet_asr
+    SOURCES
+        src/models/citrinet_asr/assets.cpp
+        src/models/citrinet_asr/runtime.cpp
+        src/models/citrinet_asr/session.cpp
+    INCLUDES
+        engine/models/citrinet_asr/session.h
+    LOADERS
+        engine::models::citrinet_asr::make_citrinet_asr_loader
+)
+
+audiocpp_add_model(vevo2
+    SOURCES
+        src/models/vevo2/ar.cpp
+        src/models/vevo2/assets.cpp
+        src/models/vevo2/components.cpp
+        src/models/vevo2/fm.cpp
+        src/models/vevo2/prompt_builder.cpp
+        src/models/vevo2/session.cpp
+        src/models/vevo2/tokenizer_ar.cpp
+        src/models/vevo2/vocoder.cpp
+        src/models/vevo2/loader.cpp
+    INCLUDES
+        engine/models/vevo2/loader.h
+    LOADERS
+        engine::models::vevo2::make_vevo2_loader
+)
+
+audiocpp_add_model(seed_vc
+    SOURCES
+        src/models/seed_vc/assets.cpp
+        src/models/seed_vc/audio_features.cpp
+        src/models/seed_vc/length_regulator.cpp
+        src/models/seed_vc/astral_quantizer.cpp
+        src/models/seed_vc/content_features.cpp
+        src/models/seed_vc/rmvpe.cpp
+        src/models/seed_vc/whisper_content.cpp
+        src/models/seed_vc/v1_cfm.cpp
+        src/models/seed_vc/v2_cfm.cpp
+        src/models/seed_vc/session.cpp
+        src/models/seed_vc/loader.cpp
+    INCLUDES
+        engine/models/seed_vc/loader.h
+    LOADERS
+        engine::models::seed_vc::make_seed_vc_loader
+)
+
+audiocpp_add_model(rvc
+    SOURCES
+        src/models/rvc/assets.cpp
+        src/models/rvc/hubert.cpp
+        src/models/rvc/native_pipeline.cpp
+        src/models/rvc/retrieval_index.cpp
+        src/models/rvc/session.cpp
+        src/models/rvc/synthesizer.cpp
+        src/models/rvc/voice_model.cpp
+        src/models/rvc/loader.cpp
+    INCLUDES
+        engine/models/rvc/loader.h
+    LOADERS
+        engine::models::rvc::make_rvc_loader
+)
+
+audiocpp_add_model(chatterbox
+    SOURCES
+        src/models/chatterbox/assets.cpp
+        src/models/chatterbox/campplus_encoder_impl.cpp
+        src/models/chatterbox/audio_features.cpp
+        src/models/chatterbox/audio_processing.cpp
+        src/models/chatterbox/component_weights.cpp
+        src/models/chatterbox/conditionals.cpp
+        src/models/chatterbox/hift_vocoder_impl.cpp
+        src/models/chatterbox/loader.cpp
+        src/models/chatterbox/s3_tokenizer_impl.cpp
+        src/models/chatterbox/s3gen_flow.cpp
+        src/models/chatterbox/s3gen_inference.cpp
+        src/models/chatterbox/session.cpp
+        src/models/chatterbox/t3_component.cpp
+        src/models/chatterbox/t3_weights.cpp
+        src/models/chatterbox/text_tokenizer.cpp
+        src/models/chatterbox/tts.cpp
+        src/models/chatterbox/vc.cpp
+        src/models/chatterbox/voice_encoder_impl.cpp
+    INCLUDES
+        engine/models/chatterbox/loader.h
+    LOADERS
+        engine::models::chatterbox::make_chatterbox_loader
+)
+
+audiocpp_add_model(ace_step
+    SOURCES
+        src/models/ace_step/assets.cpp
+        src/models/ace_step/condition_encoder.cpp
+        src/models/ace_step/cover_tokenizer.cpp
+        src/models/ace_step/detokenizer.cpp
+        src/models/ace_step/diffusion.cpp
+        src/models/ace_step/dit_weights_runtime.cpp
+        src/models/ace_step/loader.cpp
+        src/models/ace_step/planner.cpp
+        src/models/ace_step/pre_dit.cpp
+        src/models/ace_step/prompt_builder.cpp
+        src/models/ace_step/repaint.cpp
+        src/models/ace_step/request_parser.cpp
+        src/models/ace_step/session.cpp
+        src/models/ace_step/task_route.cpp
+        src/models/ace_step/text_encoder.cpp
+        src/models/ace_step/tokenizer_text.cpp
+        src/models/ace_step/vae_decoder.cpp
+        src/models/ace_step/vae_encoder.cpp
+    INCLUDES
+        engine/models/ace_step/loader.h
+    LOADERS
+        engine::models::ace_step::make_ace_step_loader
+)
+
+set(AUDIOCPP_ENABLED_MODELS "")
+if (AUDIOCPP_MODEL_SET STREQUAL "full")
+    set(AUDIOCPP_ENABLED_MODELS ${AUDIOCPP_MODEL_TARGETS})
+elseif (AUDIOCPP_MODEL_SET STREQUAL "core")
+    set(AUDIOCPP_ENABLED_MODELS "")
+elseif (AUDIOCPP_MODEL_SET STREQUAL "custom")
+    string(REPLACE "," ";" AUDIOCPP_REQUESTED_MODELS "${AUDIOCPP_MODELS}")
+    foreach(requested_model IN LISTS AUDIOCPP_REQUESTED_MODELS)
+        string(STRIP "${requested_model}" requested_model)
+        if (requested_model STREQUAL "")
+            continue()
+        endif()
+        if (DEFINED AUDIOCPP_MODEL_ALIAS_${requested_model})
+            list(APPEND AUDIOCPP_ENABLED_MODELS ${AUDIOCPP_MODEL_ALIAS_${requested_model}})
+        else()
+            message(FATAL_ERROR "Unknown AUDIOCPP_MODELS entry: ${requested_model}")
+        endif()
+    endforeach()
+    list(REMOVE_DUPLICATES AUDIOCPP_ENABLED_MODELS)
+else()
+    message(FATAL_ERROR "AUDIOCPP_MODEL_SET must be full, core, or custom")
+endif()
+
+set(AUDIOCPP_REGISTRY_INCLUDE_CONTENT "")
+set(AUDIOCPP_REGISTRY_LOADER_CONTENT "")
+foreach(model_name IN LISTS AUDIOCPP_ENABLED_MODELS)
+    foreach(include_name IN LISTS AUDIOCPP_MODEL_${model_name}_INCLUDES)
+        string(APPEND AUDIOCPP_REGISTRY_INCLUDE_CONTENT "#include \"${include_name}\"\n")
+    endforeach()
+    foreach(loader_name IN LISTS AUDIOCPP_MODEL_${model_name}_LOADERS)
+        string(APPEND AUDIOCPP_REGISTRY_LOADER_CONTENT "        ${loader_name}(),\n")
+    endforeach()
+endforeach()
+file(GENERATE
+    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/generated/model_registry_includes.inc"
+    CONTENT "${AUDIOCPP_REGISTRY_INCLUDE_CONTENT}")
+file(GENERATE
+    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/generated/model_registry_loaders.inc"
+    CONTENT "${AUDIOCPP_REGISTRY_LOADER_CONTENT}")
+
+set(AUDIOCPP_RUNTIME_OBJECTS
+    $<TARGET_OBJECTS:engine_core>
+    $<TARGET_OBJECTS:engine_model_silero_vad>
+    $<TARGET_OBJECTS:engine_model_marblenet_vad>
+)
+foreach(model_name IN LISTS AUDIOCPP_ENABLED_MODELS)
+    list(APPEND AUDIOCPP_RUNTIME_OBJECTS $<TARGET_OBJECTS:engine_model_${model_name}>)
+endforeach()
+
+message(STATUS "audio.cpp model composite: ${AUDIOCPP_MODEL_SET} [${AUDIOCPP_ENABLED_MODELS}]")
+add_library(engine_runtime STATIC
+    src/framework/runtime/registry.cpp
+    ${AUDIOCPP_RUNTIME_OBJECTS}
 )
 
 add_library(cjson_vendor STATIC

--- a/README.md
+++ b/README.md
@@ -154,6 +154,23 @@ brew install audio-cpp
 
 For Nix and NixOS builds, see [docs/build/nixos.md](docs/build/nixos.md).
 
+### Composite Builds
+
+Composite builds let you compile only the model families you need. `full` is the default and is what release/Docker builds should use. `custom` registers only the requested loaders while still linking required internal dependencies; `core` builds the runtime without the optional model-family set.
+
+The helper scripts expose this as `--model-set` and `--models` on Linux/macOS, and `-ModelSet` and `-Models` on Windows:
+
+```bash
+scripts/build_linux.sh --backend cuda --model-set custom --models qwen3_tts,pocket_tts,qwen3_asr --target audiocpp_cli
+```
+
+Direct CMake builds use the same underlying variables:
+
+```bash
+cmake -S . -B build/debug -DCMAKE_BUILD_TYPE=Debug -DAUDIOCPP_MODEL_SET=custom -DAUDIOCPP_MODELS=qwen3_tts,pocket_tts,qwen3_asr
+cmake --build build/debug --target audiocpp_cli -j 8
+```
+
 ### Linux Build
 
 Use the Linux helper script for CPU, CUDA, or Vulkan builds:
@@ -165,6 +182,14 @@ scripts/build_linux.sh --backend cpu --target audiocpp_cli --target audiocpp_ser
 ```
 
 The script writes to aligned build directories such as `build/linux-cuda-release`, `build/linux-vulkan-release`, and `build/linux-cpu-release`.
+
+Composite examples:
+
+```bash
+scripts/build_linux.sh --backend cuda --model-set full --target audiocpp_cli
+scripts/build_linux.sh --backend cuda --model-set custom --models qwen3_tts,pocket_tts,qwen3_asr --target audiocpp_cli
+scripts/build_linux.sh --backend cpu --model-set core --target audiocpp_cli
+```
 
 For portable CPU kernels on machines where native ISA flags are not suitable:
 
@@ -194,6 +219,7 @@ Common presets:
 .\scripts\build_windows.ps1 -Preset windows-cuda-release -Target audiocpp_cli
 .\scripts\build_windows.ps1 -Preset windows-cpu-release -Target audiocpp_cli
 .\scripts\build_windows.ps1 -Target audiocpp_server -Jobs 16
+.\scripts\build_windows.ps1 -Preset windows-cuda-release -ModelSet custom -Models "qwen3_tts,pocket_tts,qwen3_asr" -Target audiocpp_cli
 ```
 
 From `cmd.exe`, use the wrapper:
@@ -225,6 +251,7 @@ Useful variants:
 ```bash
 scripts/build_metal.sh --target audiocpp_server
 scripts/build_metal.sh --build-type Release --archs arm64 --target audiocpp_cli
+scripts/build_metal.sh --model-set custom --models qwen3_tts,pocket_tts --target audiocpp_cli
 scripts/build_metal.sh --with-tests --target audio_dsp_test
 scripts/build_metal.sh --openmp auto --target audiocpp_cli
 scripts/build_metal.sh --native-cpu OFF --target audiocpp_cli
@@ -252,6 +279,8 @@ build/macos-metal-release/bin/audiocpp_cli
 | `ENGINE_BUILD_TESTS` | Build framework unit tests. | `OFF` |
 | `ENGINE_BUILD_WARMBENCH` | Build warmbench helper binaries. | `OFF` |
 | `AUDIOCPP_DEPLOYMENT_BUILD` | Compile package specs into CLI/server binaries for standalone GGUF and package-spec fallback loading. Script builds expose this as `--deployment-build` on Linux/macOS and `-DeploymentBuild` on Windows. | `OFF` |
+| `AUDIOCPP_MODEL_SET` | Model composite to build: `full`, `core`, or `custom`. Script builds expose this as `--model-set` on Linux/macOS and `-ModelSet` on Windows. | `full` |
+| `AUDIOCPP_MODELS` | Comma or semicolon separated model target names when `AUDIOCPP_MODEL_SET=custom`, such as `qwen3_tts,pocket_tts,qwen3_asr`. Script builds expose this as `--models` on Linux/macOS and `-Models` on Windows. | empty |
 
 ## Usage
 

--- a/docs/maintainers/loader_and_catalog.md
+++ b/docs/maintainers/loader_and_catalog.md
@@ -18,7 +18,7 @@ For every **installable, standalone** `ModelPackage`:
 |---|---|
 | `ModelPackage.family` | The loader family string advertised by the C++ loader |
 | `model_specs/<family>.json` | Present when the family uses package-spec loading |
-| `registry.cpp` entry | Uncommented `make_<family>_loader()` (or the family's actual factory name) |
+| `CMakeLists.txt` `LOADERS` entry | `make_<family>_loader` (or the family's actual factory name) so the generated registry includes it |
 | `docs/model_manager.md` package table | Lists the package; use **Unavailable** when not installable |
 
 Dependency / subcomponent packages (`standalone=False`, with
@@ -30,12 +30,13 @@ allowed. List them in `BUNDLED_LOADERS_WITHOUT_PACKAGE` inside
 
 If a loader is not ready for this release tree:
 
-1. Keep it **commented out** in `src/framework/runtime/registry.cpp`, and
+1. Do not include it in an enabled `audiocpp_add_model(... LOADERS ...)` entry, and
 2. Mark matching catalog packages as `UnsupportedSource(reason=...)`, **or**
    remove them from `CATALOG`, and
 3. Mark the `docs/model_manager.md` package row **Unavailable**.
 
-Do **not** leave a live `SnapshotSource` for a commented-out loader.
+Do **not** leave a live `SnapshotSource` for a loader that is not emitted into
+the generated registry.
 
 Optional catalog↔registry family renames for parked stubs go in
 `PARKED_FAMILY_ALIASES` in the sync check (collapse to one id when re-enabling).
@@ -45,9 +46,9 @@ Optional catalog↔registry family renames for parked stubs go in
 1. Implement `include/engine/models/<family>/` (or `community_models/`) with a
    loader that overrides `advertised_capabilities()` so tasks/endpoints are
    explicit.
-2. Register it in `src/framework/runtime/registry.cpp` (include +
-   `available_loaders` entry). Prefer the factory name
-   `make_<family>_loader()` so the id matches the advertised family.
+2. Register it in `CMakeLists.txt` with `audiocpp_add_model(... INCLUDES ...
+   LOADERS ...)`. Prefer the factory name `make_<family>_loader` so the id
+   matches the advertised family.
 3. Add `model_specs/<family>.json` when the family needs package-spec discovery.
 4. Add one or more `ModelPackage` entries in `tools/model_manager.py`:
    - Set `family="<family>"` explicitly when the package id does not strip cleanly
@@ -70,7 +71,7 @@ for that family set `"family"` to the same string.
 
 ## Checklist: parking or removing a family
 
-1. Comment out the include and `make_*_loader()` entry in `registry.cpp`.
+1. Remove the family from the enabled `LOADERS` list in `CMakeLists.txt`.
 2. Convert related **standalone** packages to `UnsupportedSource` with a reason
    that names the missing loader and points at this doc (or delete them).
 3. Leave `family=` / `tasks=` on unsupported entries if useful for history.
@@ -83,6 +84,7 @@ Pick **one** family string and use it everywhere:
 
 - C++ loader / `advertised_capabilities()`
 - `make_<family>_loader()` naming (when practical)
+- `CMakeLists.txt` `LOADERS` entry
 - `model_specs/<family>.json`
 - `ModelPackage.family`
 - README “Supported Models” family column
@@ -96,6 +98,9 @@ Integrators match on the string; aliases are not implied unless listed in
 builds. It:
 
 - Parses active vs commented `make_*_loader()` calls in `registry.cpp`
+- Parses generated-registry loader declarations from `CMakeLists.txt`
+- Unions both sources because most model loaders are generated from CMake, while
+  bundled loaders may still be listed directly in `registry.cpp`
 - Compares them to installable standalone packages from `model_manager.py`
 - Cross-checks the `docs/model_manager.md` recommended package table
 - Does **not** require a compiled binary

--- a/include/engine/models/rvc/rmvpe.h
+++ b/include/engine/models/rvc/rmvpe.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "engine/framework/assets/tensor_source.h"
+#include "engine/framework/core/backend.h"
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace engine::models::rvc {
+
+class RvcRmvpeF0Extractor {
+public:
+    RvcRmvpeF0Extractor() = default;
+    RvcRmvpeF0Extractor(
+        std::shared_ptr<const engine::assets::TensorSource> source,
+        engine::core::BackendConfig backend,
+        engine::assets::TensorStorageType storage_type);
+    ~RvcRmvpeF0Extractor();
+
+    RvcRmvpeF0Extractor(RvcRmvpeF0Extractor &&) noexcept;
+    RvcRmvpeF0Extractor & operator=(RvcRmvpeF0Extractor &&) noexcept;
+    RvcRmvpeF0Extractor(const RvcRmvpeF0Extractor &) = delete;
+    RvcRmvpeF0Extractor & operator=(const RvcRmvpeF0Extractor &) = delete;
+
+    std::vector<float> infer_16k_mono(
+        const std::vector<float> & waveform_16k,
+        float threshold,
+        size_t threads) const;
+
+private:
+    struct State;
+
+    std::shared_ptr<State> state_;
+};
+
+}  // namespace engine::models::rvc

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -11,6 +11,8 @@ WITH_TESTS="OFF"
 WITH_EXAMPLES="OFF"
 WITH_WARMBENCH="OFF"
 AUDIOCPP_DEPLOYMENT_BUILD="OFF"
+AUDIOCPP_MODEL_SET="full"
+AUDIOCPP_MODELS=""
 NATIVE_CPU="ON"
 LLAMAFILE="ON"
 TARGETS=()
@@ -69,6 +71,22 @@ while [[ $# -gt 0 ]]; do
         --deployment-build)
             AUDIOCPP_DEPLOYMENT_BUILD="ON"
             shift
+            ;;
+        --model-set)
+            case "$2" in
+                full|core|custom)
+                    AUDIOCPP_MODEL_SET="$2"
+                    ;;
+                *)
+                    echo "--model-set must be full, core, or custom" >&2
+                    exit 1
+                    ;;
+            esac
+            shift 2
+            ;;
+        --models)
+            AUDIOCPP_MODELS="$2"
+            shift 2
             ;;
         --native-cpu)
             case "$2" in
@@ -204,6 +222,10 @@ echo "Building examples: $WITH_EXAMPLES"
 echo "Building tests: $WITH_TESTS"
 echo "Building warmbench: $WITH_WARMBENCH"
 echo "Deployment build: $AUDIOCPP_DEPLOYMENT_BUILD"
+echo "Model composite: $AUDIOCPP_MODEL_SET"
+if [[ -n "$AUDIOCPP_MODELS" ]]; then
+    echo "Selected models: $AUDIOCPP_MODELS"
+fi
 
 "${RUNNER[@]}" cmake \
     -S . \
@@ -217,7 +239,9 @@ echo "Deployment build: $AUDIOCPP_DEPLOYMENT_BUILD"
     -DENGINE_BUILD_EXAMPLES="$WITH_EXAMPLES" \
     -DENGINE_BUILD_TESTS="$WITH_TESTS" \
     -DENGINE_BUILD_WARMBENCH="$WITH_WARMBENCH" \
-    -DAUDIOCPP_DEPLOYMENT_BUILD="$AUDIOCPP_DEPLOYMENT_BUILD"
+    -DAUDIOCPP_DEPLOYMENT_BUILD="$AUDIOCPP_DEPLOYMENT_BUILD" \
+    -DAUDIOCPP_MODEL_SET="$AUDIOCPP_MODEL_SET" \
+    -DAUDIOCPP_MODELS="$AUDIOCPP_MODELS"
 
 BUILD_CMD=("${RUNNER[@]}" cmake --build "$BUILD_DIR" --parallel "$JOBS")
 for target in "${TARGETS[@]}"; do

--- a/scripts/build_metal.sh
+++ b/scripts/build_metal.sh
@@ -11,6 +11,8 @@ WITH_TESTS="OFF"
 WITH_EXAMPLES="OFF"
 WITH_WARMBENCH="OFF"
 AUDIOCPP_DEPLOYMENT_BUILD="OFF"
+AUDIOCPP_MODEL_SET="full"
+AUDIOCPP_MODELS=""
 OPENMP_MODE="off"
 LLAMAFILE="ON"
 NATIVE_CPU="ON"
@@ -46,6 +48,11 @@ Options:
   --with-examples          Build example binaries.
   --with-warmbench         Build warmbench helper binaries.
   --deployment-build       Embed package specs for standalone GGUF/model loading.
+  --model-set full|core|custom
+                           Model composite to build.
+                           Default: full
+  --models "<list>"        Comma or semicolon separated model targets when
+                           --model-set custom is used.
   --target <name>          Build a specific CMake target. May be repeated.
   -j, --jobs <n>           Parallel build jobs.
   -h, --help               Show this help.
@@ -123,6 +130,22 @@ while [[ $# -gt 0 ]]; do
         --deployment-build)
             AUDIOCPP_DEPLOYMENT_BUILD="ON"
             shift
+            ;;
+        --model-set)
+            case "$2" in
+                full|core|custom)
+                    AUDIOCPP_MODEL_SET="$2"
+                    ;;
+                *)
+                    echo "--model-set must be full, core, or custom" >&2
+                    exit 1
+                    ;;
+            esac
+            shift 2
+            ;;
+        --models)
+            AUDIOCPP_MODELS="$2"
+            shift 2
             ;;
         --target)
             TARGETS+=("$2")
@@ -214,6 +237,8 @@ CMAKE_CMD=(
     -DENGINE_BUILD_EXAMPLES="$WITH_EXAMPLES"
     -DENGINE_BUILD_WARMBENCH="$WITH_WARMBENCH"
     -DAUDIOCPP_DEPLOYMENT_BUILD="$AUDIOCPP_DEPLOYMENT_BUILD"
+    -DAUDIOCPP_MODEL_SET="$AUDIOCPP_MODEL_SET"
+    -DAUDIOCPP_MODELS="$AUDIOCPP_MODELS"
 )
 
 if [[ -n "$GENERATOR" ]]; then
@@ -245,6 +270,10 @@ echo "Building examples: $WITH_EXAMPLES"
 echo "Building tests: $WITH_TESTS"
 echo "Building warmbench: $WITH_WARMBENCH"
 echo "Deployment build: $AUDIOCPP_DEPLOYMENT_BUILD"
+echo "Model composite: $AUDIOCPP_MODEL_SET"
+if [[ -n "$AUDIOCPP_MODELS" ]]; then
+    echo "Selected models: $AUDIOCPP_MODELS"
+fi
 
 "${CMAKE_CMD[@]}"
 

--- a/scripts/build_windows.ps1
+++ b/scripts/build_windows.ps1
@@ -13,6 +13,9 @@ param(
     [ValidateSet("ON", "OFF")]
     [string]$Llamafile = $null,
     [switch]$DeploymentBuild,
+    [ValidateSet("full", "core", "custom")]
+    [string]$ModelSet = "full",
+    [string]$Models = "",
     [string]$VsInstall = ""
 )
 
@@ -459,6 +462,10 @@ Write-Host "Native CPU optimization: $($settings.Native)"
 Write-Host "llamafile SGEMM: $($settings.Llamafile)"
 $deploymentBuildValue = if ($DeploymentBuild) { "ON" } else { "OFF" }
 Write-Host "Deployment build: $deploymentBuildValue"
+Write-Host "Model composite: $ModelSet"
+if ($Models -ne "") {
+    Write-Host "Selected models: $Models"
+}
 
 if ($Clean) {
     $buildDirForClean = Join-Path (Join-Path (Split-Path $PSScriptRoot -Parent) "build") $Preset
@@ -492,7 +499,9 @@ $configureArgs = @(
     "-DENGINE_ENABLE_NATIVE_CPU=$($settings.Native)",
     "-DENGINE_ENABLE_LLAMAFILE=$($settings.Llamafile)",
     "-DENGINE_BUILD_TESTS=$($settings.BuildTests)",
-    "-DAUDIOCPP_DEPLOYMENT_BUILD=$deploymentBuildValue"
+    "-DAUDIOCPP_DEPLOYMENT_BUILD=$deploymentBuildValue",
+    "-DAUDIOCPP_MODEL_SET=$ModelSet",
+    "-DAUDIOCPP_MODELS=$Models"
 )
 $configureArgs += $cpuArchSettings.CMakeArgs
 if ($settings.CFlagsDebug -ne "") {

--- a/scripts/build_xcframework.sh
+++ b/scripts/build_xcframework.sh
@@ -15,6 +15,8 @@ CLEAN="OFF"
 LLAMAFILE="ON"
 NATIVE_CPU="ON"
 AUDIOCPP_DEPLOYMENT_BUILD="OFF"
+AUDIOCPP_MODEL_SET="full"
+AUDIOCPP_MODELS=""
 
 usage() {
     cat <<'EOF'
@@ -41,6 +43,11 @@ Options:
   --native-cpu ON|OFF   Build ggml CPU kernels with native host ISA flags.
                         Default: ON
   --deployment-build    Embed package specs for standalone GGUF/model loading.
+  --model-set full|core|custom
+                        Model composite to build.
+                        Default: full
+  --models "<list>"     Comma or semicolon separated model targets when
+                        --model-set custom is used.
   -j, --jobs <n>        Parallel build jobs.
   -h, --help            Show this help.
 
@@ -92,6 +99,22 @@ while [[ $# -gt 0 ]]; do
         --deployment-build)
             AUDIOCPP_DEPLOYMENT_BUILD="ON"
             shift
+            ;;
+        --model-set)
+            case "$2" in
+                full|core|custom)
+                    AUDIOCPP_MODEL_SET="$2"
+                    ;;
+                *)
+                    echo "--model-set must be full, core, or custom" >&2
+                    exit 1
+                    ;;
+            esac
+            shift 2
+            ;;
+        --models)
+            AUDIOCPP_MODELS="$2"
+            shift 2
             ;;
         -j|--jobs)
             JOBS="$2"
@@ -192,7 +215,9 @@ archive_for_arch() {
         -DGGML_METAL_EMBED_LIBRARY=ON \
         -DENGINE_BUILD_TESTS=OFF \
         -DENGINE_BUILD_EXAMPLES=OFF \
-        -DAUDIOCPP_DEPLOYMENT_BUILD="$AUDIOCPP_DEPLOYMENT_BUILD"
+        -DAUDIOCPP_DEPLOYMENT_BUILD="$AUDIOCPP_DEPLOYMENT_BUILD" \
+        -DAUDIOCPP_MODEL_SET="$AUDIOCPP_MODEL_SET" \
+        -DAUDIOCPP_MODELS="$AUDIOCPP_MODELS"
     )
     if [[ -n "$GENERATOR" ]]; then
         cmake_cmd+=(-G "$GENERATOR")

--- a/src/framework/runtime/registry.cpp
+++ b/src/framework/runtime/registry.cpp
@@ -4,45 +4,10 @@
 #include "engine/framework/model_spec/package.h"
 #include "engine/framework/io/config.h"
 #include "engine/framework/io/filesystem.h"
-#include "engine/models/ace_step/loader.h"
-#include "engine/models/chatterbox/loader.h"
-#include "engine/models/citrinet_asr/session.h"
-#include "engine/models/confucius4_tts/session.h"
-#include "engine/models/demucs/loader.h"
-#include "engine/models/dramabox/loader.h"
-#include "engine/models/fish_audio/loader.h"
-#include "engine/models/heartmula/loader.h"
-#include "engine/models/higgs_audio_stt/loader.h"
-#include "engine/models/higgs_audio_tts/loader.h"
-#include "engine/models/hviske_asr/loader.h"
-#include "engine/models/index_tts2/loader.h"
-#include "engine/models/irodori_tts/loader.h"
 #include "engine/models/marblenet_vad/session.h"
-#include "engine/models/miocodec/loader.h"
-#include "engine/models/miotts/loader.h"
-#include "engine/models/moss/moss_tts_local/loader.h"
-#include "engine/models/moss/moss_tts_nano/loader.h"
-#include "engine/models/nemotron_asr/loader.h"
-#include "engine/models/omnivoice/loader.h"
-#include "engine/community_models/glm_tts/loader.h"
-#include "engine/community_models/outetts/loader.h"
-#include "engine/models/pocket_tts/loader.h"
-#include "engine/models/qwen3_asr/loader.h"
-#include "engine/models/qwen3_forced_aligner/loader.h"
-#include "engine/models/qwen3_tts/loader.h"
-#include "engine/community_models/vietneu_tts/loader.h"
-#include "engine/models/roformer/loader.h"
-#include "engine/models/rvc/loader.h"
 #include "engine/models/silero_vad/session.h"
-#include "engine/models/seed_vc/loader.h"
-#include "engine/models/sortformer_diar/loader.h"
-#include "engine/models/stable_audio/loader.h"
-#include "engine/models/supertonic/loader.h"
-#include "engine/models/vevo2/loader.h"
-#include "engine/models/vibevoice/loader.h"
-#include "engine/models/vibevoice_asr/loader.h"
-#include "engine/models/voxtral_realtime/loader.h"
-#include "engine/models/voxcpm2/loader.h"
+
+#include "model_registry_includes.inc"
 
 #include <algorithm>
 #include <cctype>
@@ -244,46 +209,9 @@ ModelRegistry make_registry_from_config(
 
 ModelRegistry make_default_registry(const std::optional<std::filesystem::path> & config_path) {
     const std::vector<std::shared_ptr<IVoiceModelLoader>> available_loaders = {
-        engine::models::ace_step::make_ace_step_loader(),
-        engine::models::demucs::make_htdemucs_loader(),
-        engine::models::roformer::make_mel_band_roformer_loader(),
-        engine::models::roformer::make_bs_roformer_loader(),
-        engine::models::omnivoice::make_omnivoice_loader(),
-        engine::models::glm_tts::make_glm_tts_loader(),
-        engine::models::outetts::make_outetts_loader(),
-        engine::models::miocodec::make_miocodec_loader(),
-        engine::models::miotts::make_miotts_loader(),
-        engine::models::moss_tts_local::make_moss_tts_local_loader(),
-        engine::models::moss_tts_nano::make_moss_tts_nano_loader(),
-        engine::models::voxcpm2::make_voxcpm2_loader(),
-        engine::models::vibevoice::make_vibevoice_loader(),
-        engine::models::vibevoice_asr::make_vibevoice_asr_loader(),
-        engine::models::voxtral_realtime::make_voxtral_realtime_loader(),
-        engine::models::fish_audio::make_fish_audio_loader(),
-        engine::models::confucius4_tts::make_confucius4_tts_loader(),
-        engine::models::dramabox::make_dramabox_loader(),
-        engine::models::heartmula::make_heartmula_loader(),
-        engine::models::higgs_audio_stt::make_higgs_audio_stt_loader(),
-        engine::models::higgs_audio_tts::make_higgs_audio_tts_loader(),
-        engine::models::hviske_asr::make_hviske_asr_loader(),
-        engine::models::irodori_tts::make_irodori_tts_loader(),
-        engine::models::nemotron_asr::make_nemotron_asr_loader(),
-        engine::models::pocket_tts::make_pocket_tts_loader(),
-        engine::models::qwen3_forced_aligner::make_qwen3_forced_aligner_loader(),
-        engine::models::qwen3_asr::make_qwen3_asr_loader(),
-        engine::models::index_tts2::make_index_tts2_loader(),
-        engine::models::qwen3_tts::make_qwen3_tts_loader(),
-        engine::models::vietneu_tts::make_vietneu_tts_loader(),
-        engine::models::sortformer_diar::make_sortformer_diar_loader(),
-        engine::models::stable_audio::make_stable_audio_loader(),
-        engine::models::supertonic::make_supertonic_loader(),
         engine::models::silero_vad::make_silero_vad_loader(),
-        engine::models::citrinet_asr::make_citrinet_asr_loader(),
         engine::models::marblenet_vad::make_marblenet_vad_loader(),
-        engine::models::vevo2::make_vevo2_loader(),
-        engine::models::seed_vc::make_seed_vc_loader(),
-        engine::models::rvc::make_rvc_loader(),
-        engine::models::chatterbox::make_chatterbox_loader(),
+#include "model_registry_loaders.inc"
     };
     if (!config_path.has_value()) {
         ModelRegistry registry;

--- a/src/models/rvc/native_pipeline.cpp
+++ b/src/models/rvc/native_pipeline.cpp
@@ -6,8 +6,8 @@
 #include "engine/framework/debug/trace.h"
 #include "engine/framework/sampling/torch_random.h"
 #include "engine/models/rvc/hubert.h"
+#include "engine/models/rvc/rmvpe.h"
 #include "engine/models/rvc/synthesizer.h"
-#include "engine/models/seed_vc/rmvpe.h"
 
 #include "retrieval_index.h"
 
@@ -518,7 +518,7 @@ struct RvcNativePipeline::State {
     engine::core::BackendConfig backend;
     engine::assets::TensorStorageType storage_type = engine::assets::TensorStorageType::Native;
     RvcHubertEncoder hubert;
-    seed_vc::SeedVcRmvpeF0Extractor rmvpe;
+    RvcRmvpeF0Extractor rmvpe;
     std::unordered_map<std::string, std::unique_ptr<RvcSynthesizer>> synthesizers;
     std::unordered_map<std::string, std::unique_ptr<RvcRetrievalIndex>> retrieval_indices;
     std::mutex mutex;
@@ -536,7 +536,7 @@ RvcNativePipeline::RvcNativePipeline(
     state_->backend = std::move(backend);
     state_->storage_type = storage_type;
     state_->hubert = RvcHubertEncoder(state_->assets->hubert, state_->backend, state_->storage_type);
-    state_->rmvpe = seed_vc::SeedVcRmvpeF0Extractor(
+    state_->rmvpe = RvcRmvpeF0Extractor(
         state_->assets->rmvpe,
         state_->backend,
         state_->storage_type);

--- a/src/models/rvc/rmvpe.cpp
+++ b/src/models/rvc/rmvpe.cpp
@@ -1,0 +1,1022 @@
+#include "engine/models/rvc/rmvpe.h"
+
+#include "engine/framework/audio/dsp.h"
+#include "engine/framework/core/backend.h"
+#include "engine/framework/core/backend_weight_store.h"
+#include "engine/framework/core/execution_context.h"
+#include "engine/framework/debug/profiler.h"
+#include "engine/framework/debug/trace.h"
+#include "engine/framework/modules/activation_modules.h"
+#include "engine/framework/modules/conv_modules.h"
+#include "engine/framework/modules/linear_module.h"
+#include "engine/framework/modules/primitive_modules.h"
+#include "engine/framework/modules/structural_modules.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace engine::models::rvc {
+namespace {
+
+using engine::core::TensorShape;
+using engine::core::TensorValue;
+
+constexpr int64_t kRmvpeMelBins = 128;
+constexpr int64_t kRmvpeFeatureDim = 384;
+constexpr int64_t kRmvpeHiddenDim = 256;
+constexpr int64_t kRmvpeClasses = 360;
+constexpr int64_t kRmvpeFeatureActiveFrames = 4096;
+constexpr int64_t kRmvpeFeatureOverlapFrames = 2048;
+constexpr int64_t kRmvpeFeatureGraphFrames = kRmvpeFeatureActiveFrames + 2 * kRmvpeFeatureOverlapFrames;
+constexpr int64_t kRmvpeGruChunkFrames = 512;
+
+struct RmvpeMelFilterbank {
+    std::vector<float> values;
+    std::vector<int64_t> starts;
+    std::vector<int64_t> ends;
+};
+
+struct RmvpePreparedMel {
+    std::vector<float> values;
+    int64_t frames = 0;
+    int64_t padded_frames = 0;
+};
+
+struct RmvpeGruOutputs {
+    TensorValue sequence;
+    TensorValue final_hidden;
+};
+
+struct RvcRmvpeWeights {
+    std::shared_ptr<engine::core::ExecutionContext> execution_context;
+    std::shared_ptr<engine::core::BackendWeightStore> store;
+    std::unordered_map<std::string, TensorValue> tensors;
+};
+
+RvcRmvpeWeights load_rmvpe_weights(
+    std::shared_ptr<const engine::assets::TensorSource> source,
+    engine::core::BackendConfig backend,
+    engine::assets::TensorStorageType storage_type) {
+    if (source == nullptr) {
+        throw std::runtime_error("RVC RMVPE requires weights");
+    }
+    RvcRmvpeWeights weights;
+    weights.execution_context = std::make_shared<engine::core::ExecutionContext>(backend);
+    weights.store = std::make_shared<engine::core::BackendWeightStore>(
+        weights.execution_context->backend(),
+        weights.execution_context->backend_type(),
+        "rvc.rmvpe.weights",
+        256ull * 1024ull * 1024ull);
+    const auto tensors = source->tensors();
+    weights.tensors.reserve(tensors.size());
+    for (const auto & tensor : tensors) {
+        if (tensor.name.size() >= 20 &&
+            tensor.name.compare(tensor.name.size() - 20, 20, ".num_batches_tracked") == 0) {
+            continue;
+        }
+        weights.tensors.emplace(
+            tensor.name,
+            weights.store->load_tensor(*source, tensor.name, storage_type, tensor.shape));
+    }
+    weights.store->upload();
+    return weights;
+}
+
+const TensorValue & require_tensor(const RvcRmvpeWeights & weights, const std::string & name) {
+    const auto it = weights.tensors.find(name);
+    if (it == weights.tensors.end()) {
+        throw std::runtime_error("RVC RMVPE missing tensor: " + name);
+    }
+    return it->second;
+}
+
+TensorValue contiguous(engine::core::ModuleBuildContext & ctx, const TensorValue & value) {
+    return engine::core::ensure_backend_addressable_layout(ctx, value);
+}
+
+TensorValue add(engine::core::ModuleBuildContext & ctx, const TensorValue & lhs, const TensorValue & rhs) {
+    return engine::modules::AddModule{}.build(ctx, lhs, rhs);
+}
+
+TensorValue mul(engine::core::ModuleBuildContext & ctx, const TensorValue & lhs, const TensorValue & rhs) {
+    return engine::modules::MulModule{}.build(ctx, lhs, rhs);
+}
+
+TensorValue sub(engine::core::ModuleBuildContext & ctx, const TensorValue & lhs, const TensorValue & rhs) {
+    return engine::core::wrap_tensor(
+        ggml_sub(ctx.ggml, contiguous(ctx, lhs).tensor, contiguous(ctx, rhs).tensor),
+        lhs.shape,
+        GGML_TYPE_F32);
+}
+
+TensorValue sigmoid(engine::core::ModuleBuildContext & ctx, const TensorValue & x) {
+    return engine::modules::SigmoidModule{}.build(ctx, x);
+}
+
+TensorValue tanh_value(engine::core::ModuleBuildContext & ctx, const TensorValue & x) {
+    return engine::modules::TanhModule{}.build(ctx, x);
+}
+
+TensorValue slice_axis(
+    engine::core::ModuleBuildContext & ctx,
+    const TensorValue & input,
+    int axis,
+    int64_t start,
+    int64_t length) {
+    return engine::modules::SliceModule({axis, start, length}).build(ctx, input);
+}
+
+engine::modules::Conv2dWeights conv2d_weights(
+    const RvcRmvpeWeights & weights,
+    const std::string & prefix,
+    bool bias) {
+    return {
+        require_tensor(weights, prefix + ".weight"),
+        bias ? std::optional<TensorValue>(require_tensor(weights, prefix + ".bias")) : std::nullopt};
+}
+
+engine::modules::LinearWeights linear_weights(
+    const RvcRmvpeWeights & weights,
+    const std::string & prefix,
+    bool bias) {
+    return {
+        require_tensor(weights, prefix + ".weight"),
+        bias ? std::optional<TensorValue>(require_tensor(weights, prefix + ".bias")) : std::nullopt};
+}
+
+engine::modules::LinearWeights linear_weights(
+    const RvcRmvpeWeights & weights,
+    const std::string & weight_name,
+    const std::string & bias_name,
+    bool bias) {
+    return {
+        require_tensor(weights, weight_name),
+        bias ? std::optional<TensorValue>(require_tensor(weights, bias_name)) : std::nullopt};
+}
+
+TensorValue batch_norm2d(
+    engine::core::ModuleBuildContext & ctx,
+    const TensorValue & input,
+    const RvcRmvpeWeights & weights,
+    const std::string & prefix) {
+    const int64_t channels = input.shape.dims[1];
+    const auto weight = engine::core::reshape_tensor(
+        ctx,
+        require_tensor(weights, prefix + ".weight"),
+        TensorShape::from_dims({1, channels, 1, 1}));
+    const auto bias = engine::core::reshape_tensor(
+        ctx,
+        require_tensor(weights, prefix + ".bias"),
+        TensorShape::from_dims({1, channels, 1, 1}));
+    const auto mean = engine::core::reshape_tensor(
+        ctx,
+        require_tensor(weights, prefix + ".running_mean"),
+        TensorShape::from_dims({1, channels, 1, 1}));
+    const auto var = engine::core::reshape_tensor(
+        ctx,
+        require_tensor(weights, prefix + ".running_var"),
+        TensorShape::from_dims({1, channels, 1, 1}));
+    const auto input_cont = contiguous(ctx, input);
+    const auto weight_rep = engine::core::wrap_tensor(
+        ggml_repeat(ctx.ggml, weight.tensor, input_cont.tensor),
+        input.shape,
+        GGML_TYPE_F32);
+    const auto bias_rep = engine::core::wrap_tensor(
+        ggml_repeat(ctx.ggml, bias.tensor, input_cont.tensor),
+        input.shape,
+        GGML_TYPE_F32);
+    const auto mean_rep = engine::core::wrap_tensor(
+        ggml_repeat(ctx.ggml, mean.tensor, input_cont.tensor),
+        input.shape,
+        GGML_TYPE_F32);
+    const auto denom = engine::core::wrap_tensor(
+        ggml_sqrt(ctx.ggml, ggml_scale_bias(ctx.ggml, var.tensor, 1.0F, 1.0e-5F)),
+        var.shape,
+        GGML_TYPE_F32);
+    const auto denom_rep = engine::core::wrap_tensor(
+        ggml_repeat(ctx.ggml, denom.tensor, input_cont.tensor),
+        input.shape,
+        GGML_TYPE_F32);
+    auto centered = engine::core::wrap_tensor(
+        ggml_sub(ctx.ggml, input_cont.tensor, mean_rep.tensor),
+        input.shape,
+        GGML_TYPE_F32);
+    auto normalized = engine::core::wrap_tensor(
+        ggml_div(ctx.ggml, centered.tensor, denom_rep.tensor),
+        input.shape,
+        GGML_TYPE_F32);
+    return add(ctx, mul(ctx, normalized, weight_rep), bias_rep);
+}
+
+TensorValue relu(engine::core::ModuleBuildContext & ctx, const TensorValue & input) {
+    return engine::core::wrap_tensor(
+        ggml_relu(ctx.ggml, contiguous(ctx, input).tensor),
+        input.shape,
+        GGML_TYPE_F32);
+}
+
+TensorValue conv_bn_relu(
+    engine::core::ModuleBuildContext & ctx,
+    const TensorValue & input,
+    const RvcRmvpeWeights & weights,
+    const std::string & conv_prefix,
+    const std::string & bn_prefix,
+    int64_t in_channels,
+    int64_t out_channels) {
+    auto x = engine::modules::Conv2dModule({in_channels, out_channels, 3, 3, 1, 1, 1, 1, 1, 1, false})
+                 .build(ctx, input, conv2d_weights(weights, conv_prefix, false));
+    x = batch_norm2d(ctx, x, weights, bn_prefix);
+    return relu(ctx, x);
+}
+
+TensorValue conv_block_res(
+    engine::core::ModuleBuildContext & ctx,
+    const TensorValue & input,
+    const RvcRmvpeWeights & weights,
+    const std::string & prefix,
+    int64_t in_channels,
+    int64_t out_channels) {
+    auto y = conv_bn_relu(ctx, input, weights, prefix + ".conv.0", prefix + ".conv.1", in_channels, out_channels);
+    y = conv_bn_relu(ctx, y, weights, prefix + ".conv.3", prefix + ".conv.4", out_channels, out_channels);
+    TensorValue residual = input;
+    if (in_channels != out_channels) {
+        residual = engine::modules::Conv2dModule({in_channels, out_channels, 1, 1, 1, 1, 0, 0, 1, 1, true})
+                       .build(ctx, input, conv2d_weights(weights, prefix + ".shortcut", true));
+    }
+    return add(ctx, y, residual);
+}
+
+TensorValue avg_pool2d_2x2(engine::core::ModuleBuildContext & ctx, const TensorValue & input) {
+    auto pooled = engine::core::wrap_tensor(
+        ggml_pool_2d(ctx.ggml, contiguous(ctx, input).tensor, GGML_OP_POOL_AVG, 2, 2, 2, 2, 0, 0),
+        TensorShape::from_dims({input.shape.dims[0], input.shape.dims[1], input.shape.dims[2] / 2, input.shape.dims[3] / 2}),
+        GGML_TYPE_F32);
+    return pooled;
+}
+
+TensorValue conv_transpose2d_pytorch_2x(
+    engine::core::ModuleBuildContext & ctx,
+    const TensorValue & input,
+    const RvcRmvpeWeights & weights,
+    const std::string & prefix,
+    int64_t out_channels) {
+    const auto weight = require_tensor(weights, prefix + ".weight");
+    auto full = engine::core::wrap_tensor(
+        ggml_conv_transpose_2d_p0(ctx.ggml, contiguous(ctx, weight).tensor, contiguous(ctx, input).tensor, 2),
+        TensorShape::from_dims({input.shape.dims[0], out_channels, input.shape.dims[2] * 2 + 1, input.shape.dims[3] * 2 + 1}),
+        GGML_TYPE_F32);
+    full = slice_axis(ctx, full, 2, 1, input.shape.dims[2] * 2);
+    full = slice_axis(ctx, full, 3, 1, input.shape.dims[3] * 2);
+    return full;
+}
+
+TensorValue decoder_upsample(
+    engine::core::ModuleBuildContext & ctx,
+    const TensorValue & input,
+    const RvcRmvpeWeights & weights,
+    const std::string & prefix,
+    int64_t out_channels) {
+    auto x = conv_transpose2d_pytorch_2x(ctx, input, weights, prefix + ".conv1.0", out_channels);
+    x = batch_norm2d(ctx, x, weights, prefix + ".conv1.1");
+    return relu(ctx, x);
+}
+
+RmvpeGruOutputs build_gru_chunk_graph(
+    engine::core::ModuleBuildContext & ctx,
+    const TensorValue & input,
+    const TensorValue & keep,
+    const TensorValue & initial_hidden,
+    const RvcRmvpeWeights & weights,
+    const std::string & suffix,
+    bool reverse) {
+    const int64_t frames = input.shape.dims[0];
+    const std::string base = "fc.0.gru.";
+    const auto projected_input = engine::modules::LinearModule({kRmvpeFeatureDim, kRmvpeHiddenDim * 3, true}).build(
+        ctx,
+        input,
+        linear_weights(weights, base + "weight_ih_l0" + suffix, base + "bias_ih_l0" + suffix, true));
+    TensorValue hidden = initial_hidden;
+    std::vector<TensorValue> steps(static_cast<size_t>(frames));
+    for (int64_t index = 0; index < frames; ++index) {
+        const int64_t t = reverse ? (frames - 1 - index) : index;
+        const auto xi = slice_axis(ctx, projected_input, 0, t, 1);
+        const auto hi = engine::modules::LinearModule({kRmvpeHiddenDim, kRmvpeHiddenDim * 3, true}).build(
+            ctx,
+            hidden,
+            linear_weights(weights, base + "weight_hh_l0" + suffix, base + "bias_hh_l0" + suffix, true));
+        const auto i_r = slice_axis(ctx, xi, 1, 0, kRmvpeHiddenDim);
+        const auto i_z = slice_axis(ctx, xi, 1, kRmvpeHiddenDim, kRmvpeHiddenDim);
+        const auto i_n = slice_axis(ctx, xi, 1, kRmvpeHiddenDim * 2, kRmvpeHiddenDim);
+        const auto h_r = slice_axis(ctx, hi, 1, 0, kRmvpeHiddenDim);
+        const auto h_z = slice_axis(ctx, hi, 1, kRmvpeHiddenDim, kRmvpeHiddenDim);
+        const auto h_n = slice_axis(ctx, hi, 1, kRmvpeHiddenDim * 2, kRmvpeHiddenDim);
+        const auto reset = sigmoid(ctx, add(ctx, i_r, h_r));
+        const auto update = sigmoid(ctx, add(ctx, i_z, h_z));
+        const auto candidate = tanh_value(ctx, add(ctx, i_n, mul(ctx, reset, h_n)));
+        const auto updated = add(ctx, candidate, mul(ctx, update, sub(ctx, hidden, candidate)));
+        const auto keep_t = slice_axis(ctx, keep, 0, t, 1);
+        const auto keep_rep = engine::core::wrap_tensor(
+            ggml_repeat(ctx.ggml, keep_t.tensor, hidden.tensor),
+            hidden.shape,
+            GGML_TYPE_F32);
+        hidden = add(ctx, hidden, mul(ctx, keep_rep, sub(ctx, updated, hidden)));
+        steps[static_cast<size_t>(t)] = hidden;
+    }
+    auto sequence = steps[0];
+    for (int64_t t = 1; t < frames; ++t) {
+        sequence = engine::modules::ConcatModule({0}).build(ctx, sequence, steps[static_cast<size_t>(t)]);
+    }
+    return {sequence, hidden};
+}
+
+TensorValue build_rmvpe_feature_graph(
+    engine::core::ModuleBuildContext & ctx,
+    const TensorValue & mel,
+    const RvcRmvpeWeights & weights) {
+    auto x = engine::modules::TransposeModule({{0, 2, 1}, 3}).build(ctx, mel);
+    x = engine::core::reshape_tensor(ctx, contiguous(ctx, x), TensorShape::from_dims({1, 1, x.shape.dims[1], x.shape.dims[2]}));
+    x = batch_norm2d(ctx, x, weights, "unet.encoder.bn");
+
+    std::vector<TensorValue> skips;
+    skips.reserve(5);
+    int64_t channels = 1;
+    int64_t out_channels = 16;
+    for (int layer = 0; layer < 5; ++layer) {
+        const std::string base = "unet.encoder.layers." + std::to_string(layer);
+        for (int block = 0; block < 4; ++block) {
+            x = conv_block_res(ctx, x, weights, base + ".conv." + std::to_string(block), channels, out_channels);
+            channels = out_channels;
+        }
+        skips.push_back(x);
+        x = avg_pool2d_2x2(ctx, x);
+        out_channels *= 2;
+    }
+
+    channels = 256;
+    for (int layer = 0; layer < 4; ++layer) {
+        const std::string base = "unet.intermediate.layers." + std::to_string(layer);
+        for (int block = 0; block < 4; ++block) {
+            x = conv_block_res(ctx, x, weights, base + ".conv." + std::to_string(block), channels, 512);
+            channels = 512;
+        }
+    }
+
+    channels = 512;
+    for (int layer = 0; layer < 5; ++layer) {
+        const int64_t dec_out = channels / 2;
+        const std::string base = "unet.decoder.layers." + std::to_string(layer);
+        x = decoder_upsample(ctx, x, weights, base, dec_out);
+        auto skip = skips.back();
+        skips.pop_back();
+        x = engine::modules::ConcatModule({1}).build(ctx, x, skip);
+        channels = dec_out * 2;
+        for (int block = 0; block < 4; ++block) {
+            x = conv_block_res(ctx, x, weights, base + ".conv2." + std::to_string(block), channels, dec_out);
+            channels = dec_out;
+        }
+    }
+
+    x = engine::modules::Conv2dModule({16, 3, 3, 3, 1, 1, 1, 1, 1, 1, true})
+            .build(ctx, x, conv2d_weights(weights, "cnn", true));
+    x = engine::modules::TransposeModule({{0, 2, 1, 3}, 4}).build(ctx, x);
+    return engine::core::reshape_tensor(ctx, contiguous(ctx, x), TensorShape::from_dims({x.shape.dims[1], kRmvpeFeatureDim}));
+}
+
+TensorValue build_rmvpe_head_graph(
+    engine::core::ModuleBuildContext & ctx,
+    const TensorValue & forward,
+    const TensorValue & reverse,
+    const RvcRmvpeWeights & weights) {
+    auto gru = engine::modules::ConcatModule({1}).build(ctx, forward, reverse);
+    auto logits = engine::modules::LinearModule({2 * kRmvpeHiddenDim, kRmvpeClasses, true})
+                      .build(ctx, gru, linear_weights(weights, "fc.1", true));
+    return sigmoid(ctx, logits);
+}
+
+std::vector<float> compute_rmvpe_log_mel(
+    const std::vector<float> & waveform_16k,
+    size_t threads) {
+    constexpr int64_t kSampleRate = 16000;
+    constexpr int64_t kNfft = 1024;
+    constexpr int64_t kHop = 160;
+    const engine::audio::STFTConfig stft_config{
+        kNfft,
+        kHop,
+        kNfft,
+        true,
+        engine::audio::STFTPadMode::Reflect,
+        engine::audio::STFTFamily::Kokoro,
+    };
+    const auto & window = engine::audio::get_cached_stft_window(stft_config);
+    const auto magnitude = engine::audio::STFT().compute_magnitude(
+        waveform_16k,
+        window,
+        1,
+        static_cast<int64_t>(waveform_16k.size()),
+        stft_config,
+        threads);
+    const int64_t freq_bins = magnitude.shape[1];
+    const int64_t frames = magnitude.shape[2];
+    static const RmvpeMelFilterbank mel_filter = [] {
+        constexpr int64_t freq_bins = kNfft / 2 + 1;
+        std::vector<double> mel_points(static_cast<size_t>(kRmvpeMelBins + 2), 0.0);
+        const auto hz_to_mel = [](double hz) {
+            return 2595.0 * std::log10(1.0 + hz / 700.0);
+        };
+        const auto mel_to_hz = [](double mel) {
+            return 700.0 * (std::pow(10.0, mel / 2595.0) - 1.0);
+        };
+        const double mel_min = hz_to_mel(30.0);
+        const double mel_max = hz_to_mel(8000.0);
+        for (int64_t i = 0; i < kRmvpeMelBins + 2; ++i) {
+            mel_points[static_cast<size_t>(i)] =
+                mel_min + (mel_max - mel_min) * static_cast<double>(i) / static_cast<double>(kRmvpeMelBins + 1);
+        }
+        std::vector<double> hz_points(static_cast<size_t>(kRmvpeMelBins + 2), 0.0);
+        for (int64_t i = 0; i < kRmvpeMelBins + 2; ++i) {
+            hz_points[static_cast<size_t>(i)] = mel_to_hz(mel_points[static_cast<size_t>(i)]);
+        }
+        RmvpeMelFilterbank filter;
+        filter.values.assign(static_cast<size_t>(kRmvpeMelBins * freq_bins), 0.0F);
+        filter.starts.assign(static_cast<size_t>(kRmvpeMelBins), freq_bins);
+        filter.ends.assign(static_cast<size_t>(kRmvpeMelBins), 0);
+        for (int64_t mel = 0; mel < kRmvpeMelBins; ++mel) {
+            const double left = hz_points[static_cast<size_t>(mel)];
+            const double center = hz_points[static_cast<size_t>(mel + 1)];
+            const double right = hz_points[static_cast<size_t>(mel + 2)];
+            const double lower_width = std::max(center - left, 1.0e-12);
+            const double upper_width = std::max(right - center, 1.0e-12);
+            for (int64_t freq = 0; freq < freq_bins; ++freq) {
+                const double hz = static_cast<double>(kSampleRate) * 0.5 *
+                    static_cast<double>(freq) / static_cast<double>(freq_bins - 1);
+                const double lower = (hz - left) / lower_width;
+                const double upper = (right - hz) / upper_width;
+                filter.values[static_cast<size_t>(mel * freq_bins + freq)] =
+                    static_cast<float>(std::max(0.0, std::min(lower, upper)));
+            }
+            const double enorm = 2.0 / std::max(right - left, 1.0e-12);
+            for (int64_t freq = 0; freq < freq_bins; ++freq) {
+                auto & value = filter.values[static_cast<size_t>(mel * freq_bins + freq)];
+                value *= static_cast<float>(enorm);
+                if (value != 0.0F) {
+                    filter.starts[static_cast<size_t>(mel)] = std::min(filter.starts[static_cast<size_t>(mel)], freq);
+                    filter.ends[static_cast<size_t>(mel)] = std::max(filter.ends[static_cast<size_t>(mel)], freq + 1);
+                }
+            }
+            if (filter.starts[static_cast<size_t>(mel)] == freq_bins) {
+                filter.starts[static_cast<size_t>(mel)] = 0;
+            }
+        }
+        return filter;
+    }();
+    std::vector<float> out(static_cast<size_t>(kRmvpeMelBins * frames), 0.0F);
+#ifdef _OPENMP
+#pragma omp parallel for collapse(2) if(kRmvpeMelBins * frames >= 4096)
+#endif
+    for (int64_t mel = 0; mel < kRmvpeMelBins; ++mel) {
+        for (int64_t frame = 0; frame < frames; ++frame) {
+            float sum = 0.0F;
+            const int64_t start = mel_filter.starts[static_cast<size_t>(mel)];
+            const int64_t end = mel_filter.ends[static_cast<size_t>(mel)];
+            for (int64_t freq = start; freq < end; ++freq) {
+                const float mag = magnitude.values[static_cast<size_t>(freq * frames + frame)];
+                sum += mel_filter.values[static_cast<size_t>(mel * freq_bins + freq)] * mag;
+            }
+            out[static_cast<size_t>(mel * frames + frame)] = std::log(std::max(sum, 1.0e-5F));
+        }
+    }
+    return out;
+}
+
+std::vector<float> pad_rmvpe_mel_time_axis(
+    const std::vector<float> & mel,
+    int64_t frames,
+    int64_t padded_frames) {
+    if (static_cast<int64_t>(mel.size()) != kRmvpeMelBins * frames || frames <= 0 || padded_frames < frames) {
+        throw std::runtime_error("RVC RMVPE mel padding shape mismatch");
+    }
+    std::vector<float> padded(static_cast<size_t>(kRmvpeMelBins * padded_frames), 0.0F);
+    for (int64_t channel = 0; channel < kRmvpeMelBins; ++channel) {
+        std::copy_n(
+            mel.begin() + static_cast<std::ptrdiff_t>(channel * frames),
+            frames,
+            padded.begin() + static_cast<std::ptrdiff_t>(channel * padded_frames));
+    }
+    return padded;
+}
+
+RmvpePreparedMel prepare_rmvpe_mel(const std::vector<float> & waveform_16k, size_t threads) {
+    auto mel = compute_rmvpe_log_mel(waveform_16k, threads);
+    const int64_t frames = static_cast<int64_t>(mel.size()) / kRmvpeMelBins;
+    const int64_t padded_frames = 32 * ((frames - 1) / 32 + 1);
+    return {pad_rmvpe_mel_time_axis(mel, frames, padded_frames), frames, padded_frames};
+}
+
+void copy_mel_window(
+    const std::vector<float> & mel,
+    int64_t padded_frames,
+    int64_t graph_frames,
+    int64_t start,
+    int64_t frames,
+    std::vector<float> & out) {
+    if (start < 0 || frames < 0 || start + frames > padded_frames) {
+        throw std::runtime_error("RVC RMVPE mel window is out of range");
+    }
+    out.assign(static_cast<size_t>(kRmvpeMelBins * graph_frames), 0.0F);
+    for (int64_t mel_bin = 0; mel_bin < kRmvpeMelBins; ++mel_bin) {
+        std::copy_n(
+            mel.begin() + static_cast<std::ptrdiff_t>(mel_bin * padded_frames + start),
+            frames,
+            out.begin() + static_cast<std::ptrdiff_t>(mel_bin * graph_frames));
+    }
+}
+
+void copy_feature_rows(
+    const std::vector<float> & source,
+    int64_t source_start,
+    int64_t rows,
+    std::vector<float> & destination,
+    int64_t destination_start) {
+    for (int64_t row = 0; row < rows; ++row) {
+        std::copy_n(
+            source.begin() + static_cast<std::ptrdiff_t>((source_start + row) * kRmvpeFeatureDim),
+            kRmvpeFeatureDim,
+            destination.begin() + static_cast<std::ptrdiff_t>((destination_start + row) * kRmvpeFeatureDim));
+    }
+}
+
+void fill_gru_chunk(
+    const std::vector<float> & features,
+    int64_t start,
+    int64_t frames,
+    std::vector<float> & chunk,
+    std::vector<float> & keep) {
+    chunk.assign(static_cast<size_t>(kRmvpeGruChunkFrames * kRmvpeFeatureDim), 0.0F);
+    keep.assign(static_cast<size_t>(kRmvpeGruChunkFrames), 0.0F);
+    for (int64_t row = 0; row < frames; ++row) {
+        std::copy_n(
+            features.begin() + static_cast<std::ptrdiff_t>((start + row) * kRmvpeFeatureDim),
+            kRmvpeFeatureDim,
+            chunk.begin() + static_cast<std::ptrdiff_t>(row * kRmvpeFeatureDim));
+        keep[static_cast<size_t>(row)] = 1.0F;
+    }
+}
+
+void copy_hidden_rows_to_chunk(
+    const std::vector<float> & source,
+    int64_t start,
+    int64_t frames,
+    std::vector<float> & chunk) {
+    chunk.assign(static_cast<size_t>(kRmvpeGruChunkFrames * kRmvpeHiddenDim), 0.0F);
+    for (int64_t row = 0; row < frames; ++row) {
+        std::copy_n(
+            source.begin() + static_cast<std::ptrdiff_t>((start + row) * kRmvpeHiddenDim),
+            kRmvpeHiddenDim,
+            chunk.begin() + static_cast<std::ptrdiff_t>(row * kRmvpeHiddenDim));
+    }
+}
+
+void copy_hidden_rows(
+    const std::vector<float> & source,
+    int64_t source_start,
+    int64_t rows,
+    std::vector<float> & destination,
+    int64_t destination_start) {
+    for (int64_t row = 0; row < rows; ++row) {
+        std::copy_n(
+            source.begin() + static_cast<std::ptrdiff_t>((source_start + row) * kRmvpeHiddenDim),
+            kRmvpeHiddenDim,
+            destination.begin() + static_cast<std::ptrdiff_t>((destination_start + row) * kRmvpeHiddenDim));
+    }
+}
+
+std::vector<float> decode_rmvpe_salience(
+    const std::vector<float> & salience,
+    int64_t frames,
+    float threshold) {
+    std::vector<float> f0(static_cast<size_t>(frames), 0.0F);
+    for (int64_t frame = 0; frame < frames; ++frame) {
+        int center = 0;
+        float best = salience[static_cast<size_t>(frame * kRmvpeClasses)];
+        for (int cls = 1; cls < kRmvpeClasses; ++cls) {
+            const float value = salience[static_cast<size_t>(frame * kRmvpeClasses + cls)];
+            if (value > best) {
+                best = value;
+                center = cls;
+            }
+        }
+        if (best <= threshold) {
+            continue;
+        }
+        float weighted = 0.0F;
+        float weight_sum = 0.0F;
+        for (int offset = -4; offset <= 4; ++offset) {
+            const int cls = center + offset;
+            if (cls < 0 || cls >= kRmvpeClasses) {
+                continue;
+            }
+            const float value = salience[static_cast<size_t>(frame * kRmvpeClasses + cls)];
+            const float cents = 20.0F * static_cast<float>(cls) + 1997.3794084376191F;
+            weighted += value * cents;
+            weight_sum += value;
+        }
+        if (weight_sum > 0.0F) {
+            const float cents = weighted / weight_sum;
+            f0[static_cast<size_t>(frame)] = 10.0F * std::pow(2.0F, cents / 1200.0F);
+        }
+    }
+    return f0;
+}
+
+}  // namespace
+
+struct RvcRmvpeF0Extractor::State {
+    ~State() {
+        release_feature_graph();
+        release_forward_graph();
+        release_reverse_graph();
+        release_head_graph();
+    }
+
+    struct FeatureGraph {
+        ggml_context * ctx = nullptr;
+        ggml_gallocr_t gallocr = nullptr;
+        ggml_cgraph * graph = nullptr;
+        TensorValue input;
+        ggml_tensor * output = nullptr;
+        int64_t frames = 0;
+    };
+
+    struct GruGraph {
+        ggml_context * ctx = nullptr;
+        ggml_gallocr_t gallocr = nullptr;
+        ggml_cgraph * graph = nullptr;
+        TensorValue input;
+        TensorValue keep;
+        TensorValue hidden;
+        ggml_tensor * sequence = nullptr;
+        ggml_tensor * final_hidden = nullptr;
+    };
+
+    struct HeadGraph {
+        ggml_context * ctx = nullptr;
+        ggml_gallocr_t gallocr = nullptr;
+        ggml_cgraph * graph = nullptr;
+        TensorValue forward;
+        TensorValue reverse;
+        ggml_tensor * output = nullptr;
+    };
+
+    static void release_feature_graph(FeatureGraph & graph) {
+        if (graph.gallocr != nullptr) {
+            ggml_gallocr_free(graph.gallocr);
+            graph.gallocr = nullptr;
+        }
+        if (graph.ctx != nullptr) {
+            ggml_free(graph.ctx);
+            graph.ctx = nullptr;
+        }
+        graph.graph = nullptr;
+        graph.input = {};
+        graph.output = nullptr;
+        graph.frames = 0;
+    }
+
+    static void release_gru_graph(GruGraph & graph) {
+        if (graph.gallocr != nullptr) {
+            ggml_gallocr_free(graph.gallocr);
+            graph.gallocr = nullptr;
+        }
+        if (graph.ctx != nullptr) {
+            ggml_free(graph.ctx);
+            graph.ctx = nullptr;
+        }
+        graph.graph = nullptr;
+        graph.input = {};
+        graph.keep = {};
+        graph.hidden = {};
+        graph.sequence = nullptr;
+        graph.final_hidden = nullptr;
+    }
+
+    static void release_head_graph(HeadGraph & graph) {
+        if (graph.gallocr != nullptr) {
+            ggml_gallocr_free(graph.gallocr);
+            graph.gallocr = nullptr;
+        }
+        if (graph.ctx != nullptr) {
+            ggml_free(graph.ctx);
+            graph.ctx = nullptr;
+        }
+        graph.graph = nullptr;
+        graph.forward = {};
+        graph.reverse = {};
+        graph.output = nullptr;
+    }
+
+    void release_feature_graph() {
+        release_feature_graph(feature);
+    }
+
+    void release_forward_graph() {
+        release_gru_graph(forward);
+    }
+
+    void release_reverse_graph() {
+        release_gru_graph(reverse);
+    }
+
+    void release_head_graph() {
+        release_head_graph(head);
+    }
+
+    void ensure_feature_graph(const RvcRmvpeWeights & weights, int64_t frames) {
+        if (frames <= 0 || frames % 32 != 0) {
+            throw std::runtime_error("RVC RMVPE feature graph requires positive 32-aligned frame count");
+        }
+        if (feature.ctx != nullptr && feature.frames == frames) {
+            return;
+        }
+        release_feature_graph();
+        if (weights.execution_context == nullptr) {
+            throw std::runtime_error("RVC RMVPE requires execution context");
+        }
+        ggml_init_params params{512ull * 1024ull * 1024ull, nullptr, true};
+        feature.ctx = ggml_init(params);
+        if (feature.ctx == nullptr) {
+            throw std::runtime_error("failed to initialize RVC RMVPE feature graph context");
+        }
+        engine::core::ModuleBuildContext build_ctx{
+            feature.ctx,
+            "rvc.rmvpe.feature",
+            weights.execution_context->backend_type()};
+        feature.input = engine::core::make_tensor(
+            build_ctx,
+            GGML_TYPE_F32,
+            TensorShape::from_dims({1, kRmvpeMelBins, frames}));
+        ggml_set_input(feature.input.tensor);
+        const auto result = build_rmvpe_feature_graph(build_ctx, feature.input, weights);
+        feature.output = result.tensor;
+        ggml_set_output(feature.output);
+        feature.graph = ggml_new_graph_custom(feature.ctx, 16384, false);
+        ggml_build_forward_expand(feature.graph, feature.output);
+        feature.gallocr = ggml_gallocr_new(ggml_backend_get_default_buffer_type(weights.execution_context->backend()));
+        if (feature.gallocr == nullptr ||
+            !ggml_gallocr_reserve(feature.gallocr, feature.graph) ||
+            !ggml_gallocr_alloc_graph(feature.gallocr, feature.graph)) {
+            release_feature_graph();
+            throw std::runtime_error("failed to allocate RVC RMVPE feature graph tensors");
+        }
+        feature.frames = frames;
+    }
+
+    void ensure_gru_graph(const RvcRmvpeWeights & weights, GruGraph & target, const std::string & suffix, bool reverse_graph) {
+        if (target.ctx != nullptr) {
+            return;
+        }
+        if (weights.execution_context == nullptr) {
+            throw std::runtime_error("RVC RMVPE requires execution context");
+        }
+        ggml_init_params params{128ull * 1024ull * 1024ull, nullptr, true};
+        target.ctx = ggml_init(params);
+        if (target.ctx == nullptr) {
+            throw std::runtime_error("failed to initialize RVC RMVPE GRU graph context");
+        }
+        engine::core::ModuleBuildContext build_ctx{
+            target.ctx,
+            reverse_graph ? "rvc.rmvpe.gru_reverse" : "rvc.rmvpe.gru_forward",
+            weights.execution_context->backend_type()};
+        target.input = engine::core::make_tensor(
+            build_ctx,
+            GGML_TYPE_F32,
+            TensorShape::from_dims({kRmvpeGruChunkFrames, kRmvpeFeatureDim}));
+        target.keep = engine::core::make_tensor(
+            build_ctx,
+            GGML_TYPE_F32,
+            TensorShape::from_dims({kRmvpeGruChunkFrames, 1}));
+        target.hidden = engine::core::make_tensor(
+            build_ctx,
+            GGML_TYPE_F32,
+            TensorShape::from_dims({1, kRmvpeHiddenDim}));
+        ggml_set_input(target.input.tensor);
+        ggml_set_input(target.keep.tensor);
+        ggml_set_input(target.hidden.tensor);
+        const auto result = build_gru_chunk_graph(
+            build_ctx,
+            target.input,
+            target.keep,
+            target.hidden,
+            weights,
+            suffix,
+            reverse_graph);
+        target.sequence = result.sequence.tensor;
+        target.final_hidden = result.final_hidden.tensor;
+        ggml_set_output(target.sequence);
+        ggml_set_output(target.final_hidden);
+        target.graph = ggml_new_graph_custom(target.ctx, 40960, false);
+        ggml_build_forward_expand(target.graph, target.sequence);
+        ggml_build_forward_expand(target.graph, target.final_hidden);
+        target.gallocr = ggml_gallocr_new(ggml_backend_get_default_buffer_type(weights.execution_context->backend()));
+        if (target.gallocr == nullptr ||
+            !ggml_gallocr_reserve(target.gallocr, target.graph) ||
+            !ggml_gallocr_alloc_graph(target.gallocr, target.graph)) {
+            release_gru_graph(target);
+            throw std::runtime_error("failed to allocate RVC RMVPE GRU graph tensors");
+        }
+    }
+
+    void ensure_head_graph(const RvcRmvpeWeights & weights) {
+        if (head.ctx != nullptr) {
+            return;
+        }
+        if (weights.execution_context == nullptr) {
+            throw std::runtime_error("RVC RMVPE requires execution context");
+        }
+        ggml_init_params params{64ull * 1024ull * 1024ull, nullptr, true};
+        head.ctx = ggml_init(params);
+        if (head.ctx == nullptr) {
+            throw std::runtime_error("failed to initialize RVC RMVPE head graph context");
+        }
+        engine::core::ModuleBuildContext build_ctx{
+            head.ctx,
+            "rvc.rmvpe.head",
+            weights.execution_context->backend_type()};
+        head.forward = engine::core::make_tensor(
+            build_ctx,
+            GGML_TYPE_F32,
+            TensorShape::from_dims({kRmvpeGruChunkFrames, kRmvpeHiddenDim}));
+        head.reverse = engine::core::make_tensor(
+            build_ctx,
+            GGML_TYPE_F32,
+            TensorShape::from_dims({kRmvpeGruChunkFrames, kRmvpeHiddenDim}));
+        ggml_set_input(head.forward.tensor);
+        ggml_set_input(head.reverse.tensor);
+        const auto result = build_rmvpe_head_graph(build_ctx, head.forward, head.reverse, weights);
+        head.output = result.tensor;
+        ggml_set_output(head.output);
+        head.graph = ggml_new_graph_custom(head.ctx, 4096, false);
+        ggml_build_forward_expand(head.graph, head.output);
+        head.gallocr = ggml_gallocr_new(ggml_backend_get_default_buffer_type(weights.execution_context->backend()));
+        if (head.gallocr == nullptr ||
+            !ggml_gallocr_reserve(head.gallocr, head.graph) ||
+            !ggml_gallocr_alloc_graph(head.gallocr, head.graph)) {
+            release_head_graph();
+            throw std::runtime_error("failed to allocate RVC RMVPE head graph tensors");
+        }
+    }
+
+    void ensure_graphs(const RvcRmvpeWeights & weights, int64_t feature_frames) {
+        ensure_feature_graph(weights, feature_frames);
+        ensure_gru_graph(weights, forward, "", false);
+        ensure_gru_graph(weights, reverse, "_reverse", true);
+        ensure_head_graph(weights);
+    }
+
+    std::mutex mutex;
+    RvcRmvpeWeights weights;
+    FeatureGraph feature;
+    GruGraph forward;
+    GruGraph reverse;
+    HeadGraph head;
+};
+
+RvcRmvpeF0Extractor::RvcRmvpeF0Extractor(
+    std::shared_ptr<const engine::assets::TensorSource> source,
+    engine::core::BackendConfig backend,
+    engine::assets::TensorStorageType storage_type)
+    : state_(std::make_shared<State>()) {
+    state_->weights = load_rmvpe_weights(std::move(source), std::move(backend), storage_type);
+}
+
+RvcRmvpeF0Extractor::~RvcRmvpeF0Extractor() = default;
+RvcRmvpeF0Extractor::RvcRmvpeF0Extractor(RvcRmvpeF0Extractor &&) noexcept = default;
+RvcRmvpeF0Extractor & RvcRmvpeF0Extractor::operator=(RvcRmvpeF0Extractor &&) noexcept = default;
+
+std::vector<float> RvcRmvpeF0Extractor::infer_16k_mono(
+    const std::vector<float> & waveform_16k,
+    float threshold,
+    size_t threads) const {
+    if (state_ == nullptr) {
+        throw std::runtime_error("RVC RMVPE is not initialized");
+    }
+    auto timing_start = std::chrono::steady_clock::now();
+    const auto mel = prepare_rmvpe_mel(waveform_16k, threads);
+    auto timing_end = std::chrono::steady_clock::now();
+    engine::debug::timing_log_scalar(
+        "rvc.rmvpe.mel_ms",
+        engine::debug::elapsed_ms(timing_start, timing_end));
+    timing_start = timing_end;
+    std::lock_guard<std::mutex> lock(state_->mutex);
+    const int64_t feature_step = mel.padded_frames <= kRmvpeFeatureActiveFrames
+        ? mel.padded_frames
+        : kRmvpeFeatureActiveFrames;
+    const int64_t feature_graph_frames = mel.padded_frames <= kRmvpeFeatureActiveFrames
+        ? mel.padded_frames
+        : kRmvpeFeatureGraphFrames;
+    state_->ensure_graphs(state_->weights, feature_graph_frames);
+    timing_end = std::chrono::steady_clock::now();
+    engine::debug::timing_log_scalar(
+        "rvc.rmvpe.prepare_ms",
+        engine::debug::elapsed_ms(timing_start, timing_end));
+    timing_start = timing_end;
+
+    const auto backend = state_->weights.execution_context->backend();
+    std::vector<float> feature_window;
+    std::vector<float> features(static_cast<size_t>(mel.padded_frames * kRmvpeFeatureDim), 0.0F);
+    for (int64_t active_start = 0; active_start < mel.padded_frames; active_start += feature_step) {
+        const int64_t active_frames =
+            std::min<int64_t>(feature_step, mel.padded_frames - active_start);
+        const int64_t context_start = std::max<int64_t>(0, active_start - kRmvpeFeatureOverlapFrames);
+        const int64_t context_end = std::min<int64_t>(
+            mel.padded_frames,
+            active_start + active_frames + kRmvpeFeatureOverlapFrames);
+        const int64_t context_frames = context_end - context_start;
+        const int64_t active_offset = active_start - context_start;
+        copy_mel_window(
+            mel.values,
+            mel.padded_frames,
+            feature_graph_frames,
+            context_start,
+            context_frames,
+            feature_window);
+        engine::core::write_tensor_f32(state_->feature.input, feature_window);
+        if (engine::core::compute_backend_graph(backend, state_->feature.graph) != GGML_STATUS_SUCCESS) {
+            throw std::runtime_error("ggml_backend_graph_compute failed for RVC RMVPE feature graph");
+        }
+        const auto feature_output = engine::core::read_tensor_f32(state_->feature.output);
+        copy_feature_rows(feature_output, active_offset, active_frames, features, active_start);
+    }
+
+    std::vector<float> feature_chunk;
+    std::vector<float> keep;
+    std::vector<float> hidden(static_cast<size_t>(kRmvpeHiddenDim), 0.0F);
+    std::vector<float> forward_states(static_cast<size_t>(mel.padded_frames * kRmvpeHiddenDim), 0.0F);
+    for (int64_t start = 0; start < mel.padded_frames; start += kRmvpeGruChunkFrames) {
+        const int64_t chunk_frames = std::min<int64_t>(kRmvpeGruChunkFrames, mel.padded_frames - start);
+        fill_gru_chunk(features, start, chunk_frames, feature_chunk, keep);
+        engine::core::write_tensor_f32(state_->forward.input, feature_chunk);
+        engine::core::write_tensor_f32(state_->forward.keep, keep);
+        engine::core::write_tensor_f32(state_->forward.hidden, hidden);
+        if (engine::core::compute_backend_graph(backend, state_->forward.graph) != GGML_STATUS_SUCCESS) {
+            throw std::runtime_error("ggml_backend_graph_compute failed for RVC RMVPE forward GRU graph");
+        }
+        const auto sequence = engine::core::read_tensor_f32(state_->forward.sequence);
+        copy_hidden_rows(sequence, 0, chunk_frames, forward_states, start);
+        hidden = engine::core::read_tensor_f32(state_->forward.final_hidden);
+    }
+
+    std::vector<float> salience(static_cast<size_t>(mel.frames * kRmvpeClasses), 0.0F);
+    std::vector<float> reverse_hidden(static_cast<size_t>(kRmvpeHiddenDim), 0.0F);
+    std::vector<float> forward_chunk;
+    for (int64_t end = mel.padded_frames; end > 0;) {
+        const int64_t start = std::max<int64_t>(0, end - kRmvpeGruChunkFrames);
+        const int64_t chunk_frames = end - start;
+        fill_gru_chunk(features, start, chunk_frames, feature_chunk, keep);
+        engine::core::write_tensor_f32(state_->reverse.input, feature_chunk);
+        engine::core::write_tensor_f32(state_->reverse.keep, keep);
+        engine::core::write_tensor_f32(state_->reverse.hidden, reverse_hidden);
+        if (engine::core::compute_backend_graph(backend, state_->reverse.graph) != GGML_STATUS_SUCCESS) {
+            throw std::runtime_error("ggml_backend_graph_compute failed for RVC RMVPE reverse GRU graph");
+        }
+        const auto reverse_sequence = engine::core::read_tensor_f32(state_->reverse.sequence);
+        reverse_hidden = engine::core::read_tensor_f32(state_->reverse.final_hidden);
+        const int64_t salience_rows =
+            start < mel.frames ? std::min<int64_t>(chunk_frames, mel.frames - start) : 0;
+        if (salience_rows > 0) {
+            copy_hidden_rows_to_chunk(forward_states, start, chunk_frames, forward_chunk);
+            engine::core::write_tensor_f32(state_->head.forward, forward_chunk);
+            engine::core::write_tensor_f32(state_->head.reverse, reverse_sequence);
+            if (engine::core::compute_backend_graph(backend, state_->head.graph) != GGML_STATUS_SUCCESS) {
+                throw std::runtime_error("ggml_backend_graph_compute failed for RVC RMVPE head graph");
+            }
+            const auto head_output = engine::core::read_tensor_f32(state_->head.output);
+            for (int64_t row = 0; row < salience_rows; ++row) {
+                std::copy_n(
+                    head_output.begin() + static_cast<std::ptrdiff_t>(row * kRmvpeClasses),
+                    kRmvpeClasses,
+                    salience.begin() + static_cast<std::ptrdiff_t>((start + row) * kRmvpeClasses));
+            }
+        }
+        end = start;
+    }
+    timing_end = std::chrono::steady_clock::now();
+    engine::debug::timing_log_scalar(
+        "rvc.rmvpe.compute_ms",
+        engine::debug::elapsed_ms(timing_start, timing_end));
+    timing_start = timing_end;
+    auto f0 = decode_rmvpe_salience(salience, mel.frames, threshold);
+    timing_end = std::chrono::steady_clock::now();
+    engine::debug::timing_log_scalar(
+        "rvc.rmvpe.decode_ms",
+        engine::debug::elapsed_ms(timing_start, timing_end));
+    return f0;
+}
+
+}  // namespace engine::models::rvc

--- a/tools/check_loader_catalog_sync.py
+++ b/tools/check_loader_catalog_sync.py
@@ -3,7 +3,7 @@
 
 ``model_manager list --json`` family fields and ``audiocpp_cli --list-loaders``
 must stay aligned. Installable standalone packages cannot advertise a family
-that is missing or commented out in ``src/framework/runtime/registry.cpp``.
+that is missing from the generated default registry source inputs.
 
 See docs/maintainers/loader_and_catalog.md.
 """
@@ -17,11 +17,12 @@ import unittest
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+CMAKE_PATH = REPO_ROOT / "CMakeLists.txt"
 REGISTRY_PATH = REPO_ROOT / "src" / "framework" / "runtime" / "registry.cpp"
 MODEL_MANAGER_PATH = REPO_ROOT / "tools" / "model_manager.py"
 PACKAGE_TABLE_PATH = REPO_ROOT / "docs" / "model_manager.md"
 
-_LOADER_CALL_RE = re.compile(r"\bmake_([a-z0-9_]+)_loader\s*\(\s*\)")
+_LOADER_CALL_RE = re.compile(r"\bmake_([a-z0-9_]+)_loader(?:\s*\(\s*\))?")
 
 # Optional: catalog family strings that map to a differently named parked stub.
 PARKED_FAMILY_ALIASES: dict[str, set[str]] = {
@@ -52,6 +53,35 @@ def parse_registry_loaders(registry_text: str) -> tuple[set[str], set[str]]:
     return active, commented
 
 
+def parse_cmake_loaders(cmake_text: str) -> tuple[set[str], set[str]]:
+    """Return (active_families, commented_families) from audiocpp_add_model LOADERS."""
+    active: set[str] = set()
+    commented: set[str] = set()
+    for raw_line in cmake_text.splitlines():
+        line = raw_line.strip()
+        match = _LOADER_CALL_RE.search(line)
+        if not match:
+            continue
+        family = match.group(1)
+        if line.startswith("#"):
+            commented.add(family)
+        else:
+            active.add(family)
+    return active, commented
+
+
+def parse_declared_loaders(cmake_text: str, registry_text: str) -> tuple[set[str], set[str]]:
+    """Return source-declared default registry loaders.
+
+    Most model-family loaders are declared in CMake and emitted into generated
+    registry include files. A few bundled loaders are still written directly in
+    registry.cpp, so the checker unions both source inputs.
+    """
+    cmake_active, cmake_commented = parse_cmake_loaders(cmake_text)
+    registry_active, registry_commented = parse_registry_loaders(registry_text)
+    return cmake_active | registry_active, cmake_commented | registry_commented
+
+
 def family_is_registered(family: str, active: set[str]) -> bool:
     return family in active
 
@@ -67,7 +97,7 @@ def family_is_parked(family: str, commented: set[str]) -> bool:
 
 def parked_hint(family: str, commented: set[str]) -> str:
     if family in commented:
-        return " (commented out in registry.cpp)"
+        return " (commented out in registry source inputs)"
     for stub, aliases in PARKED_FAMILY_ALIASES.items():
         if stub in commented and family in aliases:
             return (
@@ -157,11 +187,11 @@ def check_catalog(
         if not family_is_registered(family, active):
             errors.append(
                 f"{package_id}: installable standalone package family '{family}' "
-                f"is not registered in registry.cpp{parked_hint(family, commented)}"
+                f"is not registered in generated registry inputs{parked_hint(family, commented)}"
             )
         elif family_is_parked(family, commented):
             errors.append(
-                f"{package_id}: family '{family}' is both active and commented in registry.cpp"
+                f"{package_id}: family '{family}' is both active and commented in registry source inputs"
             )
 
     for stub in sorted(commented):
@@ -244,6 +274,18 @@ class _SyncCheckSelfTests(unittest.TestCase):
         self.assertEqual(active, {"family_b", "family_c"})
         self.assertEqual(commented, {"family_a"})
 
+    def test_parse_cmake_loader_declarations(self) -> None:
+        text = """
+        audiocpp_add_model(example
+            LOADERS
+                engine::models::family_a::make_family_a_loader
+                # engine::models::family_b::make_family_b_loader
+        )
+        """
+        active, commented = parse_cmake_loaders(text)
+        self.assertEqual(active, {"family_a"})
+        self.assertEqual(commented, {"family_b"})
+
     def test_parked_alias_blocks_installable(self) -> None:
         class Pkg:
             def __init__(self, family=None):
@@ -275,6 +317,12 @@ class _SyncCheckSelfTests(unittest.TestCase):
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
+        "--cmake",
+        type=Path,
+        default=CMAKE_PATH,
+        help="Path to top-level CMakeLists.txt",
+    )
+    parser.add_argument(
         "--registry",
         type=Path,
         default=REGISTRY_PATH,
@@ -297,6 +345,9 @@ def main() -> int:
         result = unittest.TextTestRunner(verbosity=2).run(suite)
         return 0 if result.wasSuccessful() else 1
 
+    if not args.cmake.is_file():
+        print(f"error: CMakeLists.txt not found: {args.cmake}", file=sys.stderr)
+        return 2
     if not args.registry.is_file():
         print(f"error: registry not found: {args.registry}", file=sys.stderr)
         return 2
@@ -307,9 +358,12 @@ def main() -> int:
     sys.path.insert(0, str(MODEL_MANAGER_PATH.parent))
     import model_manager as mm  # noqa: E402
 
-    active, commented = parse_registry_loaders(args.registry.read_text(encoding="utf-8"))
+    active, commented = parse_declared_loaders(
+        args.cmake.read_text(encoding="utf-8"),
+        args.registry.read_text(encoding="utf-8"),
+    )
     if not active:
-        print("error: no active loaders parsed from registry.cpp", file=sys.stderr)
+        print("error: no active loaders parsed from generated registry inputs", file=sys.stderr)
         return 2
 
     errors, warnings = check_catalog(
@@ -343,7 +397,7 @@ def main() -> int:
         for error in errors:
             print(f"  - {error}", file=sys.stderr)
         print(
-            "\nFix: register the loader in registry.cpp (with sources in-tree), "
+            "\nFix: register the loader in CMake/registry source inputs (with sources in-tree), "
             "or mark the package UnsupportedSource / update docs/model_manager.md. See "
             "docs/maintainers/loader_and_catalog.md",
             file=sys.stderr,


### PR DESCRIPTION
## Summary
- add composite model selection for full, core, and custom builds
- expose composite build options through Linux, Windows, Metal, and XCFramework build scripts
- keep Docker builds on full model builds and exclude model_specs_v1 from Docker context
- localize RVC RMVPE so custom RVC builds do not link SeedVC

## Validation
- `bash -n scripts/build_linux.sh scripts/build_metal.sh scripts/build_xcframework.sh`
- `git diff --check`
- `scripts/build_linux.sh  --backend cuda --build-type Debug --build-dir build/debug --model-set custom --models qwen3_tts,pocket_tts,qwen3_asr --target audiocpp_cli -j 8`
- `scripts/build_linux.sh --backend cuda --build-type Debug --build-dir build/debug --model-set full --target audiocpp_cli -j 8`

PowerShell parse validation was skipped locally because `pwsh` is not installed on this Linux machine.