### PR TITLE
server: add POST /v1/audio/transcriptions/live for live PCM ingest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1220,6 +1220,7 @@ add_executable(audiocpp_server
     app/server/runtime.cpp
     app/cli/args.cpp
     app/cli/request.cpp
+    app/streaming/pcm_source.cpp
     app/streaming/streaming.cpp
 )
 
@@ -1561,6 +1562,24 @@ if (ENGINE_BUILD_TESTS)
         NAME streaming_audio_input_test
         COMMAND streaming_audio_input_test
     )
+
+    add_executable(http_live_body_test
+        tests/unittests/test_http_live_body.cpp
+        app/server/http.cpp
+    )
+    target_link_libraries(http_live_body_test PRIVATE engine_runtime ggml)
+    if(WIN32)
+        target_link_libraries(http_live_body_test PRIVATE ws2_32)
+    endif()
+    target_include_directories(http_live_body_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests/unittests)
+
+    add_test(
+        NAME http_live_body_test
+        COMMAND http_live_body_test
+    )
+    # This test talks to a real loopback socket, so a framing regression could
+    # block forever rather than fail. Bound it so CI reports a failure instead.
+    set_tests_properties(http_live_body_test PROPERTIES TIMEOUT 120)
 
     add_engine_unittest(hf_sampler_test tests/unittests/test_hf_sampler.cpp)
 

--- a/app/server/README.md
+++ b/app/server/README.md
@@ -102,7 +102,7 @@ The bound is resolved in three layers, since model runtimes differ by orders of 
 
 1. **Server** — top-level `"busy_timeout_ms"` (or `--busy-timeout-ms`) sets the fleet default.
 2. **Model** — `"busy_timeout_ms"` on an entry in `"models"` overrides that default for one model, and becomes the ceiling for requests to it.
-3. **Request** — `"busy_timeout_ms"` in the request body (or as a `busy_timeout_ms` form field on multipart transcription) lets a caller bound its own wait.
+3. **Request** — `"busy_timeout_ms"` in the request body (or as a `busy_timeout_ms` form field on multipart transcription, or a `busy_timeout_ms` query parameter on the live-ingest route, whose body is audio and has nowhere to put JSON) lets a caller bound its own wait.
 
 A request may ask for a **shorter** bound than the model's ceiling but never a longer one — `effective = min(request, ceiling)` — so a client cannot weaken the guard and reintroduce the hang it prevents. Because `0` means "unbounded", it compares as infinity on both sides: a request asking for `0` is still capped by the model ceiling, while under a ceiling of `0` a request's own bound is honored.
 
@@ -303,6 +303,7 @@ Because the body carries audio rather than JSON, parameters are query parameters
 | `channels` | `1` | interleaved channel count |
 | `sample_format` | `s16le` | `s16le` or `f32le` |
 | `language` | unset | passed through to the model |
