### PR TITLE
Optimize Qwen3-TTS ROCm inference on Strix Halo

### DIFF
--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -96,11 +96,11 @@ stdenv.mkDerivation (finalAttrs: {
     # Copy the built C++ executables directly from the bin directory
     cp bin/audiocpp_cli bin/audiocpp_server bin/audiocpp_gguf $out/bin/
 
-    # Install the python model manager script
-    cp $src/tools/model_manager.py $out/bin/audiocpp_model_manager
-    chmod +x $out/bin/audiocpp_model_manager
+    # Install the supported spec-backed model manager and the catalog it reads
+    # relative to its installed location.
+    install -Dm755 $src/tools/model_manager_v2.py $out/bin/audiocpp_model_manager
+    cp -R $src/model_specs $out/model_specs
 
-    # Patch the shebang to use our python environment with torch/safetensors/pyyaml
     patchShebangs $out/bin/audiocpp_model_manager
 
     runHook postInstall

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -21,10 +21,13 @@
   metalSupport ? stdenv.isDarwin,
   rocmSupport ? config.rocmSupport or false,
   rocmGpuTargets ? (lib.optionals rocmSupport rocmPackages.clr.gpuTargets),
+  strixHaloOptimizations ? false,
   # Model selection: if non-empty, only these model targets are built.
   # See CMakeLists.txt AUDIOCPP_MODEL_SET / AUDIOCPP_MODELS.
   models ? [ ],
 }:
+
+assert !strixHaloOptimizations || rocmSupport;
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "audio.cpp";
@@ -78,7 +81,8 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional metalSupport "-DENGINE_ENABLE_METAL=ON"
   ++ lib.optional rocmSupport "-DENGINE_ENABLE_HIP=ON"
   ++ lib.optional rocmSupport "-DCMAKE_HIP_COMPILER=${rocmPackages.llvm.clang}/bin/clang"
-  ++ lib.optional rocmSupport "-DGPU_TARGETS=${lib.concatStringsSep ";" rocmGpuTargets}";
+  ++ lib.optional rocmSupport "-DGPU_TARGETS=${lib.concatStringsSep ";" rocmGpuTargets}"
+  ++ lib.optional strixHaloOptimizations "-DENGINE_HIP_STRIX_HALO_OPTIMIZATIONS=ON";
 
   env = lib.optionalAttrs rocmSupport {
     ROCM_PATH = "${rocmPackages.clr}";

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,9 @@ option(ENGINE_ENABLE_VULKAN "Build ggml with Vulkan backend support" ${ENGINE_DE
 option(ENGINE_ENABLE_METAL "Build ggml with Metal backend support" ${ENGINE_DEFAULT_ENABLE_METAL})
 option(ENGINE_ENABLE_LLAMAFILE "Build ggml with llamafile SGEMM support" ${ENGINE_DEFAULT_ENABLE_LLAMAFILE})
 option(ENGINE_ENABLE_CUDA_GRAPHS "Enable ggml CUDA graphs support" ${ENGINE_DEFAULT_ENABLE_CUDA_GRAPHS})
+option(ENGINE_HIP_STRIX_HALO_OPTIMIZATIONS
+    "Enable opt-in HIP optimizations validated only for Strix Halo (gfx1151)"
+    OFF)
 option(ENGINE_ENABLE_NATIVE_CPU "Build ggml CPU kernels with native host ISA flags" ${ENGINE_DEFAULT_ENABLE_NATIVE_CPU})
 option(ENGINE_ENABLE_OPENMP "Build host code with OpenMP support" ON)
 option(ENGINE_ENABLE_CPU_ALL_VARIANTS
@@ -103,6 +106,47 @@ if (ENGINE_ENABLE_CUDA AND ENGINE_ENABLE_HIP)
     message(FATAL_ERROR
         "ENGINE_ENABLE_CUDA and ENGINE_ENABLE_HIP are mutually exclusive; "
         "configure with exactly one of them (e.g. -DENGINE_ENABLE_CUDA=OFF -DENGINE_ENABLE_HIP=ON)")
+endif()
+
+set(AUDIOCPP_HIP_STRIX_HALO_OPTIMIZATIONS_ACTIVE OFF)
+if (ENGINE_HIP_STRIX_HALO_OPTIMIZATIONS)
+    if (NOT ENGINE_ENABLE_HIP)
+        message(FATAL_ERROR
+            "ENGINE_HIP_STRIX_HALO_OPTIMIZATIONS=ON requires ENGINE_ENABLE_HIP=ON")
+    endif()
+
+    # Match ggml HIP target precedence: an explicit CMake HIP architecture wins,
+    # followed by GPU_TARGETS and then the legacy AMDGPU_TARGETS spelling.
+    if (CMAKE_HIP_ARCHITECTURES)
+        set(AUDIOCPP_EFFECTIVE_HIP_TARGETS ${CMAKE_HIP_ARCHITECTURES})
+        set(AUDIOCPP_EFFECTIVE_HIP_TARGET_SOURCE "CMAKE_HIP_ARCHITECTURES")
+    elseif (GPU_TARGETS)
+        set(AUDIOCPP_EFFECTIVE_HIP_TARGETS ${GPU_TARGETS})
+        set(AUDIOCPP_EFFECTIVE_HIP_TARGET_SOURCE "GPU_TARGETS")
+    elseif (AMDGPU_TARGETS)
+        set(AUDIOCPP_EFFECTIVE_HIP_TARGETS ${AMDGPU_TARGETS})
+        set(AUDIOCPP_EFFECTIVE_HIP_TARGET_SOURCE "AMDGPU_TARGETS")
+    else()
+        message(FATAL_ERROR
+            "ENGINE_HIP_STRIX_HALO_OPTIMIZATIONS=ON requires exactly one explicit HIP target, gfx1151; "
+            "set -DGPU_TARGETS=gfx1151 (no project-wide gfx1151 default is provided)")
+    endif()
+
+    list(LENGTH AUDIOCPP_EFFECTIVE_HIP_TARGETS AUDIOCPP_EFFECTIVE_HIP_TARGET_COUNT)
+    if (NOT AUDIOCPP_EFFECTIVE_HIP_TARGET_COUNT EQUAL 1 OR
+        NOT "${AUDIOCPP_EFFECTIVE_HIP_TARGETS}" STREQUAL "gfx1151")
+        message(FATAL_ERROR
+            "ENGINE_HIP_STRIX_HALO_OPTIMIZATIONS=ON requires the effective HIP target list to be exactly "
+            "gfx1151; ${AUDIOCPP_EFFECTIVE_HIP_TARGET_SOURCE}='${AUDIOCPP_EFFECTIVE_HIP_TARGETS}'")
+    endif()
+
+    # hipBLASLt regressed decoder compute by roughly 3 seconds on gfx1151.
+    # Keep the validated retained-graph path on rocBLAS; the generic HIP build
+    # remains unchanged because this option is both target- and backend-gated.
+    set(GGML_HIP_HIPBLASLT OFF CACHE BOOL
+        "Use hipBLASLt instead of hipBLAS (rocBLAS) for HIP GEMM" FORCE)
+    set(AUDIOCPP_HIP_STRIX_HALO_OPTIMIZATIONS_ACTIVE ON)
+    message(STATUS "Strix Halo HIP optimizations enabled for gfx1151 with rocBLAS")
 endif()
 
 if (ENGINE_ENABLE_CUDA AND NOT ENGINE_ENABLE_HIP)
@@ -198,6 +242,9 @@ function(audiocpp_configure_runtime_object target_name)
         ${CMAKE_CURRENT_SOURCE_DIR}/external/libyaml/include
     )
     target_compile_definitions(${target_name} PRIVATE ${AUDIOCPP_LIBYAML_COMPILE_DEFINITIONS})
+    if (AUDIOCPP_HIP_STRIX_HALO_OPTIMIZATIONS_ACTIVE)
+        target_compile_definitions(${target_name} PRIVATE ENGINE_HIP_STRIX_HALO_OPTIMIZATIONS=1)
+    endif()
     target_link_libraries(${target_name} PRIVATE ggml sentencepiece)
     if (ENGINE_ENABLE_OPENMP)
         target_link_libraries(${target_name} PRIVATE OpenMP::OpenMP_CXX)
@@ -1173,6 +1220,9 @@ target_include_directories(engine_runtime PRIVATE
 
 target_link_libraries(engine_runtime PUBLIC ggml)
 target_link_libraries(engine_runtime PRIVATE sentencepiece cjson_vendor yaml_vendor)
+if (AUDIOCPP_HIP_STRIX_HALO_OPTIMIZATIONS_ACTIVE)
+    target_compile_definitions(engine_runtime PRIVATE ENGINE_HIP_STRIX_HALO_OPTIMIZATIONS=1)
+endif()
 if (ENGINE_ENABLE_OPENMP)
     target_link_libraries(engine_runtime PRIVATE OpenMP::OpenMP_CXX)
     if (MSVC)
@@ -1521,6 +1571,14 @@ if (ENGINE_BUILD_TESTS)
         NAME outetts_generation_budget_test
         COMMAND outetts_generation_budget_test
     )
+
+    if (qwen3_tts IN_LIST AUDIOCPP_LINKED_MODELS)
+        add_engine_unittest(qwen3_tts_options_config_test tests/unittests/test_qwen3_tts_options_config.cpp)
+        add_test(
+            NAME qwen3_tts_options_config_test
+            COMMAND qwen3_tts_options_config_test
+        )
+    endif()
 
     add_engine_unittest(subtitle_formatter_test tests/unittests/test_subtitle_formatter.cpp)
 

--- a/flake.nix
+++ b/flake.nix
@@ -77,6 +77,7 @@
           rocm-gfx1151 = base.override {
             rocmSupport = true;
             rocmGpuTargets = [ "gfx1151" ];
+            strixHaloOptimizations = true;
           };
         }
         // nixpkgs.lib.optionalAttrs pkgs.${system}.stdenv.isDarwin {
@@ -94,6 +95,16 @@
         // nixpkgs.lib.optionalAttrs pkgs.${system}.stdenv.isLinux {
           cuda = pkgsCuda.${system}.mkShell {
             inputsFrom = [ self.packages.${system}.cuda ];
+          };
+        }
+        # ROCm's Nix toolchain is currently supported on x86_64 Linux only.
+        # Keep the shell off aarch64 rather than exposing an unevaluable output.
+        // nixpkgs.lib.optionalAttrs (system == "x86_64-linux") {
+          rocm = pkgs.${system}.mkShell {
+            inputsFrom = [ self.packages.${system}.rocm ];
+          };
+          rocm-gfx1151 = pkgs.${system}.mkShell {
+            inputsFrom = [ self.packages.${system}.rocm-gfx1151 ];
           };
         }
       );

