### PR TITLE
Support TheRock LLVM layout in Windows HIP build script

### DIFF
--- a/scripts/build_windows_hip.ps1
+++ b/scripts/build_windows_hip.ps1
@@ -50,21 +50,40 @@ function Find-FirstFile {
 
 # --- ROCm ---
 if ($RocmPath -eq "") {
-    if ($env:HIP_PATH -and (Test-Path (Join-Path $env:HIP_PATH "bin\clang++.exe"))) {
+    $hipPathHasClang = $env:HIP_PATH -and (
+        (Test-Path (Join-Path $env:HIP_PATH "bin\clang++.exe")) -or
+        (Test-Path (Join-Path $env:HIP_PATH "lib\llvm\bin\clang++.exe"))
+    )
+    if ($hipPathHasClang) {
         $RocmPath = (Resolve-Path $env:HIP_PATH).Path
     } else {
-        $clang = Find-FirstFile @("C:\Program Files\AMD\ROCm\*\bin\clang++.exe")
+        $clang = Find-FirstFile @(
+            "C:\Program Files\AMD\ROCm\*\bin\clang++.exe",
+            "C:\TheRock\build\lib\llvm\bin\clang++.exe"
+        )
         if ($clang -eq "") {
             throw "ROCm was not found. Install the AMD HIP SDK or pass -RocmPath."
         }
-        $RocmPath = (Resolve-Path (Join-Path (Split-Path $clang -Parent) "..")).Path
+        $clangDir = Split-Path $clang -Parent
+        if ($clangDir -like "*\lib\llvm\bin") {
+            $RocmPath = (Resolve-Path (Join-Path $clangDir "..\..\..")).Path
+        } else {
+            $RocmPath = (Resolve-Path (Join-Path $clangDir "..")).Path
+        }
     }
 }
-$clangxx = Join-Path $RocmPath "bin\clang++.exe"
-$clangc  = Join-Path $RocmPath "bin\clang.exe"
-if (-not (Test-Path $clangxx) -or -not (Test-Path $clangc)) {
-    throw "ROCm clang not found under $RocmPath\bin"
+$compilerDir = @(
+    (Join-Path $RocmPath "bin"),
+    (Join-Path $RocmPath "lib\llvm\bin")
+) | Where-Object {
+    (Test-Path (Join-Path $_ "clang.exe")) -and
+    (Test-Path (Join-Path $_ "clang++.exe"))
+} | Select-Object -First 1
+if ($null -eq $compilerDir) {
+    throw "ROCm clang not found under $RocmPath\bin or $RocmPath\lib\llvm\bin"
 }
+$clangxx = Join-Path $compilerDir "clang++.exe"
+$clangc  = Join-Path $compilerDir "clang.exe"
 
 # --- GPU targets ---
 if ($GpuTargets -eq "") {
@@ -126,7 +145,7 @@ if ($Clean) {
 
 $env:HIP_PATH = $RocmPath
 $env:ROCM_PATH = $RocmPath
-$env:PATH = @((Join-Path $RocmPath "bin"), $env:PATH) -join [IO.Path]::PathSeparator
+$env:PATH = @($compilerDir, (Join-Path $RocmPath "bin"), $env:PATH) -join [IO.Path]::PathSeparator
 
 $configureArgs = @(
     "-S", $sourceDir,


### PR DESCRIPTION
## What changed

- detect Windows ROCm clang in both `bin` and `lib/llvm/bin`
- recognize the TheRock layout when resolving `HIP_PATH` or auto-discovering `C:\TheRock\build`
- prepend the selected compiler directory to `PATH` while keeping the ROCm runtime `bin` directory

## Why

Current TheRock-based Windows ROCm packages place `hipcc.exe` under `bin`, but place `clang.exe` and `clang++.exe` under `lib/llvm/bin`. The Windows HIP build script previously required `<ROCm>\bin\clang++.exe`, so an otherwise valid TheRock install failed immediately with:

```
ROCm clang not found under C:\TheRock\build\bin
```

The normal AMD HIP SDK layout remains preferred and unchanged.

## Validation

Tested on Windows 11 with Ryzen AI MAX+ 395 / Radeon 8060S (`gfx1151`):

- ROCm/TheRock 7.14.60850
- AMD Clang 23.0.0
- Visual Studio 2022 toolset 14.44
- explicit `-RocmPath C:\TheRock\build` configure: passed
- automatic `HIP_PATH=C:\TheRock\build` detection: passed
- distribution-style HIP build with `-GpuTargets gfx1151 -NoNativeCpu -DeploymentBuild -Target audiocpp_cli`: passed (708 build steps)
- resulting `audiocpp_cli.exe --help`: passed
- resulting `audiocpp_cli.exe --list-loaders --json`: passed