### PR TITLE
fix(pocket_tts): declare clone_audio_path as filesystem::path

### DIFF
--- a/tests/pocket_tts/pocket_tts_warm_bench.cpp
+++ b/tests/pocket_tts/pocket_tts_warm_bench.cpp
@@ -412,7 +412,7 @@ int main(int argc, char ** argv) {
         const std::string voice_id = arg_value(argc, argv, "--voice-id", "");
         const std::string warmup_text = arg_value(argc, argv, "--warmup-text", kDefaultWarmupText);
         const std::string voice_embedding_path = arg_value(argc, argv, "--voice-embedding-path", "");
-        const std::string clone_audio_path = arg_value(argc, argv, "--clone-audio", "");
+        const std::filesystem::path clone_audio_path = arg_value(argc, argv, "--clone-audio", "");
         const int max_steps = int_arg(argc, argv, "--max-steps", 0);
         const int frames_after_eos = int_arg(argc, argv, "--frames-after-eos", -1);
         const float temperature = float_arg(argc, argv, "--temperature", 0.7f);


### PR DESCRIPTION
## Problem

`tests/pocket_tts/pocket_tts_warm_bench.cpp` does not compile:

```
tests/pocket_tts/pocket_tts_warm_bench.cpp:511:67: error: call of overloaded 'read_wav_f32(const std::string&)' is ambiguous
  511 |   const auto audio = engine::audio::read_wav_f32(clone_audio_path);
      |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
include/engine/framework/audio/wav_reader.h:17:9: note: candidate: 'WavData read_wav_f32(std::string_view)'
include/engine/framework/audio/wav_reader.h:18:9: note: candidate: 'WavData read_wav_f32(const std::filesystem::path&)'
```

Root cause: `clone_audio_path` is declared `const std::string` on line 415. A `const std::string&` converts equally well to `string_view` and `filesystem::path`, so the call on line 511 is ambiguous.

## Fix

Change the declaration from `const std::string` to `const std::filesystem::path`. This aligns `pocket_tts_warm_bench` with every other warm bench in `tests/`:

- `tests/moss_tts_nano/moss_tts_nano_warm_bench.cpp:187` — `std::filesystem::path`
- `tests/qwen3_tts/qwen3_tts_warm_bench.cpp:206` — `std::filesystem::path(...)`
- `tests/glm_tts/glm_tts_warm_bench.cpp:175` — `std::filesystem::path`
- `tests/omnivoce/omnivoice_warm_bench.cpp:346` — `std::optional<std::filesystem::path>`

No call-site cast needed. The `.empty()` check on line 510 continues to work (`std::filesystem::path::empty()` exists).

## Call sites audited

Grepped every `read_wav_f32(` call site in `src/`, `include/`, `tests/`, `app/`, `tools/`. Every other caller passes either an `istream`, a `filesystem::path` value, or wraps the path in `resolve_path(...)` / `std::filesystem::path(...)` at the call site. `pocket_tts_warm_bench` is the only outlier with the bare-string declaration pattern.

## Validation

- Base: current `main` (`c6e3cac`)
- `cmake --build build/ --target pocket_tts_warm_bench -j 16` — exit 0
- gcc 13.2, Linux x86_64, CUDA enabled

No inference graph, tensor, or generated-output behavior changed.
