### PR TITLE
Add nix CI workflow and fix package.nix build

### DIFF
--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -92,9 +92,10 @@ stdenv.mkDerivation (finalAttrs: {
     # Copy the built C++ executables directly from the bin directory
     cp bin/audiocpp_cli bin/audiocpp_server bin/audiocpp_gguf $out/bin/
 
-    # Install the python model manager script
-    cp $src/tools/model_manager.py $out/bin/audiocpp_model_manager
-    chmod +x $out/bin/audiocpp_model_manager
+    # Install the supported spec-backed model manager and the catalog it reads
+    # relative to its installed location.
+    install -Dm755 $src/tools/model_manager_v2.py $out/bin/audiocpp_model_manager
+    cp -R $src/model_specs $out/model_specs
 
     # Patch the shebang to use our python environment with torch/safetensors/pyyaml
     patchShebangs $out/bin/audiocpp_model_manager

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -1,0 +1,43 @@
+name: Nix Build
+
+on:
+    push:
+        branches:
+            - ci/**
+            - main
+            - dev
+            - release-0.2
+    pull_request:
+        branches:
+            - main
+            - dev
+            - release-0.2
+    workflow_dispatch:
+
+jobs:
+    build:
+        name: Nix (${{ matrix.package }})
+        runs-on: ubuntu-24.04
+
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - package: cpu
+                    - package: vulkan
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Install Nix
+              uses: cachix/install-nix-action@v31
+
+            - name: Check loader/spec sync
+              run: |
+                  python3 tools/check_loader_catalog_sync.py --self-test
+                  python3 tools/check_loader_catalog_sync.py
+
+            - name: Build ${{ matrix.package }}
+              run: |
+                  nix build ".#${{ matrix.package }}"


### PR DESCRIPTION
## Changes

- New .github/workflows/nix-build.yml builds .#cpu and .#vulkan via cachix/install-nix-action@v31
 - package.nix: install spec-backed model_manager_v2.py + model_specs dir (fixes broken build). Courtesy of @fedeizzo from #170 

Note: I didn't include intentionally as the ROCm dependencies are huge to pull within Nix. We might have to leverage some caching for that. Anyway cpu and vulkan builds only reflect the matrixes of other workflows and is a good starting point.

## Tests

Verified locally with [act](https://github.com/nektos/act) the new Nix CI is working as expected.

```
nix run nixpkgs#act -- -W .github/workflows/nix-build.yml
```
