### PR TITLE
feat(nix): add ROCm/HIP backend support

### DIFF
--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -1,0 +1,100 @@
+{
+  lib,
+  stdenv,
+  cmake,
+  ninja,
+  pkg-config,
+  rocmPackages,
+  cudaPackages,
+  vulkan-headers,
+  vulkan-loader,
+  vulkan-tools,
+  glslang,
+  shaderc,
+  darwin,
+  python-scripts,
+  config,
+  version,
+
+  # Overridable feature flags
+  cudaSupport ? config.cudaSupport or false,
+  vulkanSupport ? false,
+  metalSupport ? stdenv.isDarwin,
+  rocmSupport ? config.rocmSupport or false,
+  rocmGpuTargets ? (lib.optionals rocmSupport rocmPackages.clr.gpuTargets),
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "audio.cpp";
+  inherit version;
+  src = lib.cleanSource ../..;
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+  ]
+  ++ lib.optional cudaSupport cudaPackages.cuda_nvcc
+  ++ lib.optional rocmSupport rocmPackages.clr;
+
+  buildInputs = [
+    python-scripts
+  ]
+  ++ lib.optionals vulkanSupport [
+    vulkan-headers
+    vulkan-loader
+    vulkan-tools
+    glslang
+    shaderc
+  ]
+  ++ lib.optionals cudaSupport [
+    cudaPackages.cudatoolkit
+  ]
+  ++ lib.optionals rocmSupport [
+    rocmPackages.clr
+    rocmPackages.hipblas
+    rocmPackages.rocblas
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+    "-DENGINE_ENABLE_NATIVE_CPU=ON"
+    "-DENGINE_ENABLE_LLAMAFILE=ON"
+  ] ++ lib.optional stdenv.isDarwin "-DENGINE_ENABLE_OPENMP=OFF"
+  ++ lib.optional vulkanSupport "-DENGINE_ENABLE_VULKAN=ON"
+  ++ lib.optional cudaSupport "-DENGINE_ENABLE_CUDA=ON"
+  ++ lib.optional metalSupport "-DENGINE_ENABLE_METAL=ON"
+  ++ lib.optional rocmSupport "-DENGINE_ENABLE_HIP=ON"
+  ++ lib.optional rocmSupport "-DCMAKE_HIP_COMPILER=${rocmPackages.llvm.clang}/bin/clang"
+  ++ lib.optional rocmSupport "-DGPU_TARGETS=${lib.concatStringsSep ";" rocmGpuTargets}";
+
+  env = lib.optionalAttrs rocmSupport {
+    ROCM_PATH = "${rocmPackages.clr}";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+
+    # Copy the built C++ executables directly from the bin directory
+    cp bin/audiocpp_cli bin/audiocpp_server bin/audiocpp_gguf $out/bin/
+
+    # Install the python model manager script
+    cp $src/tools/model_manager.py $out/bin/audiocpp_model_manager
+    chmod +x $out/bin/audiocpp_model_manager
+
+    # Patch the shebang to use our python environment with torch/safetensors/pyyaml
+    patchShebangs $out/bin/audiocpp_model_manager
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A high-performance C++ audio inference framework";
+    homepage = "https://github.com/0xShug0/audio.cpp";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    mainProgram = "audiocpp_cli";
+  };
+})

--- a/.devops/nix/python-scripts.nix
+++ b/.devops/nix/python-scripts.nix
@@ -1,0 +1,11 @@
+{
+  lib,
+  python3,
+}:
+
+python3.withPackages (ps: with ps; [
+  ps.torch
+  ps.safetensors
+  ps.pyyaml
+  ps.numpy
+])

--- a/.devops/nix/scope.nix
+++ b/.devops/nix/scope.nix
@@ -1,0 +1,12 @@
+{
+  lib,
+  newScope,
+  version,
+  python-scripts,
+}:
+
+lib.makeScope newScope (self: {
+  audiocpp = self.callPackage ./package.nix {
+    inherit version python-scripts;
+  };
+})