+| `busy_timeout_ms` | model policy | how long to wait for the model lock, as elsewhere; clamped by the configured ceiling, so a request can shorten its own wait but never weaken the guard |
 
 ```bash
 # Microphone straight into transcription (macOS; -f alsa on Linux, -f dshow on Windows)
@@ -319,16 +320,35 @@ Whether partial text actually appears *during* capture is a property of the mode
 
 The request ends when the client sends the terminating chunk. Closing the connection without one is an error, not an end of speech — a truncated transcript that arrives as a normal `transcript.text.done` would be indistinguishable from the speaker stopping, so the endpoint refuses to produce one. The same applies to a stall past the idle timeout, an oversized chunk, or a malformed frame: each surfaces as an SSE `error` event.
 
-Because the model is held for the length of the request, the body is bounded on four axes, all compile-time constants today:
+Because the model is held for the length of the request, the body is bounded on several axes:
 
-| bound | value | meaning |
+| key | default | meaning |
 | --- | --- | --- |
-| idle | 30 s | longest wait for more data once the reader asks for it |
-| total | 600 s | checked at every point the body advances, so it caps the whole request |
-| size | 512 MiB | received body bytes, framing included |
-| chunk | 8 MiB | largest single declared chunk |
+| `idle_timeout_ms` | 30 s | longest wait for more data once the reader asks for it |
+| `total_timeout_ms` | 600 s | checked at every point the body advances, so it caps the whole request |
+| `max_body_bytes` | 512 MiB | received body bytes, framing included |
+| `max_chunk_bytes` | 8 MiB | largest single declared chunk |
+| `send_timeout_ms` | 30 s | `SO_SNDTIMEO` on the connection, so a client that stops reading the SSE response cannot hold the model open |
 
-The 600 s figure is an upper bound on one dictation; continuous captioning would need it raised. `sample_rate` and `channels` are range-checked too (1000–384000 and 1–16): they size the model's per-chunk buffer, so an absurd value would otherwise be an allocation request made while the model lock is held.
+Those defaults suit one dictation at a time. Continuous captioning needs a longer deadline, and a trusted deployment may want a different trade entirely, so they are configurable — server-wide under `live_ingest`, with any subset overridden per model:
+
+```json
+{
+  "live_ingest": { "total_timeout_ms": 600000, "max_chunk_bytes": 8388608 },
+  "models": [
+    {
+      "id": "voxtral-realtime",
+      "family": "voxtral_realtime",
+      "mode": "streaming",
+      "live_ingest": { "total_timeout_ms": 1800000 }
+    }
+  ]
+}
+```
+
+A model entry sets only the values it needs and inherits the rest, so raising one bound for a long-capture model does not mean restating the whole policy and letting it drift. `0` means *disabled*, the same convention as `busy_timeout_ms`; a negative value is rejected at startup rather than silently treated as "no bound". The exception is `max_chunk_bytes`, which must stay positive and is rejected at `0`: a chunk is materialized in memory before it is served, so an unbounded one is not implementable, and the same value backs the overflow check that rejects a declared chunk size of `SIZE_MAX`. The keys are only consulted for this route, since no other one delivers its body incrementally.
+
+`sample_rate` and `channels` are range-checked too (1000–384000 and 1–16), and are not configurable: they size the model's per-chunk buffer, so an absurd value would be an allocation request made while the model lock is held.
 
 **Deployment.** This endpoint streams the request body and the response on one connection at the same time. That is legal HTTP/1.1, but it needs a direct connection or a proxy that does not buffer requests. Behind nginx both of these are required, because `proxy_request_buffering off` still buffers a chunked body unless the upstream connection is HTTP/1.1:
 

--- a/app/server/README.md
+++ b/app/server/README.md
@@ -286,6 +286,60 @@ curl -N http://127.0.0.1:8080/v1/audio/transcriptions \
 
 The stream emits `transcript.text.delta` events, one final `transcript.text.done` event containing the full transcript, then `data: [DONE]`.
 
+Note that `stream=true` streams the *output* of an already-uploaded file: the whole recording is sent first, and the deltas describe decoding it. It shortens time-to-first-token on long audio, but nothing can appear while the speaker is still talking. For that, use the live endpoint below.
+
+### `POST /v1/audio/transcriptions/live`
+
+Streams raw PCM **as it is captured** and returns transcript deltas on the same connection, so partial text can appear while the user is still speaking.
+
+The request body is raw interleaved PCM sent with `Transfer-Encoding: chunked`; the response is the same SSE event shape as `stream=true` above, so a client can share one reader. There is no multipart form and no file — the audio never has to exist on disk, and the transport hands each chunk to the model as it arrives rather than assembling the recording first. Whether the *model* then keeps the whole utterance in memory is its own business: `nemotron_asr`, for instance, accumulates internally regardless of how the audio reaches it.
+
+Because the body carries audio rather than JSON, parameters are query parameters:
+
+| parameter | default | meaning |
+| --- | --- | --- |
+| `model` | required | id of a model configured with `mode: "streaming"` |
+| `sample_rate` | `16000` | samples per second of the PCM being sent |
+| `channels` | `1` | interleaved channel count |
+| `sample_format` | `s16le` | `s16le` or `f32le` |
+| `language` | unset | passed through to the model |
+
+```bash
+# Microphone straight into transcription (macOS; -f alsa on Linux, -f dshow on Windows)
+ffmpeg -f avfoundation -i ":0" -ar 16000 -ac 1 -f s16le - \
+  | curl -N -X POST -H 'Expect:' -T - \
+      'http://127.0.0.1:8080/v1/audio/transcriptions/live?model=voxtral-realtime&sample_rate=16000&channels=1&sample_format=s16le'
+```
+
+`-T -` is what makes this live, and it is not interchangeable with `--data-binary @-`: the latter drains stdin to completion before opening the connection, which turns a live capture back into a file upload and defeats the endpoint. `-H 'Expect:'` suppresses curl's `Expect: 100-continue`, which the server does not answer — without it curl waits out its one-second continue timeout before sending any audio. (`-T .` reads stdin non-blocking; measured against this endpoint it behaves the same, so either works.)
+
+A headerless stream carries no format, so the parameters above are a contract the server cannot verify — sending 48 kHz audio while declaring 16 kHz produces a confident, wrong transcript rather than an error.
+
+Whether partial text actually appears *during* capture is a property of the model, not of this endpoint. A model that decodes incrementally (`voxtral_realtime`) emits deltas throughout the utterance; one whose encoder consumes the whole utterance before decoding (`nemotron_asr`) will stream its deltas only after the audio ends. Both work here; only the first feels live.
+
+The request ends when the client sends the terminating chunk. Closing the connection without one is an error, not an end of speech — a truncated transcript that arrives as a normal `transcript.text.done` would be indistinguishable from the speaker stopping, so the endpoint refuses to produce one. The same applies to a stall past the idle timeout, an oversized chunk, or a malformed frame: each surfaces as an SSE `error` event.
+
+Because the model is held for the length of the request, the body is bounded on four axes, all compile-time constants today:
+
+| bound | value | meaning |
+| --- | --- | --- |
+| idle | 30 s | longest wait for more data once the reader asks for it |
+| total | 600 s | checked at every point the body advances, so it caps the whole request |
+| size | 512 MiB | received body bytes, framing included |
+| chunk | 8 MiB | largest single declared chunk |
+
+The 600 s figure is an upper bound on one dictation; continuous captioning would need it raised. `sample_rate` and `channels` are range-checked too (1000–384000 and 1–16): they size the model's per-chunk buffer, so an absurd value would otherwise be an allocation request made while the model lock is held.
+
+**Deployment.** This endpoint streams the request body and the response on one connection at the same time. That is legal HTTP/1.1, but it needs a direct connection or a proxy that does not buffer requests. Behind nginx both of these are required, because `proxy_request_buffering off` still buffers a chunked body unless the upstream connection is HTTP/1.1:
+
+```nginx
+proxy_http_version 1.1;
+proxy_request_buffering off;
+proxy_buffering off;
+```
+
+A browser cannot drive it: `fetch()` request streaming requires HTTP/2 and is half-duplex by specification — the whole request is sent before the response is processed. It is intended for native clients — `curl`, an `ffmpeg` pipe, or a backend service. A WebSocket transport would suit browsers and intermediaries better and could be added alongside this without changing it.
+
 ### `GET /v1/audio/voices?model=<id>`
 
 Lists the cached voice ids and configured server voice preset names available for a TTS model, so a client can populate a voice picker instead of guessing generic names. For families that keep voice presets under `model_root/embeddings/*.safetensors` (`pocket_tts` today), this returns those ids too. If `model` is omitted and the server has exactly one configured model, that model is used; if multiple models are configured, omit `model` only when an empty list is acceptable.

--- a/app/server/config.cpp
+++ b/app/server/config.cpp
@@ -7,6 +7,7 @@
 
 #include <cmath>
 #include <cstdint>
+#include <limits>
 #include <stdexcept>
 #include <utility>
 
@@ -62,7 +63,150 @@ ServerModelConfig::VoicePreset parse_voice_preset(
     return preset;
 }
 
+// Every live-ingest bound uses 0 to mean "disabled", matching busy_timeout_ms, so
+// only a negative value is malformed. Rejected at parse time rather than clamped:
+// a negative deadline is a typo, and silently treating it as "no bound" would
+// remove a guard the operator believed they had set.
+//
+// Read and validated by hand rather than through optional_i32/optional_i64, both
+// of which are wrong here in two ways. They return the supplied fallback for a
+// present-but-wrong-typed field, so `"max_body_bytes": "oops"` in a MODEL override
+// would silently record the compiled default as a deliberate override and widen a
+// stricter server policy. And optional_i32 narrows to int before anything checks
+// the range, so on a 32-bit int a value of 4294967296 becomes 0 — which here means
+// "disabled", quietly removing the bound the operator was trying to set.
+double live_ingest_number(
+    const engine::io::json::Value & value,
+    const char * key,
+    const std::string & context) {
+    const auto * field = value.find(key);
+    if (field == nullptr || !field->is_number()) {
+        throw std::runtime_error(context + " " + key + " must be a number");
+    }
+    const double parsed = field->as_number();
+    constexpr double kMaxSafeJsonInteger = 9007199254740991.0;  // 2^53 - 1
+    if (std::floor(parsed) != parsed) {
+        throw std::runtime_error(context + " " + key + " must be an integer");
+    }
+    if (parsed < 0.0) {
+        throw std::runtime_error(context + " " + key + " must be >= 0 (0 disables the bound)");
+    }
+    if (parsed > kMaxSafeJsonInteger) {
+        throw std::runtime_error(context + " " + key + " must be <= 2^53 - 1");
+    }
+    return parsed;
+}
+
+int live_ingest_ms(
+    const engine::io::json::Value & value,
+    const char * key,
+    int fallback,
+    const std::string & context) {
+    if (value.find(key) == nullptr) {
+        return fallback;
+    }
+    const double parsed = live_ingest_number(value, key, context);
+    if (parsed > static_cast<double>(std::numeric_limits<int>::max())) {
+        throw std::runtime_error(
+            context + " " + key + " must be <= " + std::to_string(std::numeric_limits<int>::max()) + " ms");
+    }
+    return static_cast<int>(parsed);
+}
+
+size_t live_ingest_bytes(
+    const engine::io::json::Value & value,
+    const char * key,
+    size_t fallback,
+    const std::string & context) {
+    if (value.find(key) == nullptr) {
+        return fallback;
+    }
+    const double parsed = live_ingest_number(value, key, context);
+    // Range-checked against size_t rather than cast blindly: on a 32-bit target a
+    // legal-looking 4294967296 would otherwise truncate to 0 and disable the bound.
+    if (parsed > static_cast<double>(std::numeric_limits<size_t>::max())) {
+        throw std::runtime_error(context + " " + key + " is too large for this platform");
+    }
+    return static_cast<size_t>(parsed);
+}
+
+LiveIngestLimits parse_live_ingest_limits(
+    const engine::io::json::Value & value,
+    const LiveIngestLimits & fallback,
+    const std::string & context) {
+    if (!value.is_object()) {
+        throw std::runtime_error(context + " must be an object");
+    }
+    LiveIngestLimits limits;
+    limits.idle_timeout_ms = live_ingest_ms(value, "idle_timeout_ms", fallback.idle_timeout_ms, context);
+    limits.total_timeout_ms = live_ingest_ms(value, "total_timeout_ms", fallback.total_timeout_ms, context);
+    limits.max_body_bytes = live_ingest_bytes(value, "max_body_bytes", fallback.max_body_bytes, context);
+    limits.max_chunk_bytes = live_ingest_bytes(value, "max_chunk_bytes", fallback.max_chunk_bytes, context);
+    // The one bound that cannot be disabled. A chunk is materialized in memory
+    // before it is served, so "unbounded" is not implementable — and a 0 here would
+    // underflow the overflow guard in the chunk-size parser, re-admitting a declared
+    // size of SIZE_MAX. Rejected rather than quietly substituted.
+    if (limits.max_chunk_bytes == 0) {
+        throw std::runtime_error(
+            context + " max_chunk_bytes must be > 0: a chunk is held in memory, so it cannot be unbounded");
+    }
+    limits.send_timeout_ms = live_ingest_ms(value, "send_timeout_ms", fallback.send_timeout_ms, context);
+    return limits;
+}
+
+LiveIngestOverrides parse_live_ingest_overrides(
+    const engine::io::json::Value & value,
+    const std::string & context) {
+    if (!value.is_object()) {
+        throw std::runtime_error(context + " must be an object");
+    }
+    // Parsed against the compiled-in defaults purely to reuse the validation; only
+    // the keys actually present are recorded, so the rest still fall through to
+    // whatever server policy is at the time the override is applied.
+    const LiveIngestLimits defaults;
+    const auto parsed = parse_live_ingest_limits(value, defaults, context);
+    LiveIngestOverrides overrides;
+    if (value.find("idle_timeout_ms") != nullptr) {
+        overrides.idle_timeout_ms = parsed.idle_timeout_ms;
+    }
+    if (value.find("total_timeout_ms") != nullptr) {
+        overrides.total_timeout_ms = parsed.total_timeout_ms;
+    }
+    if (value.find("max_body_bytes") != nullptr) {
+        overrides.max_body_bytes = parsed.max_body_bytes;
+    }
+    if (value.find("max_chunk_bytes") != nullptr) {
+        overrides.max_chunk_bytes = parsed.max_chunk_bytes;
+    }
+    if (value.find("send_timeout_ms") != nullptr) {
+        overrides.send_timeout_ms = parsed.send_timeout_ms;
+    }
+    return overrides;
+}
+
 }  // namespace
+
+LiveIngestLimits resolve_live_ingest_limits(
+    const LiveIngestLimits & base,
+    const LiveIngestOverrides & overrides) {
+    LiveIngestLimits limits = base;
+    if (overrides.idle_timeout_ms.has_value()) {
+        limits.idle_timeout_ms = *overrides.idle_timeout_ms;
+    }
+    if (overrides.total_timeout_ms.has_value()) {
+        limits.total_timeout_ms = *overrides.total_timeout_ms;
+    }
+    if (overrides.max_body_bytes.has_value()) {
+        limits.max_body_bytes = *overrides.max_body_bytes;
+    }
+    if (overrides.max_chunk_bytes.has_value()) {
+        limits.max_chunk_bytes = *overrides.max_chunk_bytes;
+    }
+    if (overrides.send_timeout_ms.has_value()) {
+        limits.send_timeout_ms = *overrides.send_timeout_ms;
+    }
+    return limits;
+}
 
 engine::core::BackendType parse_server_backend(const std::string & value) {
     auto backend = minitts::cli::parse_backend(value);
@@ -87,6 +231,9 @@ ServerConfig load_server_config(const std::filesystem::path & path) {
         config.max_request_body_bytes = parse_max_request_body_bytes(*value);
     }
     config.busy_timeout_ms = engine::io::json::optional_i32(root, "busy_timeout_ms", config.busy_timeout_ms);
+    if (const auto * value = root.find("live_ingest")) {
+        config.live_ingest = parse_live_ingest_limits(*value, config.live_ingest, "server live_ingest");
+    }
     if (const auto * value = root.find("model_spec_override")) {
         config.model_spec_override = resolve_path(base, value->as_string());
     }
@@ -122,6 +269,9 @@ ServerConfig load_server_config(const std::filesystem::path & path) {
                     "busy_timeout_ms for model " + model.id + " must be >= 0 (0 disables the guard)");
             }
             model.busy_timeout_ms = busy_timeout_ms;
+        }
+        if (const auto * value = item.find("live_ingest")) {
+            model.live_ingest = parse_live_ingest_overrides(*value, "live_ingest for model " + model.id);
         }
         if (const auto * value = item.find("config")) {
             model.config_id = value->as_string();

--- a/app/server/config.h
+++ b/app/server/config.h
@@ -9,9 +9,27 @@
 
 #include "engine/framework/core/backend.h"
 
+#include "http.h"
+
 namespace minitts::server {
 
 constexpr uint64_t kDefaultMaxRequestBodyBytes = 2ull * 1024ull * 1024ull * 1024ull;
+
+// Per-model overrides of the server-level `live_ingest` block. Each field is
+// independently optional: a model that only needs a longer deadline says so and
+// inherits the rest, rather than restating the whole policy and drifting from it.
+struct LiveIngestOverrides {
+    std::optional<int> idle_timeout_ms;
+    std::optional<int> total_timeout_ms;
+    std::optional<size_t> max_body_bytes;
+    std::optional<size_t> max_chunk_bytes;
+    std::optional<int> send_timeout_ms;
+};
+
+// Server policy with any per-model override applied on top.
+LiveIngestLimits resolve_live_ingest_limits(
+    const LiveIngestLimits & base,
+    const LiveIngestOverrides & overrides);
 
 struct ServerModelConfig {
     struct VoicePreset {
@@ -32,6 +50,9 @@ struct ServerModelConfig {
     // magnitude (a short TTS clip vs. minutes of music generation), so one fleet-wide
     // bound is either too tight for the slow models or useless for the fast ones.
     std::optional<int> busy_timeout_ms;
+    // Only meaningful for a streaming model reachable over the live-ingest route;
+    // ignored otherwise, since no other route delivers its body incrementally.
+    LiveIngestOverrides live_ingest;
     std::optional<std::string> config_id;
     std::optional<std::string> weight_id;
     std::unordered_map<std::string, std::string> load_options;
@@ -58,6 +79,9 @@ struct ServerConfig {
     // single inference (music generation can take minutes). 0 disables the guard and
     // restores unbounded waiting.
     int busy_timeout_ms = 300000;
+    // Fleet-wide bounds for incrementally delivered request bodies. The defaults are
+    // in LiveIngestLimits; a model entry may override any subset of them.
+    LiveIngestLimits live_ingest;
     std::optional<std::filesystem::path> model_spec_override;
     std::vector<ServerModelConfig> models;
 };

--- a/app/server/http.cpp
+++ b/app/server/http.cpp
@@ -223,20 +223,11 @@ bool wants_incremental_body(const HttpRequest & request) {
 // an idle timeout between reads, an absolute deadline for the whole body, a cap on
 // total bytes, and a cap on any single chunk. A client that opens a body and then
 // stalls, never stops, or names an enormous chunk therefore cannot pin the model
-// indefinitely or exhaust the host.
+// indefinitely or exhaust the host. The values come from `LiveIngestLimits`
+// (app/server/http.h), which the handler resolves per request.
 class ChunkedSocketStreambuf final : public std::streambuf {
 public:
-    struct Limits {
-        int idle_timeout_ms = 30'000;
-        int total_timeout_ms = 600'000;
-        size_t max_bytes = 512u * 1024u * 1024u;
-        // Bounds one chunk, independently of the total. A chunk is held in memory
-        // twice while being de-framed, so without this a single legal chunk could
-        // name a size large enough to exhaust the host — while holding a model lock.
-        size_t max_chunk_bytes = 8u * 1024u * 1024u;
-    };
-
-    ChunkedSocketStreambuf(SocketHandle socket, std::string prefetched, Limits limits)
+    ChunkedSocketStreambuf(SocketHandle socket, std::string prefetched, LiveIngestLimits limits)
         : socket_(socket),
           pending_(std::move(prefetched)),
           limits_(limits),
@@ -250,6 +241,10 @@ protected:
         if (gptr() < egptr()) {
             return traits_type::to_int_type(*gptr());
         }
+        // Covers the bytes that arrived alongside the headers. A body short enough to
+        // fit in that first receive never calls receive_more(), so a cap enforced only
+        // there would be skipped by the single request most likely to be probing it.
+        require_within_body_cap();
         // A chunk is handed out in windows rather than all at once. Reads that stay
         // inside the published get area never re-enter underflow(), so publishing a
         // whole 8 MiB chunk would let the body keep advancing across many model
@@ -295,6 +290,12 @@ private:
 #endif
     }
 
+    void require_within_body_cap() const {
+        if (limits_.max_body_bytes > 0 && received_bytes_ > limits_.max_body_bytes) {
+            throw std::runtime_error("live request body exceeded its maximum size");
+        }
+    }
+
     // Enforced at every point where the body advances, not only before a receive:
     // checking it in receive_more() alone lets an already-buffered tail — the rest
     // of a large chunk, trailers, the terminating chunk — be consumed after the
@@ -337,9 +338,7 @@ private:
             return false;
         }
         received_bytes_ += static_cast<size_t>(received);
-        if (limits_.max_bytes > 0 && received_bytes_ > limits_.max_bytes) {
-            throw std::runtime_error("live request body exceeded its maximum size");
-        }
+        require_within_body_cap();
         pending_.append(buffer.data(), static_cast<size_t>(received));
         return true;
     }
@@ -405,6 +404,11 @@ private:
         if (header.empty()) {
             throw std::runtime_error("chunked request body: empty chunk size");
         }
+        // Unlike the other bounds, a per-chunk cap cannot be disabled: the chunk is
+        // materialized in memory, so "unbounded" is not implementable. 0 falls back
+        // to the default rather than meaning "no limit".
+        const size_t chunk_cap =
+            limits_.max_chunk_bytes > 0 ? limits_.max_chunk_bytes : LiveIngestLimits{}.max_chunk_bytes;
         size_t size = 0;
         for (const char digit : header) {
             int value = 0;
@@ -418,10 +422,20 @@ private:
                 throw std::runtime_error(
                     "chunked request body: invalid chunk size \"" + header + "\"");
             }
-            if (size > (limits_.max_chunk_bytes - static_cast<size_t>(value)) / 16) {
+            // Checked in two steps, each on operands already known to be in range.
+            // The single-expression form `size > (cap - value) / 16` underflows
+            // whenever cap < value — at cap = 1 a digit of 'f' wraps to a huge
+            // quotient and is accepted — which is the same class of bug this
+            // hand-rolled parse exists to prevent.
+            if (size > chunk_cap / 16) {
                 throw std::runtime_error("chunked request body: chunk size exceeds the maximum");
             }
-            size = size * 16 + static_cast<size_t>(value);
+            size *= 16;
+            // size <= (cap / 16) * 16 <= cap here, so the subtraction cannot wrap.
+            if (static_cast<size_t>(value) > chunk_cap - size) {
+                throw std::runtime_error("chunked request body: chunk size exceeds the maximum");
+            }
+            size += static_cast<size_t>(value);
         }
         if (size == 0) {
             finished_ = true;
@@ -494,7 +508,7 @@ private:
     size_t pending_pos_ = 0;
     std::vector<char> chunk_;  // the de-framed chunk currently being served
     size_t chunk_pos_ = 0;     // how much of chunk_ has been published so far
-    Limits limits_;
+    LiveIngestLimits limits_;
     std::chrono::steady_clock::time_point started_;
     size_t received_bytes_;
     bool finished_ = false;
@@ -707,23 +721,29 @@ void handle_client(SocketHandle client, IHttpHandler & handler, uint64_t max_req
     try {
         std::string leftover;
         auto request = read_http_request(socket.get(), max_request_body_bytes, leftover);
-        if (wants_incremental_body(request)) {
+        const bool incremental_body = wants_incremental_body(request);
+        // Asked for once, before the stream exists, because the streambuf takes its
+        // bounds at construction. The handler resolves them from server config and
+        // any per-model override — the transport has no notion of models.
+        const LiveIngestLimits limits =
+            incremental_body ? handler.live_ingest_limits(request) : LiveIngestLimits{};
+        if (incremental_body && limits.send_timeout_ms > 0) {
             // Scoped to this endpoint: it is the only one whose response is written
             // while a model lock is held, so it is the only one where a client that
             // stops reading can pin a model. Applying it server-wide would risk
             // truncating a large ordinary response to a merely slow client.
-            set_send_timeout(socket.get(), 30'000);
+            set_send_timeout(socket.get(), limits.send_timeout_ms);
         }
         // Constructed unconditionally so it outlives the handler call, but only
         // published on `request` when the client actually declared a chunked body.
-        ChunkedSocketStreambuf body_buffer(socket.get(), std::move(leftover), ChunkedSocketStreambuf::Limits{});
+        ChunkedSocketStreambuf body_buffer(socket.get(), std::move(leftover), limits);
         std::istream body_stream(&body_buffer);
         // Without this, a throw from underflow() is caught by istream and turned into
         // badbit. A reader that checks gcount() then sees a short read and reports a
         // clean end of input, so a stall, an oversize chunk or a mid-body disconnect
         // would all be delivered as a successful, silently truncated body.
         body_stream.exceptions(std::ios::badbit);
-        if (wants_incremental_body(request)) {
+        if (incremental_body) {
             request.body_stream = &body_stream;
         }
         const auto response = handler.handle(request);

--- a/app/server/http.cpp
+++ b/app/server/http.cpp
@@ -6,16 +6,20 @@
 #include <array>
 #include <cctype>
 #include <charconv>
+#include <chrono>
 #include <cstdint>
 #include <cerrno>
 #include <iostream>
+#include <istream>
 #include <limits>
 #include <optional>
 #include <sstream>
 #include <stdexcept>
+#include <streambuf>
 #include <string_view>
 #include <thread>
 #include <utility>
+#include <vector>
 
 #ifdef _WIN32
 #ifndef NOMINMAX
@@ -28,6 +32,7 @@ constexpr SocketHandle kInvalidSocket = INVALID_SOCKET;
 #else
 #include <arpa/inet.h>
 #include <netinet/in.h>
+#include <poll.h>
 #include <sys/select.h>
 #include <sys/socket.h>
 #include <unistd.h>
@@ -152,7 +157,356 @@ void send_all(SocketHandle socket, const std::string & data) {
     }
 }
 
-HttpRequest read_http_request(SocketHandle socket, uint64_t max_request_body_bytes) {
+// An SSE body is written while a model lock is held, so an unbounded blocking
+// send() lets a client that uploads but never reads fill the kernel send buffer
+// and pin that model indefinitely. A send timeout turns it into a failed write.
+void set_send_timeout(SocketHandle socket, int timeout_ms) {
+#ifdef _WIN32
+    const DWORD timeout = static_cast<DWORD>(timeout_ms);
+    setsockopt(socket, SOL_SOCKET, SO_SNDTIMEO, reinterpret_cast<const char *>(&timeout), sizeof(timeout));
+#else
+    timeval timeout{};
+    timeout.tv_sec = timeout_ms / 1000;
+    timeout.tv_usec = (timeout_ms % 1000) * 1000;
+    setsockopt(socket, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout));
+#endif
+}
+
+// The one endpoint that consumes its body incrementally. Gating on the path as
+// well as the encoding keeps every other endpoint's request handling bit-for-bit
+// unchanged, instead of silently altering how any chunked request is read.
+constexpr std::string_view kLiveIngestPath = "/v1/audio/transcriptions/live";
+
+// True only when the header names exactly one transfer-coding and that coding is
+// "chunked". A substring test would accept "notchunked" as well as chains like
+// "gzip, chunked" — and for the latter, stripping the chunk framing would hand the
+// PCM decoder compressed bytes, which it would happily interpret as audio.
+bool is_chunked_only(std::string_view value) {
+    bool saw_coding = false;
+    size_t start = 0;
+    while (start <= value.size()) {
+        const size_t comma = value.find(',', start);
+        const auto end = comma == std::string_view::npos ? value.size() : comma;
+        const std::string coding = trim(std::string(value.substr(start, end - start)));
+        if (!coding.empty()) {
+            if (saw_coding || lower_ascii(coding) != "chunked") {
+                return false;
+            }
+            saw_coding = true;
+        }
+        if (comma == std::string_view::npos) {
+            break;
+        }
+        start = comma + 1;
+    }
+    return saw_coding;
+}
+
+bool wants_incremental_body(const HttpRequest & request) {
+    if (request.path != kLiveIngestPath) {
+        return false;
+    }
+    const auto it = request.headers.find("transfer-encoding");
+    if (it == request.headers.end()) {
+        return false;
+    }
+    return is_chunked_only(it->second);
+}
+
+// De-frames an HTTP/1.1 chunked request body off a live socket into a byte
+// stream. `underflow()` blocks in recv() waiting for the next chunk, which is
+// precisely the contract `AudioChunkReader` documents for a live source — so a
+// streaming task can pull capture-time audio straight through it without the
+// body ever being fully materialized.
+//
+// Bounded on four axes, because this stream is read while a model lock is held:
+// an idle timeout between reads, an absolute deadline for the whole body, a cap on
+// total bytes, and a cap on any single chunk. A client that opens a body and then
+// stalls, never stops, or names an enormous chunk therefore cannot pin the model
+// indefinitely or exhaust the host.
+class ChunkedSocketStreambuf final : public std::streambuf {
+public:
+    struct Limits {
+        int idle_timeout_ms = 30'000;
+        int total_timeout_ms = 600'000;
+        size_t max_bytes = 512u * 1024u * 1024u;
+        // Bounds one chunk, independently of the total. A chunk is held in memory
+        // twice while being de-framed, so without this a single legal chunk could
+        // name a size large enough to exhaust the host — while holding a model lock.
+        size_t max_chunk_bytes = 8u * 1024u * 1024u;
+    };
+
+    ChunkedSocketStreambuf(SocketHandle socket, std::string prefetched, Limits limits)
+        : socket_(socket),
+          pending_(std::move(prefetched)),
+          limits_(limits),
+          started_(std::chrono::steady_clock::now()),
+          // Bytes that arrived alongside the headers still count toward the total,
+          // or the cap could be overshot by one receive before it is ever consulted.
+          received_bytes_(pending_.size()) {}
+
+protected:
+    int_type underflow() override {
+        if (gptr() < egptr()) {
+            return traits_type::to_int_type(*gptr());
+        }
+        // A chunk is handed out in windows rather than all at once. Reads that stay
+        // inside the published get area never re-enter underflow(), so publishing a
+        // whole 8 MiB chunk would let the body keep advancing across many model
+        // iterations without the deadline ever being consulted again. Windowing puts
+        // a bound on how far past the deadline consumption can get.
+        if (publish_window()) {
+            return traits_type::to_int_type(*gptr());
+        }
+        if (!next_chunk()) {
+            return traits_type::eof();
+        }
+        return traits_type::to_int_type(*gptr());
+    }
+
+private:
+    // poll() rather than select(): an accepted descriptor can be >= FD_SETSIZE
+    // once enough connections are open, and FD_SET on such a descriptor is
+    // undefined behaviour that corrupts the stack.
+    bool wait_readable() const {
+        int wait_ms = limits_.idle_timeout_ms;
+        // Clamp to whatever is left of the total deadline, so a read starting just
+        // before it expires cannot overshoot by a further idle period.
+        if (limits_.total_timeout_ms > 0) {
+            const auto remaining = limits_.total_timeout_ms -
+                static_cast<int>(std::chrono::duration_cast<std::chrono::milliseconds>(
+                                     std::chrono::steady_clock::now() - started_)
+                                     .count());
+            if (remaining <= 0) {
+                return false;
+            }
+            wait_ms = (wait_ms <= 0) ? remaining : std::min(wait_ms, remaining);
+        }
+        if (wait_ms <= 0) {
+            return true;
+        }
+        pollfd descriptor{};
+        descriptor.fd = socket_;
+        descriptor.events = POLLIN;
+#ifdef _WIN32
+        return WSAPoll(&descriptor, 1, wait_ms) > 0;
+#else
+        return poll(&descriptor, 1, wait_ms) > 0;
+#endif
+    }
+
+    // Enforced at every point where the body advances, not only before a receive:
+    // checking it in receive_more() alone lets an already-buffered tail — the rest
+    // of a large chunk, trailers, the terminating chunk — be consumed after the
+    // deadline has passed, which is not what "deadline" means to a caller reasoning
+    // about how long the model can be held.
+    void require_within_deadline() const {
+        if (limits_.total_timeout_ms <= 0) {
+            return;
+        }
+        const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                 std::chrono::steady_clock::now() - started_)
+                                 .count();
+        if (elapsed >= limits_.total_timeout_ms) {
+            throw std::runtime_error("live request body exceeded its total deadline");
+        }
+    }
+
+    // Returns false on a clean half-close; throws when a bound is exceeded, so a
+    // stalled client surfaces as a stream error rather than a silent truncation
+    // that would look like a legitimate end of audio.
+    bool receive_more() {
+        require_within_deadline();
+        if (!wait_readable()) {
+            // The wait is clamped to whatever is left of the total deadline, so it can
+            // end because that expired rather than because the peer went quiet. Report
+            // which one it was instead of always blaming the idle timeout.
+            require_within_deadline();
+            throw std::runtime_error("live request body stalled: no data within the idle timeout");
+        }
+        std::array<char, 8192> buffer{};
+#ifdef _WIN32
+        const int received = recv(socket_, buffer.data(), static_cast<int>(buffer.size()), 0);
+#else
+        const ssize_t received = recv(socket_, buffer.data(), buffer.size(), 0);
+#endif
+        // Re-checked after the wait: poll() can return readable just before the
+        // deadline, so without this a final receive would be processed past it.
+        require_within_deadline();
+        if (received <= 0) {
+            return false;
+        }
+        received_bytes_ += static_cast<size_t>(received);
+        if (limits_.max_bytes > 0 && received_bytes_ > limits_.max_bytes) {
+            throw std::runtime_error("live request body exceeded its maximum size");
+        }
+        pending_.append(buffer.data(), static_cast<size_t>(received));
+        return true;
+    }
+
+    bool ensure_available(size_t count) {
+        while (pending_.size() - pending_pos_ < count) {
+            if (!receive_more()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    static constexpr size_t kMaxLineBytes = 8192;
+
+    bool read_line(std::string & line) {
+        for (;;) {
+            const auto eol = pending_.find("\r\n", pending_pos_);
+            if (eol != std::string::npos) {
+                // Checked on the found line too, not only while still searching: a
+                // receive can deliver the terminator along with enough bytes to put
+                // the line well past the cap, which would otherwise be accepted and
+                // make the stated bound roughly double what it claims.
+                if (eol - pending_pos_ > kMaxLineBytes) {
+                    throw std::runtime_error("chunked request body: oversized chunk header");
+                }
+                line = pending_.substr(pending_pos_, eol - pending_pos_);
+                pending_pos_ = eol + 2;
+                return true;
+            }
+            if (pending_.size() - pending_pos_ > kMaxLineBytes) {
+                throw std::runtime_error("chunked request body: oversized chunk header");
+            }
+            if (!receive_more()) {
+                return false;
+            }
+        }
+    }
+
+    bool next_chunk() {
+        if (finished_) {
+            return false;
+        }
+        // Bounds consumption of already-buffered framing as well as waiting for more,
+        // so the deadline holds even for a body that arrives faster than it is read.
+        require_within_deadline();
+        std::string header;
+        if (!read_line(header)) {
+            // The peer closed without the mandatory terminating 0-chunk. Treating
+            // that as a clean end would hand the caller a truncated body that looks
+            // byte-for-byte like a complete one — for audio, a cut-off sentence
+            // indistinguishable from the speaker stopping. Fail instead.
+            throw std::runtime_error(
+                "chunked request body: connection closed before the terminating chunk");
+        }
+        if (const auto extension = header.find(';'); extension != std::string::npos) {
+            header.resize(extension);  // chunk extensions are unused here
+        }
+        header = trim(header);
+        // Parsed by hand rather than with stoull: the size is attacker-controlled, and
+        // "ffffffffffffffff" would otherwise yield SIZE_MAX, whose `size + 2` wraps to
+        // 1 and slips past the availability check into invalid iterator arithmetic.
+        if (header.empty()) {
+            throw std::runtime_error("chunked request body: empty chunk size");
+        }
+        size_t size = 0;
+        for (const char digit : header) {
+            int value = 0;
+            if (digit >= '0' && digit <= '9') {
+                value = digit - '0';
+            } else if (digit >= 'a' && digit <= 'f') {
+                value = digit - 'a' + 10;
+            } else if (digit >= 'A' && digit <= 'F') {
+                value = digit - 'A' + 10;
+            } else {
+                throw std::runtime_error(
+                    "chunked request body: invalid chunk size \"" + header + "\"");
+            }
+            if (size > (limits_.max_chunk_bytes - static_cast<size_t>(value)) / 16) {
+                throw std::runtime_error("chunked request body: chunk size exceeds the maximum");
+            }
+            size = size * 16 + static_cast<size_t>(value);
+        }
+        if (size == 0) {
+            finished_ = true;
+            // Trailers are bounded: they arrive after the terminating chunk, so
+            // without a cap a peer could stream them indefinitely into pending_,
+            // which is never compacted on this path.
+            size_t trailer_bytes = 0;
+            std::string trailer;
+            for (;;) {
+                if (!read_line(trailer)) {
+                    throw std::runtime_error(
+                        "chunked request body: connection closed inside the trailer");
+                }
+                if (trailer.empty()) {
+                    break;
+                }
+                trailer_bytes += trailer.size();
+                if (trailer_bytes > 8192) {
+                    throw std::runtime_error("chunked request body: trailer section too large");
+                }
+            }
+            return false;
+        }
+        if (!ensure_available(size + 2)) {
+            throw std::runtime_error("chunked request body: connection closed mid-chunk");
+        }
+        // The two bytes after chunk data must be CRLF; accepting anything else lets a
+        // desynchronised sender's payload be silently reinterpreted as framing.
+        if (pending_.compare(pending_pos_ + size, 2, "\r\n") != 0) {
+            throw std::runtime_error("chunked request body: chunk data not terminated by CRLF");
+        }
+        // Dropped before the assign, which may reallocate and free what the get area
+        // still points at. publish_window() can throw on the deadline before it calls
+        // setg(), and leaving stale pointers across that throw would hand anyone who
+        // caught the exception and read again a dangling comparison.
+        setg(nullptr, nullptr, nullptr);
+        chunk_.assign(
+            pending_.begin() + static_cast<std::ptrdiff_t>(pending_pos_),
+            pending_.begin() + static_cast<std::ptrdiff_t>(pending_pos_ + size));
+        pending_pos_ += size + 2;  // also skip the chunk's trailing CRLF
+        if (pending_pos_ > 64 * 1024) {
+            pending_.erase(0, pending_pos_);
+            pending_pos_ = 0;
+        }
+        chunk_pos_ = 0;
+        publish_window();
+        return true;
+    }
+
+    // Exposes the next slice of the current chunk, re-checking the deadline each
+    // time. Returns false once the chunk is spent, which is the caller's signal to
+    // read the next one off the socket.
+    bool publish_window() {
+        if (chunk_pos_ >= chunk_.size()) {
+            return false;
+        }
+        require_within_deadline();
+        const size_t window = std::min(kWindowBytes, chunk_.size() - chunk_pos_);
+        setg(chunk_.data() + chunk_pos_,
+             chunk_.data() + chunk_pos_,
+             chunk_.data() + chunk_pos_ + window);
+        chunk_pos_ += window;
+        return true;
+    }
+
+    static constexpr size_t kWindowBytes = 64 * 1024;
+
+    SocketHandle socket_;
+    std::string pending_;   // received but not yet de-framed
+    size_t pending_pos_ = 0;
+    std::vector<char> chunk_;  // the de-framed chunk currently being served
+    size_t chunk_pos_ = 0;     // how much of chunk_ has been published so far
+    Limits limits_;
+    std::chrono::steady_clock::time_point started_;
+    size_t received_bytes_;
+    bool finished_ = false;
+};
+
+// `leftover` receives any body bytes that arrived alongside the headers, but only
+// for a chunked body — that case returns with the socket deliberately undrained
+// so the handler can consume the rest as it is sent.
+HttpRequest read_http_request(
+    SocketHandle socket,
+    uint64_t max_request_body_bytes,
+    std::string & leftover) {
     std::string data;
     std::array<char, 8192> buffer{};
     size_t header_end = std::string::npos;
@@ -200,7 +554,31 @@ HttpRequest read_http_request(SocketHandle socket, uint64_t max_request_body_byt
         if (pos == std::string::npos) {
             continue;
         }
-        request.headers[lower_ascii(trim(line.substr(0, pos)))] = trim(line.substr(pos + 1));
+        const std::string name = lower_ascii(trim(line.substr(0, pos)));
+        const std::string value = trim(line.substr(pos + 1));
+        // Repeated field lines are equivalent to one comma-separated list (RFC 9110
+        // 5.2), and for Transfer-Encoding that equivalence is load-bearing: splitting
+        // "gzip, chunked" across two lines would otherwise overwrite the first with
+        // the second and leave a bare "chunked" that passes the coding check. Only
+        // this header is combined, so no other endpoint's parsing changes.
+        if (name == "transfer-encoding") {
+            auto & slot = request.headers[name];
+            // Appended in place rather than rebuilt: `slot = slot + ", " + value`
+            // recopies everything accumulated so far on each line, so a header block
+            // packed with repeated fields costs quadratic time — and this runs before
+            // dispatch, on every endpoint, on attacker-supplied input.
+            if (!slot.empty()) {
+                slot.append(", ");
+            }
+            slot.append(value);
+            continue;
+        }
+        request.headers[name] = value;
+    }
+
+    if (wants_incremental_body(request)) {
+        leftover = data.substr(header_end + 4);
+        return request;
     }
 
     size_t content_length = 0;
@@ -327,7 +705,27 @@ UniqueSocket bind_listen_socket(const std::string & host, int port) {
 void handle_client(SocketHandle client, IHttpHandler & handler, uint64_t max_request_body_bytes) {
     UniqueSocket socket(client);
     try {
-        const auto request = read_http_request(socket.get(), max_request_body_bytes);
+        std::string leftover;
+        auto request = read_http_request(socket.get(), max_request_body_bytes, leftover);
+        if (wants_incremental_body(request)) {
+            // Scoped to this endpoint: it is the only one whose response is written
+            // while a model lock is held, so it is the only one where a client that
+            // stops reading can pin a model. Applying it server-wide would risk
+            // truncating a large ordinary response to a merely slow client.
+            set_send_timeout(socket.get(), 30'000);
+        }
+        // Constructed unconditionally so it outlives the handler call, but only
+        // published on `request` when the client actually declared a chunked body.
+        ChunkedSocketStreambuf body_buffer(socket.get(), std::move(leftover), ChunkedSocketStreambuf::Limits{});
+        std::istream body_stream(&body_buffer);
+        // Without this, a throw from underflow() is caught by istream and turned into
+        // badbit. A reader that checks gcount() then sees a short read and reports a
+        // clean end of input, so a stall, an oversize chunk or a mid-body disconnect
+        // would all be delivered as a successful, silently truncated body.
+        body_stream.exceptions(std::ios::badbit);
+        if (wants_incremental_body(request)) {
+            request.body_stream = &body_stream;
+        }
         const auto response = handler.handle(request);
         if (response.stream_body) {
             send_all(socket.get(), serialize_stream_headers(response));

--- a/app/server/http.h
+++ b/app/server/http.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <iosfwd>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -14,6 +15,28 @@ struct HttpRequest {
     std::string query;  // raw query string, e.g. "model=pocket-tts" (no leading '?')
     std::unordered_map<std::string, std::string> headers;
     std::string body;
+
+    // Non-null only for a route that opts into an incremental body AND whose
+    // client declared `Transfer-Encoding: chunked`. The body is then NOT collected
+    // into `body` before the handler runs — reads on this stream block until the
+    // client sends more, and reach EOF at the terminating chunk. This is what lets a
+    // handler consume audio while it is still being captured; every other request,
+    // on every other route, still arrives fully buffered in `body`.
+    //
+    // A half-close WITHOUT that terminating chunk is an error, not EOF: a body cut
+    // short by a dropped connection would otherwise be indistinguishable from one
+    // the client finished deliberately.
+    //
+    // The stream reads directly from the connection, so it stays valid for the
+    // whole exchange: through `handle()` and through any `HttpResponse::stream_body`
+    // that call returns. A handler may therefore capture it in `stream_body`, which
+    // is how the live route reads audio while writing SSE back. It must not outlive
+    // that callback — nothing owns it once the connection is done.
+    //
+    // Reading it can throw: the stream is configured with `exceptions(badbit)` so a
+    // stall, a disconnect before the terminating chunk, or a malformed frame surfaces
+    // as an exception rather than as a silently short body.
+    std::istream * body_stream = nullptr;
 };
 
 struct HttpResponse {

--- a/app/server/http.h
+++ b/app/server/http.h
@@ -9,6 +9,32 @@
 
 namespace minitts::server {
 
+// Bounds on an incrementally delivered request body. Every one of them is really a
+// bound on how long a single client can hold a model: this body is read while the
+// model lock is held, so a peer that stalls, never stops, or names an enormous chunk
+// would otherwise pin the model or exhaust the host.
+//
+// Uniformly, 0 disables that bound — the same convention `busy_timeout_ms` already
+// uses. Disabling one is a deliberate choice for a specific deployment (an hour-long
+// dictation seat behind a trusted proxy), not a default worth shipping.
+struct LiveIngestLimits {
+    // Longest gap between two receives before the body is declared stalled.
+    int idle_timeout_ms = 30'000;
+    // Wall-clock ceiling on the whole body, however steadily it arrives.
+    int total_timeout_ms = 600'000;
+    size_t max_body_bytes = 512u * 1024u * 1024u;
+    // Bounds one chunk, independently of the total. A chunk is held in memory twice
+    // while being de-framed, so without this a single legal chunk could name a size
+    // large enough to exhaust the host — while holding a model lock. The one bound
+    // that must stay non-zero: it also backs the overflow check in the chunk-size
+    // parser, so a 0 would re-admit a declared size of SIZE_MAX. Config rejects it.
+    size_t max_chunk_bytes = 8u * 1024u * 1024u;
+    // SO_SNDTIMEO on the connection, so a client that stops reading the response
+    // cannot hold the model open indefinitely. Per send() call, not an overall
+    // response deadline.
+    int send_timeout_ms = 30'000;
+};
+
 struct HttpRequest {
     std::string method;
     std::string path;
@@ -57,6 +83,16 @@ class IHttpHandler {
 public:
     virtual ~IHttpHandler() = default;
     virtual HttpResponse handle(const HttpRequest & request) = 0;
+
+    // Bounds to apply to this request's incremental body, asked for before the body
+    // stream is created and therefore before `handle()` runs. The transport has no
+    // notion of models, so resolving a per-model override is the handler's job; the
+    // default is the compiled-in policy above. Called only for a request that opts
+    // into an incremental body.
+    virtual LiveIngestLimits live_ingest_limits(const HttpRequest & request) const {
+        (void) request;
+        return {};
+    }
 };
 
 using ShutdownRequested = bool (*)();

--- a/app/server/main.cpp
+++ b/app/server/main.cpp
@@ -61,6 +61,8 @@ void print_help() {
         << "  POST /v1/audio/speech\n"
         << "  POST /v1/audio/transcriptions\n"
         << "       OpenAI-style streaming: speech stream_format=sse|audio, transcription stream=true\n"
+        << "  POST /v1/audio/transcriptions/live?model=<id>\n"
+        << "       raw PCM in a chunked body, transcript deltas as SSE on the same connection\n"
         << "  POST /v1/tasks/run\n";
 }
 

--- a/app/server/runtime.cpp
+++ b/app/server/runtime.cpp
@@ -19,6 +19,7 @@
 #include <fstream>
 #include <functional>
 #include <iostream>
+#include <limits>
 #include <optional>
 #include <sstream>
 #include <stdexcept>
@@ -717,6 +718,18 @@ void ServerState::ensure_model_loaded_locked(LoadedModel & model) {
     model.streaming = streaming;
 }
 
+LiveIngestLimits ServerState::live_ingest_limits(const HttpRequest & request) const {
+    const std::string model_id = query_param(request.query, "model");
+    if (model_id.empty()) {
+        return config_.live_ingest;
+    }
+    const auto it = model_index_.find(model_id);
+    if (it == model_index_.end()) {
+        return config_.live_ingest;
+    }
+    return resolve_live_ingest_limits(config_.live_ingest, models_.at(it->second)->config.live_ingest);
+}
+
 ServerState::LoadedModel & ServerState::require_model(const Value & body) {
     const std::string id = engine::io::json::require_string(body, "model");
     const auto it = model_index_.find(id);
@@ -1173,6 +1186,7 @@ HttpResponse ServerState::handle_transcription_live(const HttpRequest & request)
     LoadedModel * model_ptr = nullptr;
     int sample_rate = 16000;
     int channels = 1;
+    std::optional<int> busy_timeout_ms;
     minitts::app::PcmSampleFormat sample_format = minitts::app::PcmSampleFormat::S16LE;
     engine::runtime::TaskRequest task_request;
     try {
@@ -1227,6 +1241,14 @@ HttpResponse ServerState::handle_transcription_live(const HttpRequest & request)
         };
         sample_rate = parse_bounded_int("sample_rate", 16000, 1000, 384'000);
         channels = parse_bounded_int("channels", 1, 1, 16);
+        // The other routes take this in their JSON body; this one has no body to put
+        // it in, so it arrives as a query param. Same meaning either way: a request
+        // may shorten its own wait for the model lock but never lengthen it past the
+        // configured ceiling — resolve_busy_timeout_ms clamps it.
+        if (!query_param(request.query, "busy_timeout_ms").empty()) {
+            busy_timeout_ms = parse_bounded_int(
+                "busy_timeout_ms", 0, 0, std::numeric_limits<int>::max());
+        }
         const std::string sample_format_name = query_param(request.query, "sample_format");
         sample_format = minitts::app::parse_pcm_sample_format(
             sample_format_name.empty() ? "s16le" : sample_format_name);
@@ -1254,7 +1276,7 @@ HttpResponse ServerState::handle_transcription_live(const HttpRequest & request)
 
     std::istream * pcm_input = request.body_stream;
     return sse_response(
-        [this, model_ptr, task_request, pcm_input, sample_rate, channels, sample_format](
+        [this, model_ptr, task_request, pcm_input, sample_rate, channels, sample_format, busy_timeout_ms](
             HttpStreamWriter & writer) {
             const minitts::app::AudioStreamFormat format{sample_rate, channels};
             const auto audio = minitts::app::make_pcm_chunk_stream(*pcm_input, format, sample_format);
@@ -1271,7 +1293,8 @@ HttpResponse ServerState::handle_transcription_live(const HttpRequest & request)
                         "{\"type\":\"transcript.text.delta\",\"delta\":" +
                             json_quote(event.partial_text->text) +
                             "}");
-                });
+                },
+                busy_timeout_ms);
             if (!timed_result.result.text_output.has_value()) {
                 throw std::runtime_error("live transcription result did not contain transcript text");
             }

--- a/app/server/runtime.cpp
+++ b/app/server/runtime.cpp
@@ -3,6 +3,7 @@
 #include "multipart.h"
 
 #include "../cli/request.h"
+#include "../streaming/pcm_source.h"
 #include "../streaming/streaming.h"
 
 #include "engine/framework/debug/trace.h"
@@ -581,6 +582,12 @@ HttpResponse ServerState::handle(const HttpRequest & request) {
     else if (request.method == "POST" && request.path == "/v1/audio/transcriptions") {
         response = handle_transcription(request);
     }
+    // Separate path rather than a flag on the endpoint above: the input transport
+    // differs (raw chunked PCM vs a complete upload), so keeping it distinct leaves
+    // every existing transcription client untouched.
+    else if (request.method == "POST" && request.path == "/v1/audio/transcriptions/live") {
+        response = handle_transcription_live(request);
+    }
     else if (request.method == "POST" && request.path == "/v1/tasks/run") {
         response = handle_generic_run(request.body);
     }
@@ -837,9 +844,14 @@ ServerState::TimedTaskResult ServerState::run_model(
     return TimedTaskResult{std::move(result), elapsed_ms(started), std::nullopt};
 }
 
-ServerState::TimedTaskResult ServerState::run_streaming_model(
+// `audio` selects where the samples come from: null means request.audio_input, as
+// every caller did before live ingest existed; non-null pulls them from a stream
+// as they arrive. Everything else — locking, preparation, timing — is identical,
+// so both entry points share this body rather than drifting apart.
+ServerState::TimedTaskResult ServerState::run_streaming_model_impl(
     LoadedModel & model,
     const engine::runtime::TaskRequest & request,
+    const minitts::app::AudioChunkStream * audio,
     const std::function<void(const engine::runtime::StreamEvent &)> & event_sink,
     std::optional<int> busy_timeout_ms) {
     BusyGuard::Lock lock = acquire_model_run(model, busy_timeout_ms);
@@ -850,23 +862,40 @@ ServerState::TimedTaskResult ServerState::run_streaming_model(
     const auto started = Clock::now();
     model.session->prepare(engine::runtime::build_preparation_request(request));
     TimedTaskResult timed_result;
-    auto result = minitts::app::run_streaming_task(
-        *model.streaming,
-        request,
-        [&](const engine::runtime::StreamEvent & event) {
-            if (!timed_result.ttft_ms.has_value() && stream_event_has_output(event)) {
-                timed_result.ttft_ms = elapsed_ms(started);
-            }
-            if (event_sink) {
-                event_sink(event);
-            }
-        });
+    const auto sink = [&](const engine::runtime::StreamEvent & event) {
+        if (!timed_result.ttft_ms.has_value() && stream_event_has_output(event)) {
+            timed_result.ttft_ms = elapsed_ms(started);
+        }
+        if (event_sink) {
+            event_sink(event);
+        }
+    };
+    auto result = audio != nullptr
+        ? minitts::app::run_streaming_task(*model.streaming, request, sink, *audio)
+        : minitts::app::run_streaming_task(*model.streaming, request, sink);
     timed_result.result = std::move(result);
     timed_result.wall_ms = elapsed_ms(started);
     if (!timed_result.ttft_ms.has_value() && task_result_has_output(timed_result.result)) {
         timed_result.ttft_ms = timed_result.wall_ms;
     }
     return timed_result;
+}
+
+ServerState::TimedTaskResult ServerState::run_streaming_model(
+    LoadedModel & model,
+    const engine::runtime::TaskRequest & request,
+    const std::function<void(const engine::runtime::StreamEvent &)> & event_sink,
+    std::optional<int> busy_timeout_ms) {
+    return run_streaming_model_impl(model, request, nullptr, event_sink, busy_timeout_ms);
+}
+
+ServerState::TimedTaskResult ServerState::run_streaming_model_from(
+    LoadedModel & model,
+    const engine::runtime::TaskRequest & request,
+    const minitts::app::AudioChunkStream & audio,
+    const std::function<void(const engine::runtime::StreamEvent &)> & event_sink,
+    std::optional<int> busy_timeout_ms) {
+    return run_streaming_model_impl(model, request, &audio, event_sink, busy_timeout_ms);
 }
 
 HttpResponse ServerState::handle_speech(const std::string & body_text) {
@@ -1117,6 +1146,144 @@ HttpResponse ServerState::run_transcription_stream(
                 "}");
         write_sse_done(writer);
     });
+}
+
+// Live PCM ingest. The client streams raw interleaved samples in a chunked request
+// body while transcript deltas stream back as SSE on the same connection, so
+// partials track capture instead of waiting for a finished upload. Same event shape
+// as the file-backed `stream=true` path, so a client can share one SSE reader.
+//
+// Deliberately a single request rather than open/append/finish session endpoints:
+// the busy lock is held for the length of a run, so a session spread across
+// separate requests would pin the model while idling between a client's appends —
+// and wedge it outright if that client vanished. One request bounds the lock by the
+// lifetime of the connection.
+HttpResponse ServerState::handle_transcription_live(const HttpRequest & request) {
+    if (request.body_stream == nullptr) {
+        return error_response(
+            400,
+            "live transcription requires an incrementally delivered body (Transfer-Encoding: chunked)",
+            "invalid_request_error");
+    }
+
+    // Everything from here to the end of parameter parsing validates client input, so
+    // a failure is the caller's fault and belongs in a 4xx. Left to propagate, these
+    // would reach the generic handler and be reported as 500, which tells a client
+    // to retry an identical request that cannot ever succeed.
+    LoadedModel * model_ptr = nullptr;
+    int sample_rate = 16000;
+    int channels = 1;
+    minitts::app::PcmSampleFormat sample_format = minitts::app::PcmSampleFormat::S16LE;
+    engine::runtime::TaskRequest task_request;
+    try {
+        const std::string model_id = query_param(request.query, "model");
+        if (model_id.empty()) {
+            throw std::runtime_error("live transcription requires a 'model' query parameter");
+        }
+        // There is no request body to carry JSON — it is all audio — so the parameters
+        // arrive as query params and are re-shaped into the object require_model expects.
+        engine::io::json::Value::Object fields;
+        fields.emplace("model", engine::io::json::Value::make_string(model_id));
+        const auto body = engine::io::json::Value::make_object(std::move(fields));
+        auto & model = require_model(body);
+        if (model.task.mode != engine::runtime::RunMode::Streaming) {
+            throw std::runtime_error(
+                "live transcription requires a model configured with mode=streaming: " +
+                model.config.id);
+        }
+        model_ptr = &model;
+
+        // These two are not merely descriptive: the streaming policy multiplies them
+        // into a per-chunk sample count, which sizes a buffer allocated after the model
+        // lock has been taken. Left unbounded, a request naming an absurd rate or
+        // channel count overflows that multiplication or asks for a multi-terabyte
+        // allocation while holding the lock, so both are range-checked at the edge.
+        const auto parse_bounded_int = [&](const char * key, int fallback, int minimum, int maximum) {
+            const std::string raw = query_param(request.query, key);
+            if (raw.empty()) {
+                return fallback;
+            }
+            // Parsed to the end of the string on purpose: stoi stops at the first
+            // non-digit, so "16000junk" would silently become 16000. A misdeclared
+            // format produces a confident, wrong transcript, so reject it instead.
+            long long value = 0;
+            size_t consumed = 0;
+            try {
+                value = std::stoll(raw, &consumed);
+            } catch (const std::exception &) {
+                throw std::runtime_error(
+                    std::string("live transcription ") + key + " must be an integer");
+            }
+            if (consumed != raw.size()) {
+                throw std::runtime_error(
+                    std::string("live transcription ") + key + " must be an integer");
+            }
+            if (value < minimum || value > maximum) {
+                throw std::runtime_error(
+                    std::string("live transcription ") + key + " must be between " +
+                    std::to_string(minimum) + " and " + std::to_string(maximum));
+            }
+            return static_cast<int>(value);
+        };
+        sample_rate = parse_bounded_int("sample_rate", 16000, 1000, 384'000);
+        channels = parse_bounded_int("channels", 1, 1, 16);
+        const std::string sample_format_name = query_param(request.query, "sample_format");
+        sample_format = minitts::app::parse_pcm_sample_format(
+            sample_format_name.empty() ? "s16le" : sample_format_name);
+
+        // Format contract with no samples: prepare() takes the rate and channel count
+        // from here, and the samples themselves arrive from the body. Same shape the
+        // CLI's stdin path builds (app/cli/main.cpp:472-482).
+        engine::runtime::AudioBuffer audio_contract;
+        audio_contract.sample_rate = sample_rate;
+        audio_contract.channels = channels;
+        task_request.audio_input = std::move(audio_contract);
+        const std::string language = query_param(request.query, "language");
+        if (!language.empty()) {
+            task_request.options["language"] = language;
+            task_request.text_input = engine::runtime::Transcript{std::string(), language};
+        }
+    } catch (const std::runtime_error & ex) {
+        // Deliberately runtime_error and not exception: every rejection above is
+        // thrown as one, while a genuine server fault inside this block is not.
+        // std::bad_alloc derives from std::exception directly and std::out_of_range
+        // from std::logic_error, so both keep propagating to the 500 path instead of
+        // being mislabelled as the caller's mistake.
+        return error_response(400, ex.what(), "invalid_request_error");
+    }
+
+    std::istream * pcm_input = request.body_stream;
+    return sse_response(
+        [this, model_ptr, task_request, pcm_input, sample_rate, channels, sample_format](
+            HttpStreamWriter & writer) {
+            const minitts::app::AudioStreamFormat format{sample_rate, channels};
+            const auto audio = minitts::app::make_pcm_chunk_stream(*pcm_input, format, sample_format);
+            const auto timed_result = run_streaming_model_from(
+                *model_ptr,
+                task_request,
+                audio,
+                [&](const engine::runtime::StreamEvent & event) {
+                    if (!event.partial_text.has_value() || event.partial_text->text.empty()) {
+                        return;
+                    }
+                    write_sse(
+                        writer,
+                        "{\"type\":\"transcript.text.delta\",\"delta\":" +
+                            json_quote(event.partial_text->text) +
+                            "}");
+                });
+            if (!timed_result.result.text_output.has_value()) {
+                throw std::runtime_error("live transcription result did not contain transcript text");
+            }
+            write_sse(
+                writer,
+                "{\"type\":\"transcript.text.done\",\"text\":" +
+                    json_quote(timed_result.result.text_output->text) +
+                    ",\"timing\":" +
+                    ttft_timing_json(require_ttft_ms(timed_result.ttft_ms)) +
+                    "}");
+            write_sse_done(writer);
+        });
 }
 
 HttpResponse ServerState::handle_generic_run(const std::string & body_text) {

--- a/app/server/runtime.h
+++ b/app/server/runtime.h
@@ -4,6 +4,8 @@
 #include "config.h"
 #include "http.h"
 
+#include "../streaming/streaming.h"
+
 #include "engine/framework/io/json.h"
 #include "engine/framework/runtime/model.h"
 #include "engine/framework/runtime/session.h"
@@ -79,6 +81,21 @@ private:
         const engine::runtime::TaskRequest & request,
         const std::function<void(const engine::runtime::StreamEvent &)> & event_sink = {},
         std::optional<int> busy_timeout_ms = std::nullopt);
+    // Shared body of the two entry points above/below; `audio` selects the source.
+    TimedTaskResult run_streaming_model_impl(
+        LoadedModel & model,
+        const engine::runtime::TaskRequest & request,
+        const minitts::app::AudioChunkStream * audio,
+        const std::function<void(const engine::runtime::StreamEvent &)> & event_sink,
+        std::optional<int> busy_timeout_ms);
+    // Same as run_streaming_model, but pulls audio from `audio` instead of
+    // `request.audio_input`, so the samples are never fully materialized.
+    TimedTaskResult run_streaming_model_from(
+        LoadedModel & model,
+        const engine::runtime::TaskRequest & request,
+        const minitts::app::AudioChunkStream & audio,
+        const std::function<void(const engine::runtime::StreamEvent &)> & event_sink = {},
+        std::optional<int> busy_timeout_ms = std::nullopt);
     HttpResponse handle_speech(const std::string & body_text);
     HttpResponse handle_speech_stream(
         LoadedModel & model,
@@ -95,6 +112,7 @@ private:
         LoadedModel & model,
         const engine::runtime::TaskRequest & request,
         std::optional<int> busy_timeout_ms = std::nullopt);
+    HttpResponse handle_transcription_live(const HttpRequest & request);
     HttpResponse handle_generic_run(const std::string & body_text);
     HttpResponse handle_generic_stream(const std::string & body_text);
     HttpResponse handle_voices(const HttpRequest & request) const;

--- a/app/server/runtime.h
+++ b/app/server/runtime.h
@@ -27,6 +27,12 @@ public:
 
     HttpResponse handle(const HttpRequest & request) override;
 
+    // Server-level `live_ingest` policy with this request's model override applied.
+    // Deliberately does not reject an unknown or non-streaming model: it runs before
+    // the handler, and rejecting here would turn a client's mistake into a dropped
+    // connection instead of the 400 handle_transcription_live already produces.
+    LiveIngestLimits live_ingest_limits(const HttpRequest & request) const override;
+
 private:
     struct LoadedModel {
         struct RuntimeVoicePreset {

--- a/app/server/streaming_example.json
+++ b/app/server/streaming_example.json
@@ -5,6 +5,13 @@
   "device": 0,
   "threads": 1,
   "lazy_load": true,
+  "live_ingest": {
+    "idle_timeout_ms": 30000,
+    "total_timeout_ms": 600000,
+    "max_body_bytes": 536870912,
+    "max_chunk_bytes": 8388608,
+    "send_timeout_ms": 30000
+  },
   "models": [
     {
       "id": "voxcpm2-stream",
@@ -18,7 +25,10 @@
       "family": "nemotron_asr",
       "path": "/path/to/models/nemotron-3.5-asr-streaming-0.6b",
       "task": "asr",
-      "mode": "streaming"
+      "mode": "streaming",
+      "live_ingest": {
+        "total_timeout_ms": 1800000
+      }
     }
   ]
 }

--- a/docs/asr.md
+++ b/docs/asr.md
@@ -346,6 +346,29 @@ The chosen interpretation is echoed back as an `audio_input=stdin` line. Each up
 its own `partial_text=` line and flushed as it is produced, so a reader sees the transcript grow
 rather than waiting for the stream to end.
 
+### Live PCM over HTTP
+
+The same live source is available to an HTTP client through
+`POST /v1/audio/transcriptions/live`: raw PCM goes up in a chunked request body while transcript
+deltas come back as SSE on the same connection. This is the server equivalent of `--audio -`, and
+the only way to get capture-time partials without the CLI. See
+[the server README](../app/server/README.md) for parameters and examples.
+
+```bash
+ffmpeg -f alsa -i default -ar 16000 -ac 1 -f s16le - \
+  | curl -N -X POST -H 'Expect:' -T - \
+      'http://127.0.0.1:8080/v1/audio/transcriptions/live?model=voxtral-realtime'
+```
+
+Use `-T -`, not `--data-binary @-` — the latter reads stdin to EOF before it connects, so a live
+capture would be uploaded as a finished file and no partial could arrive early.
+
+Whether text appears while the speaker is still talking depends on the model's streaming policy
+rather than on the transport. `voxtral_realtime` decodes as audio arrives and emits throughout the
+utterance; `nemotron_asr` consumes the full utterance in its encoder first, so its deltas arrive
+only once the audio ends. Both are supported here — the difference is what the transcript looks
+like mid-sentence.
+
 > **Throughput.** A streaming step always advances 80 ms of audio, so a step has to cost under
 > 80 ms to keep up with a realtime source. Measured on an Apple M3 Air (Metal, q8_0):
 >

--- a/tests/unittests/test_http_live_body.cpp
+++ b/tests/unittests/test_http_live_body.cpp
@@ -92,6 +92,38 @@ public:
             "{\"stream\":true,\"bytes\":" + std::to_string(body.size()) +
             ",\"sum\":" + std::to_string(sum) + "}");
     }
+
+    // Stands in for the server's per-model resolution: a request naming
+    // `model=tight` gets tightened bounds, everything else the defaults. The real
+    // handler reads them from config; what matters here is that the transport asks,
+    // and that what it is told actually takes effect.
+    minitts::server::LiveIngestLimits live_ingest_limits(
+        const minitts::server::HttpRequest & request) const override {
+        limits_queries.fetch_add(1);
+        if (request.query.find("model=nocap") != std::string::npos) {
+            // Not reachable through config, which rejects it — but the transport must
+            // not depend on config having done so.
+            minitts::server::LiveIngestLimits nocap;
+            nocap.max_chunk_bytes = 0;
+            return nocap;
+        }
+        if (request.query.find("model=tiny") != std::string::npos) {
+            // Small enough that a single hex digit exceeds it, which is where the
+            // chunk-size guard used to underflow.
+            minitts::server::LiveIngestLimits tiny;
+            tiny.max_chunk_bytes = 1;
+            return tiny;
+        }
+        if (request.query.find("model=tight") == std::string::npos) {
+            return {};
+        }
+        minitts::server::LiveIngestLimits tight;
+        tight.max_chunk_bytes = 1024;
+        tight.max_body_bytes = 4096;
+        return tight;
+    }
+
+    mutable std::atomic<int> limits_queries{0};
 };
 
 void close_socket(socket_t handle) {
@@ -418,6 +450,92 @@ int main() {
         require(
             contains(reply, "\"buffered\":0"),
             "chunked bodies on other routes must keep their existing handling: " + reply);
+    }
+
+    // Limits are resolved per request, not compiled in. The same 2000-byte chunk is
+    // fine under the defaults and rejected once the handler tightens max_chunk_bytes
+    // for this request — which is the whole point of the per-model override.
+    {
+        const std::string chunk = payload(2000, 3);
+        const std::string relaxed = round_trip({chunk}, true, kLivePath);
+        require(contains(relaxed, "\"bytes\":2000"),
+                "a 2000-byte chunk is within the default per-chunk cap: " + relaxed);
+
+        const std::string tightened =
+            round_trip({chunk}, true, "/v1/audio/transcriptions/live?model=tight");
+        require(contains(tightened, "chunk size exceeds the maximum"),
+                "a handler-supplied per-chunk cap must be enforced: " + tightened);
+    }
+
+    // Same for the whole-body cap, which is a separate axis: each chunk is legal on
+    // its own and only their total crosses the bound.
+    {
+        const std::vector<std::string> chunks(6, payload(1000, 11));
+        const std::string relaxed = round_trip(chunks, true, kLivePath);
+        require(contains(relaxed, "\"bytes\":6000"),
+                "6000 bytes is within the default body cap: " + relaxed);
+
+        const std::string tightened =
+            round_trip(chunks, true, "/v1/audio/transcriptions/live?model=tight");
+        require(contains(tightened, "exceeded its maximum size"),
+                "a handler-supplied body cap must be enforced: " + tightened);
+    }
+
+    // A cap smaller than one hex digit's value must still reject. `cap - value`
+    // underflows for any cap below the digit, so at cap=1 a declared `f` used to be
+    // accepted outright — a 15-byte chunk against a 1-byte bound.
+    {
+        const std::string reply =
+            round_trip({}, /*terminate=*/false, "/v1/audio/transcriptions/live?model=tiny",
+                       "f\r\n123456789012345\r\n");
+        require(contains(reply, "chunk size exceeds the maximum"),
+                "a chunk cap below the digit value must not underflow: " + reply);
+    }
+
+    // The body cap must count bytes that arrived alongside the headers. A body short
+    // enough to fit in the first receive never calls receive_more(), so a cap checked
+    // only there is skipped by exactly the request most likely to be probing it.
+    {
+        std::string request = headers_for("/v1/audio/transcriptions/live?model=tight", true);
+        for (int i = 0; i < 6; ++i) {
+            std::ostringstream frame;
+            frame << std::hex << 1000 << "\r\n" << payload(1000, 23) << "\r\n";
+            request += frame.str();
+        }
+        request += "0\r\n\r\n";
+        // One write, so headers and the whole 6000-byte body land in a single recv().
+        const socket_t handle = connect_to_server();
+        send_raw(handle, request);
+        const std::string reply = read_reply(handle);
+        close_socket(handle);
+        require(contains(reply, "exceeded its maximum size"),
+                "a fully prefetched body must still be measured against the cap: " + reply);
+    }
+
+    // A zero per-chunk cap must not disable the overflow guard. Config rejects a 0,
+    // but a Limits built in code could still carry one, and this parse is the last
+    // thing between a declared SIZE_MAX and `size + 2` wrapping to 1.
+    {
+        const std::string reply =
+            round_trip({}, /*terminate=*/false, "/v1/audio/transcriptions/live?model=nocap",
+                       "ffffffffffffffff\r\n");
+        require(contains(reply, "chunk size exceeds the maximum"),
+                "a zero max_chunk_bytes must fall back to a real cap, not disable it: " + reply);
+    }
+
+    // Asked for only when the request actually opts into an incremental body: every
+    // other route must not pay for a lookup it cannot use.
+    {
+        const int before = handler.limits_queries.load();
+        const socket_t handle = connect_to_server();
+        send_raw(handle, headers_for("/v1/audio/speech", true));
+        send_raw(handle, "4\r\nabcd\r\n0\r\n\r\n");
+        (void) read_reply(handle);
+        close_socket(handle);
+        require_eq(
+            handler.limits_queries.load(),
+            before,
+            "live-ingest limits must not be resolved for a non-live route");
     }
 
     g_stop.store(true);

