### PR TITLE
feat(nix): support selecting model targets in Nix builds

### DIFF
--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -11,7 +11,6 @@
   vulkan-tools,
   glslang,
   shaderc,
-  darwin,
   python-scripts,
   config,
   version,
@@ -22,6 +21,9 @@
   metalSupport ? stdenv.isDarwin,
   rocmSupport ? config.rocmSupport or false,
   rocmGpuTargets ? (lib.optionals rocmSupport rocmPackages.clr.gpuTargets),
+  # Model selection: if non-empty, only these model targets are built.
+  # See CMakeLists.txt AUDIOCPP_MODEL_SET / AUDIOCPP_MODELS.
+  models ? [ ],
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -60,7 +62,17 @@ stdenv.mkDerivation (finalAttrs: {
     "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
     "-DENGINE_ENABLE_NATIVE_CPU=ON"
     "-DENGINE_ENABLE_LLAMAFILE=ON"
-  ] ++ lib.optional stdenv.isDarwin "-DENGINE_ENABLE_OPENMP=OFF"
+  ]
+  ++ (
+    if models != [ ] then
+      [
+        "-DAUDIOCPP_MODEL_SET=custom"
+        "-DAUDIOCPP_MODELS=${lib.concatStringsSep "," models}"
+      ]
+    else
+      [ "-DAUDIOCPP_MODEL_SET=full" ]
+  )
+  ++ lib.optional stdenv.isDarwin "-DENGINE_ENABLE_OPENMP=OFF"
   ++ lib.optional vulkanSupport "-DENGINE_ENABLE_VULKAN=ON"
   ++ lib.optional cudaSupport "-DENGINE_ENABLE_CUDA=ON"
   ++ lib.optional metalSupport "-DENGINE_ENABLE_METAL=ON"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,6 +210,7 @@ endfunction()
 function(audiocpp_add_model target_name)
     cmake_parse_arguments(ARG "" "" "SOURCES;INCLUDES;LOADERS;ALIASES;DEPENDS" ${ARGN})
     add_library(engine_model_${target_name} OBJECT ${ARG_SOURCES})
+    set_target_properties(engine_model_${target_name} PROPERTIES EXCLUDE_FROM_ALL TRUE)
     audiocpp_configure_runtime_object(engine_model_${target_name})
     set(AUDIOCPP_MODEL_TARGETS ${AUDIOCPP_MODEL_TARGETS} ${target_name} PARENT_SCOPE)
     set(AUDIOCPP_MODEL_${target_name}_INCLUDES "${ARG_INCLUDES}" PARENT_SCOPE)
@@ -352,6 +353,7 @@ add_library(engine_model_silero_vad OBJECT
     src/models/silero_vad/runtime.cpp
     src/models/silero_vad/session.cpp
 )
