### PR TITLE
fix(safetensors): validate data_offsets at parse time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1391,6 +1391,13 @@ if (ENGINE_BUILD_TESTS)
         COMMAND wav_reader_test
     )
 
+    add_engine_unittest(safetensors_offsets_test tests/unittests/test_safetensors_offsets.cpp)
+
+    add_test(
+        NAME safetensors_offsets_test
+        COMMAND safetensors_offsets_test
+    )
+
     add_engine_unittest(audio_chunking_test tests/unittests/test_audio_chunking.cpp)
 
     add_test(

--- a/src/framework/assets/tensor_source.cpp
+++ b/src/framework/assets/tensor_source.cpp
@@ -638,11 +638,19 @@ private:
         if (bytes_.empty()) {
             bytes_ = engine::io::read_binary_blob(index_.source_path);
         }
-        const size_t data_offset = index_.header_bytes + info.data_begin;
         const size_t byte_size = info.data_end - info.data_begin;
-        if (data_offset + byte_size > bytes_.size()) {
+        // Written as subtractions against the total so nothing can overflow.
+        // `header_bytes + data_begin + byte_size > total` wraps if any term is
+        // large, and a wrapped comparison passes -- handing back a span over
+        // memory past the end of the blob. Parse-time validation now rejects the
+        // inputs that made that reachable; this is the last gate before a raw
+        // pointer escapes, so it checks anyway.
+        const size_t total = bytes_.size();
+        if (index_.header_bytes > total || byte_size > total - index_.header_bytes ||
+            info.data_begin > total - index_.header_bytes - byte_size) {
             throw std::runtime_error("tensor data range is out of bounds: " + info.name);
         }
+        const size_t data_offset = index_.header_bytes + info.data_begin;
         return {bytes_.data() + static_cast<std::ptrdiff_t>(data_offset), byte_size};
     }
 

--- a/src/framework/io/safetensors.cpp
+++ b/src/framework/io/safetensors.cpp
@@ -325,6 +325,22 @@ SafeTensorIndex load_safetensors_index(const std::filesystem::path & path) {
                 if (offsets.size() != 2) {
                     throw std::runtime_error("safetensors data_offsets must contain 2 entries");
                 }
+                // Validate here, at the single point every consumer routes through.
+                //
+                // These come straight from the file header. A negative value cast to
+                // size_t becomes ~SIZE_MAX, and data_end < data_begin makes the
+                // (data_end - data_begin) that callers compute underflow to the same.
+                // Either then wraps the caller's `offset + size > blob.size()` bounds
+                // check back under the limit, producing an enormous in-bounds-looking
+                // span over out-of-bounds memory.
+                if (offsets[0] < 0 || offsets[1] < 0) {
+                    throw std::runtime_error(
+                        "safetensors data_offsets must be non-negative: " + tensor_name);
+                }
+                if (offsets[1] < offsets[0]) {
+                    throw std::runtime_error(
+                        "safetensors data_offsets must be ordered begin <= end: " + tensor_name);
+                }
                 info.data_begin = static_cast<size_t>(offsets[0]);
                 info.data_end = static_cast<size_t>(offsets[1]);
             } else {

--- a/src/models/pocket_tts/voice_state_assets.cpp
+++ b/src/models/pocket_tts/voice_state_assets.cpp
@@ -42,11 +42,16 @@ std::pair<const std::byte *, size_t> require_safetensor_data(
     const io::SafeTensorIndex & index,
     const io::BinaryBlob & bytes,
     const io::SafeTensorInfo & info) {
-    const size_t data_offset = index.header_bytes + info.data_begin;
     const size_t byte_size = info.data_end - info.data_begin;
-    if (data_offset + byte_size > bytes.size()) {
+    // Subtractions against the total, so no term can overflow the comparison
+    // and let an out-of-range span through. See the matching check in
+    // framework/assets/tensor_source.cpp.
+    const size_t total = bytes.size();
+    if (index.header_bytes > total || byte_size > total - index.header_bytes ||
+        info.data_begin > total - index.header_bytes - byte_size) {
         throw std::runtime_error("tensor data range is out of bounds: " + info.name);
     }
+    const size_t data_offset = index.header_bytes + info.data_begin;
     return {bytes.data() + static_cast<std::ptrdiff_t>(data_offset), byte_size};
 }
 

--- a/tests/unittests/test_safetensors_offsets.cpp
+++ b/tests/unittests/test_safetensors_offsets.cpp
@@ -1,0 +1,102 @@
+// A safetensors header carries data_offsets straight from the file. Casting a
+// negative value to size_t yields ~SIZE_MAX, and data_end < data_begin makes the
+// (data_end - data_begin) that every consumer computes underflow to the same.
+// Either then wraps the caller's `offset + size > blob.size()` bounds check back
+// under the limit, producing an enormous span over out-of-bounds memory from a
+// malicious model file.
+//
+// These offsets are now rejected where they are parsed, so no consumer can
+// inherit the underflow.
+
+#include "engine/framework/io/safetensors.h"
+
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+void require(bool condition, const std::string & message) {
+    if (!condition) {
+        throw std::runtime_error(message);
+    }
+}
+
+// Minimal safetensors container: u64 little-endian header length, then the
+// JSON header, then the tensor data region.
+std::filesystem::path write_safetensors(const std::string & header_json, size_t data_bytes) {
+    static int counter = 0;
+    const auto path = std::filesystem::temp_directory_path() /
+                      ("safetensors_offsets_" + std::to_string(counter++) + ".safetensors");
+    std::ofstream out(path, std::ios::binary);
+    require(out.good(), "failed to open temp safetensors file");
+
+    const uint64_t header_len = header_json.size();
+    out.write(reinterpret_cast<const char *>(&header_len), sizeof(header_len));
+    out.write(header_json.data(), static_cast<std::streamsize>(header_json.size()));
+    const std::vector<char> data(data_bytes, 0);
+    out.write(data.data(), static_cast<std::streamsize>(data.size()));
+    require(out.good(), "failed to write temp safetensors file");
+    return path;
+}
+
+bool rejects(const std::string & header_json) {
+    const auto path = write_safetensors(header_json, 64);
+    bool threw = false;
+    try {
+        (void) engine::io::load_safetensors_index(path);
+    } catch (const std::runtime_error &) {
+        threw = true;
+    }
+    std::filesystem::remove(path);
+    return threw;
+}
+
+void test_inverted_offsets_are_rejected() {
+    // data_end < data_begin: the subtraction underflows to ~SIZE_MAX.
+    require(rejects(R"({"t":{"dtype":"F32","shape":[4],"data_offsets":[32,0]}})"),
+            "inverted data_offsets must be rejected");
+}
+
+void test_negative_offsets_are_rejected() {
+    require(rejects(R"({"t":{"dtype":"F32","shape":[4],"data_offsets":[-1,16]}})"),
+            "negative data_begin must be rejected");
+    require(rejects(R"({"t":{"dtype":"F32","shape":[4],"data_offsets":[0,-1]}})"),
+            "negative data_end must be rejected");
+}
+
+void test_valid_offsets_still_parse() {
+    // The guard must not reject legitimate headers, including empty tensors
+    // where data_begin == data_end.
+    const auto path = write_safetensors(
+        R"({"a":{"dtype":"F32","shape":[4],"data_offsets":[0,16]},)"
+        R"("b":{"dtype":"F32","shape":[0],"data_offsets":[16,16]}})", 64);
+    const auto index = engine::io::load_safetensors_index(path);
+    std::filesystem::remove(path);
+
+    require(index.tensors.size() == 2, "both tensors should parse");
+    const auto & a = index.tensors.at("a");
+    require(a.data_begin == 0 && a.data_end == 16, "tensor a offsets should round-trip");
+    const auto & b = index.tensors.at("b");
+    require(b.data_begin == b.data_end, "an empty tensor should remain valid");
+}
+
+}  // namespace
+
+int main() {
+    try {
+        test_inverted_offsets_are_rejected();
+        test_negative_offsets_are_rejected();
+        test_valid_offsets_still_parse();
+    } catch (const std::exception & error) {
+        std::cerr << "safetensors offsets test failed: " << error.what() << "\n";
+        return 1;
+    }
+    std::cout << "safetensors offsets test passed\n";
+    return 0;
+}


### PR DESCRIPTION
## Problem

`data_offsets` is read straight from the safetensors header and cast to `size_t` with no validation:

```cpp
info.data_begin = static_cast<size_t>(offsets[0]);
info.data_end   = static_cast<size_t>(offsets[1]);
```

`parse_int_array` returns `int64_t`, so two shapes get through:

- a **negative** value becomes `~SIZE_MAX` on the cast
- **`data_end < data_begin`** makes the `data_end - data_begin` that every consumer computes underflow to the same

Consumers then do:

```cpp
const size_t data_offset = index_.header_bytes + info.data_begin;
const size_t byte_size   = info.data_end - info.data_begin;
if (data_offset + byte_size > bytes_.size()) { throw; }
return {bytes_.data() + data_offset, byte_size};
```

With an underflowed `byte_size`, `data_offset + byte_size` wraps and the comparison passes, so the guard does not fire and the function returns a span far larger than the mapped file — an out-of-bounds read driven by a model file's header.

Reachable wherever a `.safetensors` file is loaded from a source the operator doesn't control (a downloaded or user-supplied model). Affects both `framework/assets/tensor_source.cpp` and `models/pocket_tts/voice_state_assets.cpp`, which contain the same computation.

## Fix

**Validate at parse time**, in `safetensors.cpp`, which is the single point every consumer routes through — rather than patching each call site:

- reject negative `data_offsets`
- reject `data_end < data_begin`

**Overflow-safe bounds checks** in both consumers as defence in depth: the comparisons are rewritten as subtractions against the total (`byte_size > total - header_bytes`, etc.) so no term can overflow. Parse-time validation makes that unreachable now, but these are the last gate before a raw pointer escapes.

Zero-length tensors (`data_begin == data_end`) remain valid — covered by a test.

## Test

`tests/unittests/test_safetensors_offsets.cpp`, registered in CMake alongside the other unit tests. Covers inverted offsets, negative offsets, and that valid headers still parse.

Verified by compiling both ways: the test **fails** against the unpatched parser (`inverted data_offsets must be rejected`) and **passes** with the fix.

⚠️ I compiled and ran this test directly rather than through the full CMake build, so the change hasn't been through the project's complete build matrix — worth a CI run before merging.

## Provenance

Found by an automated security scan while evaluating that tooling; the underflow was then traced and confirmed by hand. Happy to adjust the approach if you'd rather validate elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)