### PR TITLE
Feat: list devices

### DIFF
--- a/app/cli/main.cpp
+++ b/app/cli/main.cpp
@@ -56,6 +56,7 @@ void print_task_list_help() {
         << "    --backend cpu|cuda|hip|rocm|vulkan|metal|best  (rocm is an alias for hip)\n"
         << "    --mode offline|streaming  default offline\n"
         << "    --device <n>\n"
+        << "    --list-devices  List available backend devices and exit\n"
         << "    --threads <n>  Backend and OpenMP worker threads, default 4\n"
         << "    --registry-config <path>\n"
         << "    --model-spec-override <json-or-directory>  Override package-spec resolution\n"
@@ -622,6 +623,19 @@ int audiocpp_cli_main(int argc, char ** argv) {
             for (const auto & id : ids) {
                 std::cout << id << "\n";
             }
+            return 0;
+        }
+        if (has_arg(argc, argv, "--list-devices")) {
+            const auto devices = engine::core::list_backend_devices();
+            std::cout << "available_devices=" << devices.size() << "\n";
+            for (const auto & device : devices) {
+                std::cout << device.backend << ":" << device.index;
+                if (!device.name.empty()) {
+                    std::cout << " \"" << device.name << "\"";
+                }
+                std::cout << " [" << device.type << "]\n";
+            }
+            std::cout << "select with: --backend <cuda|hip|vulkan|metal|cpu> --device <index>\n";
             return 0;
         }
         if (has_arg(argc, argv, "--list-loaders")) {

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -16,6 +16,7 @@ audiocpp_cli --task <task> --family <family> --model <model-dir> --backend <back
 | `--backend` | `cpu`, `cuda`, `vulkan`, `metal`, `best` | `cpu` | Inference backend. |
 | `--mode` | `offline`, `streaming` | `offline` | Run mode. Most models are offline. |
 | `--device` | integer | `0` | Backend device index. |
+| `--list-devices` | flag | off | List available backend devices and exit; combine with `--backend`/`--device` to select one. |
 | `--threads` | integer | `4` | Backend/OpenMP worker threads. |
 | `--log` | flag | off | Print progress and timing logs to stdout. |
 | `--log-file` | path | not set | Stream progress and timing logs to a file. |

--- a/include/engine/framework/core/backend.h
+++ b/include/engine/framework/core/backend.h
@@ -19,6 +19,16 @@ struct BackendConfig {
     int threads = 1;
 };
 
+struct BackendDeviceInfo {
+    std::string backend;    // ggml registry name, e.g. "CUDA", "ROCm", "Vulkan", "CPU"
+    int index = 0;          // device index within the owning registry (the value --device takes)
+    std::string name;       // human-readable device name
+    std::string type;       // CPU, GPU, IGPU, ACCEL, or META
+};
+
+// Enumerates every device of every loaded ggml backend registry, in registry order.
+std::vector<BackendDeviceInfo> list_backend_devices();
+
 struct BackendMemorySnapshot {
     bool available = false;
     int64_t total_bytes = 0;

--- a/src/framework/core/backend.cpp
+++ b/src/framework/core/backend.cpp
@@ -119,30 +119,15 @@ const char * backend_dev_type_label(enum ggml_backend_dev_type type) {
 
 std::string describe_available_devices() {
     std::string description;
-    for (size_t i = 0; i < ggml_backend_reg_count(); ++i) {
-        ggml_backend_reg_t reg = ggml_backend_reg_get(i);
-        if (reg == nullptr) {
-            continue;
+    for (const auto & device : list_backend_devices()) {
+        if (!description.empty()) {
+            description += ", ";
         }
-        const char * reg_name = ggml_backend_reg_name(reg);
-        for (size_t j = 0; j < ggml_backend_reg_dev_count(reg); ++j) {
-            ggml_backend_dev_t dev = ggml_backend_reg_dev_get(reg, j);
-            if (dev == nullptr) {
-                continue;
-            }
-            if (!description.empty()) {
-                description += ", ";
-            }
-            description += (reg_name != nullptr ? reg_name : "<unnamed>");
-            description += ":" + std::to_string(j);
-            const char * dev_name = ggml_backend_dev_name(dev);
-            if (dev_name != nullptr) {
-                description += " \"" + std::string(dev_name) + "\"";
-            }
-            description += " [";
-            description += backend_dev_type_label(ggml_backend_dev_type(dev));
-            description += "]";
+        description += device.backend + ":" + std::to_string(device.index);
+        if (!device.name.empty()) {
+            description += " \"" + device.name + "\"";
         }
+        description += " [" + device.type + "]";
     }
     return description.empty() ? "none" : description;
 }
@@ -188,6 +173,40 @@ bool backend_graph_validation_enabled() {
 }
 #endif
 
+}  // namespace
+
+std::vector<BackendDeviceInfo> list_backend_devices() {
+    ensure_backends_loaded();
+    std::vector<BackendDeviceInfo> devices;
+    for (size_t i = 0; i < ggml_backend_reg_count(); ++i) {
+        ggml_backend_reg_t reg = ggml_backend_reg_get(i);
+        if (reg == nullptr) {
+            continue;
+        }
+        const char * reg_name = ggml_backend_reg_name(reg);
+        for (size_t j = 0; j < ggml_backend_reg_dev_count(reg); ++j) {
+            ggml_backend_dev_t dev = ggml_backend_reg_dev_get(reg, j);
+            if (dev == nullptr) {
+                continue;
+            }
+            BackendDeviceInfo info;
+            info.backend = reg_name != nullptr ? reg_name : "<unnamed>";
+            info.index = static_cast<int>(j);
+            // Prefer the description: ggml's device name is a generic handle
+            // ("CUDA0", "ROCm0"), while the description carries the hardware
+            // name ("NVIDIA GeForce RTX 2080 Ti") that tells identical cards apart.
+            const char * dev_description = ggml_backend_dev_description(dev);
+            const char * dev_name = ggml_backend_dev_name(dev);
+            if (dev_description != nullptr && dev_description[0] != '\0') {
+                info.name = dev_description;
+            } else if (dev_name != nullptr) {
+                info.name = dev_name;
+            }
+            info.type = backend_dev_type_label(ggml_backend_dev_type(dev));
+            devices.push_back(std::move(info));
+        }
+    }
+    return devices;
 }
 
 ggml_backend_t init_backend(const BackendConfig & config) {


### PR DESCRIPTION
Hi! I'd like to add a new feature that lists the available GPU devices. Users with multiple GPUs often don't know which index maps to which card, which makes it confusing to pick a device when deploying a model. This adds a --list-devices flag for that, similar to what llama.cpp provides.

eg:

```
PS C:\Users\Mark\Workspace\CProject\my\audio.cpp\build\windows-cpu-release\bin> .\audiocpp_cli.exe --list-devices
available_devices=1
CPU:0 "AMD Ryzen 7 8745HS w/ Radeon 780M Graphics     " [CPU]
select with: --backend <cuda|hip|vulkan|metal|cpu> --device <index>
```

```
mark@MarkPC:~/Workspace/list-devices-test/build/hip/bin$ ./audiocpp_cli --list-devices
ggml_cuda_init: found 1 ROCm devices (Total VRAM: 122880 MiB):
  Device 0: AMD Radeon 8060S Graphics, gfx1151 (0x1151), VMM: no, Wave Size: 32, VRAM: 122880 MiB
available_devices=2
ROCm:0 "AMD Radeon 8060S Graphics" [GPU]
CPU:0 "AMD RYZEN AI MAX+ 395 w/ Radeon 8060S" [CPU]
select with: --backend <cuda|hip|vulkan|metal|cpu> --device <index>
```


```
mark@MarkPC:~/Workspace/list-devices-test/build/cuda/bin$ ./audiocpp_cli --list-devices
ggml_cuda_init: found 1 CUDA devices (Total VRAM: 22001 MiB):
  Device 0: NVIDIA GeForce RTX 2080 Ti, compute capability 7.5, VMM: yes, VRAM: 22001 MiB
available_devices=2
CUDA:0 "NVIDIA GeForce RTX 2080 Ti" [GPU]
CPU:0 "AMD RYZEN AI MAX+ 395 w/ Radeon 8060S" [CPU]
select with: --backend <cuda|hip|vulkan|metal|cpu> --device <index>
```