--- a/docs/build/nixos.md
+++ b/docs/build/nixos.md
@@ -3,89 +3,69 @@
 ## Prerequisites
 
 - The [Nix package manager](https://nixos.org/download) must be installed.
-- [Flakes](https://nixos.wiki/wiki/Flakes) must be enabled in your Nix configuration.
+- [Flakes](https://nixos.wiki/wiki/Flakes) must be enabled.
 
 ## Packages
 
-The `flake.nix` provides multiple platform and hardware-specific builds. 
-The following backends are available:
-- **`vulkan`**: Hardware-accelerated build using Vulkan. (Default on Linux)
-- **`cuda`**: Hardware-accelerated build using NVIDIA CUDA.
-- **`metal`**: Hardware-accelerated build using Apple Metal. (Default on macOS)
-- **`cpu`**: Portable CPU-only build.
+The flake provides backend-specific builds:
 
-All packages include the main tools: ***audiocpp_cli***, ***audiocpp_server***, ***audiocpp_gguf***, and the Python-based ***audiocpp_model_manager***.
+| Package        | Backend                  | Platform |
+| -------------- | ------------------------ | -------- |
+| `cpu`          | CPU-only                 | All      |
+| `vulkan`       | Vulkan                   | All      |
+| `cuda`         | NVIDIA CUDA              | Linux    |
+| `rocm`         | AMD ROCm                 | Linux    |
+| `rocm-gfx1151` | AMD ROCm (single target) | Linux    |
+| `metal`        | Apple Metal              | macOS    |
 
-## Build the package
+All packages include: **audiocpp_cli**, **audiocpp_server**, **audiocpp_gguf**, and **audiocpp_model_manager**.
 
-### Default (Auto-detected OS)
-
-Build the default package for your operating system:
-
-```bash
-nix build .
-```
-
-### Specific Backends
-
-Build explicitly for a desired backend:
+## Build
 
 ```bash
+nix build .#cpu
 nix build .#vulkan
 nix build .#cuda
-nix build .#metal
-nix build .#cpu
+nix build .#rocm
+nix build .#rocm-gfx1151    # Single GPU target (faster)
 ```
 
-## Usage
-
-After building, the compiled binaries will be available in the `result/bin/` directory.
-
-### Running the CLI
-
-You can execute the CLI directly via `nix run` (which uses `audiocpp_cli` as the main program):
+## Run
 
 ```bash
-nix run .#vulkan -- <arguments...>
+nix run .#rocm -- --backend hip --task tts --family supertonic --model ./model --text "hello"
+./result/bin/audiocpp_cli --backend hip --device 0
 ```
 
-### Running the Server
+## Download Models
 
-To run the server, use `nix shell` or execute from the build result:
-
-```bash
-nix shell .#vulkan -c audiocpp_server <arguments...>
-# or
-./result/bin/audiocpp_server <arguments...>
-```
-
-### Downloading Models (Model Manager)
-
-The flake seamlessly bundles the `model_manager.py` Python script along with all its required dependencies (PyTorch, Safetensors, etc.) as `audiocpp_model_manager`.
+The `python-scripts` package includes all dependencies for `model_manager.py`:
 
 ```bash
-nix shell .#vulkan -c audiocpp_model_manager install supertonic_3
+nix shell .#python-scripts -c python3 tools/model_manager.py install supertonic_3
 ```
 
 ## Development Shell
 
-If you want to work on `audio.cpp` and need a development environment with `cmake`, `ninja`, and all the necessary C++ and Python dependencies pre-configured, simply run:
-
 ```bash
-nix develop
+nix develop              # Default backend
+nix develop .#cuda       # CUDA dev environment
 ```
 
-## Using in a NixOS Configuration
+## Custom GPU Target
 
-You can easily include `audio.cpp` as a flake input in your own NixOS configuration or other Nix projects.
+Override `hipGpuTargets` for a specific GPU:
 
-In your `flake.nix`, add it to your `inputs`, making sure to use `follows` to avoid duplicating `nixpkgs` versions:
+```bash
+nix build --impure --expr '(builtins.getFlake (toString ./.)).outputs.packages.x86_64-linux.rocm.override { rocmGpuTargets = ["gfx1151"]; }'
+```
+
+## NixOS Configuration
 
 ```nix
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    
     audiocpp.url = "github:0xShug0/audio.cpp";
     audiocpp.inputs.nixpkgs.follows = "nixpkgs";
   };
@@ -94,14 +74,19 @@ In your `flake.nix`, add it to your `inputs`, making sure to use `follows` to av
     nixosConfigurations.my-machine = nixpkgs.lib.nixosSystem {
       system = "x86_64-linux";
       modules = [
-        ({ pkgs, ... }: {
+        ({ ... }: {
           environment.systemPackages = [
-            # Add the default package (auto-detects Metal/Vulkan based on OS)
             audiocpp.packages.x86_64-linux.default
-            
+
             # Or explicitly select a backend flavor:
             # audiocpp.packages.x86_64-linux.vulkan
             # audiocpp.packages.x86_64-linux.cuda
+            # audiocpp.packages.x86_64-linux.rocm
+
+            # Custom GPU target:
+            # audiocpp.packages.x86_64-linux.rocm.override {
+            #   rocmGpuTargets = [ "gfx1151" ];
+            # }
           ];
         })
       ];

--- a/flake.nix
+++ b/flake.nix
@@ -5,122 +5,94 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   };
 
-  outputs = { self, nixpkgs }:
+  outputs =
+    { self, nixpkgs }:
     let
-      supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
-      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
-      pkgs = forAllSystems (system: import nixpkgs { 
-        inherit system; 
-      });
-      pkgsCuda = forAllSystems (system: import nixpkgs { 
-        inherit system; 
-        config.cudaSupport = true;
-        config.allowUnfreePredicate = p:
-          builtins.all (
-            license:
-            license.free
-            || builtins.elem license.shortName [
-              "CUDA EULA"
-              "cuDNN EULA"
-              "cuSPARSELt EULA"
-            ]
-          ) (p.meta.licenses or (nixpkgs.lib.toList (p.meta.license or [])));
-      });
-    in
-    {
-      packages = forAllSystems (system:
-        let
-          # A function to build audio.cpp with any set of features
-          mkAudioCpp = { pkgs, cudaSupport ? false, vulkanSupport ? false, metalSupport ? pkgs.stdenv.isDarwin }: 
-            let
-              # Python environment for model_manager.py
-              myPython = pkgs.python3.withPackages (ps: with ps; [
-                (if cudaSupport then ps.torchWithCuda else if vulkanSupport then ps.torchWithVulkan else ps.torch)
-                ps.safetensors
-                ps.pyyaml
-              ]);
-            in
-            pkgs.stdenv.mkDerivation {
-              pname = "audio.cpp";
-              version = self.shortRev or self.dirtyShortRev or "dirty";
+      forAllSystems = nixpkgs.lib.genAttrs [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+      version = self.shortRev or self.dirtyShortRev or "dirty";
 
-              src = ./.;
+      pkgs = forAllSystems (system: import nixpkgs { inherit system; });
 
-              nativeBuildInputs = with pkgs; [
-                cmake
-                ninja
-                pkg-config
-              ] ++ pkgs.lib.optional cudaSupport pkgs.cudaPackages.cuda_nvcc;
-
-              buildInputs = with pkgs; [
-                myPython
-              ] ++ pkgs.lib.optionals vulkanSupport [
-                vulkan-headers
-                vulkan-loader
-                vulkan-tools
-                glslang
-                shaderc
-              ] ++ pkgs.lib.optionals cudaSupport [
-                pkgs.cudaPackages.cudatoolkit
-              ] ++ pkgs.lib.optionals metalSupport [
-                pkgs.apple-sdk_14
-              ];
-
-              cmakeFlags = [
-                "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
-                "-DENGINE_ENABLE_NATIVE_CPU=ON"
-                "-DENGINE_ENABLE_LLAMAFILE=ON"
-              ] ++ pkgs.lib.optional vulkanSupport "-DENGINE_ENABLE_VULKAN=ON"
-                ++ pkgs.lib.optional cudaSupport "-DENGINE_ENABLE_CUDA=ON"
-                ++ pkgs.lib.optional metalSupport "-DENGINE_ENABLE_METAL=ON";
-
-              installPhase = ''
-                runHook preInstall
-
-                mkdir -p $out/bin
-                
-                # Copy the built C++ executables directly from the bin directory
-                cp bin/audiocpp_cli bin/audiocpp_server bin/audiocpp_gguf $out/bin/
-
-                # Install the python model manager script
-                cp $src/tools/model_manager.py $out/bin/audiocpp_model_manager
-                chmod +x $out/bin/audiocpp_model_manager
-
-                # Patch the shebang to use our python environment with torch/safetensors/pyyaml
-                patchShebangs $out/bin/audiocpp_model_manager
-
-                runHook postInstall
-              '';
-
-              meta = with pkgs.lib; {
-                description = "A high-performance C++ audio inference framework";
-                homepage = "https://github.com/0xShug0/audio.cpp";
-                license = licenses.mit;
-                platforms = platforms.unix;
-                mainProgram = "audiocpp_cli";
-              };
-            };
-        in
-        {
-          # Expose specific backend variants
-          cpu = mkAudioCpp { pkgs = pkgs.${system}; cudaSupport = false; vulkanSupport = false; metalSupport = false; };
-          vulkan = mkAudioCpp { pkgs = pkgs.${system}; vulkanSupport = true; cudaSupport = false; metalSupport = false; };
-        } // pkgs.${system}.lib.optionalAttrs pkgs.${system}.stdenv.isLinux {
-          cuda = mkAudioCpp { pkgs = pkgsCuda.${system}; cudaSupport = true; vulkanSupport = false; metalSupport = false; };
-        } // pkgs.${system}.lib.optionalAttrs pkgs.${system}.stdenv.isDarwin {
-          metal = mkAudioCpp { pkgs = pkgs.${system}; metalSupport = true; cudaSupport = false; vulkanSupport = false; };
-        } // {
-          # Automatically select best default for the current platform
-          default = if pkgs.${system}.stdenv.isDarwin then self.packages.${system}.metal else self.packages.${system}.vulkan;
+      pkgsCuda = forAllSystems (
+        system:
+        import nixpkgs {
+          inherit system;
+          config.cudaSupport = true;
+          config.allowUnfreePredicate =
+            p:
+            builtins.all (
+              l:
+              l.free
+              || builtins.elem l.shortName [
+                "CUDA EULA"
+                "cuDNN EULA"
+                "cuSPARSELt EULA"
+              ]
+            ) (p.meta.licenses or (nixpkgs.lib.toList (p.meta.license or [ ])));
         }
       );
 
-      devShells = forAllSystems (system:
+      audioPackages = forAllSystems (
+        system:
+        pkgs.${system}.callPackage .devops/nix/scope.nix {
+          inherit version;
+          python-scripts = pythonScripts.${system};
+        }
+      );
+      audioPackagesCuda = forAllSystems (
+        system:
+        pkgsCuda.${system}.callPackage .devops/nix/scope.nix {
+          inherit version;
+          python-scripts = pythonScripts.${system};
+        }
+      );
+      pythonScripts = forAllSystems (
+        system:
+        pkgs.${system}.callPackage .devops/nix/python-scripts.nix { }
+      );
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          base = audioPackages.${system}.audiocpp;
+          baseCuda = audioPackagesCuda.${system}.audiocpp;
+        in
+        {
+          cpu = base;
+          vulkan = base.override { vulkanSupport = true; };
+          python-scripts = pythonScripts.${system};
+          default =
+            if pkgs.${system}.stdenv.isDarwin then
+              self.packages.${system}.metal
+            else
+              self.packages.${system}.cpu;
+        }
+        // nixpkgs.lib.optionalAttrs pkgs.${system}.stdenv.isLinux {
+          cuda = baseCuda.override { cudaSupport = true; };
+          rocm = base.override { rocmSupport = true; };
+          rocm-gfx1151 = base.override {
+            rocmSupport = true;
+            rocmGpuTargets = [ "gfx1151" ];
+          };
+        }
+        // nixpkgs.lib.optionalAttrs pkgs.${system}.stdenv.isDarwin {
+          metal = base.override { metalSupport = true; };
+        }
+      );
+
+      devShells = forAllSystems (
+        system:
         {
           default = pkgs.${system}.mkShell {
             inputsFrom = [ self.packages.${system}.default ];
           };
-        } // pkgs.${system}.lib.optionalAttrs pkgs.${system}.stdenv.isLinux {
+        }
+        // nixpkgs.lib.optionalAttrs pkgs.${system}.stdenv.isLinux {
           cuda = pkgsCuda.${system}.mkShell {
             inputsFrom = [ self.packages.${system}.cuda ];
           };


### PR DESCRIPTION
## Summary

This PR adds the ROCm build target through the nix build system introduced in #48 . It also refactors flake.nix in multiple nix modules following llama-cpp's approach.

## Changes

- Split flake into .devops/nix/ (package.nix, scope.nix, python-scripts.nix) following llama-cpp's approach
- All backend flags overridable: this is especially useful to limit the number of gpu targets for ROCm. Example: `.override { rocmSupport = true; rocmGpuTargets = ["gfx1151"]; }`
- python-scripts standalone package for model_manager.py
- Removed vulkan/cuda torch builds in favour of vanilla build as cpu device is enforced
- Removed x86_64-darwin as no more supported from upstream nixpkgs
- Added missing numpy dependency in python-scripts
- Updated docs/build/nixos.md

## Tests

On Linux x86:

```shell
nix run .#rocm-gfx1151 -- --task tts --model /home/fbozzo/projects/audio.cpp/models/Qwen3-TTS-12Hz-1.7B-Base --backend rocm --text "audio.cpp is running locally." --family qwen3_tts --voice-ref assets/resources/sample.wav --reference-text "Some call me nature. Others call me Mother Nature. I've been here for over 4.5 billion years. 22,500 times longer than you." --out out3.wav

nix shell .#python-scripts -c python3 tools/model_manager.py install supertonic_3
```

On MacOS:

```shell
nix build 'git+https://github.com/francescobozzo/audio.cpp.git?ref=feature/nix-rocm#metal'
```
