### PR TITLE
model:  enable HIP backend for Vibe Voice TTS

### DIFF
--- a/docs/build/HIP.md
+++ b/docs/build/HIP.md
@@ -325,11 +325,12 @@ The following locations check `BackendType::Cuda` specifically and will not appl
 | `src/framework/modules/optimizations/fast_projection_modules.cpp` | 62 | CUDA projection acceleration |
 | `src/models/miocodec/audio_pipeline.cpp` | 294 | CUDA audio pipeline |
 | `src/models/index_tts2/gpt.cpp` | 83 | CUDA-required GPT module |
-| `src/models/vibevoice/session.cpp` | 164 | CUDA-specific max seconds |
 | `src/models/vibevoice_asr/session.cpp` | 543, 545 | CUDA-specific weight storage |
 | `src/models/vibevoice_asr/speech_encoder.cpp` | 54 | CUDA-specific speech encoder |
 
 **To enable:** Change `== BackendType::Cuda` to `== BackendType::Cuda || == BackendType::Hip` on a per-file basis after verifying each optimization works correctly on AMD hardware.
+
+**Enabled for HIP:** VibeVoice TTS (`src/models/vibevoice/session.cpp` -- backend whitelist and the 30 s voice-prompt cap) and the conv-transpose1d col2im fast path (`src/framework/modules/conv_modules.cpp`) are enabled for HIP. Validated on gfx1151 (ROCm 7.14, Linux): prompt-side fingerprints (text encoding, acoustic encoder, prompt embeddings, prefill logits/top-5) match CPU/CUDA within ~1e-3 relative float noise, `test-backend-ops` passes 11953/11953 on ROCm0, and the remaining end-to-end divergence vs CPU is the same chaotic argmax amplification that CUDA exhibits vs CPU.
 
 ### Switch statements missing `Hip` case (compiler warnings)
 

--- a/src/framework/modules/conv_modules.cpp
+++ b/src/framework/modules/conv_modules.cpp
@@ -304,7 +304,8 @@ core::TensorValue view_batch_matrix(
 bool is_conv_transpose1d_col2im_fast_path_eligible(
     const core::ModuleBuildContext & ctx,
     const ConvTranspose1dConfig & config) noexcept {
-    return ctx.backend_type == core::BackendType::Cuda && config.dilation == 1;
+    return (ctx.backend_type == core::BackendType::Cuda || ctx.backend_type == core::BackendType::Hip) &&
+           config.dilation == 1;
 }
 
 Conv1dModule::Conv1dModule(Conv1dConfig config) : config_(config) {

--- a/src/models/vibevoice/session.cpp
+++ b/src/models/vibevoice/session.cpp
@@ -46,9 +46,10 @@ void validate_weight_storage(engine::assets::TensorStorageType storage_type, con
 const runtime::SessionOptions & require_supported_backend_options(const runtime::SessionOptions & options) {
     if (options.backend.type != engine::core::BackendType::Cpu &&
         options.backend.type != engine::core::BackendType::Cuda &&
+        options.backend.type != engine::core::BackendType::Hip &&
         options.backend.type != engine::core::BackendType::Vulkan &&
         options.backend.type != engine::core::BackendType::Metal) {
-        throw std::runtime_error("VibeVoice session supports only CPU, CUDA, Vulkan, and Metal backends");
+        throw std::runtime_error("VibeVoice session supports only CPU, CUDA, HIP, Vulkan, and Metal backends");
     }
     for (const auto & [key, value] : options.options) {
         if (key == "vibevoice.weight_type" ||
@@ -161,7 +162,7 @@ runtime::AudioBuffer cap_voice_sample_duration(
     runtime::AudioBuffer audio,
     core::BackendType backend_type,
     const std::string & path) {
-    const int64_t max_seconds = backend_type == core::BackendType::Cuda
+    const int64_t max_seconds = (backend_type == core::BackendType::Cuda || backend_type == core::BackendType::Hip)
         ? kCudaVoicePromptMaxSeconds
         : kDefaultVoicePromptMaxSeconds;
     const int64_t max_frames = static_cast<int64_t>(audio.sample_rate) * max_seconds;


### PR DESCRIPTION
## Summary

Removes the ROCm/HIP restriction for VibeVoice TTS after validation on AMD hardware:

- `src/models/vibevoice/session.cpp`: add `BackendType::Hip` to the session
  backend whitelist; align the voice prompt duration cap with CUDA (30 s).
- `src/framework/modules/conv_modules.cpp`: enable the conv-transpose1d
  col2im fast path for HIP (used by the VibeVoice acoustic decoder).
- `docs/HIP.md`: move VibeVoice TTS out of the "not yet enabled" list and
  record the validation results.

## Validation (gfx1151 / Strix Halo iGPU, ROCm 7.14, Linux)

- Prompt-side fingerprints (text encoding, acoustic encoder, prompt
  embeddings, prefill logits + top-5) match CPU and CUDA within ~1e-3
  relative float noise.
- ggml `test-backend-ops` on ROCm0: **11953 OK / 0 FAIL**.
- CUDA graphs on/off and op fusion on/off produce bit-identical output.
- End-to-end TTS generation works and produces clean audio.

Note on numerical parity: with identical inputs (same seed + injected
diffusion noise), HIP, CUDA, and CPU all agree for the first ~34
autoregressive steps, then diverge at a near-tie argmax step. Crucially,
**CUDA diverges from CPU the same way** (one step earlier than HIP), so
this is inherent bf16 summation-order noise amplified by autoregressive
generation — not a HIP-specific defect.

AI usage : I reviewed the VibeVoice logic, designed a workflow, and had Kimi K3 run tests separately on my servers (equipped with 2080TI, 3090, and GFX1151). I confirmed that there are no significant differences between the HIP and CUDA backends.

Output:
[out_hip.wav](https://github.com/user-attachments/files/30581545/out_hip.wav)
