### PR TITLE
metal: dispatch conv_transpose_1d with 256-thread threadgroups (~5.6x AudioVAE decode)

### DIFF
--- a/external/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/external/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -599,6 +599,8 @@ typedef struct {
     int32_t  IL;
     int32_t  K;
     int32_t  s0;
+    int32_t  OL;
+    int32_t  OC;
     uint64_t nb0;
     uint64_t nb1;
 } ggml_metal_kargs_conv_transpose_1d;

--- a/external/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/external/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -4053,6 +4053,8 @@ int ggml_metal_op_conv_transpose_1d(ggml_metal_op_t ctx, int idx) {
         /*.IL  =*/ IL,
         /*.K   =*/ K,
         /*.s0  =*/ s0,
+        /*.OL  =*/ OL,
+        /*.OC  =*/ OC,
         /*.nb0 =*/ nb0,
         /*.nb1 =*/ nb1,
     };
@@ -4065,7 +4067,9 @@ int ggml_metal_op_conv_transpose_1d(ggml_metal_op_t ctx, int idx) {
     ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[1]), 2);
     ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op),         3);
 
-    ggml_metal_encoder_dispatch_threadgroups(enc, OL, OC, 1, 1, 1, 1);
+    const int nth = MIN(256, ggml_metal_pipeline_max_theads_per_threadgroup(pipeline));
+
+    ggml_metal_encoder_dispatch_threadgroups(enc, (OL + nth - 1)/nth, OC, 1, nth, 1, 1);
 
     return 1;
 }

--- a/external/ggml/src/ggml-metal/ggml-metal.metal
+++ b/external/ggml/src/ggml-metal/ggml-metal.metal
@@ -5120,14 +5120,22 @@ kernel void kernel_conv_transpose_1d(
         device const float * src1,
         device        char * dst,
         uint3   tgpig[[threadgroup_position_in_grid]],
-        uint3   tgpg[[threadgroups_per_grid]]) {
+        uint3   tpitg[[thread_position_in_threadgroup]],
+        uint3   ntg  [[threads_per_threadgroup]]) {
+
+    // One thread per output element, grouped ntg.x to a threadgroup so the
+    // whole SIMD width does useful work (the previous one-thread-per-
+    // threadgroup dispatch left 31/32 lanes idle).
+    const int32_t j = tgpig[0] * ntg[0] + tpitg[0];
+    if (j >= args.OL) {
+        return;
+    }
 
     // For output position j on the time axis, only input positions
     //   i such that i*s0 <= j < i*s0 + K
     // contribute -- i.e. i in [ceil((j - K + 1)/s0), floor(j/s0)]
     // intersected with [0, IL-1]. That's at most ceil(K/s0) values
     // (typically 2 for stride==K/2 transposed convs).
-    const int32_t j  = tgpig[0];
     const int32_t s0 = args.s0;
     const int32_t K  = args.K;
     const int32_t IL = args.IL;
@@ -5142,8 +5150,8 @@ kernel void kernel_conv_transpose_1d(
 
     float v = 0.0f;
     if (i_min <= i_max) {
-        for (int64_t c = 0; c < args.IC; c++) {
-            const int32_t kernel_offset = c * tgpg[1] * K + K * tgpig[1];
+        for (int32_t c = 0; c < args.IC; c++) {
+            const int32_t kernel_offset = c * args.OC * K + K * tgpig[1];
             const int32_t input_offset  = c * IL;
 
             for (int32_t i = i_min; i <= i_max; i++) {
@@ -5152,7 +5160,7 @@ kernel void kernel_conv_transpose_1d(
         }
     }
 
-    device float * dst_ptr = (device float *) (dst + tgpig[0] * args.nb0 + tgpig[1] * args.nb1);
+    device float * dst_ptr = (device float *) (dst + j * args.nb0 + tgpig[1] * args.nb1);
 
     dst_ptr[0] = v;
 }
@@ -5164,7 +5172,8 @@ kernel void kernel_conv_transpose_1d<float>(
     device const float * src1,
     device        char * dst,
     uint3   tgpig[[threadgroup_position_in_grid]],
-    uint3    tgpg[[threadgroups_per_grid]]);
+    uint3   tpitg[[thread_position_in_threadgroup]],
+    uint3   ntg  [[threads_per_threadgroup]]);
 
 template [[host_name("kernel_conv_transpose_1d_f16_f32")]]
 kernel void kernel_conv_transpose_1d<half>(
@@ -5173,7 +5182,8 @@ kernel void kernel_conv_transpose_1d<half>(
     device const float * src1,
     device        char * dst,
     uint3   tgpig[[threadgroup_position_in_grid]],
-    uint3    tgpg[[threadgroups_per_grid]]);
+    uint3   tpitg[[thread_position_in_threadgroup]],
+    uint3   ntg  [[threads_per_threadgroup]]);
 
 
 template <typename T>


### PR DESCRIPTION
## What

`kernel_conv_transpose_1d` was dispatched as `OL x OC` threadgroups of a **single thread** each, so 31/32 SIMD lanes of every warp were idle. This PR keeps the kernel's math and loop order unchanged and only regroups the launch: 256 output positions per threadgroup, with a bounds check against a new `args.OL`; the kernel now reads `OC` from kargs instead of `threadgroups_per_grid`.

Diff is +24/-8 across the three Metal backend files (kargs struct, host dispatch, kernel + template instantiations).

## Why it matters

`conv_transpose_1d` dominates AudioVAE-style waveform decoders (VoxCPM2 among them). On Apple Silicon the one-thread-per-threadgroup launch makes waveform decode the single largest cost of a TTS request.

## Measurements

M3 Max (Metal build, `GGML_METAL_EMBED_LIBRARY=OFF`), VoxCPM2-2B `q8_0` from `audio-cpp/audio.cpp-gguf`, voice clone, fixed `--seed 1234`, 15.5 s of 48 kHz output, warm session (`--log` timing):

| metric | before | after |
|---|---:|---:|
| `voxcpm2.audiovae_decoder_ms` | 10 234 | 1 806–1 871 (**~5.6x**) |
| `session.wall_ms` | 22 579 | 14 144–14 611 |

## Correctness

- Same seed, same command: output WAV is **bit-identical** to the previous kernel (`max |diff| = 0` over 744 960 samples). Per-output-element summation order is unchanged, so this is expected, not tolerance-based.
- Streaming mode (`--mode streaming`, chunked AudioVAE decode) runs through the same kernel: regression-tested OK.
- `qwen3_asr` transcription regression-tested OK (unchanged output).

Commands used are reproducible from the table above; happy to add more shapes or an f16-weight run if useful.

## Disclosure

Developed with AI assistance (Claude Code); the same fix has been validated for weeks in a downstream VoxCPM.cpp fork where it was originally written against upstream ggml.