--- a/include/engine/framework/core/module.h
+++ b/include/engine/framework/core/module.h
@@ -19,6 +19,12 @@ enum class BackendType {
     BestAvailable,
 };
 
+// CUDA and HIP share ggml's ggml-cuda implementation for a small set of
+// explicitly verified operators. This is intentionally not a generic GPU test.
+constexpr bool uses_ggml_cuda_family_backend(BackendType type) noexcept {
+    return type == BackendType::Cuda || type == BackendType::Hip;
+}
+
 constexpr size_t kMaxTensorRank = 4;
 
 struct TensorShape {

--- a/include/engine/models/qwen3_tts/assets.h
+++ b/include/engine/models/qwen3_tts/assets.h
@@ -88,6 +88,7 @@ struct Qwen3TTSAssets {
     std::shared_ptr<const assets::TensorSource> speech_tokenizer_weights;
 };
 
+void validate_qwen3_tts_config(const Qwen3TTSConfig & config);
 std::shared_ptr<const Qwen3TTSAssets> load_qwen3_tts_assets(const std::filesystem::path & model_path);
 
 }  // namespace engine::models::qwen3_tts

--- a/include/engine/models/qwen3_tts/session.h
+++ b/include/engine/models/qwen3_tts/session.h
@@ -18,6 +18,10 @@
 
 namespace engine::models::qwen3_tts {
 
+Qwen3TTSGenerationOptions qwen3_tts_generation_options_from_request(
+    const runtime::TaskRequest & request,
+    const Qwen3TTSConfig & config);
+
 class Qwen3TTSSession final
     : public runtime::RuntimeSessionBase
     , public runtime::IOfflineVoiceTaskSession {

--- a/include/engine/models/qwen3_tts/talker.h
+++ b/include/engine/models/qwen3_tts/talker.h
@@ -37,6 +37,10 @@ struct Qwen3TalkerCodes {
     Qwen3SpeechCodes decoder_input_codes;
 };
 
+void validate_qwen3_talker_voice_clone_prefill(
+    const Qwen3TalkerPrefill & prefill,
+    int64_t hidden_size);
+
 class Qwen3TalkerWeightsRuntime;
 class Qwen3TalkerStepRuntime;
 

--- a/include/engine/models/qwen3_tts/tokenizer_speech_decoder.h
+++ b/include/engine/models/qwen3_tts/tokenizer_speech_decoder.h
@@ -6,6 +6,7 @@
 #include "engine/models/qwen3_tts/assets.h"
 #include "engine/models/qwen3_tts/types.h"
 
+#include <array>
 #include <cstddef>
 #include <memory>
 
@@ -45,6 +46,9 @@ private:
     Qwen3TTSPerfMode perf_mode_ = Qwen3TTSPerfMode::Standard;
     std::unique_ptr<core::ConstantTensorCache> constants_;
     mutable std::unique_ptr<Qwen3SpeechTokenizerDecoderGraph> graph_;
+    // Always present to keep this public class layout identical when the private
+    // Strix Halo compile definition differs between translation units.
+    mutable std::array<std::unique_ptr<Qwen3SpeechTokenizerDecoderGraph>, 2> optimized_graphs_;
 };
 
 }  // namespace qwen3_tts