--- a/tests/unittests/test_http_live_body.cpp
+++ b/tests/unittests/test_http_live_body.cpp
@@ -1,0 +1,427 @@
+// Framing tests for the incrementally delivered request body used by
+// POST /v1/audio/transcriptions/live.
+//
+// Driven over a real loopback socket against serve_http rather than against the
+// streambuf directly: the behaviour under test is the interaction between the
+// header parser, the undrained socket and the handler, and a direct unit test of
+// the buffer would not cover the part most likely to break.
+//
+// The cases that matter are the ones where a wrong answer is INVISIBLE. A body
+// truncated by a stall, a disconnect or a desynchronised sender must surface as
+// an error, because for audio a silently short body is indistinguishable from a
+// speaker who simply stopped talking.
+//
+// Scope, stated so nobody mistakes this for end-to-end coverage: it links
+// http.cpp and not the server runtime, so it exercises the framing, the bounds
+// and the isolation of other routes — and NOT the `/v1/audio/transcriptions/live`
+// route itself, its query-parameter defaults, the PCM adapter, the model
+// invocation, or the conversion of a body error into an SSE `error` event. Those
+// need a loaded model, are not covered anywhere in this suite, and were verified
+// by hand against a running server. Removing the route would not fail this test.
+
+#include "../../app/server/http.h"
+
+#include "test_assert.h"
+
+#include <atomic>
+#include <chrono>
+#include <iostream>
+#include <istream>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#endif
+
+namespace {
+
+using engine::test::require;
+using engine::test::require_eq;
+
+constexpr int kPort = 18094;
+constexpr const char * kLivePath = "/v1/audio/transcriptions/live";
+
+// The socket API's handle type is not `int` on Windows, and narrowing it there
+// truncates a valid handle.
+#ifdef _WIN32
+using socket_t = SOCKET;
+constexpr socket_t kInvalidSocket = INVALID_SOCKET;
+#else
+using socket_t = int;
+constexpr socket_t kInvalidSocket = -1;
+#endif
+
+std::atomic<bool> g_stop{false};
+bool stop_requested() {
+    return g_stop.load();
+}
+
+// Reports what the body stream actually yielded, so a test can tell a complete
+// body from a truncated one and a truncation from an error.
+class EchoHandler final : public minitts::server::IHttpHandler {
+public:
+    minitts::server::HttpResponse handle(const minitts::server::HttpRequest & request) override {
+        if (request.body_stream == nullptr) {
+            return minitts::server::json_response(
+                "{\"stream\":false,\"buffered\":" + std::to_string(request.body.size()) + "}");
+        }
+        std::string body;
+        try {
+            char buffer[4096];
+            while (request.body_stream->read(buffer, sizeof(buffer)) || request.body_stream->gcount() > 0) {
+                body.append(buffer, static_cast<size_t>(request.body_stream->gcount()));
+            }
+        } catch (const std::exception & ex) {
+            return minitts::server::json_response(
+                std::string("{\"error\":\"") + ex.what() + "\"}");
+        }
+        size_t sum = 0;
+        for (const unsigned char byte : body) {
+            sum += byte;
+        }
+        return minitts::server::json_response(
+            "{\"stream\":true,\"bytes\":" + std::to_string(body.size()) +
+            ",\"sum\":" + std::to_string(sum) + "}");
+    }
+};
+
+void close_socket(socket_t handle) {
+#ifdef _WIN32
+    closesocket(handle);
+#else
+    close(handle);
+#endif
+}
+
+// Retries rather than trusting a fixed startup sleep: the listener becomes ready
+// on its own thread, and a sleep long enough to always win is either flaky or
+// wasteful.
+socket_t connect_to_server() {
+    sockaddr_in address{};
+    address.sin_family = AF_INET;
+    address.sin_port = htons(static_cast<uint16_t>(kPort));
+    inet_pton(AF_INET, "127.0.0.1", &address.sin_addr);
+    for (int attempt = 0; attempt < 200; ++attempt) {
+        const socket_t handle = socket(AF_INET, SOCK_STREAM, 0);
+        require(handle != kInvalidSocket, "could not create client socket");
+        if (connect(handle, reinterpret_cast<sockaddr *>(&address), sizeof(address)) == 0) {
+            return handle;
+        }
+        close_socket(handle);
+        std::this_thread::sleep_for(std::chrono::milliseconds(25));
+    }
+    require(false, "could not connect to the test server");
+    return kInvalidSocket;
+}
+
+void send_raw(socket_t handle, const std::string & data) {
+    size_t offset = 0;
+    while (offset < data.size()) {
+#ifdef _WIN32
+        const int written = send(handle, data.data() + offset, static_cast<int>(data.size() - offset), 0);
+#else
+        const ssize_t written = send(handle, data.data() + offset, data.size() - offset, 0);
+#endif
+        require(written > 0, "send to the test server failed");
+        offset += static_cast<size_t>(written);
+    }
+}
+
+std::string read_reply(socket_t handle) {
+    std::string reply;
+    char buffer[4096];
+    for (;;) {
+#ifdef _WIN32
+        const int received = recv(handle, buffer, sizeof(buffer), 0);
+#else
+        const ssize_t received = recv(handle, buffer, sizeof(buffer), 0);
+#endif
+        if (received <= 0) {
+            break;
+        }
+        reply.append(buffer, static_cast<size_t>(received));
+    }
+    return reply;
+}
+
+std::string headers_for(const char * path, bool chunked) {
+    std::string out = std::string("POST ") + path + " HTTP/1.1\r\nHost: test\r\n";
+    out += chunked ? "Transfer-Encoding: chunked\r\n" : "Content-Length: 0\r\n";
+    return out + "\r\n";
+}
+
+// Same, with a verbatim Transfer-Encoding value, for testing how the header is parsed.
+std::string headers_with_encoding(const char * path, const std::string & encoding) {
+    return std::string("POST ") + path + " HTTP/1.1\r\nHost: test\r\nTransfer-Encoding: " +
+           encoding + "\r\n\r\n";
+}
+
+// Sends `body` as one chunk per entry and returns the server's reply.
+std::string round_trip(const std::vector<std::string> & chunks, bool terminate = true,
+                       const char * path = kLivePath, const std::string & raw_tail = {}) {
+    const socket_t handle = connect_to_server();
+    send_raw(handle, headers_for(path, true));
+    for (const auto & piece : chunks) {
+        std::ostringstream frame;
+        frame << std::hex << piece.size() << "\r\n" << piece << "\r\n";
+        send_raw(handle, frame.str());
+    }
+    if (!raw_tail.empty()) {
+        send_raw(handle, raw_tail);
+    }
+    if (terminate) {
+        send_raw(handle, "0\r\n\r\n");
+    } else {
+#ifdef _WIN32
+        shutdown(handle, SD_SEND);
+#else
+        shutdown(handle, SHUT_WR);
+#endif
+    }
+    const std::string reply = read_reply(handle);
+    close_socket(handle);
+    return reply;
+}
+
+bool contains(const std::string & haystack, const std::string & needle) {
+    return haystack.find(needle) != std::string::npos;
+}
+
+std::string payload(size_t length, unsigned char seed) {
+    std::string out;
+    out.reserve(length);
+    for (size_t i = 0; i < length; ++i) {
+        out.push_back(static_cast<char>((seed + i) % 251));
+    }
+    return out;
+}
+
+size_t byte_sum(const std::string & data) {
+    size_t sum = 0;
+    for (const unsigned char byte : data) {
+        sum += byte;
+    }
+    return sum;
+}
+
+}  // namespace
+
+int main() {
+#ifdef _WIN32
+    WSADATA wsa;
+    WSAStartup(MAKEWORD(2, 2), &wsa);
+#endif
+    EchoHandler handler;
+    // The server default, spelled out rather than pulled from config.h so this test
+    // keeps linking the transport alone. It bounds a Content-Length body and never
+    // the incremental one under test, which has its own LiveIngestLimits.
+    constexpr uint64_t kMaxBufferedBody = 2ull * 1024ull * 1024ull * 1024ull;
+    std::thread server([&] {
+        minitts::server::serve_http("127.0.0.1", kPort, handler, stop_requested, kMaxBufferedBody);
+    });
+    // No startup sleep: connect_to_server() retries until the listener is up.
+
+    // A body split into several chunks must arrive byte-identical and complete.
+    {
+        const std::string a = payload(5000, 7);
+        const std::string b = payload(3000, 61);
+        const std::string reply = round_trip({a, b});
+        require(contains(reply, "\"stream\":true"), "live path should expose a body stream");
+        require(
+            contains(reply, "\"bytes\":" + std::to_string(a.size() + b.size())),
+            "multi-chunk body should arrive complete: " + reply);
+        require(
+            contains(reply, "\"sum\":" + std::to_string(byte_sum(a) + byte_sum(b))),
+            "multi-chunk body should arrive byte-identical: " + reply);
+    }
+
+    // A single chunk far larger than the 8 KiB receive buffer, so the chunk is
+    // assembled across many recv() calls rather than found whole in one.
+    {
+        const std::string big = payload(300'000, 11);
+        const std::string reply = round_trip({big});
+        require(contains(reply, "\"bytes\":" + std::to_string(big.size())),
+                "a chunk spanning many receives should arrive complete: " + reply);
+        require(contains(reply, "\"sum\":" + std::to_string(byte_sum(big))),
+                "a chunk spanning many receives should arrive intact: " + reply);
+    }
+
+    // Drives total consumed bytes past the 64 KiB mark at which the de-framer
+    // compacts its pending buffer. Compaction shifts the bytes the reader has not
+    // consumed yet, so a mistake here silently corrupts or drops audio rather than
+    // failing loudly — and it cannot happen at all in the small-payload cases.
+    {
+        std::vector<std::string> chunks;
+        size_t total = 0;
+        size_t sum = 0;
+        for (int i = 0; i < 80; ++i) {
+            chunks.push_back(payload(4096, static_cast<unsigned char>(i * 7)));
+            total += chunks.back().size();
+            sum += byte_sum(chunks.back());
+        }
+        require(total > 4 * 64 * 1024, "compaction case must exceed the compaction threshold");
+        const std::string reply = round_trip(chunks);
+        require(contains(reply, "\"bytes\":" + std::to_string(total)),
+                "body spanning several compactions should be complete: " + reply);
+        require(contains(reply, "\"sum\":" + std::to_string(sum)),
+                "compaction must not corrupt or drop unconsumed bytes: " + reply);
+    }
+
+    // Many small chunks exercise the path where several chunks arrive inside a
+    // single recv().
+    {
+        std::vector<std::string> chunks;
+        size_t total = 0;
+        size_t sum = 0;
+        for (int i = 0; i < 40; ++i) {
+            chunks.push_back(payload(97, static_cast<unsigned char>(i)));
+            total += chunks.back().size();
+            sum += byte_sum(chunks.back());
+        }
+        const std::string reply = round_trip(chunks);
+        require(contains(reply, "\"bytes\":" + std::to_string(total)), "many small chunks: " + reply);
+        require(contains(reply, "\"sum\":" + std::to_string(sum)), "many small chunks intact: " + reply);
+    }
+
+    // Chunk extensions are legal and must be ignored rather than parsed as size.
+    {
+        const socket_t handle = connect_to_server();
+        send_raw(handle, headers_for(kLivePath, true));
+        send_raw(handle, "4;name=value\r\nabcd\r\n0\r\n\r\n");
+        const std::string reply = read_reply(handle);
+        close_socket(handle);
+        require(contains(reply, "\"bytes\":4"), "chunk extensions should be ignored: " + reply);
+    }
+
+    // Trailer headers after the terminating chunk are legal.
+    {
+        const socket_t handle = connect_to_server();
+        send_raw(handle, headers_for(kLivePath, true));
+        send_raw(handle, "4\r\nwxyz\r\n0\r\nX-Trailer: value\r\n\r\n");
+        const std::string reply = read_reply(handle);
+        close_socket(handle);
+        require(contains(reply, "\"bytes\":4"), "trailers should be accepted: " + reply);
+    }
+
+    // Each malformed case asserts the SPECIFIC diagnostic, not merely that something
+    // failed. Half-closing the connection to end these requests would itself produce
+    // an error, so a bare "did it fail" check would pass even with the guard removed
+    // — it would just be failing later, for the wrong reason.
+
+    // A peer that closes without the terminating chunk must NOT look like a clean
+    // end of body — that is the silent-truncation failure this endpoint cannot have.
+    {
+        const std::string reply = round_trip({payload(2000, 3)}, /*terminate=*/false);
+        require(contains(reply, "closed before the terminating chunk"),
+                "premature close must be an error, not a short body: " + reply);
+    }
+
+    // A declared size that would overflow size_t must be rejected before any
+    // arithmetic on it, not wrap into a tiny length.
+    {
+        const std::string reply = round_trip({}, /*terminate=*/false, kLivePath, "ffffffffffffffff\r\nX");
+        require(contains(reply, "chunk size exceeds the maximum"),
+                "overflowing chunk size must be rejected by the size guard: " + reply);
+    }
+
+    // A chunk larger than the per-chunk cap must be rejected by its declared size,
+    // before the data behind it is waited for.
+    {
+        const std::string reply = round_trip({}, /*terminate=*/false, kLivePath, "1000000\r\n");
+        require(contains(reply, "chunk size exceeds the maximum"),
+                "oversized chunk must be rejected by the size guard: " + reply);
+    }
+
+    // Chunk data must be CRLF-terminated; otherwise a desynchronised sender's
+    // payload can be silently reinterpreted as framing.
+    {
+        const std::string reply = round_trip({}, /*terminate=*/false, kLivePath, "4\r\nabcdXX0\r\n\r\n");
+        require(contains(reply, "not terminated by CRLF"),
+                "chunk not CRLF-terminated must be rejected: " + reply);
+    }
+
+    // A non-hex size is a protocol error rather than an empty body.
+    {
+        const std::string reply = round_trip({}, /*terminate=*/false, kLivePath, "zz\r\n");
+        require(contains(reply, "invalid chunk size"),
+                "invalid chunk size must be rejected: " + reply);
+    }
+
+    // The header names a transfer-coding, so it must be matched as a token rather
+    // than searched for as a substring. "notchunked" is not chunked, and a chain
+    // like "gzip, chunked" is chunked framing around bytes this server cannot
+    // decode — de-framing that and handing the result to the PCM decoder would
+    // turn compressed data into confident nonsense. Both must decline the
+    // incremental path rather than accept it.
+    for (const std::string encoding : {"notchunked", "chunked-garbage", "gzip, chunked"}) {
+        const socket_t handle = connect_to_server();
+        send_raw(handle, headers_with_encoding(kLivePath, encoding));
+        send_raw(handle, "4\r\nabcd\r\n0\r\n\r\n");
+        const std::string reply = read_reply(handle);
+        close_socket(handle);
+        require(contains(reply, "\"stream\":false"),
+                "Transfer-Encoding \"" + encoding + "\" must not select the incremental path: " + reply);
+    }
+
+    // The same unsupported chain split across two header lines must be rejected the
+    // same way. Repeated field lines mean one comma-separated list, so a parser that
+    // overwrites instead of combining sees a bare "chunked" and accepts what it just
+    // rejected on a single line.
+    {
+        const socket_t handle = connect_to_server();
+        send_raw(handle,
+                 std::string("POST ") + kLivePath +
+                     " HTTP/1.1\r\nHost: test\r\nTransfer-Encoding: gzip\r\n"
+                     "Transfer-Encoding: chunked\r\n\r\n");
+        send_raw(handle, "4\r\nabcd\r\n0\r\n\r\n");
+        const std::string reply = read_reply(handle);
+        close_socket(handle);
+        require(contains(reply, "\"stream\":false"),
+                "a transfer-coding chain split across header lines must not select the "
+                "incremental path: " + reply);
+    }
+
+    // A chunk header line past the cap must be rejected, including when its
+    // terminator arrives in the same receive as the bytes that exceed it.
+    {
+        const std::string reply =
+            round_trip({}, /*terminate=*/false, kLivePath, std::string(9000, 'a') + ";x\r\n");
+        require(contains(reply, "oversized chunk header"),
+                "an over-long chunk header line must be rejected: " + reply);
+    }
+
+    // Every other endpoint must be untouched: a chunked request elsewhere still
+    // goes through the ordinary buffered path, with no body stream published.
+    {
+        const socket_t handle = connect_to_server();
+        send_raw(handle, headers_for("/v1/audio/speech", true));
+        send_raw(handle, "4\r\nabcd\r\n0\r\n\r\n");
+        const std::string reply = read_reply(handle);
+        close_socket(handle);
+        require(
+            contains(reply, "\"stream\":false"),
+            "only the live endpoint may consume an incremental body: " + reply);
+        // Pins pre-existing behaviour rather than endorsing it: the buffered path
+        // sizes the body from Content-Length, which a chunked request does not send,
+        // so it has always yielded an empty body there. Asserted so that a future
+        // change to chunked handling elsewhere is a deliberate one, and to show this
+        // change did not introduce it.
+        require(
+            contains(reply, "\"buffered\":0"),
+            "chunked bodies on other routes must keep their existing handling: " + reply);
+    }
+
+    g_stop.store(true);
+    server.join();
+    std::cout << "http_live_body_test: all cases passed\n";
+    return 0;
+}


### PR DESCRIPTION
## What this is

The engine already does incremental transcription. `audiocpp_cli --audio -` reads PCM from a pipe and emits partial transcripts as speech arrives — `AudioChunkStream`, `run_streaming_task`, `StreamingInputKind::AudioChunks` are all already there and already tested.

The HTTP server can't reach any of it. Every ASR endpoint buffers the entire request body before the model is touched, so a client whose only interface to audio.cpp is HTTP has no way to get a partial transcript, regardless of which model it loads. This PR is the missing transport, not a new capability.

## The endpoint

```
POST /v1/audio/transcriptions/live?model=<id>&sample_rate=16000&channels=1&sample_format=s16le
Transfer-Encoding: chunked

<raw PCM, written continuously>
```

SSE deltas stream back on the same connection while the upload is still in progress:

```
data: {"type":"transcript.text.delta","delta":"so I was"}
data: {"type":"transcript.text.delta","delta":" thinking"}
...
data: {"type":"transcript.text.done","text":"..."}
data: [DONE]
```

| param | default | notes |
|---|---|---|
| `model` | — | required, must be `mode: "streaming"` |
| `sample_rate` | `16000` | 1000–384000 |
| `channels` | `1` | 1–16 |
| `sample_format` | `s16le` | or `f32le` |
| `language` | — | passed through to the model |

`sample_rate` and `channels` are range-checked rather than merely validated as positive: they are multiplied into the per-chunk sample count that sizes a buffer allocated *after* the model lock is taken, so unbounded values are an allocation request made while holding the lock. Every malformed parameter returns `400` with the specific reason.

Working example:

```bash
ffmpeg -f alsa -i default -ar 16000 -ac 1 -f s16le - 2>/dev/null \
  | curl -N -X POST -H 'Expect:' -T - \
    'http://localhost:8080/v1/audio/transcriptions/live?model=voxtral-realtime'
```

`-T -` is load-bearing and not interchangeable with `--data-binary @-`: the latter drains stdin to EOF before opening the connection, which turns a live capture back into a file upload. `-H 'Expect:'` suppresses `Expect: 100-continue`, which this server does not answer.

## Why query params instead of a JSON envelope

The body is the audio — there's nowhere to put a JSON envelope without either framing the audio inside it or spending a second request on setup. Deepgram's `/v1/listen` takes raw audio as the body with `encoding`/`sample_rate`/`channels` as query params for the same reason. This is not an OpenAI-compatible endpoint and doesn't claim to be; `/v1/audio/transcriptions` keeps its existing shape untouched.

## Why not a WebSocket

A WebSocket would mean a framing layer, a handshake, and a second server loop, for a stream that is one-directional in and one-directional out. HTTP/1.1 already permits a request body and a response body to be in flight simultaneously on one connection, and that's exactly the shape of the problem. If a WebSocket surface is wanted later it can sit on top of the same `AudioChunkStream` plumbing this PR adds — nothing here forecloses it.

## Measured on a 3090

Whether you get partials *during* speech is a property of the model, not of this transport. Two separate runs, stated with their conditions rather than merged into one table, because they used different recordings.

**The reproducible one**, through the exact `curl` command above, feeding a 20 s recording at real-time pace — re-run after every change in this PR, with identical results each time:

| | voxtral-realtime |
|---|---|
| first delta | 1.50 s |
| deltas arriving while audio was still uploading | 63 / 63 |
| `transcript.text.done` | at the moment the audio ended |

**A model comparison** on a shorter clip, included because the difference matters when picking a model:

| model | first delta | deltas before speech ended | tail after last audio |
|---|---|---|---|
| voxtral-realtime | 1.44 s | 27 / 28 | 12–15 ms |
| nemotron_asr | 9.7 s | 0 | ~600 ms |
| faster-whisper (batch, for reference) | n/a | never | ~187 ms |

nemotron buffers internally, so over this endpoint it behaves like a batch model with extra steps. It works; it just doesn't feel live. The docs say so plainly rather than implying the endpoint makes any model live.

## Implementation

- `HttpRequest::body_stream` (`std::istream *`) is non-null **only** when the client declared `Transfer-Encoding: chunked` **and** targeted this exact path. Every other endpoint keeps the existing buffered `request.body` path, byte for byte.
- `ChunkedSocketStreambuf` de-frames chunked encoding incrementally, bounded on four axes: 30 s idle, 600 s absolute, 512 MiB total, 8 MiB per chunk.
- Chunk sizes are parsed with an overflow-safe hand-rolled hex loop (a declared `ffffffffffffffff` is rejected, not wrapped). Chunk data is verified CRLF-terminated so a desynchronised sender's payload can't be reinterpreted as framing. Trailers are capped.
- **A peer that disconnects without the terminating chunk is an error, never a short body.** For audio, a silently truncated body is indistinguishable from a speaker who stopped talking, so it must not be reported as success. The stream is configured `exceptions(badbit)` so this can't be swallowed.
- `run_streaming_model` and `run_streaming_model_from` now share `run_streaming_model_impl`, which selects between `request.audio_input` and a live `AudioChunkStream`. No behaviour change for existing callers.
- `app/streaming/pcm_source.cpp` was CLI-only; it's now also linked into `audiocpp_server`.

## Things you should know before merging

Stated up front rather than left to be found:

1. **HTTP/1.1 duplex is not universally proxied.** Behind nginx it needs `proxy_http_version 1.1` as well as `proxy_request_buffering off` — the latter alone still buffers a chunked body. Browser `fetch()` cannot drive it at all: request streaming is half-duplex by specification. This endpoint targets server-side and native clients, and `app/server/README.md` says so.
1. **`Expect: 100-continue` is not implemented.** A client that sends it gets no interim response and waits out its own continue timeout before uploading. curl adds it for some POSTs, so the documented example passes `-H 'Expect:'`. Worth implementing properly if you'd like — I left it out to keep this change to one concern.
2. **`SO_SNDTIMEO` is per-call, not an overall response deadline.** A client that reads one byte per timeout period can hold a connection longer than the nominal bound. Bounded in practice by the existing model busy guard. (Configurable since the review round below, as `live_ingest.send_timeout_ms`.)
3. **Pre-existing, not introduced here, but now more reachable:** the listener uses `select()`/`FD_SET`, which is UB above `FD_SETSIZE`, and each client runs on a detached thread with no cap. The new code uses `poll()`/`WSAPoll` for its own waits. Happy to convert the listener in a separate PR if you'd like it, but I didn't want to bundle an unrelated change.
4. ~~**The four limits are hardcoded.**~~ **Fixed in review** — they are now a `live_ingest` config block, server-wide with per-model overrides. See below.
5. **`ENGINE_BUILD_TESTS=ON` is already broken on `main`.** Three `tests/moss_tts_local/` targets fail on constructor signature mismatches at `c0d1c9f` — unrelated to this change (those sources are untouched here, and the CMakeLists diff is purely additive). Flagging it because the new test lives under the same guard, so enabling tests in order to run it will surface those pre-existing failures.

## What was already found and fixed

I put this through several independent adversarial review rounds before opening it, at escalating effort, and they found real defects. Listing them so you can see what has already been looked at rather than spending your review rediscovering it:

- **Unbounded `sample_rate`/`channels`** fed `resolve_chunk_samples()`, whose product sizes a `vector::resize` reached *after* the model lock. Two `INT_MAX` values overflowed the multiply; smaller ones requested hundreds of GB while holding the lock. `std::stoi` also stopped at the first non-digit, so `16000junk` silently became `16000`.
- **`Transfer-Encoding` matched by substring**, so `notchunked` selected the incremental path. Fixing that to token matching then revealed a second route to the same place: repeated field lines overwrote each other, so `gzip` on one line and `chunked` on the next read as bare `chunked`.
- **The 600 s deadline was only checked before a socket read**, so a buffered tail — up to a whole 8 MiB chunk, many model iterations — could be consumed past it. Hence the 64 KiB windowing.
- **The 8 KiB chunk-header bound admitted ~16 KiB**; the length test ran only while still searching for CRLF.
- **Validation failures returned 500** instead of 400.
- **The documented `curl` command did not stream at all.** `--data-binary @-` drains stdin before connecting, turning a live capture into a file upload — the exact thing this endpoint exists to avoid. Measured against a timestamping listener, corrected to `-T -`, re-verified end to end.
- **Two test assertions passed for the wrong reason.** They asserted only that *an* error occurred, but these requests end by half-closing, which is itself an error — so they held even with the guard removed. Each now asserts its specific diagnostic.
- **No test crossed the 64 KiB compaction threshold**, so that branch never executed. The added case is mutation-verified: making compaction drop one unconsumed byte fails it, and it passes again on revert.

The chunked de-framing state machine was independently verified clean twice over — no byte skipped or repeated, exact-window-multiple chunks correct, compaction unable to invalidate the get area, bulk `read()` unable to bypass the deadline windows.

## Tests

`tests/unittests/test_http_live_body.cpp` drives real loopback sockets against `serve_http`, 13 cases:

- multi-chunk body arrives byte-identical and complete
- one 300 KB chunk, assembled across many `recv()` calls
- a body spanning several buffer compactions (the 64 KiB branch)
- 40 small chunks arriving several to a `recv()`
- chunk extensions ignored rather than parsed as size
- trailers accepted
- premature close → error, **not** a short body
- `ffffffffffffffff` overflow → rejected
- chunk over the per-chunk cap → rejected
- chunk data not CRLF-terminated → rejected
- non-hex size → rejected
- isolation: a chunked `POST /v1/audio/speech` still takes the buffered path, publishes no body stream, and keeps its existing (empty) buffered body

The compaction case is verified non-vacuous by mutation: making compaction drop one unconsumed byte fails it, and it passes again on revert.

Scope, stated plainly: this test links the transport, not the server runtime, so it covers framing/bounds/isolation and does **not** exercise the route itself or the SSE error conversion. Its header comment says so.

Existing `streaming_audio_input_test`, `citrinet_tokenizer_decode_test`, `sentencepiece_tokenizer1_test` pass unchanged. CUDA build clean.

---

## Review round (commit 2)

Both changes @0xShug0 asked for, in this PR rather than as follow-ups.

### 1. `live_ingest` is configurable, server → model

```json
{
  "live_ingest": { "total_timeout_ms": 600000, "max_chunk_bytes": 8388608 },
  "models": [
    { "id": "voxtral-realtime", "live_ingest": { "total_timeout_ms": 1800000 } }
  ]
}
```

A model entry overrides only the keys it names and inherits the rest, so raising one bound for a long-capture model doesn't mean restating the whole policy and letting it drift from the fleet default.

`send_timeout_ms` joined the set. It is the same class of bound — a client that stops reading holds the model open — and it was equally hardcoded, so leaving it out would have made the block look complete while one axis stayed fixed.

Values use `0` to mean *disabled*, matching `busy_timeout_ms` rather than inventing a second convention. **`max_chunk_bytes` is the exception and must stay positive**: a chunk is materialized in memory, so unbounded is not implementable, and the same value backs the chunk-size overflow check (see below). A negative value is rejected at startup naming the offending scope; silently reading it as "no bound" would remove a guard the operator believed they had set.

One design note worth flagging, since it touches the transport interface: the streambuf takes its bounds at construction, before `handle()` runs, and the transport has no notion of models. So `IHttpHandler` gains a virtual `live_ingest_limits(request)`, consulted once and only for a request that opts into an incremental body; `ServerState` resolves it from config. It deliberately does **not** reject an unknown or non-streaming model — that would turn a client's mistake into a dropped connection instead of the `400` `handle_transcription_live` already produces.

### 2. `busy_timeout_ms` query parameter

```
/v1/audio/transcriptions/live?model=voxtral-realtime&busy_timeout_ms=30000
```

A query parameter for the same reason the other parameters are: the body is audio and has nowhere to hold JSON. Semantics are unchanged from the other routes — clamped by the configured ceiling by the existing `resolve_busy_timeout_ms`, so a request can shorten its own wait but never weaken the guard. Malformed or out-of-range values return `400` with the specific reason.

### Three defects this change surfaced

Making the bounds settable made them reachable at values the compiled defaults never took, and an adversarial review pass found three real bugs there. Each is fixed with a mutation-verified test:

1. **The chunk-size guard underflowed for small caps.** `size > (cap - value) / 16` wraps whenever `cap < value`. At `max_chunk_bytes: 1` a declared `f` was accepted outright, and at `0` the guard never fired — re-admitting the `ffffffffffffffff` declaration whose `size + 2` wraps to 1, which is the exact bug this hand-rolled parse exists to prevent. Split into two checks, each on operands already in range.
2. **`max_body_bytes` missed a fully-prefetched body.** It was enforced only after a `recv()`, but a body short enough to arrive alongside the headers never re-enters that path — so the cap was skipped by exactly the request most likely to be probing it. Now also checked before the first byte is served.
3. **The config helpers accepted wrong-typed and truncating values.** `optional_i32`/`optional_i64` return the supplied fallback for a present-but-wrong-typed field, so in a model override `"max_body_bytes": "oops"` recorded the compiled 512 MiB default as a deliberate override and widened a stricter server policy. `optional_i32` also narrows before any range check, so `4294967296` became `0` (= disabled) on a 32-bit int. Both now parse and validate explicitly.

### Verification

`test_http_live_body.cpp` is now 18 cases. The new ones: a per-request cap takes effect where the default would allow it (chunk and body, separately); a cap below one hex digit still rejects; a zero cap falls back rather than disabling; a fully-prefetched body is still measured against the cap; and the limits hook is not consulted for a non-live route. Every one is mutation-verified — reverting the corresponding fix fails it, restoring passes.

The branch was rebased onto current `main`; `read_http_request` had gained `max_request_body_bytes` from #143 in the same place this branch splits off the incremental path. Resolved so the two bounds are complementary: the chunked early return precedes Content-Length handling, so a live body is bounded by `live_ingest.max_body_bytes` and a buffered one by `max_request_body_bytes`, with neither path escaping both.

Against a running server: a server-level `max_chunk_bytes` rejects a 64 KiB chunk the compiled default would accept, adding a per-model override to 1 MiB makes the identical request succeed, and negative values in either scope fail at startup with a message naming the scope. `busy_timeout_ms=abc`, `=-1` and a 20-digit value each return `400`; a real value streams normally.