+set_target_properties(engine_model_silero_vad PROPERTIES EXCLUDE_FROM_ALL TRUE)
 audiocpp_configure_runtime_object(engine_model_silero_vad)
 
 add_library(engine_model_marblenet_vad OBJECT
@@ -359,6 +361,7 @@ add_library(engine_model_marblenet_vad OBJECT
     src/models/marblenet_vad/runtime.cpp
     src/models/marblenet_vad/session.cpp
 )
+set_target_properties(engine_model_marblenet_vad PROPERTIES EXCLUDE_FROM_ALL TRUE)
 audiocpp_configure_runtime_object(engine_model_marblenet_vad)
 
 audiocpp_add_model(roformer
@@ -1290,13 +1293,16 @@ if (ENGINE_ENABLE_OPENMP)
     target_link_libraries(torch_bin_parity PRIVATE OpenMP::OpenMP_CXX)
 endif()
 
-add_executable(vibevoice_finetune_overlay_check
-    tests/vibevoice/finetune_overlay_check.cpp
-)
-
-target_link_libraries(vibevoice_finetune_overlay_check PRIVATE engine_runtime ggml)
-if (ENGINE_ENABLE_OPENMP)
-    target_link_libraries(vibevoice_finetune_overlay_check PRIVATE OpenMP::OpenMP_CXX)
+# Only build this parity check when the vibevoice model is linked, since it
+# directly references model-internal symbols (load_vibevoice_assets etc.).
+if (vibevoice IN_LIST AUDIOCPP_LINKED_MODELS)
+    add_executable(vibevoice_finetune_overlay_check
+        tests/vibevoice/finetune_overlay_check.cpp
+    )
+    target_link_libraries(vibevoice_finetune_overlay_check PRIVATE engine_runtime ggml)
+    if (ENGINE_ENABLE_OPENMP)
+        target_link_libraries(vibevoice_finetune_overlay_check PRIVATE OpenMP::OpenMP_CXX)
+    endif()
 endif()
 
 if (ENGINE_BUILD_TESTS)

--- a/docs/build/nixos.md
+++ b/docs/build/nixos.md
@@ -60,6 +60,27 @@ Override `hipGpuTargets` for a specific GPU:
 nix build --impure --expr '(builtins.getFlake (toString ./.)).outputs.packages.x86_64-linux.rocm.override { rocmGpuTargets = ["gfx1151"]; }'
 ```
 
+## Model Selection
+
+By default, Nix builds include **all** model backends. Pass a list of model
+target names via `models` to build only those — this automatically maps to
+the CMake `AUDIOCPP_MODEL_SET=custom` option.
+This works with any backend flavor. Refer to the
+[CMake model targets](https://github.com/0xShug0/audio.cpp/blob/main/CMakeLists.txt)
+(search for `audiocpp_add_model`) for the full, up-to-date list.
+
+Build with a custom model list from the command line:
+
+```bash
+nix build --impure --expr '(builtins.getFlake (toString ./.)).outputs.packages.x86_64-linux.cpu.override { models = [ "chatterbox" "roformer" ]; }'
+```
+
+Combine with a backend (e.g. CUDA + custom models):
+
+```bash
+nix build --impure --expr '(builtins.getFlake (toString ./.)).outputs.packages.x86_64-linux.cuda.override { models = [ "chatterbox" ]; }'
+```
+
 ## NixOS Configuration
 
 ```nix
@@ -86,6 +107,11 @@ nix build --impure --expr '(builtins.getFlake (toString ./.)).outputs.packages.x
             # Custom GPU target:
             # audiocpp.packages.x86_64-linux.rocm.override {
             #   rocmGpuTargets = [ "gfx1151" ];
+            # }
+
+            # Custom model list (only build specific models):
+            # audiocpp.packages.x86_64-linux.cpu.override {
+            #   models = [ "roformer" "miotts" ];
             # }
           ];
         })

--- a/flake.nix
+++ b/flake.nix
@@ -51,8 +51,7 @@
         }
       );
       pythonScripts = forAllSystems (
-        system:
-        pkgs.${system}.callPackage .devops/nix/python-scripts.nix { }
+        system: pkgs.${system}.callPackage .devops/nix/python-scripts.nix { }
       );
     in
     {


### PR DESCRIPTION
## Changes

 - package.nix: Added models parameter: non-empty list auto-sets `AUDIOCPP_MODEL_SET=custom`, empty defaults to full
 - CMakeLists.txt: `EXCLUDE_FROM_ALL` on all model OBJECT libraries so unselected models aren't compiled; `vibevoice_finetune_overlay_check` now gated on vibevoice being linked. Note: this change influences all other build pipelines, but was necessary to exclude unwanted models not just from linking but also from compile time.
 - docs/build/nixos.md: New Model Selection section with CLI and NixOS examples

## Tests

Validated model list reduces the number of building steps in cmake with the following configuration:

```
vulkan = base.override {
  vulkanSupport = true;
  models = [
    "vibevoice"
    "miotts"
  ];
};
```