--- a/src/framework/modules/conv_modules.cpp
+++ b/src/framework/modules/conv_modules.cpp
@@ -304,7 +304,7 @@ core::TensorValue view_batch_matrix(
 bool is_conv_transpose1d_col2im_fast_path_eligible(
     const core::ModuleBuildContext & ctx,
     const ConvTranspose1dConfig & config) noexcept {
-    return ctx.backend_type == core::BackendType::Cuda && config.dilation == 1;
+    return core::uses_ggml_cuda_family_backend(ctx.backend_type) && config.dilation == 1;
 }
 
 Conv1dModule::Conv1dModule(Conv1dConfig config) : config_(config) {

--- a/src/framework/modules/optimizations/fast_projection_modules.cpp
+++ b/src/framework/modules/optimizations/fast_projection_modules.cpp
@@ -59,8 +59,8 @@ core::TensorValue FastPackedProjection4Module::build(
     if (ctx.ggml == nullptr) {
         throw std::runtime_error("ModuleBuildContext.ggml is null");
     }
-    if (ctx.backend_type != core::BackendType::Cuda) {
-        throw std::runtime_error("FastPackedProjection4Module is CUDA-only");
+    if (!core::uses_ggml_cuda_family_backend(ctx.backend_type)) {
+        throw std::runtime_error("FastPackedProjection4Module requires a ggml CUDA-family backend");
     }
 
     core::validate_rank_between(input, 1, core::kMaxTensorRank, "input");

--- a/src/models/qwen3_tts/assets.cpp
+++ b/src/models/qwen3_tts/assets.cpp
@@ -3,6 +3,7 @@
 #include "engine/framework/model_spec/package.h"
 #include "engine/framework/io/json.h"
 
+#include <cmath>
 #include <stdexcept>
 #include <utility>
 
@@ -23,6 +24,25 @@ Qwen3TTSVariant parse_variant(const std::string & value) {
     throw std::runtime_error("Qwen3 TTS unsupported tts_model_type: " + value);
 }
 
+int64_t parse_head_dim(
+    const json::Value & value,
+    int64_t hidden_size,
+    int64_t attention_heads,
+    const char * component) {
+    if (const auto * head_dim = value.find("head_dim")) {
+        return head_dim->as_i64();
+    }
+    if (hidden_size <= 0 || attention_heads <= 0) {
+        throw std::runtime_error(std::string("Qwen3 TTS ") + component +
+            " hidden_size and num_attention_heads must be positive");
+    }
+    if (hidden_size % attention_heads != 0) {
+        throw std::runtime_error(std::string("Qwen3 TTS ") + component +
+            " hidden_size must be divisible by num_attention_heads when head_dim is omitted");
+    }
+    return hidden_size / attention_heads;
+}
+
 Qwen3TTSCodePredictorConfig parse_code_predictor_config(const json::Value & value) {
     Qwen3TTSCodePredictorConfig config;
     config.hidden_size = json::require_i64(value, "hidden_size");
@@ -30,7 +50,11 @@ Qwen3TTSCodePredictorConfig parse_code_predictor_config(const json::Value & valu
     config.num_hidden_layers = json::require_i64(value, "num_hidden_layers");
     config.num_attention_heads = json::require_i64(value, "num_attention_heads");
     config.num_key_value_heads = json::require_i64(value, "num_key_value_heads");
-    config.head_dim = json::optional_i64(value, "head_dim", config.hidden_size / config.num_attention_heads);
+    config.head_dim = parse_head_dim(
+        value,
+        config.hidden_size,
+        config.num_attention_heads,
+        "code predictor");
     config.vocab_size = json::require_i64(value, "vocab_size");
     config.rms_norm_eps = json::optional_f32(value, "rms_norm_eps", config.rms_norm_eps);
     config.rope_theta = json::optional_f32(value, "rope_theta", config.rope_theta);
@@ -47,7 +71,11 @@ Qwen3TTSTalkerConfig parse_talker_config(const json::Value & value) {
     config.num_hidden_layers = json::require_i64(value, "num_hidden_layers");
     config.num_attention_heads = json::require_i64(value, "num_attention_heads");
     config.num_key_value_heads = json::require_i64(value, "num_key_value_heads");
-    config.head_dim = json::optional_i64(value, "head_dim", config.hidden_size / config.num_attention_heads);
+    config.head_dim = parse_head_dim(
+        value,
+        config.hidden_size,
+        config.num_attention_heads,
+        "talker");
     config.num_code_groups = json::require_i64(value, "num_code_groups");
     config.vocab_size = json::require_i64(value, "vocab_size");
     config.codec_bos_id = json::require_i64(value, "codec_bos_id");
@@ -134,22 +162,95 @@ Qwen3TTSConfig parse_config(const assets::ResourceBundle & resources) {
     return config;
 }
 
-void validate_config(const Qwen3TTSConfig & config) {
+void validate_transformer_shape(
+    int64_t hidden_size,
+    int64_t intermediate_size,
+    int64_t layers,
+    int64_t attention_heads,
+    int64_t key_value_heads,
+    int64_t head_dim,
+    const char * component) {
+    if (hidden_size <= 0 || intermediate_size <= 0 || layers <= 0 ||
+        attention_heads <= 0 || key_value_heads <= 0 || head_dim <= 0) {
+        throw std::runtime_error(std::string("Qwen3 TTS ") + component +
+            " transformer dimensions must be positive");
+    }
+    if (attention_heads % key_value_heads != 0) {
+        throw std::runtime_error(std::string("Qwen3 TTS ") + component +
+            " num_attention_heads must be divisible by num_key_value_heads");
+    }
+}
+
+void validate_config_impl(const Qwen3TTSConfig & config) {
     if (config.tokenizer_type != "qwen3_tts_tokenizer_12hz") {
         throw std::runtime_error("Qwen3 TTS currently supports qwen3_tts_tokenizer_12hz");
     }
-    if (config.variant == Qwen3TTSVariant::Base && !config.has_speaker_encoder) {
-        throw std::runtime_error("Qwen3 base TTS model must provide speaker_encoder_config for voice clone");
+    if (config.max_new_tokens <= 0) {
+        throw std::runtime_error("Qwen3 TTS max_new_tokens must be positive");
     }
-    if (config.variant == Qwen3TTSVariant::CustomVoice && config.talker.speaker_id.empty()) {
-        throw std::runtime_error("Qwen3 custom voice model must provide speaker ids");
+    validate_transformer_shape(
+        config.talker.hidden_size,
+        config.talker.intermediate_size,
+        config.talker.num_hidden_layers,
+        config.talker.num_attention_heads,
+        config.talker.num_key_value_heads,
+        config.talker.head_dim,
+        "talker");
+    if (config.talker.max_position_embeddings <= 0 || config.talker.text_hidden_size <= 0 ||
+        config.talker.text_vocab_size <= 0 || config.talker.num_code_groups <= 1 ||
+        config.talker.vocab_size <= 0) {
+        throw std::runtime_error("Qwen3 TTS talker sizes must be positive and include multiple code groups");
+    }
+    if (!std::isfinite(config.talker.rms_norm_eps) || config.talker.rms_norm_eps <= 0.0F ||
+        !std::isfinite(config.talker.rope_theta) || config.talker.rope_theta <= 0.0F) {
+        throw std::runtime_error("Qwen3 TTS talker norm and RoPE parameters must be finite and positive");
+    }
+    validate_transformer_shape(
+        config.code_predictor.hidden_size,
+        config.code_predictor.intermediate_size,
+        config.code_predictor.num_hidden_layers,
+        config.code_predictor.num_attention_heads,
+        config.code_predictor.num_key_value_heads,
+        config.code_predictor.head_dim,
+        "code predictor");
+    if (config.code_predictor.vocab_size <= 0 ||
+        !std::isfinite(config.code_predictor.rms_norm_eps) || config.code_predictor.rms_norm_eps <= 0.0F ||
+        !std::isfinite(config.code_predictor.rope_theta) || config.code_predictor.rope_theta <= 0.0F) {
+        throw std::runtime_error("Qwen3 TTS code predictor vocabulary, norm, and RoPE parameters must be positive");
     }
     if (config.speech_tokenizer.model_type != "qwen3_tts_tokenizer_12hz") {
         throw std::runtime_error("Qwen3 TTS speech tokenizer must be qwen3_tts_tokenizer_12hz");
     }
+    if (config.speech_tokenizer.input_sample_rate <= 0 ||
+        config.speech_tokenizer.output_sample_rate <= 0 ||
+        config.speech_tokenizer.num_quantizers <= 0 ||
+        config.speech_tokenizer.codebook_size <= 0 ||
+        config.speech_tokenizer.semantic_codebook_size <= 0) {
+        throw std::runtime_error("Qwen3 TTS speech tokenizer sizes and sample rates must be positive");
+    }
+    if (config.talker.num_code_groups != config.speech_tokenizer.num_quantizers) {
+        throw std::runtime_error("Qwen3 TTS talker code groups must match speech tokenizer quantizers");
+    }
+    if (config.variant == Qwen3TTSVariant::Base && !config.has_speaker_encoder) {
+        throw std::runtime_error("Qwen3 base TTS model must provide speaker_encoder_config for voice clone");
+    }
+    if (config.has_speaker_encoder &&
+        (config.speaker_encoder.embedding_dim <= 0 || config.speaker_encoder.sample_rate <= 0)) {
+        throw std::runtime_error("Qwen3 TTS speaker encoder dimensions and sample rate must be positive");
+    }
+    if (config.has_speaker_encoder && config.speaker_encoder.embedding_dim != config.talker.hidden_size) {
+        throw std::runtime_error("Qwen3 TTS speaker encoder embedding_dim must match talker hidden_size");
+    }
+    if (config.variant == Qwen3TTSVariant::CustomVoice && config.talker.speaker_id.empty()) {
+        throw std::runtime_error("Qwen3 custom voice model must provide speaker ids");
+    }
 }
 
 }  // namespace
+
+void validate_qwen3_tts_config(const Qwen3TTSConfig & config) {
+    validate_config_impl(config);
+}
 
 std::shared_ptr<const Qwen3TTSAssets> load_qwen3_tts_assets(const std::filesystem::path & model_path) {
     auto resources = engine::model_spec::load_resource_bundle(
@@ -157,7 +258,7 @@ std::shared_ptr<const Qwen3TTSAssets> load_qwen3_tts_assets(const std::filesyste
         engine::model_spec::default_spec_path("qwen3_tts"));
     auto assets = std::make_shared<Qwen3TTSAssets>();
     assets->config = parse_config(resources);
-    validate_config(assets->config);
+    validate_qwen3_tts_config(assets->config);
     assets->model_weights = resources.open_tensor_source("model_weights");
     assets->speech_tokenizer_weights = resources.open_tensor_source("speech_tokenizer_weights");
     assets->resources = std::move(resources);

--- a/src/models/qwen3_tts/session.cpp
+++ b/src/models/qwen3_tts/session.cpp
@@ -26,7 +26,7 @@ std::shared_ptr<const Qwen3TTSAssets> require_assets(std::shared_ptr<const Qwen3
     return assets;
 }
 
-Qwen3TTSGenerationOptions generation_options_from_request(
+Qwen3TTSGenerationOptions generation_options_from_request_impl(
     const runtime::TaskRequest & request,
     const Qwen3TTSConfig & config) {
     Qwen3TTSGenerationOptions options;
@@ -40,39 +40,50 @@ Qwen3TTSGenerationOptions generation_options_from_request(
     if (const auto value = runtime::find_option(request.options, {"do_sample"})) {
         options.do_sample = runtime::parse_bool_option(*value, "do_sample");
     }
-    if (const auto value = runtime::find_option(
-            request.options,
-            {"subtalker_do_sample"})) {
+    if (const auto value = runtime::find_option(request.options, {"subtalker_do_sample"})) {
         options.subtalker_do_sample = runtime::parse_bool_option(*value, "subtalker_do_sample");
     }
-    if (const auto value = runtime::parse_float_option(request.options, {"temperature"})) {
+    if (const auto value = runtime::parse_finite_float_option(request.options, {"temperature"})) {
         options.temperature = *value;
     }
     if (const auto value = runtime::parse_int_option(request.options, {"top_k"})) {
         options.top_k = *value;
     }
-    if (const auto value = runtime::parse_float_option(request.options, {"top_p"})) {
+    if (const auto value = runtime::parse_finite_float_option(request.options, {"top_p"})) {
         options.top_p = *value;
     }
-    if (const auto value = runtime::parse_float_option(
-            request.options,
-            {"repetition_penalty"})) {
+    if (const auto value = runtime::parse_finite_float_option(request.options, {"repetition_penalty"})) {
         options.repetition_penalty = *value;
     }
-    if (const auto value = runtime::parse_float_option(
-            request.options,
-            {"subtalker_temperature"})) {
+    if (const auto value = runtime::parse_finite_float_option(request.options, {"subtalker_temperature"})) {
         options.subtalker_temperature = *value;
     }
-    if (const auto value = runtime::parse_int_option(
-            request.options,
-            {"subtalker_top_k"})) {
+    if (const auto value = runtime::parse_int_option(request.options, {"subtalker_top_k"})) {
         options.subtalker_top_k = *value;
     }
-    if (const auto value = runtime::parse_float_option(
-            request.options,
-            {"subtalker_top_p"})) {
+    if (const auto value = runtime::parse_finite_float_option(request.options, {"subtalker_top_p"})) {
         options.subtalker_top_p = *value;
+    }
+    if (options.do_sample && options.temperature <= 0.0F) {
+        throw std::runtime_error("Qwen3 TTS temperature must be positive when sampling");
+    }
+    if (options.top_k < 0) {
+        throw std::runtime_error("Qwen3 TTS top_k must be non-negative");
+    }
+    if (options.top_p < 0.0F || options.top_p > 1.0F) {
+        throw std::runtime_error("Qwen3 TTS top_p must be in [0, 1]");
+    }
+    if (options.repetition_penalty <= 0.0F) {
+        throw std::runtime_error("Qwen3 TTS repetition_penalty must be positive");
+    }
+    if (options.subtalker_do_sample && options.subtalker_temperature <= 0.0F) {
+        throw std::runtime_error("Qwen3 TTS subtalker_temperature must be positive when sampling");
+    }
+    if (options.subtalker_top_k < 0) {
+        throw std::runtime_error("Qwen3 TTS subtalker_top_k must be non-negative");
+    }
+    if (options.subtalker_top_p < 0.0F || options.subtalker_top_p > 1.0F) {
+        throw std::runtime_error("Qwen3 TTS subtalker_top_p must be in [0, 1]");
     }
     options.seed = runtime::parse_u32_option(request.options, {"seed"})
         .value_or(runtime::random_u32_seed());
@@ -179,7 +190,45 @@ void validate_conv_weight_storage(engine::assets::TensorStorageType storage_type
     throw std::runtime_error(std::string(option_name) + " currently supports only native, f32, and f16");
 }
 
+class TalkerCachedStepReleaseGuard {
+public:
+    TalkerCachedStepReleaseGuard(Qwen3TalkerStepRuntime * runtime, bool enabled)
+        : runtime_(runtime), enabled_(enabled) {}
+
+    ~TalkerCachedStepReleaseGuard() noexcept {
+        try {
+            release();
+        } catch (...) {
+            // Cleanup must not replace the request exception during stack unwinding.
+        }
+    }
+
+    void release() {
+        if (!enabled_ || released_ || runtime_ == nullptr) {
+            return;
+        }
+        const auto release_start = Clock::now();
+        const int64_t released_steps = runtime_->release_cached_step_graph();
+        debug::timing_log_scalar(
+            "qwen3_tts.talker.cached_step_release_ms",
+            engine::debug::elapsed_ms(release_start, Clock::now()));
+        debug::timing_log_scalar("qwen3_tts.talker.cached_step_released_steps", released_steps);
+        released_ = true;
+    }
+
+private:
+    Qwen3TalkerStepRuntime * runtime_ = nullptr;
+    bool enabled_ = false;
+    bool released_ = false;
+};
+
 }  // namespace
+
+Qwen3TTSGenerationOptions qwen3_tts_generation_options_from_request(
+    const runtime::TaskRequest & request,
+    const Qwen3TTSConfig & config) {
+    return generation_options_from_request_impl(request, config);
+}
 
 bool Qwen3TTSSession::VoicePromptCacheKeyEqual::operator()(
     const VoicePromptCacheKey & lhs,
@@ -336,16 +385,7 @@ void Qwen3TTSSession::prepare(const runtime::SessionPreparationRequest & request
 runtime::TaskResult Qwen3TTSSession::run(const runtime::TaskRequest & request) {
     require_prepared("Qwen3 TTS run");
     const auto wall_start = Clock::now();
-    auto release_talker_cached_step_graph = [&]() {
-        if (mem_saver_) {
-            const auto release_start = Clock::now();
-            const int64_t released_steps = talker_step_->release_cached_step_graph();
-            debug::timing_log_scalar(
-                "qwen3_tts.talker.cached_step_release_ms",
-                engine::debug::elapsed_ms(release_start, Clock::now()));
-            debug::timing_log_scalar("qwen3_tts.talker.cached_step_released_steps", released_steps);
-        }
-    };
+    TalkerCachedStepReleaseGuard release_talker_cached_step_graph(talker_step_.get(), mem_saver_);
     const int64_t text_chunk_size =
         engine::text::parse_text_chunk_size_override(request.options).value_or(kDefaultTextChunkSize);
     const auto chunk_requests = runtime::chunk_text_request(request, text_chunk_size);
@@ -375,7 +415,7 @@ runtime::TaskResult Qwen3TTSSession::run(const runtime::TaskRequest & request) {
                 speech_decoder_->decode(codes.generated_codes));
             decoder_ms += engine::debug::elapsed_ms(decoder_start, Clock::now());
         }
-        release_talker_cached_step_graph();
+        release_talker_cached_step_graph.release();
         runtime::TaskResult result;
         result.audio_output = std::move(merged_audio);
         debug::timing_log_scalar("qwen3_tts.voice_design_prefill_build_ms", prefill_ms);
@@ -410,7 +450,7 @@ runtime::TaskResult Qwen3TTSSession::run(const runtime::TaskRequest & request) {
                 speech_decoder_->decode(codes.generated_codes));
             decoder_ms += engine::debug::elapsed_ms(decoder_start, Clock::now());
         }
-        release_talker_cached_step_graph();
+        release_talker_cached_step_graph.release();
         runtime::TaskResult result;
         result.audio_output = std::move(merged_audio);
         debug::timing_log_scalar("qwen3_tts.custom_voice_prefill_build_ms", prefill_ms);
@@ -444,9 +484,6 @@ runtime::TaskResult Qwen3TTSSession::run(const runtime::TaskRequest & request) {
         const auto prefill_start = Clock::now();
         const auto prefill = prompt_builder.build_prefill(qwen_request, voice_prompt);
         prefill_ms += engine::debug::elapsed_ms(prefill_start, Clock::now());
-        if (!voice_prompt.reference_codes.has_value()) {
-            throw std::runtime_error("Qwen3 base TTS talker currently requires ICL reference codes");
-        }
         const auto talker_start = Clock::now();
         const auto codes = talker_step_->generate(
             prefill,
@@ -454,14 +491,15 @@ runtime::TaskResult Qwen3TTSSession::run(const runtime::TaskRequest & request) {
             qwen_request.generation.repetition_penalty);
         talker_ms += engine::debug::elapsed_ms(talker_start, Clock::now());
         const auto decoder_start = Clock::now();
-        runtime::append_audio_buffer(
-            merged_audio,
-            speech_decoder_->decode_and_trim_reference(
-                *voice_prompt.reference_codes,
-                codes.generated_codes));
+        runtime::AudioBuffer decoded = voice_prompt.reference_codes.has_value()
+            ? speech_decoder_->decode_and_trim_reference(
+                  *voice_prompt.reference_codes,
+                  codes.generated_codes)
+            : speech_decoder_->decode(codes.generated_codes);
+        runtime::append_audio_buffer(merged_audio, decoded);
         decoder_ms += engine::debug::elapsed_ms(decoder_start, Clock::now());
     }
-    release_talker_cached_step_graph();
+    release_talker_cached_step_graph.release();
     runtime::TaskResult result;
     result.audio_output = std::move(merged_audio);
     debug::timing_log_scalar("qwen3_tts.voice_prompt_ms", prompt_ms);
@@ -529,7 +567,7 @@ Qwen3TTSRequest Qwen3TTSSession::make_request(const runtime::TaskRequest & reque
     Qwen3TTSRequest out;
     out.text = request.text_input->text;
     out.language = !request.text_input->language.empty() ? request.text_input->language : "Auto";
-    out.generation = generation_options_from_request(request, assets_->config);
+    out.generation = qwen3_tts_generation_options_from_request(request, assets_->config);
     if (assets_->config.variant == Qwen3TTSVariant::Base) {
         const runtime::AudioBuffer * reference_audio = nullptr;
         if (request.voice.has_value()

--- a/src/models/qwen3_tts/talker.cpp
+++ b/src/models/qwen3_tts/talker.cpp
@@ -34,6 +34,21 @@
 #include <vector>
 
 namespace engine::models::qwen3_tts {
+
+void validate_qwen3_talker_voice_clone_prefill(
+    const Qwen3TalkerPrefill & prefill,
+    int64_t hidden_size) {
+    if (!prefill.speaker_embedding.has_value() || prefill.speaker_embedding->dims != hidden_size) {
+        throw std::runtime_error("Qwen3 talker voice clone prefill requires speaker embedding");
+    }
+    if (prefill.icl_mode == prefill.x_vector_only_mode) {
+        throw std::runtime_error("Qwen3 talker voice clone prefill requires exactly one prompt mode");
+    }
+    if (prefill.icl_mode && (!prefill.reference_codes.has_value() || prefill.reference_ids.empty())) {
+        throw std::runtime_error("Qwen3 talker ICL prefill requires reference ids and codes");
+    }
+}
+
 namespace {
 
 using Clock = std::chrono::steady_clock;
@@ -521,12 +536,7 @@ PromptEmbeddingState build_prompt_state(
         return state;
     }
 
-    if (!prefill.speaker_embedding.has_value() || prefill.speaker_embedding->dims != config.hidden_size) {
-        throw std::runtime_error("Qwen3 talker voice clone prefill requires speaker embedding");
-    }
-    if (!prefill.reference_codes.has_value() || prefill.reference_ids.empty()) {
-        throw std::runtime_error("Qwen3 talker ICL prefill requires reference ids and codes");
-    }
+    validate_qwen3_talker_voice_clone_prefill(prefill, config.hidden_size);
 
     PromptEmbeddingState state;
     state.tts_pad = tts_pad;
@@ -549,6 +559,26 @@ PromptEmbeddingState build_prompt_state(
     append_row(state.prompt, add_rows(tts_bos, row_at(codec_embed, codec_rows - 2, config.hidden_size)));
 
     const std::vector<int32_t> text_ids(prefill.input_ids.begin() + 3, prefill.input_ids.end() - 5);
+    if (prefill.x_vector_only_mode) {
+        auto text_embed = text_project_host(
+            lookup_rows(weights.text_embedding, config.text_hidden_size, text_ids),
+            static_cast<int64_t>(text_ids.size()),
+            weights,
+            config);
+        append_row(text_embed, tts_eos);
+        append_rows(
+            state.prompt,
+            add_rows(
+                text_embed,
+                lookup_rows(
+                    weights.codec_embedding,
+                    config.hidden_size,
+                    std::vector<int32_t>(text_ids.size() + 1, static_cast<int32_t>(config.codec_pad_id)))));
+        append_row(state.prompt, add_rows(tts_pad, row_at(codec_embed, codec_rows - 1, config.hidden_size)));
+        state.trailing_text = tts_pad;
+        return state;
+    }
+
     const std::vector<int32_t> ref_text_ids(prefill.reference_ids.begin() + 3, prefill.reference_ids.end() - 2);
     std::vector<int32_t> combined_text = ref_text_ids;
     combined_text.insert(combined_text.end(), text_ids.begin(), text_ids.end());
@@ -968,8 +998,9 @@ public:
         }
         ggml_backend_tensor_set(input_, embeddings.data(), 0, embeddings.size() * sizeof(float));
         core::set_backend_threads(weights_->backend(), weights_->threads());
+        // compute_backend_graph is synchronous; an additional backend-wide wait
+        // before the blocking output reads only duplicates that synchronization.
         const ggml_status status = engine::core::compute_backend_graph(weights_->backend(), graph_);
-        ggml_backend_synchronize(weights_->backend());
         if (status != GGML_STATUS_SUCCESS) {
             throw std::runtime_error("Qwen3 talker prefill graph compute failed");
         }
@@ -1120,7 +1151,6 @@ public:
         core::set_backend_threads(weights_->backend(), weights_->threads());
         timing_start = Clock::now();
         const ggml_status status = engine::core::compute_backend_graph(weights_->backend(), graph_);
-        ggml_backend_synchronize(weights_->backend());
         last_timing_.graph_compute_ms = engine::debug::elapsed_ms(timing_start, Clock::now());
         if (status != GGML_STATUS_SUCCESS) {
             throw std::runtime_error("Qwen3 talker cached step graph compute failed");
@@ -1555,7 +1585,6 @@ private:
         core::set_backend_threads(weights_->backend(), weights_->threads());
         timing_start = Clock::now();
         const ggml_status status = engine::core::compute_backend_graph(weights_->backend(), prefill_graph_);
-        ggml_backend_synchronize(weights_->backend());
         timing_.graph_compute_ms += engine::debug::elapsed_ms(timing_start, Clock::now());
         if (status != GGML_STATUS_SUCCESS) {
             throw std::runtime_error("Qwen3 code predictor prefill graph compute failed");
@@ -1597,7 +1626,6 @@ private:
         core::set_backend_threads(weights_->backend(), weights_->threads());
         timing_start = Clock::now();
         const ggml_status status = engine::core::compute_backend_graph(weights_->backend(), step_graph.graph);
-        ggml_backend_synchronize(weights_->backend());
         timing_.graph_compute_ms += engine::debug::elapsed_ms(timing_start, Clock::now());
         if (status != GGML_STATUS_SUCCESS) {
             throw std::runtime_error("Qwen3 code predictor step graph compute failed");

--- a/src/models/qwen3_tts/tokenizer_speech_decoder.cpp
+++ b/src/models/qwen3_tts/tokenizer_speech_decoder.cpp
@@ -27,6 +27,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <stdexcept>
@@ -45,6 +46,12 @@ constexpr int64_t kSampleRate = 24000;
 constexpr int64_t kDecodeSamplesPerCode = 1920;
 constexpr int64_t kChunkCodes = 300;
 constexpr int64_t kLeftContextCodes = 25;
+constexpr std::array<int64_t, 2> kStrixHaloCachedChunkFrames{300, 105};
+#if defined(ENGINE_HIP_STRIX_HALO_OPTIMIZATIONS)
+constexpr bool kStrixHaloGraphCacheEnabled = true;
+#else
+constexpr bool kStrixHaloGraphCacheEnabled = false;
+#endif
 constexpr float kCodebookEps = 1.0e-5F;
 constexpr float kMaskNegInf = -1.0e9F;
 
@@ -1018,21 +1025,20 @@ public:
         if (gallocr_ == nullptr || !ggml_gallocr_alloc_graph(gallocr_, graph_)) {
             throw std::runtime_error("failed to allocate Qwen3 speech decoder graph");
         }
-        std::vector<int32_t> positions(static_cast<size_t>(code_frames_));
+        positions_data_.resize(static_cast<size_t>(code_frames_));
         for (int64_t i = 0; i < code_frames_; ++i) {
-            positions[static_cast<size_t>(i)] = static_cast<int32_t>(i);
+            positions_data_[static_cast<size_t>(i)] = static_cast<int32_t>(i);
         }
         const auto mask = make_mask(code_frames_, config.sliding_window);
-        ggml_backend_tensor_set(positions_, positions.data(), 0, positions.size() * sizeof(int32_t));
         if (perf_mode_ == Qwen3TTSPerfMode::FlashAttention) {
-            std::vector<ggml_fp16_t> mask_f16(mask.size());
+            mask_f16_data_.resize(mask.size());
             for (size_t index = 0; index < mask.size(); ++index) {
-                mask_f16[index] = ggml_fp32_to_fp16(mask[index]);
+                mask_f16_data_[index] = ggml_fp32_to_fp16(mask[index]);
             }
-            ggml_backend_tensor_set(mask_, mask_f16.data(), 0, mask_f16.size() * sizeof(ggml_fp16_t));
         } else {
-            ggml_backend_tensor_set(mask_, mask.data(), 0, mask.size() * sizeof(float));
+            mask_f32_data_ = mask;
         }
+        upload_static_inputs();
     }
 
     ~Qwen3SpeechTokenizerDecoderGraph() {
@@ -1059,6 +1065,10 @@ public:
             throw std::runtime_error("Qwen3 speech decoder code count exceeds graph capacity");
         }
         const auto upload_start = Clock::now();
+        // Cached GGML graphs may reuse backend allocations whose input contents are
+        // not guaranteed to survive a prior execution. Restore every declared input,
+        // not only the request-varying codes, before replaying a retained graph.
+        upload_static_inputs();
         std::vector<int32_t> tensor_codes(expected, 0);
         for (int64_t frame = 0; frame < input_frames; ++frame) {
             for (int64_t group = 0; group < weights_->config.num_quantizers; ++group) {
@@ -1071,7 +1081,6 @@ public:
         const auto compute_start = Clock::now();
         core::set_backend_threads(backend_, compute_threads_);
         const ggml_status status = engine::core::compute_backend_graph(backend_, graph_);
-        ggml_backend_synchronize(backend_);
         last_graph_compute_ms_ = engine::debug::elapsed_ms(compute_start, Clock::now());
         if (status != GGML_STATUS_SUCCESS) {
             throw std::runtime_error("Qwen3 speech decoder graph compute failed");
@@ -1096,6 +1105,27 @@ public:
     }
 
 private:
+    void upload_static_inputs() {
+        ggml_backend_tensor_set(
+            positions_,
+            positions_data_.data(),
+            0,
+            positions_data_.size() * sizeof(int32_t));
+        if (perf_mode_ == Qwen3TTSPerfMode::FlashAttention) {
+            ggml_backend_tensor_set(
+                mask_,
+                mask_f16_data_.data(),
+                0,
+                mask_f16_data_.size() * sizeof(ggml_fp16_t));
+        } else {
+            ggml_backend_tensor_set(
+                mask_,
+                mask_f32_data_.data(),
+                0,
+                mask_f32_data_.size() * sizeof(float));
+        }
+    }
+
     std::shared_ptr<const Qwen3SpeechTokenizerDecoderWeights> weights_;
     int64_t code_frames_ = 0;
     int64_t waveform_frames_ = 0;
@@ -1106,6 +1136,9 @@ private:
     ggml_tensor * positions_ = nullptr;
     ggml_tensor * mask_ = nullptr;
     ggml_tensor * output_ = nullptr;
+    std::vector<int32_t> positions_data_;
+    std::vector<float> mask_f32_data_;
+    std::vector<ggml_fp16_t> mask_f16_data_;
     ggml_cgraph * graph_ = nullptr;
     ggml_gallocr_t gallocr_ = nullptr;
     Qwen3TTSPerfMode perf_mode_ = Qwen3TTSPerfMode::Standard;
@@ -1161,6 +1194,8 @@ runtime::AudioBuffer Qwen3SpeechTokenizerDecoderRuntime::decode(const Qwen3Speec
     int64_t chunks = 0;
     int64_t graph_rebuilds = 0;
     int64_t max_chunk_frames = 0;
+    const bool optimized_cache_enabled =
+        kStrixHaloGraphCacheEnabled && execution_context_->backend_type() == core::BackendType::Hip;
     for (int64_t start = 0; start < codec_codes.frames; start += kChunkCodes) {
         const int64_t end = std::min<int64_t>(start + kChunkCodes, codec_codes.frames);
         const int64_t context = start > kLeftContextCodes ? kLeftContextCodes : start;
@@ -1175,10 +1210,23 @@ runtime::AudioBuffer Qwen3SpeechTokenizerDecoderRuntime::decode(const Qwen3Speec
             std::copy(src, src + codec_codes.code_groups, dst);
         }
         const int threads = std::max(1, execution_context_->config().threads);
-        if (graph_ == nullptr || !graph_->matches(*weights_, chunk_frames, execution_context_->backend(), threads)) {
+        auto * graph_slot = &graph_;
+#if defined(ENGINE_HIP_STRIX_HALO_OPTIMIZATIONS)
+        if (optimized_cache_enabled) {
+            for (size_t index = 0; index < kStrixHaloCachedChunkFrames.size(); ++index) {
+                if (chunk_frames == kStrixHaloCachedChunkFrames[index]) {
+                    graph_slot = &optimized_graphs_[index];
+                    break;
+                }
+            }
+        }
+#endif
+        auto & graph = *graph_slot;
+        const bool graph_rebuilt =
+            graph == nullptr || !graph->matches(*weights_, chunk_frames, execution_context_->backend(), threads);
+        if (graph_rebuilt) {
             const auto build_start = Clock::now();
-            graph_.reset();
-            graph_ = std::make_unique<Qwen3SpeechTokenizerDecoderGraph>(
+            auto replacement = std::make_unique<Qwen3SpeechTokenizerDecoderGraph>(
                 weights_,
                 chunk_frames,
                 *execution_context_,
@@ -1186,12 +1234,13 @@ runtime::AudioBuffer Qwen3SpeechTokenizerDecoderRuntime::decode(const Qwen3Speec
                 graph_arena_bytes_,
                 perf_mode_);
             graph_build_ms += engine::debug::elapsed_ms(build_start, Clock::now());
+            graph = std::move(replacement);
             ++graph_rebuilds;
         }
-        auto decoded = graph_->run(chunk.data(), chunk.size());
-        input_upload_ms += graph_->last_input_upload_ms();
-        graph_compute_ms += graph_->last_graph_compute_ms();
-        output_read_ms += graph_->last_output_read_ms();
+        auto decoded = graph->run(chunk.data(), chunk.size());
+        input_upload_ms += graph->last_input_upload_ms();
+        graph_compute_ms += graph->last_graph_compute_ms();
+        output_read_ms += graph->last_output_read_ms();
         ++chunks;
         const int64_t drop = context * kDecodeSamplesPerCode;
         if (drop > static_cast<int64_t>(decoded.size())) {
@@ -1221,22 +1270,34 @@ runtime::AudioBuffer Qwen3SpeechTokenizerDecoderRuntime::decode_and_trim_referen
     if (reference_codes.code_groups != generated_codes.code_groups) {
         throw std::runtime_error("Qwen3 speech decoder reference/generated code group mismatch");
     }
+    if (reference_codes.frames < 0 || generated_codes.frames < 0 || reference_codes.code_groups <= 0) {
+        throw std::runtime_error("Qwen3 speech decoder reference/generated code shape is invalid");
+    }
+    if (reference_codes.frames > std::numeric_limits<int64_t>::max() - generated_codes.frames) {
+        throw std::runtime_error("Qwen3 speech decoder combined frame count is too large");
+    }
     Qwen3SpeechCodes combined;
     combined.frames = reference_codes.frames + generated_codes.frames;
     combined.code_groups = reference_codes.code_groups;
-    combined.codes.reserve(static_cast<size_t>(combined.frames * combined.code_groups));
+    if (combined.frames > std::numeric_limits<int64_t>::max() / combined.code_groups) {
+        throw std::runtime_error("Qwen3 speech decoder combined code count is too large");
+    }
+    const int64_t combined_code_count = combined.frames * combined.code_groups;
+    if (static_cast<uint64_t>(combined_code_count) > std::numeric_limits<size_t>::max()) {
+        throw std::runtime_error("Qwen3 speech decoder combined code count exceeds host size limits");
+    }
+    combined.codes.reserve(static_cast<size_t>(combined_code_count));
     combined.codes.insert(combined.codes.end(), reference_codes.codes.begin(), reference_codes.codes.end());
     combined.codes.insert(combined.codes.end(), generated_codes.codes.begin(), generated_codes.codes.end());
     auto audio = decode(combined);
-    const int64_t cut = combined.frames > 0
-        ? static_cast<int64_t>(
-              static_cast<double>(reference_codes.frames) / static_cast<double>(combined.frames) *
-              static_cast<double>(audio.samples.size()))
-        : 0;
-    if (cut < 0 || cut > static_cast<int64_t>(audio.samples.size())) {
+    if (reference_codes.frames > std::numeric_limits<int64_t>::max() / kDecodeSamplesPerCode) {
+        throw std::runtime_error("Qwen3 speech decoder reference sample count is too large");
+    }
+    const int64_t cut = reference_codes.frames * kDecodeSamplesPerCode;
+    if (static_cast<uint64_t>(cut) > audio.samples.size()) {
         throw std::runtime_error("Qwen3 speech decoder reference trim is out of range");
     }
-    audio.samples.erase(audio.samples.begin(), audio.samples.begin() + cut);
+    audio.samples.erase(audio.samples.begin(), audio.samples.begin() + static_cast<std::ptrdiff_t>(cut));
     return audio;
 }
 

--- a/tests/unittests/test_conv_transpose_fast_path.cpp
+++ b/tests/unittests/test_conv_transpose_fast_path.cpp
@@ -337,6 +337,22 @@ RunResult run_conv_transpose_ab_case(
     return runner.run_f32(output);
 }
 
+void require_cuda_family_backend_classification() {
+    static_assert(engine::core::uses_ggml_cuda_family_backend(engine::core::BackendType::Cuda));
+    static_assert(engine::core::uses_ggml_cuda_family_backend(engine::core::BackendType::Hip));
+    static_assert(!engine::core::uses_ggml_cuda_family_backend(engine::core::BackendType::Cpu));
+    static_assert(!engine::core::uses_ggml_cuda_family_backend(engine::core::BackendType::Vulkan));
+    static_assert(!engine::core::uses_ggml_cuda_family_backend(engine::core::BackendType::Metal));
+
+    const ConvTransposeCase test_case{"hip_trigger_condition_probe", 1, 256, 128, 96, 10, 5, true};
+    const auto eligible_config = make_config(test_case);
+    engine::core::ModuleBuildContext hip_context{};
+    hip_context.backend_type = engine::core::BackendType::Hip;
+    if (!engine::modules::is_conv_transpose1d_col2im_fast_path_eligible(hip_context, eligible_config)) {
+        throw std::runtime_error("expected HIP conv-transpose config to be col2im fast-path eligible");
+    }
+}
+
 void require_fast_path_trigger_conditions(engine::core::BackendType backend_type) {
     BackendModuleRunner cuda_runner("conv_transpose_fast_path_test.cuda_trigger", backend_type);
     BackendModuleRunner cpu_runner("conv_transpose_fast_path_test.cpu_trigger", engine::core::BackendType::Cpu);
@@ -459,6 +475,7 @@ int main() {
     try {
         const ConvTransposeCase qwen3_case{"qwen3_decoder_mid_block_biased", 1, 256, 128, 96, 10, 5, true};
         const ConvTransposeCase batched_case{"batched_decoder_block_no_bias", 2, 192, 192, 48, 2, 2, false};
+        require_cuda_family_backend_classification();
 
         constexpr auto kBackend = engine::core::BackendType::Cuda;
         if (!backend_is_available(kBackend)) {

--- a/tests/unittests/test_qwen3_tts_options_config.cpp
+++ b/tests/unittests/test_qwen3_tts_options_config.cpp
@@ -1,0 +1,201 @@
+#include "engine/models/qwen3_tts/assets.h"
+#include "engine/models/qwen3_tts/session.h"
+#include "engine/models/qwen3_tts/talker.h"
+
+#include <functional>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+using engine::models::qwen3_tts::Qwen3TTSConfig;
+
+Qwen3TTSConfig valid_config() {
+  Qwen3TTSConfig config;
+  config.variant = engine::models::qwen3_tts::Qwen3TTSVariant::Base;
+  config.tokenizer_type = "qwen3_tts_tokenizer_12hz";
+  config.max_new_tokens = 64;
+
+  config.talker.max_position_embeddings = 4096;
+  config.talker.hidden_size = 128;
+  config.talker.text_hidden_size = 128;
+  config.talker.text_vocab_size = 1024;
+  config.talker.intermediate_size = 256;
+  config.talker.num_hidden_layers = 2;
+  config.talker.num_attention_heads = 4;
+  config.talker.num_key_value_heads = 2;
+  config.talker.head_dim = 32;
+  config.talker.num_code_groups = 4;
+  config.talker.vocab_size = 2048;
+
+  config.code_predictor.hidden_size = 128;
+  config.code_predictor.intermediate_size = 256;
+  config.code_predictor.num_hidden_layers = 2;
+  config.code_predictor.num_attention_heads = 4;
+  config.code_predictor.num_key_value_heads = 2;
+  config.code_predictor.head_dim = 32;
+  config.code_predictor.vocab_size = 2048;
+
+  config.speech_tokenizer.model_type = "qwen3_tts_tokenizer_12hz";
+  config.speech_tokenizer.input_sample_rate = 24000;
+  config.speech_tokenizer.output_sample_rate = 24000;
+  config.speech_tokenizer.num_quantizers = 4;
+  config.speech_tokenizer.codebook_size = 2048;
+  config.speech_tokenizer.semantic_codebook_size = 2048;
+
+  config.has_speaker_encoder = true;
+  config.speaker_encoder.embedding_dim = 128;
+  config.speaker_encoder.sample_rate = 24000;
+  return config;
+}
+
+void expect_throw(const std::function<void()> &fn, const std::string &label) {
+  try {
+    fn();
+  } catch (const std::exception &) {
+    return;
+  }
+  throw std::runtime_error(label + " did not throw");
+}
+
+void test_config_validation() {
+  auto config = valid_config();
+  engine::models::qwen3_tts::validate_qwen3_tts_config(config);
+
+  auto invalid = config;
+  invalid.talker.num_attention_heads = 0;
+  expect_throw(
+      [&] { engine::models::qwen3_tts::validate_qwen3_tts_config(invalid); },
+      "zero talker attention heads");
+
+  invalid = config;
+  invalid.code_predictor.head_dim = 31;
+  engine::models::qwen3_tts::validate_qwen3_tts_config(invalid);
+
+  invalid = config;
+  invalid.code_predictor.head_dim = 0;
+  expect_throw(
+      [&] { engine::models::qwen3_tts::validate_qwen3_tts_config(invalid); },
+      "non-positive code predictor head dimension");
+
+  invalid = config;
+  invalid.speaker_encoder.embedding_dim = 64;
+  expect_throw(
+      [&] { engine::models::qwen3_tts::validate_qwen3_tts_config(invalid); },
+      "speaker encoder and talker dimension mismatch");
+
+  invalid = config;
+  invalid.speech_tokenizer.num_quantizers = 3;
+  expect_throw(
+      [&] { engine::models::qwen3_tts::validate_qwen3_tts_config(invalid); },
+      "mismatched codec group count");
+}
+
+void test_generation_options() {
+  const auto config = valid_config();
+  engine::runtime::TaskRequest request;
+  request.options["max_tokens"] = "8";
+  request.options["seed"] = "123";
+  request.options["do_sample"] = "false";
+  request.options["subtalker_do_sample"] = "false";
+  request.options["temperature"] = "0";
+  request.options["subtalker_temperature"] = "0";
+  request.options["top_k"] = "0";
+  request.options["subtalker_top_k"] = "0";
+  request.options["top_p"] = "0";
+  request.options["subtalker_top_p"] = "0";
+  request.options["repetition_penalty"] = "1.1";
+
+  const auto options =
+      engine::models::qwen3_tts::qwen3_tts_generation_options_from_request(
+          request, config);
+  if (options.max_new_tokens != 8 || options.seed != 123 || options.do_sample ||
+      options.subtalker_do_sample || options.top_p != 0.0F ||
+      options.subtalker_top_p != 0.0F) {
+    throw std::runtime_error(
+        "canonical Qwen3 TTS generation options were not parsed");
+  }
+
+  request.options["do_sample"] = "true";
+  expect_throw(
+      [&] {
+        (void)engine::models::qwen3_tts::
+            qwen3_tts_generation_options_from_request(request, config);
+      },
+      "zero sampling temperature");
+
+  request.options["do_sample"] = "false";
+  request.options["top_p"] = "nan";
+  expect_throw(
+      [&] {
+        (void)engine::models::qwen3_tts::
+            qwen3_tts_generation_options_from_request(request, config);
+      },
+      "non-finite top_p");
+
+  request.options["top_p"] = "-0.1";
+  expect_throw(
+      [&] {
+        (void)engine::models::qwen3_tts::
+            qwen3_tts_generation_options_from_request(request, config);
+      },
+      "negative top_p");
+
+  request.options["top_p"] = "1";
+  request.options["subtalker_top_p"] = "-0.1";
+  expect_throw(
+      [&] {
+        (void)engine::models::qwen3_tts::
+            qwen3_tts_generation_options_from_request(request, config);
+      },
+      "negative subtalker_top_p");
+
+  request.options["subtalker_top_p"] = "1";
+  request.options["subtalker_top_k"] = "-1";
+  expect_throw(
+      [&] {
+        (void)engine::models::qwen3_tts::
+            qwen3_tts_generation_options_from_request(request, config);
+      },
+      "negative subtalker_top_k");
+}
+
+void test_voice_clone_prefill_mode_validation() {
+  engine::models::qwen3_tts::Qwen3TalkerPrefill prefill;
+  prefill.speaker_embedding = engine::models::qwen3_tts::Qwen3SpeakerEmbedding{
+      std::vector<float>(128, 0.0F), 128};
+  prefill.x_vector_only_mode = true;
+  engine::models::qwen3_tts::validate_qwen3_talker_voice_clone_prefill(
+      prefill, 128);
+
+  prefill.x_vector_only_mode = false;
+  prefill.icl_mode = true;
+  expect_throw(
+      [&] {
+        engine::models::qwen3_tts::validate_qwen3_talker_voice_clone_prefill(
+            prefill, 128);
+      },
+      "ICL prefill without reference state");
+
+  prefill.reference_ids = {1};
+  prefill.reference_codes = engine::models::qwen3_tts::Qwen3SpeechCodes{};
+  engine::models::qwen3_tts::validate_qwen3_talker_voice_clone_prefill(
+      prefill, 128);
+}
+
+} // namespace
+
+int main() {
+  try {
+    test_config_validation();
+    test_generation_options();
+    test_voice_clone_prefill_mode_validation();
+    std::cout << "qwen3_tts_options_config_test: ok\n";
+    return 0;
+  } catch (const std::exception &ex) {
+    std::cerr << "qwen3_tts_options_config_test: failed: " << ex.what() << '\n';
+    return 1;
+  }
+}

--- a/tests/unittests/test_qwen_decoder_packed_projections.cpp
+++ b/tests/unittests/test_qwen_decoder_packed_projections.cpp
@@ -2,6 +2,7 @@
 #include "engine/framework/modules/transformers/qwen_causal_decoder.h"
 #include "engine/framework/modules/transformers/qwen_decoder.h"
 #include "engine/framework/modules/optimizations/fast_kv_modules.h"
+#include "engine/framework/modules/optimizations/fast_projection_modules.h"
 
 #include <cmath>
 #include <initializer_list>
@@ -398,6 +399,72 @@ std::string graph_ops(ggml_cgraph * graph) {
     return out.str();
 }
 
+void test_fast_projection_accepts_cuda_family_backends() {
+    constexpr int64_t in_features = 8;
+    constexpr int64_t out_features = 12;
+    for (const auto backend_type : {
+             engine::core::BackendType::Cuda,
+             engine::core::BackendType::Hip,
+         }) {
+        ggml_init_params params{kGraphBytes, nullptr, true};
+        ggml_context * ggml = ggml_init(params);
+        if (ggml == nullptr) {
+            throw std::runtime_error("failed to initialize fast projection graph test context");
+        }
+        try {
+            engine::core::ModuleBuildContext ctx{ggml, "fast_projection_cuda_family_test", backend_type};
+            const auto input = engine::core::make_tensor(
+                ctx,
+                GGML_TYPE_F32,
+                engine::core::TensorShape::from_dims({1, in_features}));
+            const auto weight = engine::core::make_tensor(
+                ctx,
+                GGML_TYPE_F32,
+                engine::core::TensorShape::from_dims({out_features, in_features}));
+            const auto output = engine::modules::FastPackedProjection4Module({in_features, out_features})
+                                    .build(ctx, input, {weight, std::nullopt});
+            if (output.shape.rank != 2 || output.shape.dims[0] != 1 || output.shape.dims[1] != out_features) {
+                throw std::runtime_error("fast projection CUDA-family output shape mismatch");
+            }
+            ggml_free(ggml);
+        } catch (...) {
+            ggml_free(ggml);
+            throw;
+        }
+    }
+
+    ggml_init_params params{kGraphBytes, nullptr, true};
+    ggml_context * ggml = ggml_init(params);
+    if (ggml == nullptr) {
+        throw std::runtime_error("failed to initialize fast projection rejection test context");
+    }
+    bool rejected = false;
+    try {
+        engine::core::ModuleBuildContext ctx{ggml, "fast_projection_cpu_rejection_test", engine::core::BackendType::Cpu};
+        const auto input = engine::core::make_tensor(
+            ctx,
+            GGML_TYPE_F32,
+            engine::core::TensorShape::from_dims({1, in_features}));
+        const auto weight = engine::core::make_tensor(
+            ctx,
+            GGML_TYPE_F32,
+            engine::core::TensorShape::from_dims({out_features, in_features}));
+        try {
+            (void) engine::modules::FastPackedProjection4Module({in_features, out_features})
+                .build(ctx, input, {weight, std::nullopt});
+        } catch (const std::runtime_error &) {
+            rejected = true;
+        }
+        ggml_free(ggml);
+    } catch (...) {
+        ggml_free(ggml);
+        throw;
+    }
+    if (!rejected) {
+        throw std::runtime_error("fast projection must reject non-CUDA-family backends");
+    }
+}
+
 void test_higgs_decode_graph_exposes_cuda_fast_paths() {
     constexpr int64_t hidden = 8;
     constexpr int64_t heads = 2;
@@ -504,6 +571,7 @@ int main() {
         test_suffix_causal_mask();
         test_f16_kv_set_rows();
         test_f16_kv_set_rows_batched();
+        test_fast_projection_accepts_cuda_family_backends();
         test_higgs_decode_graph_exposes_cuda_fast_paths();
         std::cout << "qwen_decoder_packed_projection_test: ok\n";
         return 0;


### PR DESCRIPTION
## What does this PR do?

- `.devops/nix/package.nix`, `flake.nix`, `CMakeLists.txt`: add an opt-in `rocm-gfx1151` build. It enables the Strix Halo path only for HIP with exactly `gfx1151`, and keeps rocBLAS because hipBLASLt regressed latency on this hardware.
- `include/engine/framework/core/module.h`, `src/framework/modules/{conv_modules.cpp,optimizations/fast_projection_modules.cpp}`: allow HIP to use the verified GGML CUDA-family ConvTranspose1d and packed-projection paths used by Qwen3-TTS. Other backends keep their existing behavior.
- `src/models/qwen3_tts/assets.cpp`: validate transformer dimensions, model configuration, and numeric parameters before loading invalid graphs.
- `src/models/qwen3_tts/session.cpp`, `src/models/qwen3_tts/talker.cpp`: validate generation options and voice-clone inputs, support speaker-embedding-only mode, make `mem_saver` cleanup exception-safe, and remove redundant backend synchronizations.
- `src/models/qwen3_tts/tokenizer_speech_decoder.cpp`: retain the common 300- and 105-frame decoder graphs, restore every graph input before reuse, safely replace fallback shapes, and validate reference-audio trimming.
- `tests/unittests/*qwen*`, `tests/unittests/test_conv_transpose_fast_path.cpp`: cover configuration validation and HIP fast-path selection while confirming unsupported backends are rejected.

All Strix-specific behavior is disabled by default. Generic CPU, CUDA, Vulkan, Metal, and HIP builds retain their current defaults.

## Motivation

Qwen3-TTS repeatedly rebuilt stable decoder graphs on Strix Halo and showed a 1-second/2-second decoder compute mode. Reusing those graphs removes graph construction and stabilizes decoder execution, but reuse is only correct when codes, positions, and attention masks are restored before every invocation.

The implementation is restricted to the tested `gfx1151` HIP configuration so hardware-specific tuning does not affect generic builds. hipBLASLt and HIP graph capture are not enabled because they were slower in testing.

## Gains

Correctness-matched Ryzen AI Max / Strix Halo results with HIP graphs disabled:

| Metric | Before | After | Gain |
| --- | ---: | ---: | ---: |
| Mean synthesis latency | 10.400 s | 9.454 s | **9.1%** |
| Median synthesis latency | 10.499 s | 9.354 s | **10.9%** |
| Decoder latency | 2.369 s | 1.304 s | **45.0%** |
| Decoder graph build | 140 ms | 0 ms | **100%** |

All 29 cold, warmup, and measured calls produced the same audio digest and sample metadata.

## How to use it

Use the specialized Nix development shell:

```bash
nix develop .#rocm-gfx1151
```

Or configure manually:

```bash
cmake -S . -B build/rocm-gfx1151 -G Ninja \
  -DCMAKE_BUILD_TYPE=Release \
  -DENGINE_ENABLE_HIP=ON \
  -DGPU_TARGETS=gfx1151 \
  -DENGINE_HIP_STRIX_HALO_OPTIMIZATIONS=ON
cmake --build build/rocm-gfx1151 --parallel
```

Run `audiocpp_cli` normally with the HIP backend. The decoder cache activates automatically for the specialized build when the runtime backend is HIP.

For generic ROCm behavior, use `nix develop .#rocm` or leave `ENGINE_HIP_STRIX_HALO_OPTIMIZATIONS=OFF`.

## AI usage disclosure

AI was used for the following purposes:

- understand project structure and validate hypothesis about code organization
- help defining benchmarking scripts (not included in the PR)
- clean-up code after manual definition

AI was NOT used for the following purposes:

- optimization ideas
- basic implementation
- initial exploration of similar projects like llama-cpp and [CrispASR](https://github.com/CrispStrobe/CrispASR)