### PR TITLE
Promote reusable framework runtime building blocks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,6 +247,7 @@ add_library(engine_core OBJECT
     src/framework/runtime/options.cpp
     src/framework/runtime/session_base.cpp
     src/framework/runtime/workspace.cpp
+    src/framework/midi/midi_file.cpp
     src/framework/io/filesystem.cpp
     src/framework/io/config.cpp
     src/framework/io/json.cpp
@@ -338,6 +339,7 @@ add_library(engine_core OBJECT
     src/framework/audio/zipenhancer.cpp
     src/framework/modules/speaker_encoders/ecapa_tdnn_runtime.cpp
     src/framework/modules/speaker_encoders/titanet_runtime.cpp
+    src/framework/codecs/mimi_codec_runtime.cpp
     src/framework/codecs/neural_audio.cpp
     src/framework/sampling/decode_modules.cpp
     src/framework/sampling/diffusion_math.cpp
@@ -1431,6 +1433,13 @@ if (ENGINE_BUILD_TESTS)
     add_test(
         NAME audio_dsp_test
         COMMAND audio_dsp_test
+    )
+
+    add_engine_unittest(midi_file_test tests/unittests/test_midi_file.cpp)
+
+    add_test(
+        NAME midi_file_test
+        COMMAND midi_file_test
     )
 
     add_engine_unittest(wav_reader_test tests/unittests/test_wav_reader.cpp)

--- a/app/workflow/file_sink.cpp
+++ b/app/workflow/file_sink.cpp
@@ -82,6 +82,8 @@ const char * artifact_kind_name(engine::runtime::ArtifactKind kind) {
         return "prompt_embedding";
     case engine::runtime::ArtifactKind::AcousticTokens:
         return "acoustic_tokens";
+    case engine::runtime::ArtifactKind::Midi:
+        return "midi";
     case engine::runtime::ArtifactKind::TranscriptAlignment:
         return "transcript_alignment";
     case engine::runtime::ArtifactKind::DiarizationState:
@@ -174,6 +176,38 @@ void write_wav_output(
     const auto tmp = path.parent_path() / (path.filename().string() + ".tmp");
     std::filesystem::remove(tmp);
     engine::audio::WavPcm16Sink().write(tmp, audio);
+    if (std::filesystem::exists(path)) {
+        std::filesystem::remove(path);
+    }
+    std::filesystem::rename(tmp, path);
+}
+
+std::string artifact_extension(const engine::runtime::VoiceArtifact & artifact) {
+    if (artifact.kind == engine::runtime::ArtifactKind::Midi) {
+        return ".mid";
+    }
+    return ".json";
+}
+
+void write_artifact_output(
+    const std::filesystem::path & path,
+    const engine::runtime::VoiceArtifact & artifact) {
+    if (!path.parent_path().empty()) {
+        std::filesystem::create_directories(path.parent_path());
+    }
+    const auto tmp = path.parent_path() / (path.filename().string() + ".tmp");
+    std::filesystem::remove(tmp);
+    std::ofstream output(tmp, std::ios::binary);
+    if (!output) {
+        throw std::runtime_error("failed to open artifact output: " + tmp.string());
+    }
+    output.write(
+        reinterpret_cast<const char *>(artifact.payload.data()),
+        static_cast<std::streamsize>(artifact.payload.size()));
+    if (!output) {
+        throw std::runtime_error("failed to write artifact output: " + tmp.string());
+    }
+    output.close();
     if (std::filesystem::exists(path)) {
         std::filesystem::remove(path);
     }
@@ -365,8 +399,12 @@ void emit_task_result(
                       << " bytes=" << artifact.payload.size() << "\n";
             if (artifact_out_dir.has_value()) {
                 std::filesystem::create_directories(*artifact_out_dir);
-                const auto path = *artifact_out_dir / (safe_output_name(artifact.id) + ".json");
-                std::ofstream(path) << artifact_to_json(artifact) << "\n";
+                const auto path = *artifact_out_dir / (safe_output_name(artifact.id) + artifact_extension(artifact));
+                if (artifact.kind == engine::runtime::ArtifactKind::Midi) {
+                    write_artifact_output(path, artifact);
+                } else {
+                    std::ofstream(path) << artifact_to_json(artifact) << "\n";
+                }
                 std::cout << "artifact_out[" << artifact.id << "]=" << path.string() << "\n";
             }
         }

--- a/include/engine/framework/codecs/mimi_codec_runtime.h
+++ b/include/engine/framework/codecs/mimi_codec_runtime.h
@@ -1,0 +1,221 @@
+#pragma once
+
+#include "engine/framework/assets/tensor_source.h"
+#include "engine/framework/codecs/neural_audio.h"
+#include "engine/framework/core/backend_weight_store.h"
+#include "engine/framework/modules/attention/types.h"
+#include "engine/framework/modules/attention/feed_forward.h"
+#include "engine/framework/modules/conditioning_modules.h"
+#include "engine/framework/modules/conv_modules.h"
+#include "engine/framework/modules/linear_module.h"
+#include "engine/framework/modules/norm_modules.h"
+#include "engine/framework/modules/streaming_conv_modules.h"
+#include "engine/framework/runtime/session.h"
+
+#include "ggml-backend.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace engine::codecs {
+
+struct MimiCodecConfig {
+    int sample_rate = 24000;
+    float frame_rate = 12.5F;
+    int64_t channels = 1;
+    int64_t hidden_size = 512;
+    int64_t num_heads = 8;
+    int64_t intermediate_size = 2048;
+    int64_t transformer_layers = 8;
+    int64_t context = 250;
+    int64_t latent_size = 256;
+    int64_t codebooks = 8;
+    int64_t total_codebooks = 32;
+    int64_t codebook_size = 2048;
+    int64_t encoder_upsample_stride = 16;
+};
+
+struct MimiCodecTransformerLayerWeights {
+    modules::NormWeights norm1;
+    modules::AttentionWeights self_attn;
+    modules::LayerScaleWeights layer_scale1;
+    modules::NormWeights norm2;
+    modules::FeedForwardWeights feed_forward;
+    modules::LayerScaleWeights layer_scale2;
+};
+
+struct MimiCodecResidualWeights {
+    modules::StreamingConv1dWeights conv1;
+    modules::StreamingConv1dWeights conv2;
+};
+
+struct MimiCodecEncoderWeights {
+    modules::StreamingConv1dWeights input_projection;
+    std::vector<MimiCodecResidualWeights> residual_blocks;
+    std::vector<modules::StreamingConv1dWeights> downsample_layers;
+    modules::StreamingConv1dWeights output_projection;
+    std::vector<MimiCodecTransformerLayerWeights> transformer_layers;
+    modules::StreamingConv1dWeights downsample_conv;
+};
+
+struct MimiCodecCodebookWeights {
+    core::TensorValue embedding;
+    std::vector<float> host_embedding;
+};
+
+struct MimiCodecQuantizerWeights {
+    std::vector<MimiCodecCodebookWeights> semantic_codebooks;
+    std::vector<MimiCodecCodebookWeights> acoustic_codebooks;
+    modules::Conv1dWeights semantic_input_proj;
+    modules::Conv1dWeights acoustic_input_proj;
+    modules::Conv1dWeights semantic_output_proj;
+    modules::Conv1dWeights acoustic_output_proj;
+};
+
+struct MimiCodecDecoderWeights {
+    std::vector<MimiCodecTransformerLayerWeights> transformer_layers;
+    modules::DepthwiseConvTranspose1dWeights upsample_conv;
+    SEANetDecoderWeights seanet;
+    std::vector<std::vector<float>> seanet_upsample_bias_values;
+};
+
+struct MimiCodecWeights {
+    std::shared_ptr<core::BackendWeightStore> store;
+    MimiCodecEncoderWeights encoder;
+    MimiCodecQuantizerWeights quantizer;
+    MimiCodecDecoderWeights decoder;
+};
+
+struct MimiCodecWeightBinding {
+    std::string encoder_input_projection_weight = "encoder.model.0.conv.conv.weight";
+    std::string encoder_input_projection_bias = "encoder.model.0.conv.conv.bias";
+    std::vector<std::string> encoder_residual_prefixes = {
+        "encoder.model.1",
+        "encoder.model.4",
+        "encoder.model.7",
+        "encoder.model.10",
+    };
+    std::vector<std::string> encoder_downsample_weight_names = {
+        "encoder.model.3.conv.conv.weight",
+        "encoder.model.6.conv.conv.weight",
+        "encoder.model.9.conv.conv.weight",
+        "encoder.model.12.conv.conv.weight",
+    };
+    std::vector<std::string> encoder_downsample_bias_names = {
+        "encoder.model.3.conv.conv.bias",
+        "encoder.model.6.conv.conv.bias",
+        "encoder.model.9.conv.conv.bias",
+        "encoder.model.12.conv.conv.bias",
+    };
+    std::string encoder_output_projection_weight = "encoder.model.14.conv.conv.weight";
+    std::string encoder_output_projection_bias = "encoder.model.14.conv.conv.bias";
+    std::string encoder_transformer_layer_prefix = "encoder_transformer.transformer.layers.";
+    std::string downsample_weight = "downsample.conv.conv.conv.weight";
+
+    std::string semantic_codebook_prefix = "quantizer.rvq_first.vq.layers.0._codebook.";
+    std::string acoustic_codebook_layer_prefix = "quantizer.rvq_rest.vq.layers.";
+    std::string acoustic_codebook_suffix = "._codebook.";
+    std::string semantic_input_projection_weight = "quantizer.rvq_first.input_proj.weight";
+    std::string acoustic_input_projection_weight = "quantizer.rvq_rest.input_proj.weight";
+    std::string semantic_output_projection_weight = "quantizer.rvq_first.output_proj.weight";
+    std::string acoustic_output_projection_weight = "quantizer.rvq_rest.output_proj.weight";
+
+    std::string decoder_transformer_layer_prefix = "decoder_transformer.transformer.layers.";
+    std::string decoder_upsample_weight = "upsample.convtr.convtr.convtr.weight";
+    std::string decoder_input_projection_weight = "decoder.model.0.conv.conv.weight";
+    std::string decoder_input_projection_bias = "decoder.model.0.conv.conv.bias";
+    std::vector<std::string> decoder_upsample_weight_names = {
+        "decoder.model.2.convtr.convtr.weight",
+        "decoder.model.5.convtr.convtr.weight",
+        "decoder.model.8.convtr.convtr.weight",
+        "decoder.model.11.convtr.convtr.weight",
+    };
+    std::vector<std::string> decoder_upsample_bias_names = {
+        "decoder.model.2.convtr.convtr.bias",
+        "decoder.model.5.convtr.convtr.bias",
+        "decoder.model.8.convtr.convtr.bias",
+        "decoder.model.11.convtr.convtr.bias",
+    };
+    std::vector<std::string> decoder_residual_prefixes = {
+        "decoder.model.3",
+        "decoder.model.6",
+        "decoder.model.9",
+        "decoder.model.12",
+    };
+    std::string decoder_output_projection_weight = "decoder.model.14.conv.conv.weight";
+    std::string decoder_output_projection_bias = "decoder.model.14.conv.conv.bias";
+};
+
+class MimiCodecComponent {
+public:
+    static MimiCodecComponent load_from_tensor_source(
+        std::shared_ptr<const assets::TensorSource> source,
+        MimiCodecConfig config,
+        MimiCodecWeightBinding weight_binding,
+        ggml_backend_t backend,
+        core::BackendType backend_type,
+        size_t context_bytes,
+        assets::TensorStorageType storage_type);
+
+    MimiCodecComponent() = default;
+    MimiCodecComponent(MimiCodecConfig config, std::shared_ptr<const MimiCodecWeights> weights);
+
+    const MimiCodecConfig & config() const noexcept;
+    const std::shared_ptr<const MimiCodecWeights> & weights() const noexcept;
+
+private:
+    MimiCodecConfig config_;
+    std::shared_ptr<const MimiCodecWeights> weights_;
+};
+
+class MimiDecoderRuntime {
+public:
+    MimiDecoderRuntime(
+        std::shared_ptr<const MimiCodecWeights> weights,
+        MimiCodecConfig config,
+        ggml_backend_t backend,
+        core::BackendType backend_type,
+        int threads,
+        size_t graph_arena_bytes);
+    ~MimiDecoderRuntime();
+
+    runtime::AudioBuffer decode(const std::vector<int32_t> & codes, int64_t frames);
+    void reset_streaming();
+    runtime::AudioBuffer decode_streaming(const std::vector<int32_t> & codes, int64_t frames);
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+class MimiEncoderRuntime {
+public:
+    MimiEncoderRuntime(
+        std::shared_ptr<const MimiCodecWeights> weights,
+        MimiCodecConfig config,
+        ggml_backend_t backend,
+        core::BackendType backend_type,
+        int threads,
+        size_t graph_arena_bytes);
+    ~MimiEncoderRuntime();
+
+    std::vector<int32_t> encode(const runtime::AudioBuffer & audio);
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+std::shared_ptr<const MimiCodecWeights> load_mimi_codec_weights(
+    const assets::TensorSource & source,
+    const MimiCodecConfig & config,
+    MimiCodecWeightBinding weight_binding,
+    ggml_backend_t backend,
+    core::BackendType backend_type,
+    size_t context_bytes,
+    assets::TensorStorageType storage_type);
+
+}  // namespace engine::codecs

--- a/include/engine/framework/midi/midi_file.h
+++ b/include/engine/framework/midi/midi_file.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <cstdint>
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace engine::midi {
+
+constexpr int kDrumProgram = 128;
+
+struct MidiNote {
+    bool is_drum = false;
+    int program = 0;
+    double onset_seconds = 0.0;
+    double offset_seconds = 0.0;
+    int pitch = 0;
+    std::string track_name;
+};
+
+struct MidiFileOptions {
+    int ticks_per_beat = 480;
+    int tempo_us_per_beat = 500000;
+    int velocity = 100;
+};
+
+std::vector<MidiNote> clean_midi_notes(std::vector<MidiNote> notes);
+std::vector<std::byte> write_standard_midi_file(
+    const std::vector<MidiNote> & notes,
+    const MidiFileOptions & options = {});
+
+}  // namespace engine::midi

--- a/include/engine/framework/modules/attention/feed_forward.h
+++ b/include/engine/framework/modules/attention/feed_forward.h
@@ -13,6 +13,7 @@ struct FeedForwardConfig {
     int64_t intermediate_size = 0;
     bool use_bias = true;
     GeluApproximation gelu_approximation = GeluApproximation::ExactErf;
+    ggml_prec projection_precision = GGML_PREC_DEFAULT;
 };
 
 struct FeedForwardWeights {

--- a/include/engine/framework/modules/attention/scaled_dot_product_attention.h
+++ b/include/engine/framework/modules/attention/scaled_dot_product_attention.h
@@ -12,6 +12,7 @@ enum class ScaledDotProductAttentionLowering {
     Explicit,
     Flash,
     FlashPreserveViews,
+    ExplicitCpuPerHead,
 };
 
 enum class AttentionCausality {

--- a/include/engine/framework/modules/attention/transformer_blocks.h
+++ b/include/engine/framework/modules/attention/transformer_blocks.h
@@ -19,6 +19,9 @@ struct TransformerEncoderBlockConfig {
     int64_t intermediate_size = 0;
     float eps = 1e-5f;
     bool use_bias = true;
+    ggml_prec projection_precision = GGML_PREC_DEFAULT;
+    ggml_prec attention_precision = GGML_PREC_DEFAULT;
+    AttentionPrefixCacheLayout prefix_cache_layout = AttentionPrefixCacheLayout::SequenceHeads;
 };
 
 struct TransformerEncoderBlockWeights {
@@ -80,6 +83,9 @@ struct StreamingTransformerStackConfig {
     int64_t layers = 0;
     float eps = 1e-5f;
     bool use_bias = true;
+    ggml_prec projection_precision = GGML_PREC_DEFAULT;
+    ggml_prec attention_precision = GGML_PREC_DEFAULT;
+    AttentionPrefixCacheLayout prefix_cache_layout = AttentionPrefixCacheLayout::SequenceHeads;
 };
 
 struct StreamingTransformerStackWeights {
@@ -127,6 +133,9 @@ struct ProjectedTransformerConfig {
     int64_t layers = 0;
     float eps = 1e-5f;
     bool use_bias = true;
+    ggml_prec projection_precision = GGML_PREC_DEFAULT;
+    ggml_prec attention_precision = GGML_PREC_DEFAULT;
+    AttentionPrefixCacheLayout prefix_cache_layout = AttentionPrefixCacheLayout::SequenceHeads;
 };
 
 struct ProjectedTransformerWeights {
@@ -186,6 +195,9 @@ struct TransformerStackConfig {
     int64_t layers = 0;
     float eps = 1e-5f;
     bool use_bias = true;
+    ggml_prec projection_precision = GGML_PREC_DEFAULT;
+    ggml_prec attention_precision = GGML_PREC_DEFAULT;
+    AttentionPrefixCacheLayout prefix_cache_layout = AttentionPrefixCacheLayout::SequenceHeads;
 };
 
 struct TransformerStackWeights {

--- a/include/engine/framework/modules/attention/types.h
+++ b/include/engine/framework/modules/attention/types.h
@@ -6,10 +6,18 @@
 
 namespace engine::modules {
 
+enum class AttentionPrefixCacheLayout {
+    SequenceHeads,
+    HeadsSequence,
+};
+
 struct AttentionConfig {
     int64_t hidden_size = 0;
     int64_t num_heads = 0;
     bool use_bias = true;
+    ggml_prec projection_precision = GGML_PREC_DEFAULT;
+    ggml_prec attention_precision = GGML_PREC_DEFAULT;
+    AttentionPrefixCacheLayout prefix_cache_layout = AttentionPrefixCacheLayout::SequenceHeads;
 };
 
 struct RelativeAttentionConfig {

--- a/include/engine/framework/modules/norm_modules.h
+++ b/include/engine/framework/modules/norm_modules.h
@@ -11,6 +11,7 @@ struct NormConfig {
     float eps = 1e-5f;
     bool use_weight = true;
     bool use_bias = true;
+    bool preserve_input_layout = false;
 };
 
 struct NormWeights {

--- a/include/engine/framework/modules/transformers/qwen_causal_decoder.h
+++ b/include/engine/framework/modules/transformers/qwen_causal_decoder.h
@@ -25,6 +25,7 @@ struct QwenCausalDecoderConfig {
     QwenCausalDecoderLogitsMode logits_mode = QwenCausalDecoderLogitsMode::LastStep;
     bool use_lm_head_bias = false;
     ggml_prec lm_head_precision = GGML_PREC_DEFAULT;
+    std::optional<ggml_type> lm_head_input_type;
 };
 
 struct QwenCausalDecoderWeights {

--- a/include/engine/framework/runtime/bounded_static_kv_decode.h
+++ b/include/engine/framework/runtime/bounded_static_kv_decode.h
@@ -1,12 +1,7 @@
 #pragma once
 
-#include "engine/framework/runtime/kv_cache.h"
+#include "engine/framework/runtime/cached_decode.h"
 
-#include <algorithm>
-#include <cstdint>
-#include <functional>
-#include <memory>
-#include <stdexcept>
 #include <string>
 #include <utility>
 
@@ -18,12 +13,7 @@ struct BoundedStaticKVDecodeConfig {
     std::string label = "bounded static KV decode";
 };
 
-struct BoundedStaticKVDecodeStep {
-    int64_t position = 0;
-    int64_t valid_steps = 0;
-    int64_t cache_steps = 0;
-    int32_t cache_slot = 0;
-};
+using BoundedStaticKVDecodeStep = CachedDecodeStep;
 
 int64_t bounded_static_kv_cache_steps_for_required(
     const BoundedStaticKVDecodeConfig & config,
@@ -32,6 +22,7 @@ int64_t bounded_static_kv_cache_steps_for_required(
 class BoundedStaticKVDecodeCursor {
 public:
     void import_state(const TransformerKVState & state, int64_t cache_steps);
+    void reset_to_empty(int64_t cache_steps);
     BoundedStaticKVDecodeStep next_step() const;
     void advance_after_direct_append(int64_t steps);
     void reset() noexcept;
@@ -42,92 +33,52 @@ private:
     int64_t cache_steps_ = 0;
 };
 
-template <typename Graph>
-class BoundedStaticKVDecodeRuntime {
+class BoundedStaticKVDecodePolicy {
 public:
-    using Factory = std::function<std::unique_ptr<Graph>(int64_t cache_steps)>;
+    using Config = BoundedStaticKVDecodeConfig;
 
-    BoundedStaticKVDecodeRuntime() = default;
-
-    explicit BoundedStaticKVDecodeRuntime(BoundedStaticKVDecodeConfig config)
+    BoundedStaticKVDecodePolicy() = default;
+    explicit BoundedStaticKVDecodePolicy(BoundedStaticKVDecodeConfig config)
         : config_(std::move(config)) {}
-
-    bool prepare_for_prefill(int64_t required_steps, const Factory & factory) {
-        const int64_t target_steps = target_cache_steps(required_steps);
-        if (graph_ != nullptr && graph_->cache_steps() == target_steps) {
-            return false;
-        }
-        graph_ = factory(target_steps);
-        cursor_.reset();
-        return true;
-    }
-
-    bool grow_for_next_step(int64_t required_steps, const Factory & factory) {
-        const int64_t target_steps = target_cache_steps(required_steps);
-        if (graph_ != nullptr && graph_->cache_steps() >= target_steps) {
-            return false;
-        }
-        if (graph_ == nullptr) {
-            throw std::runtime_error(config_.label + " requires an initialized graph before cache growth");
-        }
-        auto state = graph_->export_state();
-        graph_ = factory(target_steps);
-        import_state(state);
-        return true;
-    }
-
-    void import_state(const TransformerKVState & state) {
-        if (graph_ == nullptr) {
-            throw std::runtime_error(config_.label + " requires a graph before importing KV state");
-        }
-        graph_->import_state(state);
-        cursor_.import_state(state, graph_->cache_steps());
-    }
-
-    BoundedStaticKVDecodeStep next_step() const {
-        if (graph_ == nullptr) {
-            throw std::runtime_error(config_.label + " requires an initialized graph before decode");
-        }
-        return cursor_.next_step();
-    }
-
-    void advance_after_direct_append(int64_t steps) {
-        if (graph_ == nullptr) {
-            throw std::runtime_error(config_.label + " requires an initialized graph before cache advance");
-        }
-        const auto before = cursor_.next_step();
-        if (before.valid_steps < before.cache_steps) {
-            graph_->advance_cache_after_direct_append(steps);
-        }
-        cursor_.advance_after_direct_append(steps);
-    }
-
-    bool has_graph() const noexcept {
-        return graph_ != nullptr;
-    }
-
-    Graph & graph() {
-        if (graph_ == nullptr) {
-            throw std::runtime_error(config_.label + " graph is not initialized");
-        }
-        return *graph_;
-    }
-
-    const Graph & graph() const {
-        if (graph_ == nullptr) {
-            throw std::runtime_error(config_.label + " graph is not initialized");
-        }
-        return *graph_;
-    }
 
     int64_t target_cache_steps(int64_t required_steps) const {
         return bounded_static_kv_cache_steps_for_required(config_, required_steps);
     }
 
+    void reset() noexcept {
+        cursor_.reset();
+    }
+
+    void import_state(const TransformerKVState & state, int64_t cache_steps) {
+        cursor_.import_state(state, cache_steps);
+    }
+
+    void reset_to_empty(int64_t cache_steps) {
+        cursor_.reset_to_empty(cache_steps);
+    }
+
+    CachedDecodeStep next_step() const {
+        return cursor_.next_step();
+    }
+
+    bool should_advance_graph_cache(const CachedDecodeStep & step, int64_t /*steps*/) const noexcept {
+        return step.valid_steps < step.cache_steps;
+    }
+
+    void advance_after_direct_append(int64_t steps) {
+        cursor_.advance_after_direct_append(steps);
+    }
+
+    const std::string & label() const noexcept {
+        return config_.label;
+    }
+
 private:
     BoundedStaticKVDecodeConfig config_;
-    std::unique_ptr<Graph> graph_;
     BoundedStaticKVDecodeCursor cursor_;
 };
+
+template <typename Graph>
+using BoundedStaticKVDecodeRuntime = CachedDecodeRuntime<Graph, BoundedStaticKVDecodePolicy>;
 
 }  // namespace engine::runtime

--- a/include/engine/framework/runtime/cached_decode.h
+++ b/include/engine/framework/runtime/cached_decode.h
@@ -1,0 +1,118 @@
+#pragma once
+
+#include "engine/framework/runtime/kv_cache.h"
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <stdexcept>
+#include <utility>
+
+namespace engine::runtime {
+
+struct CachedDecodeStep {
+    int64_t position = 0;
+    int64_t valid_steps = 0;
+    int64_t cache_steps = 0;
+    int32_t cache_slot = 0;
+    int64_t logical_start = 0;
+    bool wrapped = false;
+};
+
+template <typename Graph, typename Policy>
+class CachedDecodeRuntime {
+public:
+    using Factory = std::function<std::unique_ptr<Graph>(int64_t cache_steps)>;
+    using Config = typename Policy::Config;
+
+    CachedDecodeRuntime() = default;
+
+    explicit CachedDecodeRuntime(Config config)
+        : policy_(std::move(config)) {}
+
+    bool prepare_for_prefill(int64_t required_steps, const Factory & factory) {
+        const int64_t target_steps = target_cache_steps(required_steps);
+        if (graph_ != nullptr && graph_->cache_steps() == target_steps) {
+            return false;
+        }
+        graph_ = factory(target_steps);
+        policy_.reset();
+        return true;
+    }
+
+    bool grow_for_next_step(int64_t required_steps, const Factory & factory) {
+        const int64_t target_steps = target_cache_steps(required_steps);
+        if (graph_ != nullptr && graph_->cache_steps() >= target_steps) {
+            return false;
+        }
+        if (graph_ == nullptr) {
+            throw std::runtime_error(policy_.label() + " requires an initialized graph before cache growth");
+        }
+        auto state = graph_->export_state();
+        graph_ = factory(target_steps);
+        import_state(state);
+        return true;
+    }
+
+    void import_state(const TransformerKVState & state) {
+        if (graph_ == nullptr) {
+            throw std::runtime_error(policy_.label() + " requires a graph before importing KV state");
+        }
+        graph_->import_state(state);
+        policy_.import_state(state, graph_->cache_steps());
+    }
+
+    void reset_to_empty_cache() {
+        if (graph_ == nullptr) {
+            throw std::runtime_error(policy_.label() + " requires a graph before reset");
+        }
+        graph_->reset_state();
+        policy_.reset_to_empty(graph_->cache_steps());
+    }
+
+    CachedDecodeStep next_step() const {
+        if (graph_ == nullptr) {
+            throw std::runtime_error(policy_.label() + " requires an initialized graph before decode");
+        }
+        return policy_.next_step();
+    }
+
+    void advance_after_direct_append(int64_t steps) {
+        if (graph_ == nullptr) {
+            throw std::runtime_error(policy_.label() + " requires an initialized graph before cache advance");
+        }
+        const auto before = policy_.next_step();
+        if (policy_.should_advance_graph_cache(before, steps)) {
+            graph_->advance_cache_after_direct_append(steps);
+        }
+        policy_.advance_after_direct_append(steps);
+    }
+
+    bool has_graph() const noexcept {
+        return graph_ != nullptr;
+    }
+
+    Graph & graph() {
+        if (graph_ == nullptr) {
+            throw std::runtime_error(policy_.label() + " graph is not initialized");
+        }
+        return *graph_;
+    }
+
+    const Graph & graph() const {
+        if (graph_ == nullptr) {
+            throw std::runtime_error(policy_.label() + " graph is not initialized");
+        }
+        return *graph_;
+    }
+
+    int64_t target_cache_steps(int64_t required_steps) const {
+        return policy_.target_cache_steps(required_steps);
+    }
+
+private:
+    Policy policy_;
+    std::unique_ptr<Graph> graph_;
+};
+
+}  // namespace engine::runtime

--- a/include/engine/framework/runtime/session.h
+++ b/include/engine/framework/runtime/session.h
@@ -129,6 +129,7 @@ enum class ArtifactKind {
     StyleEmbedding,
     PromptEmbedding,
     AcousticTokens,
+    Midi,
     TranscriptAlignment,
     DiarizationState,
     VadState,

--- a/src/framework/codecs/mimi_codec_runtime.cpp
+++ b/src/framework/codecs/mimi_codec_runtime.cpp
@@ -1,0 +1,2068 @@
+#include "engine/framework/codecs/mimi_codec_runtime.h"
+
+#include "engine/framework/audio/conversion.h"
+#include "engine/framework/core/backend.h"
+#include "engine/framework/modules/activation_modules.h"
+#include "engine/framework/modules/attention/transformer_blocks.h"
+#include "engine/framework/modules/lookup_modules.h"
+#include "engine/framework/modules/primitive_modules.h"
+#include "engine/framework/modules/structural_modules.h"
+#include "engine/framework/modules/weight_binding.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstring>
+#include <limits>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace engine::codecs {
+namespace {
+
+constexpr float kCodebookEps = 1.0e-5F;
+constexpr float kMaskedAttentionBias = -std::numeric_limits<float>::infinity();
+constexpr int64_t kMimiActiveCodebooks = 8;
+constexpr int64_t kMimiFrameSamples = 1920;
+namespace binding = engine::modules::binding;
+
+struct GgmlContextDeleter {
+    void operator()(ggml_context * ctx) const noexcept {
+        if (ctx != nullptr) {
+            ggml_free(ctx);
+        }
+    }
+};
+
+modules::TransformerEncoderBlockWeights as_transformer_layer_weights(
+    const MimiCodecTransformerLayerWeights & weights) {
+    return {
+        weights.norm1,
+        weights.self_attn,
+        weights.layer_scale1,
+        weights.norm2,
+        weights.feed_forward,
+        weights.layer_scale2,
+    };
+}
+
+std::vector<float> transformer_attention_mask(int64_t frames, int64_t cache_steps, int64_t context, int64_t current_end) {
+    if (frames <= 0 || cache_steps < 0 || context <= 0 || current_end < 0) {
+        throw std::runtime_error("Mimi codec transformer attention mask received invalid dimensions");
+    }
+    std::vector<float> values(static_cast<size_t>(frames * (cache_steps + frames)), kMaskedAttentionBias);
+    for (int64_t query = 0; query < frames; ++query) {
+        const int64_t query_position = current_end + query;
+        for (int64_t slot = 0; slot < cache_steps; ++slot) {
+            int64_t key_position = -1;
+            if (current_end <= cache_steps) {
+                if (slot < current_end) {
+                    key_position = slot;
+                }
+            } else {
+                const int64_t end_slot = current_end % cache_steps;
+                const int64_t delta = slot - end_slot;
+                key_position = delta < 0 ? current_end + delta : current_end + delta - cache_steps;
+            }
+            const int64_t distance = query_position - key_position;
+            if (key_position >= 0 && distance >= 0 && distance < context) {
+                values[static_cast<size_t>(query * (cache_steps + frames) + slot)] = 0.0F;
+            }
+        }
+        for (int64_t local_key = 0; local_key <= query; ++local_key) {
+            const int64_t key_position = current_end + local_key;
+            if (query_position - key_position < context) {
+                values[static_cast<size_t>(query * (cache_steps + frames) + cache_steps + local_key)] = 0.0F;
+            }
+        }
+    }
+    return values;
+}
+
+struct StreamingConv1dState {
+    int64_t channels = 0;
+    int64_t history_frames = 0;
+    bool first = true;
+    std::vector<float> previous;
+};
+
+struct StreamingConvTranspose1dState {
+    int64_t channels = 0;
+    int64_t partial_frames = 0;
+    std::vector<float> partial;
+};
+
+struct MimiTransformerState {
+    int64_t current_end = 0;
+};
+
+struct MimiDecoderState {
+    StreamingConvTranspose1dState encoder_rate_upsample;
+    MimiTransformerState transformer;
+    StreamingConv1dState input_projection;
+    std::vector<StreamingConvTranspose1dState> stage_upsamples;
+    std::vector<std::array<StreamingConv1dState, 2>> stage_residual_convs;
+    StreamingConv1dState output_projection;
+};
+
+struct MimiEncoderState {
+    StreamingConv1dState input_projection;
+    std::vector<std::array<StreamingConv1dState, 2>> stage_residual_convs;
+    std::vector<StreamingConv1dState> stage_downsamples;
+    StreamingConv1dState output_projection;
+    MimiTransformerState transformer;
+    StreamingConv1dState downsample;
+};
+
+void release_graph_runtime(
+    ggml_gallocr_t & gallocr,
+    ggml_backend_buffer_t & params_buffer,
+    ggml_context *& context) {
+    if (gallocr != nullptr) {
+        ggml_gallocr_free(gallocr);
+        gallocr = nullptr;
+    }
+    if (params_buffer != nullptr) {
+        ggml_backend_buffer_free(params_buffer);
+        params_buffer = nullptr;
+    }
+    if (context != nullptr) {
+        ggml_free(context);
+        context = nullptr;
+    }
+}
+
+StreamingConv1dState make_streaming_conv1d_state(int64_t channels, int64_t kernel_size, int stride, int dilation) {
+    StreamingConv1dState state;
+    state.channels = channels;
+    state.history_frames = std::max<int64_t>(0, (kernel_size - 1) * dilation + 1 - stride);
+    state.previous.assign(static_cast<size_t>(state.channels * state.history_frames), 0.0F);
+    return state;
+}
+
+StreamingConvTranspose1dState make_streaming_convtranspose_state(int64_t channels, int64_t kernel_size, int stride) {
+    StreamingConvTranspose1dState state;
+    state.channels = channels;
+    state.partial_frames = std::max<int64_t>(0, kernel_size - stride);
+    state.partial.assign(static_cast<size_t>(state.channels * state.partial_frames), 0.0F);
+    return state;
+}
+
+MimiDecoderState make_mimi_decoder_state(const MimiCodecConfig & config) {
+    MimiDecoderState state;
+    state.encoder_rate_upsample = make_streaming_convtranspose_state(config.hidden_size, 4, 2);
+    state.input_projection = make_streaming_conv1d_state(config.hidden_size, 7, 1, 1);
+    state.stage_upsamples.push_back(make_streaming_convtranspose_state(512, 16, 8));
+    state.stage_upsamples.push_back(make_streaming_convtranspose_state(256, 12, 6));
+    state.stage_upsamples.push_back(make_streaming_convtranspose_state(128, 10, 5));
+    state.stage_upsamples.push_back(make_streaming_convtranspose_state(64, 8, 4));
+    state.stage_residual_convs = {
+        std::array<StreamingConv1dState, 2>{
+            make_streaming_conv1d_state(512, 3, 1, 1),
+            make_streaming_conv1d_state(256, 1, 1, 1),
+        },
+        std::array<StreamingConv1dState, 2>{
+            make_streaming_conv1d_state(256, 3, 1, 1),
+            make_streaming_conv1d_state(128, 1, 1, 1),
+        },
+        std::array<StreamingConv1dState, 2>{
+            make_streaming_conv1d_state(128, 3, 1, 1),
+            make_streaming_conv1d_state(64, 1, 1, 1),
+        },
+        std::array<StreamingConv1dState, 2>{
+            make_streaming_conv1d_state(64, 3, 1, 1),
+            make_streaming_conv1d_state(32, 1, 1, 1),
+        },
+    };
+    state.output_projection = make_streaming_conv1d_state(64, 3, 1, 1);
+    return state;
+}
+
+MimiEncoderState make_mimi_encoder_state(const MimiCodecConfig & config) {
+    MimiEncoderState state;
+    state.input_projection = make_streaming_conv1d_state(config.channels, 7, 1, 1);
+    state.stage_residual_convs = {
+        std::array<StreamingConv1dState, 2>{
+            make_streaming_conv1d_state(64, 3, 1, 1),
+            make_streaming_conv1d_state(32, 1, 1, 1),
+        },
+        std::array<StreamingConv1dState, 2>{
+            make_streaming_conv1d_state(128, 3, 1, 1),
+            make_streaming_conv1d_state(64, 1, 1, 1),
+        },
+        std::array<StreamingConv1dState, 2>{
+            make_streaming_conv1d_state(256, 3, 1, 1),
+            make_streaming_conv1d_state(128, 1, 1, 1),
+        },
+        std::array<StreamingConv1dState, 2>{
+            make_streaming_conv1d_state(512, 3, 1, 1),
+            make_streaming_conv1d_state(256, 1, 1, 1),
+        },
+    };
+    state.stage_downsamples.push_back(make_streaming_conv1d_state(64, 8, 4, 1));
+    state.stage_downsamples.push_back(make_streaming_conv1d_state(128, 10, 5, 1));
+    state.stage_downsamples.push_back(make_streaming_conv1d_state(256, 12, 6, 1));
+    state.stage_downsamples.push_back(make_streaming_conv1d_state(512, 16, 8, 1));
+    state.output_projection = make_streaming_conv1d_state(1024, 3, 1, 1);
+    state.downsample = make_streaming_conv1d_state(config.hidden_size, 4, 2, 1);
+    return state;
+}
+
+struct StatefulConv1dOutput {
+    core::TensorValue output;
+    std::optional<core::TensorValue> next_history;
+};
+
+StatefulConv1dOutput build_stateful_conv1d(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    const std::optional<core::TensorValue> & history,
+    const modules::StreamingConv1dWeights & weights,
+    int64_t in_channels,
+    int64_t out_channels,
+    int64_t kernel_size,
+    int stride,
+    int dilation,
+    bool use_bias) {
+    auto full_input = input;
+    if (history.has_value()) {
+        full_input = modules::ConcatModule({2}).build(ctx, *history, input);
+    }
+    auto output = modules::Conv1dModule({
+        in_channels,
+        out_channels,
+        kernel_size,
+        stride,
+        0,
+        dilation,
+        use_bias,
+    }).build(ctx, full_input, weights);
+    std::optional<core::TensorValue> next_history = std::nullopt;
+    if (history.has_value()) {
+        next_history = modules::SliceModule({
+            2,
+            full_input.shape.dims[2] - history->shape.dims[2],
+            history->shape.dims[2],
+        }).build(ctx, full_input);
+    }
+    return {output, next_history};
+}
+
+struct StatefulConvTranspose1dOutput {
+    core::TensorValue output;
+    std::optional<core::TensorValue> next_partial;
+};
+
+StatefulConvTranspose1dOutput build_stateful_convtranspose1d(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    const std::optional<core::TensorValue> & partial,
+    const modules::ConvTranspose1dWeights & weights,
+    int64_t in_channels,
+    int64_t out_channels,
+    int64_t kernel_size,
+    int stride,
+    bool use_bias) {
+    auto raw = modules::ConvTranspose1dModule({
+        in_channels,
+        out_channels,
+        kernel_size,
+        stride,
+        0,
+        1,
+        use_bias,
+    }).build(ctx, input, weights);
+    if (!partial.has_value()) {
+        return {raw, std::nullopt};
+    }
+    const int64_t partial_frames = partial->shape.dims[2];
+    auto prefix = modules::SliceModule({2, 0, partial_frames}).build(ctx, raw);
+    prefix = modules::AddModule().build(ctx, prefix, *partial);
+    auto suffix = modules::SliceModule({2, partial_frames, raw.shape.dims[2] - partial_frames}).build(ctx, raw);
+    auto combined = modules::ConcatModule({2}).build(ctx, prefix, suffix);
+    auto output = modules::SliceModule({2, 0, raw.shape.dims[2] - partial_frames}).build(ctx, combined);
+    auto next_partial = modules::SliceModule({
+        2,
+        raw.shape.dims[2] - partial_frames,
+        partial_frames,
+    }).build(ctx, combined);
+    return {output, next_partial};
+}
+
+StatefulConvTranspose1dOutput build_stateful_depthwise_convtranspose1d(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    const std::optional<core::TensorValue> & partial,
+    const modules::DepthwiseConvTranspose1dWeights & weights,
+    int64_t channels,
+    int64_t kernel_size,
+    int stride) {
+    auto raw = modules::DepthwiseConvTranspose1dModule({
+        channels,
+        kernel_size,
+        stride,
+        false,
+    }).build(ctx, input, weights);
+    if (!partial.has_value()) {
+        return {raw, std::nullopt};
+    }
+    const int64_t partial_frames = partial->shape.dims[2];
+    auto prefix = modules::SliceModule({2, 0, partial_frames}).build(ctx, raw);
+    prefix = modules::AddModule().build(ctx, prefix, *partial);
+    auto suffix = modules::SliceModule({2, partial_frames, raw.shape.dims[2] - partial_frames}).build(ctx, raw);
+    auto combined = modules::ConcatModule({2}).build(ctx, prefix, suffix);
+    auto output = modules::SliceModule({2, 0, raw.shape.dims[2] - partial_frames}).build(ctx, combined);
+    auto next_partial = modules::SliceModule({
+        2,
+        raw.shape.dims[2] - partial_frames,
+        partial_frames,
+    }).build(ctx, combined);
+    return {output, next_partial};
+}
+
+core::TensorValue build_mimi_residual_block(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    const MimiCodecResidualWeights & weights,
+    int64_t channels,
+    int64_t hidden_channels,
+    const std::optional<core::TensorValue> & conv1_history,
+    const std::optional<core::TensorValue> & conv2_history,
+    std::vector<core::TensorValue> & next_histories) {
+    auto x = modules::EluModule().build(ctx, input);
+    auto conv1 = build_stateful_conv1d(
+        ctx,
+        x,
+        conv1_history,
+        weights.conv1,
+        channels,
+        hidden_channels,
+        3,
+        1,
+        1,
+        weights.conv1.bias.has_value());
+    if (conv1.next_history.has_value()) {
+        next_histories.push_back(*conv1.next_history);
+    }
+    x = modules::EluModule().build(ctx, conv1.output);
+    auto conv2 = build_stateful_conv1d(
+        ctx,
+        x,
+        conv2_history,
+        weights.conv2,
+        hidden_channels,
+        channels,
+        1,
+        1,
+        1,
+        weights.conv2.bias.has_value());
+    if (conv2.next_history.has_value()) {
+        next_histories.push_back(*conv2.next_history);
+    }
+    return modules::ResidualAddModule().build(ctx, input, conv2.output);
+}
+
+core::TensorValue build_seanet_residual_block(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    const SEANetResidualWeights & weights,
+    int64_t channels,
+    int64_t hidden_channels,
+    const std::optional<core::TensorValue> & conv1_history,
+    const std::optional<core::TensorValue> & conv2_history,
+    std::vector<core::TensorValue> & next_histories) {
+    auto x = modules::EluModule().build(ctx, input);
+    auto conv1 = build_stateful_conv1d(
+        ctx,
+        x,
+        conv1_history,
+        weights.conv1,
+        channels,
+        hidden_channels,
+        3,
+        1,
+        1,
+        weights.conv1.bias.has_value());
+    if (conv1.next_history.has_value()) {
+        next_histories.push_back(*conv1.next_history);
+    }
+    x = modules::EluModule().build(ctx, conv1.output);
+    auto conv2 = build_stateful_conv1d(
+        ctx,
+        x,
+        conv2_history,
+        weights.conv2,
+        hidden_channels,
+        channels,
+        1,
+        1,
+        1,
+        weights.conv2.bias.has_value());
+    if (conv2.next_history.has_value()) {
+        next_histories.push_back(*conv2.next_history);
+    }
+    return modules::ResidualAddModule().build(ctx, input, conv2.output);
+}
+
+void write_streaming_history(
+    const core::TensorValue & tensor,
+    const StreamingConv1dState & state,
+    const std::vector<float> & current,
+    int64_t channels,
+    int64_t frames,
+    modules::StreamingPadMode pad_mode) {
+    if (state.history_frames <= 0) {
+        return;
+    }
+    std::vector<float> history(static_cast<size_t>(channels * state.history_frames), 0.0F);
+    if (pad_mode == modules::StreamingPadMode::Replicate && state.first) {
+        for (int64_t channel = 0; channel < channels; ++channel) {
+            std::fill_n(
+                history.data() + static_cast<size_t>(channel * state.history_frames),
+                static_cast<size_t>(state.history_frames),
+                current[static_cast<size_t>(channel * frames)]);
+        }
+    } else {
+        history = state.previous;
+    }
+    core::write_tensor_f32(tensor, history);
+}
+
+void read_streaming_history(
+    const core::TensorValue & tensor,
+    StreamingConv1dState & state) {
+    if (state.history_frames <= 0) {
+        state.first = false;
+        return;
+    }
+    state.previous = core::read_tensor_f32(tensor.tensor);
+    state.first = false;
+}
+
+void write_streaming_partial(
+    const core::TensorValue & tensor,
+    const StreamingConvTranspose1dState & state) {
+    if (state.partial_frames > 0) {
+        core::write_tensor_f32(tensor, state.partial);
+    }
+}
+
+void read_streaming_partial(
+    const core::TensorValue & tensor,
+    StreamingConvTranspose1dState & state,
+    const std::vector<float> & bias_values) {
+    if (state.partial_frames <= 0) {
+        return;
+    }
+    state.partial = core::read_tensor_f32(tensor.tensor);
+    if (!bias_values.empty()) {
+        for (int64_t channel = 0; channel < state.channels; ++channel) {
+            const float bias = bias_values[static_cast<size_t>(channel)];
+            for (int64_t frame = 0; frame < state.partial_frames; ++frame) {
+                state.partial[static_cast<size_t>(channel * state.partial_frames + frame)] -= bias;
+            }
+        }
+    }
+}
+
+class MimiEncoderPreTransformerGraph {
+public:
+    MimiEncoderPreTransformerGraph(
+        ggml_backend_t backend,
+        core::BackendType backend_type,
+        int threads,
+        size_t graph_context_bytes,
+        std::shared_ptr<const MimiCodecWeights> weights,
+        MimiCodecConfig config)
+        : backend_(backend),
+          threads_(threads),
+          weights_(std::move(weights)),
+          config_(std::move(config)) {
+        if (weights_ == nullptr) {
+            throw std::runtime_error("Mimi codec encoder pre-transformer graph requires weights");
+        }
+        ggml_ctx_ = ggml_init({graph_context_bytes, nullptr, true});
+        if (ggml_ctx_ == nullptr) {
+            throw std::runtime_error("failed to initialize Mimi codec encoder pre-transformer graph context");
+        }
+        core::ModuleBuildContext ctx{ggml_ctx_, "mimi_codec.encoder_pre_transformer", backend_type};
+        input_ = core::make_tensor(ctx, GGML_TYPE_F32, core::TensorShape::from_dims({1, config_.channels, kMimiFrameSamples}));
+
+        std::vector<core::TensorValue> residual_histories;
+        auto input_history = make_history_tensor(ctx, config_.channels, 6);
+        auto input_projection = build_stateful_conv1d(
+            ctx,
+            input_,
+            input_history,
+            weights_->encoder.input_projection,
+            config_.channels,
+            64,
+            7,
+            1,
+            1,
+            weights_->encoder.input_projection.bias.has_value());
+        next_histories_.push_back(*input_projection.next_history);
+        auto x = input_projection.output;
+
+        const int64_t channels[] = {64, 128, 256, 512};
+        const int64_t hidden_channels[] = {32, 64, 128, 256};
+        const int64_t downsample_kernels[] = {8, 10, 12, 16};
+        const int downsample_strides[] = {4, 5, 6, 8};
+        for (size_t stage = 0; stage < 4; ++stage) {
+            x = build_mimi_residual_block(
+                ctx,
+                x,
+                weights_->encoder.residual_blocks[stage],
+                channels[stage],
+                hidden_channels[stage],
+                make_history_tensor(ctx, channels[stage], 2),
+                make_history_tensor(ctx, hidden_channels[stage], 0),
+                residual_histories);
+            x = modules::EluModule().build(ctx, x);
+            auto downsample = build_stateful_conv1d(
+                ctx,
+                x,
+                make_history_tensor(ctx, channels[stage], downsample_kernels[stage] - downsample_strides[stage]),
+                weights_->encoder.downsample_layers[stage],
+                channels[stage],
+                channels[stage] * 2,
+                downsample_kernels[stage],
+                downsample_strides[stage],
+                1,
+                weights_->encoder.downsample_layers[stage].bias.has_value());
+            x = downsample.output;
+            next_histories_.push_back(*downsample.next_history);
+        }
+        next_histories_.insert(next_histories_.end(), residual_histories.begin(), residual_histories.end());
+
+        x = modules::EluModule().build(ctx, x);
+        auto output_projection = build_stateful_conv1d(
+            ctx,
+            x,
+            make_history_tensor(ctx, 1024, 2),
+            weights_->encoder.output_projection,
+            1024,
+            config_.hidden_size,
+            3,
+            1,
+            1,
+            weights_->encoder.output_projection.bias.has_value());
+        next_histories_.push_back(*output_projection.next_history);
+        output_ = output_projection.output;
+        build_runtime(ctx);
+    }
+
+    ~MimiEncoderPreTransformerGraph() {
+        release_graph_runtime(galloc_, params_buffer_, ggml_ctx_);
+    }
+
+    std::vector<float> run(const std::vector<float> & input, MimiEncoderState & state) const {
+        if (static_cast<int64_t>(input.size()) != config_.channels * kMimiFrameSamples) {
+            throw std::runtime_error("Mimi codec encoder pre-transformer input size mismatch");
+        }
+        core::write_tensor_f32(input_, input);
+        size_t history = 0;
+        write_streaming_history(history_tensors_[history++], state.input_projection, input, config_.channels, kMimiFrameSamples, modules::StreamingPadMode::Constant);
+        for (size_t stage = 0; stage < 4; ++stage) {
+            write_streaming_history(history_tensors_[history++], state.stage_residual_convs[stage][0], {}, 0, 0, modules::StreamingPadMode::Constant);
+            write_streaming_history(history_tensors_[history++], state.stage_downsamples[stage], {}, 0, 0, modules::StreamingPadMode::Constant);
+        }
+        write_streaming_history(history_tensors_[history++], state.output_projection, {}, 0, 0, modules::StreamingPadMode::Constant);
+        if (core::compute_backend_graph(backend_, graph_) != GGML_STATUS_SUCCESS) {
+            throw std::runtime_error("Mimi codec encoder pre-transformer graph compute failed");
+        }
+        size_t output_history = 0;
+        read_streaming_history(next_histories_[output_history++], state.input_projection);
+        for (size_t stage = 0; stage < 4; ++stage) {
+            read_streaming_history(next_histories_[output_history++], state.stage_downsamples[stage]);
+        }
+        for (size_t stage = 0; stage < 4; ++stage) {
+            read_streaming_history(next_histories_[output_history++], state.stage_residual_convs[stage][0]);
+        }
+        read_streaming_history(next_histories_[output_history++], state.output_projection);
+        return core::read_tensor_f32(output_.tensor);
+    }
+
+private:
+    std::optional<core::TensorValue> make_history_tensor(
+        core::ModuleBuildContext & ctx,
+        int64_t channels,
+        int64_t frames) {
+        if (frames <= 0) {
+            return std::nullopt;
+        }
+        history_tensors_.push_back(core::make_tensor(ctx, GGML_TYPE_F32, core::TensorShape::from_dims({1, channels, frames})));
+        return history_tensors_.back();
+    }
+
+    void build_runtime(core::ModuleBuildContext &) {
+        if (core::is_host_backend(backend_)) {
+            params_buffer_ = ggml_backend_alloc_ctx_tensors(ggml_ctx_, backend_);
+            if (params_buffer_ == nullptr) {
+                release_graph_runtime(galloc_, params_buffer_, ggml_ctx_);
+                throw std::runtime_error("Mimi codec encoder pre-transformer context tensor allocation failed");
+            }
+        }
+        core::set_backend_threads(backend_, threads_);
+        graph_ = ggml_new_graph_custom(ggml_ctx_, 65536, false);
+        ggml_build_forward_expand(graph_, output_.tensor);
+        for (const auto & history : next_histories_) {
+            ggml_build_forward_expand(graph_, history.tensor);
+        }
+        galloc_ = ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend_));
+        if (galloc_ == nullptr || !ggml_gallocr_reserve(galloc_, graph_) || !ggml_gallocr_alloc_graph(galloc_, graph_)) {
+            release_graph_runtime(galloc_, params_buffer_, ggml_ctx_);
+            throw std::runtime_error("Mimi codec encoder pre-transformer graph allocation failed");
+        }
+    }
+
+    ggml_backend_t backend_ = nullptr;
+    int threads_ = 1;
+    std::shared_ptr<const MimiCodecWeights> weights_;
+    MimiCodecConfig config_;
+    ggml_context * ggml_ctx_ = nullptr;
+    ggml_backend_buffer_t params_buffer_ = nullptr;
+    ggml_cgraph * graph_ = nullptr;
+    ggml_gallocr_t galloc_ = nullptr;
+    core::TensorValue input_;
+    std::vector<core::TensorValue> history_tensors_;
+    std::vector<core::TensorValue> next_histories_;
+    core::TensorValue output_;
+};
+
+class MimiEncoderPostTransformerGraph {
+public:
+    MimiEncoderPostTransformerGraph(
+        ggml_backend_t backend,
+        core::BackendType backend_type,
+        int threads,
+        size_t graph_context_bytes,
+        std::shared_ptr<const MimiCodecWeights> weights,
+        MimiCodecConfig config,
+        int64_t frames)
+        : backend_(backend),
+          threads_(threads),
+          weights_(std::move(weights)),
+          config_(std::move(config)),
+          frames_(frames) {
+        if (weights_ == nullptr || frames_ <= 0) {
+            throw std::runtime_error("Mimi codec encoder post-transformer graph requires weights and frames");
+        }
+        ggml_ctx_ = ggml_init({graph_context_bytes, nullptr, true});
+        if (ggml_ctx_ == nullptr) {
+            throw std::runtime_error("failed to initialize Mimi codec encoder post-transformer graph context");
+        }
+        core::ModuleBuildContext ctx{ggml_ctx_, "mimi_codec.encoder_post_transformer", backend_type};
+        input_ = core::make_tensor(ctx, GGML_TYPE_F32, core::TensorShape::from_dims({1, config_.hidden_size, frames_}));
+        downsample_history_ = core::make_tensor(ctx, GGML_TYPE_F32, core::TensorShape::from_dims({1, config_.hidden_size, 2}));
+        auto downsample = build_stateful_conv1d(
+            ctx,
+            input_,
+            downsample_history_,
+            weights_->encoder.downsample_conv,
+            config_.hidden_size,
+            config_.hidden_size,
+            4,
+            2,
+            1,
+            weights_->encoder.downsample_conv.bias.has_value());
+        next_downsample_history_ = *downsample.next_history;
+        if (downsample.output.shape.dims[2] != 1) {
+            throw std::runtime_error("Mimi codec encoder post-transformer expected one latent frame");
+        }
+        auto latent = modules::TransposeModule({{0, 2, 1, 3}, 3}).build(ctx, downsample.output);
+        latent = modules::ReshapeModule({core::TensorShape::from_dims({1, config_.hidden_size})}).build(ctx, latent);
+        const auto semantic_weight = core::reshape_tensor(
+            ctx,
+            weights_->quantizer.semantic_input_proj.weight,
+            core::TensorShape::from_dims({config_.latent_size, config_.hidden_size}));
+        semantic_ = modules::LinearModule({
+            config_.hidden_size,
+            config_.latent_size,
+            weights_->quantizer.semantic_input_proj.bias.has_value(),
+            GGML_PREC_F32,
+        }).build(ctx, latent, modules::LinearWeights{semantic_weight, weights_->quantizer.semantic_input_proj.bias});
+        const auto acoustic_weight = core::reshape_tensor(
+            ctx,
+            weights_->quantizer.acoustic_input_proj.weight,
+            core::TensorShape::from_dims({config_.latent_size, config_.hidden_size}));
+        acoustic_ = modules::LinearModule({
+            config_.hidden_size,
+            config_.latent_size,
+            weights_->quantizer.acoustic_input_proj.bias.has_value(),
+            GGML_PREC_F32,
+        }).build(ctx, latent, modules::LinearWeights{acoustic_weight, weights_->quantizer.acoustic_input_proj.bias});
+        build_runtime();
+    }
+
+    ~MimiEncoderPostTransformerGraph() {
+        release_graph_runtime(galloc_, params_buffer_, ggml_ctx_);
+    }
+
+    std::pair<std::vector<float>, std::vector<float>> run(
+        const std::vector<float> & input,
+        MimiEncoderState & state) const {
+        if (static_cast<int64_t>(input.size()) != config_.hidden_size * frames_) {
+            throw std::runtime_error("Mimi codec encoder post-transformer input size mismatch");
+        }
+        core::write_tensor_f32(input_, input);
+        write_streaming_history(
+            downsample_history_,
+            state.downsample,
+            input,
+            config_.hidden_size,
+            frames_,
+            modules::StreamingPadMode::Replicate);
+        if (core::compute_backend_graph(backend_, graph_) != GGML_STATUS_SUCCESS) {
+            throw std::runtime_error("Mimi codec encoder post-transformer graph compute failed");
+        }
+        read_streaming_history(next_downsample_history_, state.downsample);
+        return {core::read_tensor_f32(semantic_.tensor), core::read_tensor_f32(acoustic_.tensor)};
+    }
+
+private:
+    void build_runtime() {
+        if (core::is_host_backend(backend_)) {
+            params_buffer_ = ggml_backend_alloc_ctx_tensors(ggml_ctx_, backend_);
+            if (params_buffer_ == nullptr) {
+                release_graph_runtime(galloc_, params_buffer_, ggml_ctx_);
+                throw std::runtime_error("Mimi codec encoder post-transformer context tensor allocation failed");
+            }
+        }
+        core::set_backend_threads(backend_, threads_);
+        graph_ = ggml_new_graph_custom(ggml_ctx_, 32768, false);
+        ggml_build_forward_expand(graph_, semantic_.tensor);
+        ggml_build_forward_expand(graph_, acoustic_.tensor);
+        ggml_build_forward_expand(graph_, next_downsample_history_.tensor);
+        galloc_ = ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend_));
+        if (galloc_ == nullptr || !ggml_gallocr_reserve(galloc_, graph_) || !ggml_gallocr_alloc_graph(galloc_, graph_)) {
+            release_graph_runtime(galloc_, params_buffer_, ggml_ctx_);
+            throw std::runtime_error("Mimi codec encoder post-transformer graph allocation failed");
+        }
+    }
+
+    ggml_backend_t backend_ = nullptr;
+    int threads_ = 1;
+    std::shared_ptr<const MimiCodecWeights> weights_;
+    MimiCodecConfig config_;
+    int64_t frames_ = 0;
+    ggml_context * ggml_ctx_ = nullptr;
+    ggml_backend_buffer_t params_buffer_ = nullptr;
+    ggml_cgraph * graph_ = nullptr;
+    ggml_gallocr_t galloc_ = nullptr;
+    core::TensorValue input_;
+    core::TensorValue downsample_history_;
+    core::TensorValue next_downsample_history_;
+    core::TensorValue semantic_;
+    core::TensorValue acoustic_;
+};
+
+class MimiDecoderPreTransformerGraph {
+public:
+    MimiDecoderPreTransformerGraph(
+        ggml_backend_t backend,
+        core::BackendType backend_type,
+        int threads,
+        size_t graph_context_bytes,
+        std::shared_ptr<const MimiCodecWeights> weights,
+        MimiCodecConfig config)
+        : backend_(backend),
+          threads_(threads),
+          weights_(std::move(weights)),
+          config_(std::move(config)) {
+        if (weights_ == nullptr) {
+            throw std::runtime_error("Mimi codec decoder pre-transformer graph requires weights");
+        }
+        ggml_ctx_ = ggml_init({graph_context_bytes, nullptr, true});
+        if (ggml_ctx_ == nullptr) {
+            throw std::runtime_error("failed to initialize Mimi codec decoder pre-transformer graph context");
+        }
+        core::ModuleBuildContext ctx{ggml_ctx_, "mimi_codec.decoder_pre_transformer", backend_type};
+        input_ = core::make_tensor(ctx, GGML_TYPE_F32, core::TensorShape::from_dims({1, config_.hidden_size, 1}));
+        partial_ = core::make_tensor(ctx, GGML_TYPE_F32, core::TensorShape::from_dims({1, config_.hidden_size, 2}));
+        auto upsample = build_stateful_depthwise_convtranspose1d(
+            ctx,
+            input_,
+            partial_,
+            weights_->decoder.upsample_conv,
+            config_.hidden_size,
+            4,
+            2);
+        output_ = upsample.output;
+        next_partial_ = *upsample.next_partial;
+        build_runtime();
+    }
+
+    ~MimiDecoderPreTransformerGraph() {
+        release_graph_runtime(galloc_, params_buffer_, ggml_ctx_);
+    }
+
+    std::vector<float> run(const std::vector<float> & input, MimiDecoderState & state) const {
+        if (static_cast<int64_t>(input.size()) != config_.hidden_size) {
+            throw std::runtime_error("Mimi codec decoder pre-transformer input size mismatch");
+        }
+        core::write_tensor_f32(input_, input);
+        write_streaming_partial(partial_, state.encoder_rate_upsample);
+        if (core::compute_backend_graph(backend_, graph_) != GGML_STATUS_SUCCESS) {
+            throw std::runtime_error("Mimi codec decoder pre-transformer graph compute failed");
+        }
+        read_streaming_partial(next_partial_, state.encoder_rate_upsample, {});
+        return core::read_tensor_f32(output_.tensor);
+    }
+
+private:
+    void build_runtime() {
+        if (core::is_host_backend(backend_)) {
+            params_buffer_ = ggml_backend_alloc_ctx_tensors(ggml_ctx_, backend_);
+            if (params_buffer_ == nullptr) {
+                release_graph_runtime(galloc_, params_buffer_, ggml_ctx_);
+                throw std::runtime_error("Mimi codec decoder pre-transformer context tensor allocation failed");
+            }
+        }
+        core::set_backend_threads(backend_, threads_);
+        graph_ = ggml_new_graph_custom(ggml_ctx_, 32768, false);
+        ggml_build_forward_expand(graph_, output_.tensor);
+        ggml_build_forward_expand(graph_, next_partial_.tensor);
+        galloc_ = ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend_));
+        if (galloc_ == nullptr || !ggml_gallocr_reserve(galloc_, graph_) || !ggml_gallocr_alloc_graph(galloc_, graph_)) {
+            release_graph_runtime(galloc_, params_buffer_, ggml_ctx_);
+            throw std::runtime_error("Mimi codec decoder pre-transformer graph allocation failed");
+        }
+    }
+
+    ggml_backend_t backend_ = nullptr;
+    int threads_ = 1;
+    std::shared_ptr<const MimiCodecWeights> weights_;
+    MimiCodecConfig config_;
+    ggml_context * ggml_ctx_ = nullptr;
+    ggml_backend_buffer_t params_buffer_ = nullptr;
+    ggml_cgraph * graph_ = nullptr;
+    ggml_gallocr_t galloc_ = nullptr;
+    core::TensorValue input_;
+    core::TensorValue partial_;
+    core::TensorValue next_partial_;
+    core::TensorValue output_;
+};
+
+class MimiDecoderPostTransformerGraph {
+public:
+    MimiDecoderPostTransformerGraph(
+        ggml_backend_t backend,
+        core::BackendType backend_type,
+        int threads,
+        size_t graph_context_bytes,
+        std::shared_ptr<const MimiCodecWeights> weights,
+        MimiCodecConfig config,
+        int64_t frames)
+        : backend_(backend),
+          threads_(threads),
+          weights_(std::move(weights)),
+          config_(std::move(config)),
+          frames_(frames) {
+        if (weights_ == nullptr || frames_ <= 0) {
+            throw std::runtime_error("Mimi codec decoder post-transformer graph requires weights and frames");
+        }
+        ggml_ctx_ = ggml_init({graph_context_bytes, nullptr, true});
+        if (ggml_ctx_ == nullptr) {
+            throw std::runtime_error("failed to initialize Mimi codec decoder post-transformer graph context");
+        }
+        core::ModuleBuildContext ctx{ggml_ctx_, "mimi_codec.decoder_post_transformer", backend_type};
+        input_ = core::make_tensor(ctx, GGML_TYPE_F32, core::TensorShape::from_dims({1, config_.hidden_size, frames_}));
+        auto input_projection = build_stateful_conv1d(
+            ctx,
+            input_,
+            make_history_tensor(ctx, config_.hidden_size, 6),
+            weights_->decoder.seanet.input_projection,
+            config_.hidden_size,
+            1024,
+            7,
+            1,
+            1,
+            weights_->decoder.seanet.input_projection.bias.has_value());
+        next_histories_.push_back(*input_projection.next_history);
+        auto x = input_projection.output;
+
+        const int64_t stage_in_channels[] = {1024, 512, 256, 128};
+        const int64_t stage_out_channels[] = {512, 256, 128, 64};
+        const int64_t stage_hidden_channels[] = {256, 128, 64, 32};
+        const int64_t stage_kernel_sizes[] = {16, 12, 10, 8};
+        const int stage_strides[] = {8, 6, 5, 4};
+        std::vector<core::TensorValue> residual_histories;
+        for (size_t stage = 0; stage < 4; ++stage) {
+            x = modules::EluModule().build(ctx, x);
+            auto upsample = build_stateful_convtranspose1d(
+                ctx,
+                x,
+                make_partial_tensor(ctx, stage_out_channels[stage], stage_kernel_sizes[stage] - stage_strides[stage]),
+                weights_->decoder.seanet.stages[stage].upsample,
+                stage_in_channels[stage],
+                stage_out_channels[stage],
+                stage_kernel_sizes[stage],
+                stage_strides[stage],
+                weights_->decoder.seanet.stages[stage].upsample.bias.has_value());
+            next_partials_.push_back(*upsample.next_partial);
+            x = build_seanet_residual_block(
+                ctx,
+                upsample.output,
+                weights_->decoder.seanet.stages[stage].residual_blocks.front(),
+                stage_out_channels[stage],
+                stage_hidden_channels[stage],
+                make_history_tensor(ctx, stage_out_channels[stage], 2),
+                make_history_tensor(ctx, stage_hidden_channels[stage], 0),
+                residual_histories);
+        }
+        next_histories_.insert(next_histories_.end(), residual_histories.begin(), residual_histories.end());
+        x = modules::EluModule().build(ctx, x);
+        auto output_projection = build_stateful_conv1d(
+            ctx,
+            x,
+            make_history_tensor(ctx, 64, 2),
+            weights_->decoder.seanet.output_projection,
+            64,
+            config_.channels,
+            3,
+            1,
+            1,
+            weights_->decoder.seanet.output_projection.bias.has_value());
+        next_histories_.push_back(*output_projection.next_history);
+        output_ = output_projection.output;
+        build_runtime();
+    }
+
+    ~MimiDecoderPostTransformerGraph() {
+        release_graph_runtime(galloc_, params_buffer_, ggml_ctx_);
+    }
+
+    std::vector<float> run(const std::vector<float> & input, MimiDecoderState & state) const {
+        if (static_cast<int64_t>(input.size()) != config_.hidden_size * frames_) {
+            throw std::runtime_error("Mimi codec decoder post-transformer input size mismatch");
+        }
+        core::write_tensor_f32(input_, input);
+        size_t history = 0;
+        write_streaming_history(history_tensors_[history++], state.input_projection, input, config_.hidden_size, frames_, modules::StreamingPadMode::Constant);
+        for (size_t stage = 0; stage < 4; ++stage) {
+            write_streaming_partial(partial_tensors_[stage], state.stage_upsamples[stage]);
+            write_streaming_history(history_tensors_[history++], state.stage_residual_convs[stage][0], {}, 0, 0, modules::StreamingPadMode::Constant);
+        }
+        write_streaming_history(history_tensors_[history++], state.output_projection, {}, 0, 0, modules::StreamingPadMode::Constant);
+        if (core::compute_backend_graph(backend_, graph_) != GGML_STATUS_SUCCESS) {
+            throw std::runtime_error("Mimi codec decoder post-transformer graph compute failed");
+        }
+        size_t output_history = 0;
+        read_streaming_history(next_histories_[output_history++], state.input_projection);
+        for (size_t stage = 0; stage < 4; ++stage) {
+            read_streaming_history(next_histories_[output_history++], state.stage_residual_convs[stage][0]);
+        }
+        read_streaming_history(next_histories_[output_history++], state.output_projection);
+        for (size_t stage = 0; stage < 4; ++stage) {
+            read_streaming_partial(next_partials_[stage], state.stage_upsamples[stage], weights_->decoder.seanet_upsample_bias_values[stage]);
+        }
+        auto output = core::read_tensor_f32(output_.tensor);
+        for (float & sample : output) {
+            sample = std::clamp(sample, -1.0F, 1.0F);
+        }
+        return output;
+    }
+
+private:
+    std::optional<core::TensorValue> make_history_tensor(
+        core::ModuleBuildContext & ctx,
+        int64_t channels,
+        int64_t frames) {
+        if (frames <= 0) {
+            return std::nullopt;
+        }
+        history_tensors_.push_back(core::make_tensor(ctx, GGML_TYPE_F32, core::TensorShape::from_dims({1, channels, frames})));
+        return history_tensors_.back();
+    }
+
+    std::optional<core::TensorValue> make_partial_tensor(
+        core::ModuleBuildContext & ctx,
+        int64_t channels,
+        int64_t frames) {
+        if (frames <= 0) {
+            return std::nullopt;
+        }
+        partial_tensors_.push_back(core::make_tensor(ctx, GGML_TYPE_F32, core::TensorShape::from_dims({1, channels, frames})));
+        return partial_tensors_.back();
+    }
+
+    void build_runtime() {
+        if (core::is_host_backend(backend_)) {
+            params_buffer_ = ggml_backend_alloc_ctx_tensors(ggml_ctx_, backend_);
+            if (params_buffer_ == nullptr) {
+                release_graph_runtime(galloc_, params_buffer_, ggml_ctx_);
+                throw std::runtime_error("Mimi codec decoder post-transformer context tensor allocation failed");
+            }
+        }
+        core::set_backend_threads(backend_, threads_);
+        graph_ = ggml_new_graph_custom(ggml_ctx_, 65536, false);
+        ggml_build_forward_expand(graph_, output_.tensor);
+        for (const auto & history : next_histories_) {
+            ggml_build_forward_expand(graph_, history.tensor);
+        }
+        for (const auto & partial : next_partials_) {
+            ggml_build_forward_expand(graph_, partial.tensor);
+        }
+        galloc_ = ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend_));
+        if (galloc_ == nullptr || !ggml_gallocr_reserve(galloc_, graph_) || !ggml_gallocr_alloc_graph(galloc_, graph_)) {
+            release_graph_runtime(galloc_, params_buffer_, ggml_ctx_);
+            throw std::runtime_error("Mimi codec decoder post-transformer graph allocation failed");
+        }
+    }
+
+    ggml_backend_t backend_ = nullptr;
+    int threads_ = 1;
+    std::shared_ptr<const MimiCodecWeights> weights_;
+    MimiCodecConfig config_;
+    int64_t frames_ = 0;
+    ggml_context * ggml_ctx_ = nullptr;
+    ggml_backend_buffer_t params_buffer_ = nullptr;
+    ggml_cgraph * graph_ = nullptr;
+    ggml_gallocr_t galloc_ = nullptr;
+    core::TensorValue input_;
+    std::vector<core::TensorValue> history_tensors_;
+    std::vector<core::TensorValue> partial_tensors_;
+    std::vector<core::TensorValue> next_histories_;
+    std::vector<core::TensorValue> next_partials_;
+    core::TensorValue output_;
+};
+
+class MimiTransformerRuntime {
+public:
+    MimiTransformerRuntime(
+        ggml_backend_t backend,
+        core::BackendType backend_type,
+        int threads,
+        size_t graph_context_bytes,
+        const std::vector<MimiCodecTransformerLayerWeights> & layers,
+        const MimiCodecConfig & config,
+        int64_t frames)
+        : backend_(backend),
+          threads_(threads),
+          config_(config),
+          frames_(frames),
+          cache_steps_(std::max<int64_t>(0, config.context - frames)),
+          head_dim_(config.hidden_size / config.num_heads) {
+        ggml_ctx_ = ggml_init({graph_context_bytes, nullptr, true});
+        if (ggml_ctx_ == nullptr) {
+            throw std::runtime_error("failed to initialize Mimi codec transformer runtime context");
+        }
+        core::ModuleBuildContext ctx{ggml_ctx_, "mimi_codec.transformer", backend_type};
+        input_bct_ = core::make_tensor(ctx, GGML_TYPE_F32, core::TensorShape::from_dims({1, config.hidden_size, frames}));
+        positions_buffer_.resize(static_cast<size_t>(frames));
+        positions_ = core::make_tensor(ctx, GGML_TYPE_I32, core::TensorShape::from_dims({frames}));
+        attention_mask_ = core::make_tensor(ctx, GGML_TYPE_F32, core::TensorShape::from_dims({1, 1, frames, cache_steps_ + frames}));
+        auto x = modules::TransposeModule({{0, 2, 1, 3}, 3}).build(ctx, input_bct_);
+        for (int64_t layer = 0; layer < config.transformer_layers; ++layer) {
+            std::optional<core::TensorValue> prefix_key = std::nullopt;
+            std::optional<core::TensorValue> prefix_value = std::nullopt;
+            if (cache_steps_ > 0) {
+                prefix_key = core::make_tensor(ctx, GGML_TYPE_F32, core::TensorShape::from_dims({1, config.num_heads, cache_steps_, head_dim_}));
+                prefix_value = core::make_tensor(ctx, GGML_TYPE_F32, core::TensorShape::from_dims({1, config.num_heads, cache_steps_, head_dim_}));
+                prefix_keys_.push_back(*prefix_key);
+                prefix_values_.push_back(*prefix_value);
+            }
+            auto outputs = modules::StreamingTransformerEncoderBlockModule({
+                config.hidden_size,
+                config.num_heads,
+                config.intermediate_size,
+                1.0e-5F,
+                false,
+                GGML_PREC_F32,
+                GGML_PREC_F32,
+                modules::AttentionPrefixCacheLayout::HeadsSequence,
+            }).build(
+                ctx,
+                x,
+                positions_,
+                as_transformer_layer_weights(layers.at(static_cast<size_t>(layer))),
+                prefix_key,
+                prefix_value,
+                attention_mask_);
+            x = outputs.output;
+            keys_.push_back(outputs.key);
+            values_.push_back(outputs.value);
+        }
+        output_bct_ = modules::TransposeModule({{0, 2, 1, 3}, 3}).build(ctx, x);
+        build_transfer_views();
+        if (core::is_host_backend(backend_)) {
+            params_buffer_ = ggml_backend_alloc_ctx_tensors(ggml_ctx_, backend_);
+            if (params_buffer_ == nullptr) {
+                release_graph_runtime(galloc_, params_buffer_, ggml_ctx_);
+                throw std::runtime_error("Mimi codec transformer context tensor allocation failed");
+            }
+        }
+        core::set_backend_threads(backend_, threads_);
+        graph_ = ggml_new_graph_custom(ggml_ctx_, 65536, false);
+        ggml_build_forward_expand(graph_, output_bct_.tensor);
+        for (size_t layer = 0; layer < keys_.size(); ++layer) {
+            ggml_build_forward_expand(graph_, keys_[layer].tensor);
+            ggml_build_forward_expand(graph_, values_[layer].tensor);
+        }
+        for (auto * view : key_update_sources_) {
+            ggml_build_forward_expand(graph_, view);
+        }
+        for (auto * view : value_update_sources_) {
+            ggml_build_forward_expand(graph_, view);
+        }
+        for (auto * view : key_update_destinations_) {
+            ggml_build_forward_expand(graph_, view);
+        }
+        for (auto * view : value_update_destinations_) {
+            ggml_build_forward_expand(graph_, view);
+        }
+        galloc_ = ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend_));
+        if (galloc_ == nullptr || !ggml_gallocr_reserve(galloc_, graph_) || !ggml_gallocr_alloc_graph(galloc_, graph_)) {
+            release_graph_runtime(galloc_, params_buffer_, ggml_ctx_);
+            throw std::runtime_error("Mimi codec transformer graph allocation failed");
+        }
+        core::write_tensor_f32(input_bct_, std::vector<float>(static_cast<size_t>(config.hidden_size * frames), 0.0F));
+        core::write_tensor_f32(attention_mask_, transformer_attention_mask(frames_, cache_steps_, config_.context, 0));
+        if (cache_steps_ > 0) {
+            const std::vector<float> zero_prefix(static_cast<size_t>(cache_steps_ * config.num_heads * head_dim_), 0.0F);
+            for (size_t layer = 0; layer < prefix_keys_.size(); ++layer) {
+                core::write_tensor_f32(prefix_keys_[layer], zero_prefix);
+                core::write_tensor_f32(prefix_values_[layer], zero_prefix);
+            }
+        }
+    }
+
+    ~MimiTransformerRuntime() {
+        release_graph_runtime(galloc_, params_buffer_, ggml_ctx_);
+    }
+
+    void reset_sequence(int64_t current_end) {
+        current_end_ = current_end;
+        sequence_initialized_ = true;
+        for (size_t layer = 0; layer < prefix_keys_.size(); ++layer) {
+            const std::vector<float> zero_prefix(static_cast<size_t>(cache_steps_ * config_.num_heads * head_dim_), 0.0F);
+            core::write_tensor_f32(prefix_keys_[layer], zero_prefix);
+            core::write_tensor_f32(prefix_values_[layer], zero_prefix);
+        }
+    }
+
+    std::vector<float> run(const std::vector<float> & input_bct) {
+        if (static_cast<int64_t>(input_bct.size()) != config_.hidden_size * frames_) {
+            throw std::runtime_error("Mimi codec transformer input size mismatch");
+        }
+        if (!sequence_initialized_) {
+            throw std::runtime_error("Mimi codec transformer must be reset before run");
+        }
+        core::write_tensor_f32(input_bct_, input_bct);
+        for (int64_t index = 0; index < frames_; ++index) {
+            positions_buffer_[static_cast<size_t>(index)] = static_cast<int32_t>(current_end_ + index);
+        }
+        core::write_tensor_i32(positions_, positions_buffer_);
+        core::write_tensor_f32(attention_mask_, transformer_attention_mask(frames_, cache_steps_, config_.context, current_end_));
+        if (core::compute_backend_graph(backend_, graph_) != GGML_STATUS_SUCCESS) {
+            throw std::runtime_error("Mimi codec transformer graph compute failed");
+        }
+        auto output = core::read_tensor_f32(output_bct_.tensor);
+        if (cache_steps_ > 0) {
+            for (size_t layer = 0; layer < prefix_keys_.size(); ++layer) {
+                for (int64_t frame = 0; frame < frames_; ++frame) {
+                    const int64_t slot = (current_end_ + frame) % cache_steps_;
+                    for (int64_t head = 0; head < config_.num_heads; ++head) {
+                        const size_t view_index = static_cast<size_t>((frame * config_.num_heads + head) * config_.transformer_layers + static_cast<int64_t>(layer));
+                        const size_t dst_index = static_cast<size_t>((slot * config_.num_heads + head) * config_.transformer_layers + static_cast<int64_t>(layer));
+                        ggml_backend_tensor_copy(key_update_sources_[view_index], key_update_destinations_[dst_index]);
+                        ggml_backend_tensor_copy(value_update_sources_[view_index], value_update_destinations_[dst_index]);
+                    }
+                }
+            }
+        }
+        current_end_ += frames_;
+        return output;
+    }
+
+private:
+    void build_transfer_views() {
+        if (cache_steps_ <= 0) {
+            return;
+        }
+        const size_t source_count = static_cast<size_t>(frames_ * config_.num_heads * config_.transformer_layers);
+        const size_t destination_count = static_cast<size_t>(cache_steps_ * config_.num_heads * config_.transformer_layers);
+        key_update_sources_.assign(source_count, nullptr);
+        value_update_sources_.assign(source_count, nullptr);
+        key_update_destinations_.assign(destination_count, nullptr);
+        value_update_destinations_.assign(destination_count, nullptr);
+        for (int64_t frame = 0; frame < frames_; ++frame) {
+            for (int64_t head = 0; head < config_.num_heads; ++head) {
+                const size_t source_offset = static_cast<size_t>((head * frames_ + frame) * head_dim_) * sizeof(float);
+                for (size_t layer = 0; layer < keys_.size(); ++layer) {
+                    const size_t index = static_cast<size_t>(
+                        (frame * config_.num_heads + head) * config_.transformer_layers + static_cast<int64_t>(layer));
+                    key_update_sources_[index] = ggml_view_1d(ggml_ctx_, keys_[layer].tensor, head_dim_, source_offset);
+                    value_update_sources_[index] = ggml_view_1d(ggml_ctx_, values_[layer].tensor, head_dim_, source_offset);
+                }
+            }
+        }
+        for (int64_t slot = 0; slot < cache_steps_; ++slot) {
+            for (int64_t head = 0; head < config_.num_heads; ++head) {
+                const size_t destination_offset = static_cast<size_t>((head * cache_steps_ + slot) * head_dim_) * sizeof(float);
+                for (size_t layer = 0; layer < prefix_keys_.size(); ++layer) {
+                    const size_t index = static_cast<size_t>(
+                        (slot * config_.num_heads + head) * config_.transformer_layers + static_cast<int64_t>(layer));
+                    key_update_destinations_[index] = ggml_view_1d(
+                        ggml_ctx_,
+                        prefix_keys_[layer].tensor,
+                        head_dim_,
+                        destination_offset);
+                    value_update_destinations_[index] = ggml_view_1d(
+                        ggml_ctx_,
+                        prefix_values_[layer].tensor,
+                        head_dim_,
+                        destination_offset);
+                }
+            }
+        }
+    }
+
+    ggml_backend_t backend_ = nullptr;
+    int threads_ = 1;
+    MimiCodecConfig config_;
+    int64_t frames_ = 0;
+    int64_t cache_steps_ = 0;
+    int64_t head_dim_ = 0;
+    ggml_context * ggml_ctx_ = nullptr;
+    ggml_backend_buffer_t params_buffer_ = nullptr;
+    ggml_cgraph * graph_ = nullptr;
+    ggml_gallocr_t galloc_ = nullptr;
+    core::TensorValue input_bct_;
+    core::TensorValue positions_;
+    core::TensorValue attention_mask_;
+    std::vector<core::TensorValue> prefix_keys_;
+    std::vector<core::TensorValue> prefix_values_;
+    std::vector<core::TensorValue> keys_;
+    std::vector<core::TensorValue> values_;
+    std::vector<int32_t> positions_buffer_;
+    std::vector<ggml_tensor *> key_update_sources_;
+    std::vector<ggml_tensor *> value_update_sources_;
+    std::vector<ggml_tensor *> key_update_destinations_;
+    std::vector<ggml_tensor *> value_update_destinations_;
+    core::TensorValue output_bct_;
+    int64_t current_end_ = 0;
+    bool sequence_initialized_ = false;
+};
+
+core::TensorValue make_qkv_slice(
+    core::BackendWeightStore & store,
+    const assets::TensorSource & source,
+    const std::string & name,
+    assets::TensorStorageType storage_type,
+    int64_t hidden_size,
+    int64_t slice_index) {
+    const auto packed = source.require_f32(name, {3 * hidden_size, hidden_size});
+    std::vector<float> slice(static_cast<size_t>(hidden_size * hidden_size));
+    const size_t offset = static_cast<size_t>(slice_index * hidden_size * hidden_size);
+    std::copy_n(packed.begin() + static_cast<std::ptrdiff_t>(offset), slice.size(), slice.begin());
+    return store.make_from_f32(
+        core::TensorShape::from_dims({hidden_size, hidden_size}),
+        storage_type,
+        std::move(slice));
+}
+
+modules::AttentionWeights load_attention(
+    core::BackendWeightStore & store,
+    const assets::TensorSource & source,
+    const std::string & prefix,
+    assets::TensorStorageType storage_type,
+    int64_t hidden_size) {
+    const std::string packed_name = prefix + "self_attn.in_proj_weight";
+    modules::AttentionWeights weights;
+    weights.q_weight = make_qkv_slice(store, source, packed_name, storage_type, hidden_size, 0);
+    weights.k_weight = make_qkv_slice(store, source, packed_name, storage_type, hidden_size, 1);
+    weights.v_weight = make_qkv_slice(store, source, packed_name, storage_type, hidden_size, 2);
+    weights.out_weight = binding::tensor_from_named_source(
+        store,
+        source,
+        prefix + "self_attn.out_proj.weight",
+        storage_type);
+    return weights;
+}
+
+MimiCodecTransformerLayerWeights load_transformer_layer(
+    core::BackendWeightStore & store,
+    const assets::TensorSource & source,
+    const std::string & prefix,
+    assets::TensorStorageType storage_type,
+    int64_t hidden_size) {
+    MimiCodecTransformerLayerWeights layer;
+    layer.norm1 = binding::norm_from_named_source(store, source, prefix + "norm1.weight", prefix + "norm1.bias");
+    layer.self_attn = load_attention(store, source, prefix, storage_type, hidden_size);
+    layer.layer_scale1 = binding::layer_scale_from_named_source(store, source, prefix + "layer_scale_1.scale");
+    layer.norm2 = binding::norm_from_named_source(store, source, prefix + "norm2.weight", prefix + "norm2.bias");
+    layer.feed_forward = modules::FeedForwardWeights{
+        binding::tensor_from_named_source(store, source, prefix + "linear1.weight", storage_type),
+        std::nullopt,
+        binding::tensor_from_named_source(store, source, prefix + "linear2.weight", storage_type),
+        std::nullopt,
+    };
+    layer.layer_scale2 = binding::layer_scale_from_named_source(store, source, prefix + "layer_scale_2.scale");
+    return layer;
+}
+
+MimiCodecResidualWeights load_residual_block(
+    core::BackendWeightStore & store,
+    const assets::TensorSource & source,
+    const std::string & prefix,
+    assets::TensorStorageType storage_type) {
+    return {
+        binding::conv1d_from_named_source(store, source, prefix + ".block.1.conv.conv.weight", prefix + ".block.1.conv.conv.bias", storage_type),
+        binding::conv1d_from_named_source(store, source, prefix + ".block.3.conv.conv.weight", prefix + ".block.3.conv.conv.bias", storage_type),
+    };
+}
+
+std::vector<float> normalized_codebook(
+    const assets::TensorSource & source,
+    const std::string & prefix,
+    int64_t size,
+    int64_t dim) {
+    const auto cluster_usage = source.require_f32(prefix + "cluster_usage", {size});
+    const auto embedding_sum = source.require_f32(prefix + "embedding_sum", {size, dim});
+    std::vector<float> embedding(embedding_sum.size(), 0.0F);
+    for (int64_t code = 0; code < size; ++code) {
+        const float denom = std::max(cluster_usage[static_cast<size_t>(code)], kCodebookEps);
+        for (int64_t col = 0; col < dim; ++col) {
+            const size_t offset = static_cast<size_t>(code * dim + col);
+            embedding[offset] = embedding_sum[offset] / denom;
+        }
+    }
+    return embedding;
+}
+
+MimiCodecCodebookWeights load_codebook(
+    core::BackendWeightStore & store,
+    const assets::TensorSource & source,
+    const std::string & prefix,
+    int64_t size,
+    int64_t dim) {
+    auto embedding = normalized_codebook(source, prefix, size, dim);
+    return {
+        store.make_f32(
+            core::TensorShape::from_dims({size, dim}),
+            std::vector<float>(embedding)),
+        std::move(embedding),
+    };
+}
+
+void load_encoder_weights(
+    MimiCodecEncoderWeights & weights,
+    core::BackendWeightStore & store,
+    const assets::TensorSource & source,
+    const MimiCodecConfig & config,
+    const MimiCodecWeightBinding & weight_binding,
+    assets::TensorStorageType storage_type) {
+    weights.input_projection = binding::conv1d_from_named_source(
+        store,
+        source,
+        weight_binding.encoder_input_projection_weight,
+        weight_binding.encoder_input_projection_bias,
+        storage_type);
+    weights.residual_blocks.reserve(weight_binding.encoder_residual_prefixes.size());
+    for (const auto & prefix : weight_binding.encoder_residual_prefixes) {
+        weights.residual_blocks.push_back(load_residual_block(store, source, prefix, storage_type));
+    }
+    if (weight_binding.encoder_downsample_weight_names.size() != weight_binding.encoder_downsample_bias_names.size()) {
+        throw std::runtime_error("Mimi codec encoder downsample binding size mismatch");
+    }
+    weights.downsample_layers.reserve(weight_binding.encoder_downsample_weight_names.size());
+    for (size_t index = 0; index < weight_binding.encoder_downsample_weight_names.size(); ++index) {
+        weights.downsample_layers.push_back(binding::conv1d_from_named_source(
+            store,
+            source,
+            weight_binding.encoder_downsample_weight_names[index],
+            weight_binding.encoder_downsample_bias_names[index],
+            storage_type));
+    }
+    weights.output_projection = binding::conv1d_from_named_source(
+        store,
+        source,
+        weight_binding.encoder_output_projection_weight,
+        weight_binding.encoder_output_projection_bias,
+        storage_type);
+    weights.transformer_layers.reserve(static_cast<size_t>(config.transformer_layers));
+    for (int64_t layer = 0; layer < config.transformer_layers; ++layer) {
+        weights.transformer_layers.push_back(load_transformer_layer(
+            store,
+            source,
+            weight_binding.encoder_transformer_layer_prefix + std::to_string(layer) + ".",
+            storage_type,
+            config.hidden_size));
+    }
+    weights.downsample_conv = binding::conv1d_from_named_source(
+        store,
+        source,
+        weight_binding.downsample_weight,
+        std::nullopt,
+        storage_type);
+}
+
+void load_quantizer_weights(
+    MimiCodecQuantizerWeights & weights,
+    core::BackendWeightStore & store,
+    const assets::TensorSource & source,
+    const MimiCodecConfig & config,
+    const MimiCodecWeightBinding & weight_binding,
+    assets::TensorStorageType storage_type) {
+    weights.semantic_codebooks.push_back(load_codebook(
+        store,
+        source,
+        weight_binding.semantic_codebook_prefix,
+        config.codebook_size,
+        config.latent_size));
+    weights.acoustic_codebooks.reserve(static_cast<size_t>(config.total_codebooks - config.codebooks));
+    for (int64_t layer = 0; layer < config.total_codebooks - 1; ++layer) {
+        weights.acoustic_codebooks.push_back(load_codebook(
+            store,
+            source,
+            weight_binding.acoustic_codebook_layer_prefix + std::to_string(layer) + weight_binding.acoustic_codebook_suffix,
+            config.codebook_size,
+            config.latent_size));
+    }
+    weights.semantic_input_proj = binding::conv1d_from_named_source(
+        store,
+        source,
+        weight_binding.semantic_input_projection_weight,
+        std::nullopt,
+        storage_type);
+    weights.acoustic_input_proj = binding::conv1d_from_named_source(
+        store,
+        source,
+        weight_binding.acoustic_input_projection_weight,
+        std::nullopt,
+        storage_type);
+    weights.semantic_output_proj = binding::conv1d_from_named_source(
+        store,
+        source,
+        weight_binding.semantic_output_projection_weight,
+        std::nullopt,
+        storage_type);
+    weights.acoustic_output_proj = binding::conv1d_from_named_source(
+        store,
+        source,
+        weight_binding.acoustic_output_projection_weight,
+        std::nullopt,
+        storage_type);
+}
+
+SEANetResidualWeights to_seanet_residual(const MimiCodecResidualWeights & weights) {
+    return {weights.conv1, weights.conv2};
+}
+
+core::TensorValue codebook_decode(
+    core::ModuleBuildContext & ctx,
+    ggml_tensor * codes_t_q_b,
+    const MimiCodecCodebookWeights & codebook,
+    const MimiCodecConfig & config,
+    int64_t codebook_index) {
+    auto * code_slice = ggml_view_2d(
+        ctx.ggml,
+        codes_t_q_b,
+        codes_t_q_b->ne[0],
+        codes_t_q_b->ne[2],
+        codes_t_q_b->nb[2],
+        static_cast<size_t>(codebook_index) * codes_t_q_b->nb[1]);
+    auto indices = core::wrap_tensor(
+        code_slice,
+        core::TensorShape::from_dims({code_slice->ne[1], code_slice->ne[0]}),
+        GGML_TYPE_I32);
+    indices = core::ensure_backend_addressable_layout(ctx, indices);
+    return modules::CodebookLookupModule({config.codebook_size, config.latent_size}).build(
+        ctx,
+        indices,
+        codebook.embedding);
+}
+
+core::TensorValue project_quantized_latent(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & quantized_btd,
+    const modules::Conv1dWeights & weights,
+    const MimiCodecConfig & config) {
+    auto bct = modules::TransposeModule({{0, 2, 1, 3}, 3}).build(ctx, quantized_btd);
+    return modules::Conv1dModule({
+        config.latent_size,
+        config.hidden_size,
+        1,
+        1,
+        0,
+        1,
+        false,
+    }).build(ctx, bct, weights);
+}
+
+core::TensorValue quantizer_decode(
+    core::ModuleBuildContext & ctx,
+    ggml_tensor * codes_t_q_b,
+    const MimiCodecWeights & weights,
+    const MimiCodecConfig & config) {
+    auto semantic = codebook_decode(
+        ctx,
+        codes_t_q_b,
+        weights.quantizer.semantic_codebooks.front(),
+        config,
+        0);
+    semantic = project_quantized_latent(ctx, semantic, weights.quantizer.semantic_output_proj, config);
+
+    core::TensorValue acoustic;
+    for (int64_t codebook = 1; codebook < kMimiActiveCodebooks; ++codebook) {
+        auto decoded = codebook_decode(
+            ctx,
+            codes_t_q_b,
+            weights.quantizer.acoustic_codebooks[static_cast<size_t>(codebook - 1)],
+            config,
+            codebook);
+        acoustic = acoustic.valid() ? modules::AddModule{}.build(ctx, acoustic, decoded) : decoded;
+    }
+    acoustic = project_quantized_latent(ctx, acoustic, weights.quantizer.acoustic_output_proj, config);
+    return modules::AddModule{}.build(ctx, semantic, acoustic);
+}
+
+std::vector<int32_t> quantize_projected(
+    const std::vector<float> & projected,
+    int64_t frames,
+    const std::vector<MimiCodecCodebookWeights> & codebooks,
+    int64_t latent_size) {
+    std::vector<float> residual(projected);
+    std::vector<int32_t> codes(static_cast<size_t>(frames * static_cast<int64_t>(codebooks.size())));
+    for (size_t q = 0; q < codebooks.size(); ++q) {
+        const auto & table = codebooks[q].host_embedding;
+        for (int64_t frame = 0; frame < frames; ++frame) {
+            const size_t frame_offset = static_cast<size_t>(frame * latent_size);
+            int32_t best = 0;
+            float best_dist = std::numeric_limits<float>::infinity();
+            for (int64_t code = 0; code < static_cast<int64_t>(table.size()) / latent_size; ++code) {
+                const size_t code_offset = static_cast<size_t>(code * latent_size);
+                float dist = 0.0F;
+                for (int64_t dim = 0; dim < latent_size; ++dim) {
+                    const float delta = residual[frame_offset + static_cast<size_t>(dim)] -
+                        table[code_offset + static_cast<size_t>(dim)];
+                    dist += delta * delta;
+                }
+                if (dist < best_dist) {
+                    best_dist = dist;
+                    best = static_cast<int32_t>(code);
+                }
+            }
+            codes[static_cast<size_t>(frame * static_cast<int64_t>(codebooks.size()) + static_cast<int64_t>(q))] = best;
+            const size_t code_offset = static_cast<size_t>(best) * static_cast<size_t>(latent_size);
+            for (int64_t dim = 0; dim < latent_size; ++dim) {
+                residual[frame_offset + static_cast<size_t>(dim)] -= table[code_offset + static_cast<size_t>(dim)];
+            }
+        }
+    }
+    return codes;
+}
+
+void load_decoder_weights(
+    MimiCodecDecoderWeights & weights,
+    core::BackendWeightStore & store,
+    const assets::TensorSource & source,
+    const MimiCodecConfig & config,
+    const MimiCodecWeightBinding & weight_binding,
+    assets::TensorStorageType storage_type) {
+    weights.transformer_layers.reserve(static_cast<size_t>(config.transformer_layers));
+    for (int64_t layer = 0; layer < config.transformer_layers; ++layer) {
+        weights.transformer_layers.push_back(load_transformer_layer(
+            store,
+            source,
+            weight_binding.decoder_transformer_layer_prefix + std::to_string(layer) + ".",
+            storage_type,
+            config.hidden_size));
+    }
+    auto upsample_weight = source.require_f32(
+        weight_binding.decoder_upsample_weight,
+        {config.hidden_size, 1, 2 * 2});
+    for (int64_t channel = 0; channel < config.hidden_size; ++channel) {
+        auto * kernel = upsample_weight.data() + static_cast<size_t>(channel) * 4;
+        std::reverse(kernel, kernel + 4);
+    }
+    weights.upsample_conv = {
+        store.make_from_f32(
+            core::TensorShape::from_dims({config.hidden_size, 1, 1, 2 * 2}),
+            storage_type,
+            upsample_weight),
+        std::nullopt,
+    };
+    weights.seanet.input_projection = binding::conv1d_from_named_source(
+        store,
+        source,
+        weight_binding.decoder_input_projection_weight,
+        weight_binding.decoder_input_projection_bias,
+        storage_type);
+    if (weight_binding.decoder_upsample_weight_names.size() != weight_binding.decoder_upsample_bias_names.size() ||
+        weight_binding.decoder_upsample_weight_names.size() != weight_binding.decoder_residual_prefixes.size()) {
+        throw std::runtime_error("Mimi codec decoder stage binding size mismatch");
+    }
+    weights.seanet.stages.reserve(weight_binding.decoder_upsample_weight_names.size());
+    for (size_t stage = 0; stage < weight_binding.decoder_upsample_weight_names.size(); ++stage) {
+        SEANetDecoderStageWeights stage_weights;
+        stage_weights.upsample = binding::conv_transpose1d_from_named_source(
+            store,
+            source,
+            weight_binding.decoder_upsample_weight_names[stage],
+            weight_binding.decoder_upsample_bias_names[stage],
+            storage_type);
+        weights.seanet_upsample_bias_values.push_back(source.require_f32(
+            weight_binding.decoder_upsample_bias_names[stage],
+            {stage_weights.upsample.bias->shape.dims[0]}));
+        stage_weights.residual_blocks.push_back(to_seanet_residual(load_residual_block(
+            store,
+            source,
+            weight_binding.decoder_residual_prefixes[stage],
+            storage_type)));
+        weights.seanet.stages.push_back(std::move(stage_weights));
+    }
+    weights.seanet.output_projection = binding::conv1d_from_named_source(
+        store,
+        source,
+        weight_binding.decoder_output_projection_weight,
+        weight_binding.decoder_output_projection_bias,
+        storage_type);
+}
+
+}  // namespace
+
+std::shared_ptr<const MimiCodecWeights> load_mimi_codec_weights(
+    const assets::TensorSource & source,
+    const MimiCodecConfig & config,
+    MimiCodecWeightBinding weight_binding,
+    ggml_backend_t backend,
+    core::BackendType backend_type,
+    size_t context_bytes,
+    assets::TensorStorageType storage_type) {
+    auto weights = std::make_shared<MimiCodecWeights>();
+    weights->store = std::make_shared<core::BackendWeightStore>(
+        backend,
+        backend_type,
+        "MimiCodec.weights",
+        context_bytes);
+    load_encoder_weights(weights->encoder, *weights->store, source, config, weight_binding, storage_type);
+    load_quantizer_weights(weights->quantizer, *weights->store, source, config, weight_binding, storage_type);
+    load_decoder_weights(weights->decoder, *weights->store, source, config, weight_binding, storage_type);
+    weights->store->upload();
+    return weights;
+}
+
+MimiCodecComponent MimiCodecComponent::load_from_tensor_source(
+    std::shared_ptr<const assets::TensorSource> source,
+    MimiCodecConfig config,
+    MimiCodecWeightBinding weight_binding,
+    ggml_backend_t backend,
+    core::BackendType backend_type,
+    size_t context_bytes,
+    assets::TensorStorageType storage_type) {
+    if (source == nullptr) {
+        throw std::runtime_error("MimiCodecComponent requires a tensor source");
+    }
+    auto weights = load_mimi_codec_weights(
+        *source,
+        config,
+        std::move(weight_binding),
+        backend,
+        backend_type,
+        context_bytes,
+        storage_type);
+    return MimiCodecComponent(std::move(config), std::move(weights));
+}
+
+MimiCodecComponent::MimiCodecComponent(
+    MimiCodecConfig config,
+    std::shared_ptr<const MimiCodecWeights> weights)
+    : config_(std::move(config)),
+      weights_(std::move(weights)) {
+    if (weights_ == nullptr) {
+        throw std::runtime_error("MimiCodecComponent requires loaded weights");
+    }
+}
+
+const MimiCodecConfig & MimiCodecComponent::config() const noexcept {
+    return config_;
+}
+
+const std::shared_ptr<const MimiCodecWeights> & MimiCodecComponent::weights() const noexcept {
+    return weights_;
+}
+
+struct MimiDecoderRuntime::Impl {
+    struct QuantizerGraph {
+        QuantizerGraph(
+            std::shared_ptr<const MimiCodecWeights> weights,
+            MimiCodecConfig config,
+            ggml_backend_t backend,
+            core::BackendType backend_type,
+            int threads,
+            size_t graph_arena_bytes,
+            int64_t code_frames)
+            : weights(std::move(weights)),
+              config(std::move(config)),
+              backend(backend),
+              backend_type(backend_type),
+              threads(std::max(1, threads)),
+              code_frames(code_frames) {
+            if (this->weights == nullptr) {
+                throw std::runtime_error("Mimi codec quantizer decoder requires weights");
+            }
+            if (code_frames <= 0) {
+                throw std::runtime_error("Mimi codec quantizer decoder requires positive frame count");
+            }
+            ctx.reset(ggml_init({graph_arena_bytes, nullptr, true}));
+            if (ctx == nullptr) {
+                throw std::runtime_error("failed to initialize Mimi codec quantizer decoder graph context");
+            }
+            core::ModuleBuildContext build_ctx{
+                ctx.get(),
+                "mimi_codec.quantizer_decode",
+                backend_type,
+            };
+            codes = ggml_new_tensor_3d(ctx.get(), GGML_TYPE_I32, code_frames, kMimiActiveCodebooks, 1);
+            ggml_set_input(codes);
+            auto hidden = core::ensure_backend_addressable_layout(
+                build_ctx,
+                quantizer_decode(build_ctx, codes, *this->weights, this->config));
+            output = hidden.tensor;
+            ggml_set_output(output);
+
+            graph = ggml_new_graph_custom(ctx.get(), 65536, false);
+            ggml_build_forward_expand(graph, output);
+            if (core::is_host_backend(backend)) {
+                params_buffer = ggml_backend_alloc_ctx_tensors(ctx.get(), backend);
+                if (params_buffer == nullptr) {
+                    throw std::runtime_error("Mimi codec quantizer decoder context tensor allocation failed");
+                }
+            }
+            galloc = ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend));
+            if (galloc == nullptr ||
+                !ggml_gallocr_reserve(galloc, graph) ||
+                !ggml_gallocr_alloc_graph(galloc, graph)) {
+                throw std::runtime_error("failed to allocate Mimi codec quantizer decoder graph");
+            }
+        }
+
+        ~QuantizerGraph() {
+            engine::core::release_backend_graph_resources(backend, graph);
+            if (galloc != nullptr) {
+                ggml_gallocr_free(galloc);
+            }
+            if (params_buffer != nullptr) {
+                ggml_backend_buffer_free(params_buffer);
+            }
+        }
+
+        std::vector<float> run(const std::vector<int32_t> & input_codes) {
+            if (static_cast<int64_t>(input_codes.size()) != code_frames * kMimiActiveCodebooks) {
+                throw std::runtime_error("Mimi codec quantizer decoder code tensor size mismatch");
+            }
+            std::vector<int32_t> tensor_codes(static_cast<size_t>(code_frames * kMimiActiveCodebooks));
+            for (int64_t frame = 0; frame < code_frames; ++frame) {
+                for (int64_t codebook = 0; codebook < kMimiActiveCodebooks; ++codebook) {
+                    tensor_codes[static_cast<size_t>(frame + code_frames * codebook)] =
+                        input_codes[static_cast<size_t>(frame * kMimiActiveCodebooks + codebook)];
+                }
+            }
+            ggml_backend_tensor_set(codes, tensor_codes.data(), 0, tensor_codes.size() * sizeof(int32_t));
+            core::set_backend_threads(backend, threads);
+            const ggml_status status = core::compute_backend_graph(backend, graph, nullptr, "mimi_codec.quantizer_decode");
+            ggml_backend_synchronize(backend);
+            if (status != GGML_STATUS_SUCCESS) {
+                throw std::runtime_error("Mimi codec quantizer decoder graph compute failed");
+            }
+            return core::read_tensor_f32(output);
+        }
+
+        std::shared_ptr<const MimiCodecWeights> weights;
+        MimiCodecConfig config;
+        ggml_backend_t backend = nullptr;
+        core::BackendType backend_type = core::BackendType::Cpu;
+        int threads = 1;
+        int64_t code_frames = 0;
+        std::unique_ptr<ggml_context, GgmlContextDeleter> ctx;
+        ggml_tensor * codes = nullptr;
+        ggml_tensor * output = nullptr;
+        ggml_cgraph * graph = nullptr;
+        ggml_gallocr_t galloc = nullptr;
+        ggml_backend_buffer_t params_buffer = nullptr;
+    };
+
+    struct RuntimeCache {
+        std::unique_ptr<QuantizerGraph> quantizer_graph;
+        int64_t quantizer_frames = -1;
+        std::unique_ptr<MimiDecoderPreTransformerGraph> pre_transformer_graph;
+        std::unique_ptr<MimiTransformerRuntime> transformer_runtime;
+        int64_t transformer_frames = -1;
+        std::unique_ptr<MimiDecoderPostTransformerGraph> post_transformer_graph;
+        int64_t post_transformer_frames = -1;
+    };
+
+    runtime::AudioBuffer decode_with_state(
+        const std::vector<int32_t> & codes,
+        int64_t frames,
+        MimiDecoderState & state,
+        bool & transformer_initialized);
+
+    std::shared_ptr<const MimiCodecWeights> weights;
+    MimiCodecConfig config;
+    ggml_backend_t backend = nullptr;
+    core::BackendType backend_type = core::BackendType::Cpu;
+    int threads = 1;
+    size_t graph_arena_bytes = 0;
+    RuntimeCache cache;
+    std::optional<MimiDecoderState> streaming_state;
+    bool streaming_transformer_initialized = false;
+};
+
+MimiDecoderRuntime::MimiDecoderRuntime(
+    std::shared_ptr<const MimiCodecWeights> weights,
+    MimiCodecConfig config,
+    ggml_backend_t backend,
+    core::BackendType backend_type,
+    int threads,
+    size_t graph_arena_bytes)
+    : impl_(std::make_unique<Impl>()) {
+    impl_->weights = std::move(weights);
+    impl_->config = std::move(config);
+    impl_->backend = backend;
+    impl_->backend_type = backend_type;
+    impl_->threads = std::max(1, threads);
+    impl_->graph_arena_bytes = graph_arena_bytes;
+}
+
+MimiDecoderRuntime::~MimiDecoderRuntime() = default;
+
+runtime::AudioBuffer MimiDecoderRuntime::Impl::decode_with_state(
+    const std::vector<int32_t> & codes,
+    int64_t frames,
+    MimiDecoderState & state,
+    bool & transformer_initialized) {
+    if (frames <= 0 || static_cast<int64_t>(codes.size()) != frames * kMimiActiveCodebooks) {
+        throw std::runtime_error("Mimi codec decode requires frames * 8 codes");
+    }
+    if (cache.quantizer_graph == nullptr || cache.quantizer_frames != frames) {
+        cache.quantizer_graph = std::make_unique<Impl::QuantizerGraph>(
+            weights,
+            config,
+            backend,
+            backend_type,
+            threads,
+            graph_arena_bytes,
+            frames);
+        cache.quantizer_frames = frames;
+    }
+
+    const auto & config = this->config;
+    auto latents_bct = cache.quantizer_graph->run(codes);
+    std::vector<float> audio;
+    audio.reserve(static_cast<size_t>(frames * kMimiFrameSamples));
+
+    std::vector<float> latent_step(static_cast<size_t>(config.hidden_size), 0.0F);
+
+    for (int64_t frame = 0; frame < frames; ++frame) {
+        for (int64_t channel = 0; channel < config.hidden_size; ++channel) {
+            latent_step[static_cast<size_t>(channel)] =
+                latents_bct[static_cast<size_t>(channel * frames + frame)];
+        }
+        if (cache.pre_transformer_graph == nullptr) {
+            cache.pre_transformer_graph = std::make_unique<MimiDecoderPreTransformerGraph>(
+                backend,
+                backend_type,
+                threads,
+                graph_arena_bytes,
+                this->weights,
+                config);
+        }
+        auto x = cache.pre_transformer_graph->run(latent_step, state);
+        const int64_t encoder_frames = static_cast<int64_t>(x.size()) / config.hidden_size;
+        if (cache.transformer_runtime == nullptr || cache.transformer_frames != encoder_frames) {
+            cache.transformer_runtime = std::make_unique<MimiTransformerRuntime>(
+                backend,
+                backend_type,
+                threads,
+                graph_arena_bytes,
+                weights->decoder.transformer_layers,
+                config,
+                encoder_frames);
+            cache.transformer_frames = encoder_frames;
+        }
+        if (!transformer_initialized) {
+            cache.transformer_runtime->reset_sequence(state.transformer.current_end);
+            transformer_initialized = true;
+        }
+        x = cache.transformer_runtime->run(x);
+        if (cache.post_transformer_graph == nullptr || cache.post_transformer_frames != encoder_frames) {
+            cache.post_transformer_graph = std::make_unique<MimiDecoderPostTransformerGraph>(
+                backend,
+                backend_type,
+                threads,
+                graph_arena_bytes,
+                this->weights,
+                config,
+                encoder_frames);
+            cache.post_transformer_frames = encoder_frames;
+        }
+        x = cache.post_transformer_graph->run(x, state);
+        audio.insert(audio.end(), x.begin(), x.end());
+    }
+    return runtime::AudioBuffer{config.sample_rate, static_cast<int>(config.channels), std::move(audio)};
+}
+
+runtime::AudioBuffer MimiDecoderRuntime::decode(const std::vector<int32_t> & codes, int64_t frames) {
+    auto state = make_mimi_decoder_state(impl_->config);
+    bool transformer_initialized = false;
+    return impl_->decode_with_state(codes, frames, state, transformer_initialized);
+}
+
+void MimiDecoderRuntime::reset_streaming() {
+    impl_->streaming_state = make_mimi_decoder_state(impl_->config);
+    impl_->streaming_transformer_initialized = false;
+}
+
+runtime::AudioBuffer MimiDecoderRuntime::decode_streaming(const std::vector<int32_t> & codes, int64_t frames) {
+    if (!impl_->streaming_state.has_value()) {
+        reset_streaming();
+    }
+    return impl_->decode_with_state(
+        codes,
+        frames,
+        *impl_->streaming_state,
+        impl_->streaming_transformer_initialized);
+}
+
+struct MimiEncoderRuntime::Impl {
+    struct RuntimeCache {
+        std::unique_ptr<MimiEncoderPreTransformerGraph> pre_transformer_graph;
+        std::unique_ptr<MimiTransformerRuntime> transformer_runtime;
+        int64_t transformer_frames = -1;
+        std::unique_ptr<MimiEncoderPostTransformerGraph> post_transformer_graph;
+        int64_t post_transformer_frames = -1;
+    };
+
+    std::vector<int32_t> encode_streaming_with_state(
+        const std::vector<float> & mono,
+        MimiEncoderState & state,
+        bool & transformer_initialized) {
+        if (mono.empty() || static_cast<int64_t>(mono.size()) % kMimiFrameSamples != 0) {
+            throw std::runtime_error("Mimi codec streaming encoder requires full Mimi frames");
+        }
+        const auto & config = this->config;
+        const auto & weights = *this->weights;
+
+        const int64_t code_frames = static_cast<int64_t>(mono.size()) / kMimiFrameSamples;
+        std::vector<int32_t> out(static_cast<size_t>(code_frames * kMimiActiveCodebooks));
+        std::vector<MimiCodecCodebookWeights> acoustic_codebooks;
+        acoustic_codebooks.reserve(static_cast<size_t>(kMimiActiveCodebooks - 1));
+        for (int64_t index = 0; index < kMimiActiveCodebooks - 1; ++index) {
+            acoustic_codebooks.push_back(weights.quantizer.acoustic_codebooks[static_cast<size_t>(index)]);
+        }
+
+        for (int64_t frame = 0; frame < code_frames; ++frame) {
+            std::vector<float> x(
+                mono.begin() + static_cast<std::ptrdiff_t>(frame * kMimiFrameSamples),
+                mono.begin() + static_cast<std::ptrdiff_t>((frame + 1) * kMimiFrameSamples));
+            if (cache.pre_transformer_graph == nullptr) {
+                cache.pre_transformer_graph = std::make_unique<MimiEncoderPreTransformerGraph>(
+                    backend,
+                    backend_type,
+                    threads,
+                    graph_arena_bytes,
+                    this->weights,
+                    config);
+            }
+            x = cache.pre_transformer_graph->run(x, state);
+
+            const int64_t transformer_frames = static_cast<int64_t>(x.size()) / config.hidden_size;
+            if (cache.transformer_runtime == nullptr || cache.transformer_frames != transformer_frames) {
+                cache.transformer_runtime = std::make_unique<MimiTransformerRuntime>(
+                    backend,
+                    backend_type,
+                    threads,
+                    graph_arena_bytes,
+                    weights.encoder.transformer_layers,
+                    config,
+                    transformer_frames);
+                cache.transformer_frames = transformer_frames;
+            }
+            if (!transformer_initialized) {
+                cache.transformer_runtime->reset_sequence(state.transformer.current_end);
+                transformer_initialized = true;
+            }
+            x = cache.transformer_runtime->run(x);
+
+            if (cache.post_transformer_graph == nullptr || cache.post_transformer_frames != transformer_frames) {
+                cache.post_transformer_graph = std::make_unique<MimiEncoderPostTransformerGraph>(
+                    backend,
+                    backend_type,
+                    threads,
+                    graph_arena_bytes,
+                    this->weights,
+                    config,
+                    transformer_frames);
+                cache.post_transformer_frames = transformer_frames;
+            }
+            const auto [semantic, acoustic] = cache.post_transformer_graph->run(x, state);
+            const auto semantic_codes = quantize_projected(
+                semantic,
+                1,
+                weights.quantizer.semantic_codebooks,
+                config.latent_size);
+            const auto acoustic_codes = quantize_projected(
+                acoustic,
+                1,
+                acoustic_codebooks,
+                config.latent_size);
+            out[static_cast<size_t>(frame * kMimiActiveCodebooks)] = semantic_codes.front();
+            for (int64_t q = 1; q < kMimiActiveCodebooks; ++q) {
+                out[static_cast<size_t>(frame * kMimiActiveCodebooks + q)] =
+                    acoustic_codes[static_cast<size_t>(q - 1)];
+            }
+        }
+        return out;
+    }
+
+    std::shared_ptr<const MimiCodecWeights> weights;
+    MimiCodecConfig config;
+    ggml_backend_t backend = nullptr;
+    core::BackendType backend_type = core::BackendType::Cpu;
+    int threads = 1;
+    size_t graph_arena_bytes = 0;
+    RuntimeCache cache;
+};
+
+MimiEncoderRuntime::MimiEncoderRuntime(
+    std::shared_ptr<const MimiCodecWeights> weights,
+    MimiCodecConfig config,
+    ggml_backend_t backend,
+    core::BackendType backend_type,
+    int threads,
+    size_t graph_arena_bytes)
+    : impl_(std::make_unique<Impl>()) {
+    impl_->weights = std::move(weights);
+    impl_->config = std::move(config);
+    impl_->backend = backend;
+    impl_->backend_type = backend_type;
+    impl_->threads = std::max(1, threads);
+    impl_->graph_arena_bytes = graph_arena_bytes;
+}
+
+MimiEncoderRuntime::~MimiEncoderRuntime() = default;
+
+std::vector<int32_t> MimiEncoderRuntime::encode(const runtime::AudioBuffer & audio) {
+    auto mono = engine::audio::convert_interleaved_audio_to_mono_linear_resampled(
+        audio.samples,
+        audio.sample_rate,
+        audio.channels,
+        impl_->config.sample_rate);
+    if (mono.empty()) {
+        throw std::runtime_error("Mimi codec encoder received empty audio");
+    }
+    const int64_t padded_samples =
+        ((static_cast<int64_t>(mono.size()) + kMimiFrameSamples - 1) / kMimiFrameSamples) * kMimiFrameSamples;
+    mono.resize(static_cast<size_t>(padded_samples), 0.0F);
+    auto state = make_mimi_encoder_state(impl_->config);
+    bool transformer_initialized = false;
+    return impl_->encode_streaming_with_state(mono, state, transformer_initialized);
+}
+
+}  // namespace engine::codecs

--- a/src/framework/midi/midi_file.cpp
+++ b/src/framework/midi/midi_file.cpp
@@ -1,0 +1,266 @@
+#include "engine/framework/midi/midi_file.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <map>
+#include <stdexcept>
+#include <tuple>
+#include <utility>
+
+namespace engine::midi {
+namespace {
+
+constexpr double kMinimumNoteDurationSeconds = 0.01;
+
+struct NoteEvent {
+    bool is_drum = false;
+    int program = 0;
+    double time_seconds = 0.0;
+    int velocity = 0;
+    int pitch = 0;
+    std::string track_name;
+};
+
+void require_u7(int value, const char * name) {
+    if (value < 0 || value > 127) {
+        throw std::runtime_error(std::string(name) + " must be in [0, 127]");
+    }
+}
+
+void append_u8(std::vector<std::byte> & out, uint8_t value) {
+    out.push_back(static_cast<std::byte>(value));
+}
+
+void append_u16_be(std::vector<std::byte> & out, uint16_t value) {
+    append_u8(out, static_cast<uint8_t>((value >> 8) & 0xff));
+    append_u8(out, static_cast<uint8_t>(value & 0xff));
+}
+
+void append_u24_be(std::vector<std::byte> & out, uint32_t value) {
+    append_u8(out, static_cast<uint8_t>((value >> 16) & 0xff));
+    append_u8(out, static_cast<uint8_t>((value >> 8) & 0xff));
+    append_u8(out, static_cast<uint8_t>(value & 0xff));
+}
+
+void append_u32_be(std::vector<std::byte> & out, uint32_t value) {
+    append_u8(out, static_cast<uint8_t>((value >> 24) & 0xff));
+    append_u8(out, static_cast<uint8_t>((value >> 16) & 0xff));
+    append_u8(out, static_cast<uint8_t>((value >> 8) & 0xff));
+    append_u8(out, static_cast<uint8_t>(value & 0xff));
+}
+
+void append_ascii(std::vector<std::byte> & out, const char * text) {
+    while (*text != '\0') {
+        append_u8(out, static_cast<uint8_t>(*text));
+        ++text;
+    }
+}
+
+void append_bytes(std::vector<std::byte> & out, const std::string & text) {
+    for (const unsigned char ch : text) {
+        append_u8(out, ch);
+    }
+}
+
+void append_varlen(std::vector<std::byte> & out, uint32_t value) {
+    uint8_t buffer[5] = {};
+    int index = 4;
+    buffer[index] = static_cast<uint8_t>(value & 0x7f);
+    while ((value >>= 7) != 0) {
+        --index;
+        buffer[index] = static_cast<uint8_t>((value & 0x7f) | 0x80);
+    }
+    for (; index < 5; ++index) {
+        append_u8(out, buffer[index]);
+    }
+}
+
+int64_t seconds_to_tick(double seconds, const MidiFileOptions & options) {
+    const double ticks = seconds *
+        static_cast<double>(options.ticks_per_beat) *
+        1000000.0 /
+        static_cast<double>(options.tempo_us_per_beat);
+    return static_cast<int64_t>(std::llround(ticks));
+}
+
+int note_key_program(const MidiNote & note) {
+    return note.is_drum ? kDrumProgram : note.program;
+}
+
+int event_key_program(const NoteEvent & event) {
+    return event.is_drum ? kDrumProgram : event.program;
+}
+
+std::vector<NoteEvent> note_events_from_notes(const std::vector<MidiNote> & notes) {
+    std::vector<NoteEvent> events;
+    events.reserve(notes.size() * 2);
+    for (const auto & note : notes) {
+        require_u7(note.pitch, "MIDI note pitch");
+        if (!note.is_drum) {
+            require_u7(note.program, "MIDI program");
+        }
+        events.push_back(NoteEvent{
+            note.is_drum,
+            note.program,
+            note.onset_seconds,
+            1,
+            note.pitch,
+            note.track_name,
+        });
+        events.push_back(NoteEvent{
+            note.is_drum,
+            note.program,
+            note.is_drum ? note.onset_seconds + kMinimumNoteDurationSeconds : note.offset_seconds,
+            0,
+            note.pitch,
+            note.track_name,
+        });
+    }
+    std::sort(events.begin(), events.end(), [](const NoteEvent & lhs, const NoteEvent & rhs) {
+        return std::tie(lhs.time_seconds, lhs.is_drum, lhs.program, lhs.velocity, lhs.pitch) <
+            std::tie(rhs.time_seconds, rhs.is_drum, rhs.program, rhs.velocity, rhs.pitch);
+    });
+    return events;
+}
+
+void append_midi_track(std::vector<std::byte> & file, const std::vector<std::byte> & track) {
+    append_ascii(file, "MTrk");
+    append_u32_be(file, static_cast<uint32_t>(track.size()));
+    file.insert(file.end(), track.begin(), track.end());
+}
+
+}  // namespace
+
+std::vector<MidiNote> clean_midi_notes(std::vector<MidiNote> notes) {
+    for (auto & note : notes) {
+        if (note.is_drum) {
+            note.program = kDrumProgram;
+            note.offset_seconds = note.onset_seconds + kMinimumNoteDurationSeconds;
+        } else if (note.onset_seconds > note.offset_seconds ||
+                   note.offset_seconds - note.onset_seconds < kMinimumNoteDurationSeconds) {
+            note.offset_seconds = note.onset_seconds + kMinimumNoteDurationSeconds;
+        }
+    }
+    std::map<std::tuple<int, int, bool>, std::vector<MidiNote>> channels;
+    for (auto & note : notes) {
+        channels[{note_key_program(note), note.pitch, note.is_drum}].push_back(std::move(note));
+    }
+    std::vector<MidiNote> out;
+    out.reserve(notes.size());
+    for (auto & [key, channel_notes] : channels) {
+        (void)key;
+        std::sort(channel_notes.begin(), channel_notes.end(), [](const MidiNote & lhs, const MidiNote & rhs) {
+            return lhs.onset_seconds < rhs.onset_seconds;
+        });
+        for (size_t i = 1; i < channel_notes.size(); ++i) {
+            if (channel_notes[i - 1].offset_seconds > channel_notes[i].onset_seconds) {
+                channel_notes[i - 1].offset_seconds = channel_notes[i].onset_seconds;
+            }
+        }
+        for (auto & note : channel_notes) {
+            if (note.is_drum || note.onset_seconds < note.offset_seconds) {
+                out.push_back(std::move(note));
+            }
+        }
+    }
+    std::sort(out.begin(), out.end(), [](const MidiNote & lhs, const MidiNote & rhs) {
+        return std::tie(lhs.onset_seconds, lhs.is_drum, lhs.program, lhs.pitch, lhs.offset_seconds) <
+            std::tie(rhs.onset_seconds, rhs.is_drum, rhs.program, rhs.pitch, rhs.offset_seconds);
+    });
+    return out;
+}
+
+std::vector<std::byte> write_standard_midi_file(
+    const std::vector<MidiNote> & notes,
+    const MidiFileOptions & options) {
+    if (options.ticks_per_beat <= 0) {
+        throw std::runtime_error("MIDI ticks_per_beat must be positive");
+    }
+    if (options.tempo_us_per_beat <= 0 || options.tempo_us_per_beat > 0x00ffffff) {
+        throw std::runtime_error("MIDI tempo_us_per_beat must fit in a tempo meta event");
+    }
+    require_u7(options.velocity, "MIDI velocity");
+
+    const auto clean_notes = clean_midi_notes(notes);
+    const auto events = note_events_from_notes(clean_notes);
+
+    std::vector<std::byte> meta_track;
+    append_u8(meta_track, 0x00);
+    append_u8(meta_track, 0xff);
+    append_u8(meta_track, 0x51);
+    append_u8(meta_track, 0x03);
+    append_u24_be(meta_track, static_cast<uint32_t>(options.tempo_us_per_beat));
+    append_u8(meta_track, 0x00);
+    append_u8(meta_track, 0xff);
+    append_u8(meta_track, 0x2f);
+    append_u8(meta_track, 0x00);
+
+    std::map<int, std::vector<std::byte>> tracks;
+    std::map<int, int64_t> track_ticks;
+    std::map<int, int> channels;
+    std::vector<int> available_channels{0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 13, 14, 15};
+    std::vector<int> track_order;
+    for (const auto & event : events) {
+        const int key = event_key_program(event);
+        if (!tracks.count(key)) {
+            track_order.push_back(key);
+            auto & track = tracks[key];
+            track_ticks[key] = 0;
+            const bool is_drum = key == kDrumProgram;
+            const int channel = is_drum
+                ? 9
+                : (available_channels.empty() ? 15 : available_channels.front());
+            if (!is_drum && !available_channels.empty()) {
+                available_channels.erase(available_channels.begin());
+            }
+            channels[key] = channel;
+            const std::string name = !event.track_name.empty()
+                ? event.track_name
+                : (is_drum ? std::string("drums") : "program " + std::to_string(key));
+            append_u8(track, 0x00);
+            append_u8(track, 0xff);
+            append_u8(track, 0x03);
+            append_varlen(track, static_cast<uint32_t>(name.size()));
+            append_bytes(track, name);
+            append_u8(track, 0x00);
+            append_u8(track, static_cast<uint8_t>(0xc0 | channels[key]));
+            append_u8(track, static_cast<uint8_t>(is_drum ? 0 : key));
+        }
+        const int64_t absolute_tick = seconds_to_tick(event.time_seconds, options);
+        if (absolute_tick < 0) {
+            throw std::runtime_error("MIDI note time must be non-negative");
+        }
+        const int64_t delta_tick = absolute_tick - track_ticks[key];
+        if (delta_tick < 0) {
+            throw std::runtime_error("MIDI events for a track must be time sorted");
+        }
+        track_ticks[key] = absolute_tick;
+        auto & track = tracks[key];
+        append_varlen(track, static_cast<uint32_t>(delta_tick));
+        append_u8(track, static_cast<uint8_t>((event.velocity > 0 ? 0x90 : 0x80) | channels[key]));
+        append_u8(track, static_cast<uint8_t>(event.pitch));
+        append_u8(track, static_cast<uint8_t>(event.velocity > 0 ? options.velocity : 0));
+    }
+    for (const int key : track_order) {
+        auto & track = tracks[key];
+        append_u8(track, 0x00);
+        append_u8(track, 0xff);
+        append_u8(track, 0x2f);
+        append_u8(track, 0x00);
+    }
+
+    std::vector<std::byte> file;
+    append_ascii(file, "MThd");
+    append_u32_be(file, 6);
+    append_u16_be(file, 1);
+    append_u16_be(file, static_cast<uint16_t>(1 + track_order.size()));
+    append_u16_be(file, static_cast<uint16_t>(options.ticks_per_beat));
+    append_midi_track(file, meta_track);
+    for (const int key : track_order) {
+        append_midi_track(file, tracks[key]);
+    }
+    return file;
+}
+
+}  // namespace engine::midi

--- a/src/framework/modules/attention/attention_internal.h
+++ b/src/framework/modules/attention/attention_internal.h
@@ -401,9 +401,9 @@ inline core::TensorValue build_feed_forward_impl(
     const core::TensorValue & input,
     const FeedForwardConfig & config,
     const FeedForwardWeights & weights) {
-    const LinearModule fc1({config.hidden_size, config.intermediate_size, config.use_bias});
+    const LinearModule fc1({config.hidden_size, config.intermediate_size, config.use_bias, config.projection_precision});
     const GeluModule gelu({config.gelu_approximation});
-    const LinearModule fc2({config.intermediate_size, config.hidden_size, config.use_bias});
+    const LinearModule fc2({config.intermediate_size, config.hidden_size, config.use_bias, config.projection_precision});
 
     auto hidden = fc1.build(ctx, input, make_linear_weights(weights.fc1_weight, weights.fc1_bias));
     hidden = gelu.build(ctx, hidden);
@@ -487,10 +487,10 @@ inline core::TensorValue build_attention_impl(
     const int64_t head_dim = config.hidden_size / config.num_heads;
     const float scale = 1.0f / std::sqrt(static_cast<float>(head_dim));
 
-    const LinearModule q_proj({config.hidden_size, config.hidden_size, config.use_bias});
-    const LinearModule k_proj({config.hidden_size, config.hidden_size, config.use_bias});
-    const LinearModule v_proj({config.hidden_size, config.hidden_size, config.use_bias});
-    const LinearModule out_proj({config.hidden_size, config.hidden_size, config.use_bias});
+    const LinearModule q_proj({config.hidden_size, config.hidden_size, config.use_bias, config.projection_precision});
+    const LinearModule k_proj({config.hidden_size, config.hidden_size, config.use_bias, config.projection_precision});
+    const LinearModule v_proj({config.hidden_size, config.hidden_size, config.use_bias, config.projection_precision});
+    const LinearModule out_proj({config.hidden_size, config.hidden_size, config.use_bias, config.projection_precision});
     const MatMulModule matmul;
 
     auto q = q_proj.build(ctx, query, make_linear_weights(weights.q_weight, weights.q_bias));
@@ -507,10 +507,16 @@ inline core::TensorValue build_attention_impl(
     auto k_transposed = permute_tensor(ctx, k_heads, {0, 1, 3, 2});
 
     auto scores = matmul.build(ctx, q_heads, k_transposed);
+    if (config.attention_precision != GGML_PREC_DEFAULT) {
+        ggml_mul_mat_set_prec(scores.tensor, config.attention_precision);
+    }
     scores = core::wrap_tensor(ggml_scale(ctx.ggml, scores.tensor, scale), scores.shape, GGML_TYPE_F32);
     auto attn = core::wrap_tensor(ggml_soft_max(ctx.ggml, scores.tensor), scores.shape, GGML_TYPE_F32);
 
     auto context = matmul.build(ctx, attn, v_heads);
+    if (config.attention_precision != GGML_PREC_DEFAULT) {
+        ggml_mul_mat_set_prec(context.tensor, config.attention_precision);
+    }
     context = permute_tensor(ctx, context, {0, 2, 1, 3});
     context = ensure_contiguous_layout(ctx, context);
     context = core::reshape_tensor(

--- a/src/framework/modules/attention/scaled_dot_product_attention.cpp
+++ b/src/framework/modules/attention/scaled_dot_product_attention.cpp
@@ -5,8 +5,11 @@
 #include "engine/framework/modules/primitive_modules.h"
 #include "engine/framework/modules/structural_modules.h"
 
+#include <algorithm>
+#include <array>
 #include <cmath>
 #include <stdexcept>
+#include <vector>
 
 namespace engine::modules {
 namespace {
@@ -79,6 +82,127 @@ core::TensorValue build_explicit(
     auto context = matmul.build(ctx, attn, v_heads);
     ggml_mul_mat_set_prec(context.tensor, precision);
     return TransposeModule({{0, 2, 1, 3}, context.shape.rank}).build(ctx, context);
+}
+
+std::array<int, core::kMaxTensorRank> transpose_last_two_axes(size_t rank) {
+    std::array<int, core::kMaxTensorRank> axes = {0, 1, 2, 3};
+    if (rank < 2) {
+        throw std::runtime_error("ScaledDotProductAttention CPU matmul requires rank >= 2");
+    }
+    std::swap(axes[rank - 2], axes[rank - 1]);
+    return axes;
+}
+
+core::TensorValue cpu_matmul_f32(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & lhs,
+    const core::TensorValue & rhs,
+    ggml_prec precision) {
+    const size_t rank = lhs.shape.rank;
+    auto rhs_t = TransposeModule({transpose_last_two_axes(rank), rank}).build(ctx, rhs);
+    rhs_t = core::wrap_tensor(ggml_cont(ctx.ggml, rhs_t.tensor), rhs_t.shape, rhs_t.type);
+    ggml_tensor * out = ggml_mul_mat(ctx.ggml, rhs_t.tensor, lhs.tensor);
+    ggml_mul_mat_set_prec(out, precision);
+    core::TensorShape out_shape = lhs.shape;
+    out_shape.dims[rank - 1] = rhs.shape.dims[rank - 1];
+    return core::wrap_tensor(out, out_shape, GGML_TYPE_F32);
+}
+
+core::TensorValue build_explicit_cpu_per_head_one(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & q,
+    const core::TensorValue & k,
+    const core::TensorValue & v,
+    int64_t head_dim,
+    float scale,
+    ggml_prec precision,
+    AttentionCausality causality) {
+    if (q.shape.dims[0] != 1 || q.shape.dims[1] != 1 ||
+        k.shape.dims[0] != 1 || k.shape.dims[1] != 1 ||
+        v.shape.dims[0] != 1 || v.shape.dims[1] != 1) {
+        throw std::runtime_error("ScaledDotProductAttention ExplicitCpuPerHead expects one sliced batch/head");
+    }
+    const int64_t query_steps = q.shape.dims[2];
+    const int64_t key_steps = k.shape.dims[2];
+    auto q_2d = core::reshape_tensor(
+        ctx,
+        core::ensure_backend_addressable_layout(ctx, q),
+        core::TensorShape::from_dims({query_steps, head_dim}));
+    auto k_2d = core::reshape_tensor(
+        ctx,
+        core::ensure_backend_addressable_layout(ctx, k),
+        core::TensorShape::from_dims({key_steps, head_dim}));
+    auto v_2d = core::reshape_tensor(
+        ctx,
+        core::ensure_backend_addressable_layout(ctx, v),
+        core::TensorShape::from_dims({key_steps, head_dim}));
+    ggml_tensor * scores_raw = ggml_mul_mat(ctx.ggml, k_2d.tensor, q_2d.tensor);
+    ggml_mul_mat_set_prec(scores_raw, precision);
+    auto scores = core::wrap_tensor(
+        scores_raw,
+        core::TensorShape::from_dims({query_steps, key_steps}),
+        GGML_TYPE_F32);
+    scores = core::wrap_tensor(ggml_scale(ctx.ggml, scores.tensor, scale), scores.shape, GGML_TYPE_F32);
+    if (causality == AttentionCausality::Causal) {
+        scores = core::wrap_tensor(ggml_diag_mask_inf(ctx.ggml, scores.tensor, 0), scores.shape, GGML_TYPE_F32);
+    }
+    scores = core::wrap_tensor(ggml_cont(ctx.ggml, scores.tensor), scores.shape, scores.type);
+    auto attn = core::wrap_tensor(ggml_soft_max(ctx.ggml, scores.tensor), scores.shape, GGML_TYPE_F32);
+    auto context = cpu_matmul_f32(ctx, attn, v_2d, precision);
+    return core::reshape_tensor(
+        ctx,
+        core::ensure_backend_addressable_layout(ctx, context),
+        core::TensorShape::from_dims({1, query_steps, 1, head_dim}));
+}
+
+core::TensorValue build_explicit_cpu_per_head(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & q_heads,
+    const core::TensorValue & k_heads,
+    const core::TensorValue & v_heads,
+    const std::optional<core::TensorValue> & attention_mask,
+    float scale,
+    ggml_prec precision,
+    AttentionCausality causality) {
+    if (ctx.backend_type != core::BackendType::Cpu) {
+        throw std::runtime_error("ScaledDotProductAttention ExplicitCpuPerHead requires CPU backend");
+    }
+    if (attention_mask.has_value()) {
+        throw std::runtime_error("ScaledDotProductAttention ExplicitCpuPerHead does not support attention masks");
+    }
+    std::vector<core::TensorValue> batches;
+    batches.reserve(static_cast<size_t>(q_heads.shape.dims[0]));
+    for (int64_t batch = 0; batch < q_heads.shape.dims[0]; ++batch) {
+        const auto q_batch = SliceModule({0, batch, 1}).build(ctx, q_heads);
+        const auto k_batch = SliceModule({0, batch, 1}).build(ctx, k_heads);
+        const auto v_batch = SliceModule({0, batch, 1}).build(ctx, v_heads);
+        std::vector<core::TensorValue> heads;
+        heads.reserve(static_cast<size_t>(q_heads.shape.dims[1]));
+        for (int64_t head = 0; head < q_heads.shape.dims[1]; ++head) {
+            const auto q_head = SliceModule({1, head, 1}).build(ctx, q_batch);
+            const auto k_head = SliceModule({1, head, 1}).build(ctx, k_batch);
+            const auto v_head = SliceModule({1, head, 1}).build(ctx, v_batch);
+            heads.push_back(build_explicit_cpu_per_head_one(
+                ctx,
+                q_head,
+                k_head,
+                v_head,
+                q_heads.shape.dims[3],
+                scale,
+                precision,
+                causality));
+        }
+        auto batch_context = heads.front();
+        for (size_t i = 1; i < heads.size(); ++i) {
+            batch_context = ConcatModule({2}).build(ctx, batch_context, heads[i]);
+        }
+        batches.push_back(batch_context);
+    }
+    auto context = batches.front();
+    for (size_t i = 1; i < batches.size(); ++i) {
+        context = ConcatModule({0}).build(ctx, context, batches[i]);
+    }
+    return core::ensure_backend_addressable_layout(ctx, context);
 }
 
 core::TensorValue build_flash(
@@ -154,6 +278,8 @@ core::TensorValue ScaledDotProductAttentionModule::build(
     switch (config_.lowering) {
         case ScaledDotProductAttentionLowering::Explicit:
             return build_explicit(ctx, q_heads, k_heads, v_heads, attention_mask, scale, config_.precision, config_.causality);
+        case ScaledDotProductAttentionLowering::ExplicitCpuPerHead:
+            return build_explicit_cpu_per_head(ctx, q_heads, k_heads, v_heads, attention_mask, scale, config_.precision, config_.causality);
         case ScaledDotProductAttentionLowering::Flash:
             return build_flash(ctx, q_heads, k_heads, v_heads, attention_mask, scale, config_.precision, config_.causality);
         case ScaledDotProductAttentionLowering::FlashPreserveViews:

--- a/src/framework/modules/attention/self_attention.cpp
+++ b/src/framework/modules/attention/self_attention.cpp
@@ -53,15 +53,22 @@ StreamingAttentionOutputs StreamingSelfAttentionModule::build(
         if (prefix_key->shape.dims[0] != input.shape.dims[0] || prefix_value->shape.dims[0] != input.shape.dims[0]) {
             throw std::runtime_error("Streaming self-attention prefix batch size must match input");
         }
+        if (config_.prefix_cache_layout == AttentionPrefixCacheLayout::HeadsSequence) {
+            if (prefix_key->shape.dims[1] != config_.num_heads || prefix_value->shape.dims[1] != config_.num_heads) {
+                throw std::runtime_error("Streaming self-attention BHTD prefix head count mismatch");
+            }
+        } else if (prefix_key->shape.dims[2] != config_.num_heads || prefix_value->shape.dims[2] != config_.num_heads) {
+            throw std::runtime_error("Streaming self-attention BTHD prefix head count mismatch");
+        }
     }
 
     const int64_t head_dim = config_.hidden_size / config_.num_heads;
     const float scale = 1.0f / std::sqrt(static_cast<float>(head_dim));
 
-    const LinearModule q_proj({config_.hidden_size, config_.hidden_size, config_.use_bias});
-    const LinearModule k_proj({config_.hidden_size, config_.hidden_size, config_.use_bias});
-    const LinearModule v_proj({config_.hidden_size, config_.hidden_size, config_.use_bias});
-    const LinearModule out_proj({config_.hidden_size, config_.hidden_size, config_.use_bias});
+    const LinearModule q_proj({config_.hidden_size, config_.hidden_size, config_.use_bias, config_.projection_precision});
+    const LinearModule k_proj({config_.hidden_size, config_.hidden_size, config_.use_bias, config_.projection_precision});
+    const LinearModule v_proj({config_.hidden_size, config_.hidden_size, config_.use_bias, config_.projection_precision});
+    const LinearModule out_proj({config_.hidden_size, config_.hidden_size, config_.use_bias, config_.projection_precision});
     const MatMulModule matmul;
 
     auto q = q_proj.build(ctx, input, make_linear_weights(weights.q_weight, weights.q_bias));
@@ -81,12 +88,25 @@ StreamingAttentionOutputs StreamingSelfAttentionModule::build(
 
     core::TensorValue context;
     if (prefix_key.has_value()) {
-        auto all_k = concat_sequence_axis(ctx, prefix_key, k);
-        auto all_v = concat_sequence_axis(ctx, prefix_value, v);
-        auto all_k_heads = permute_tensor(ctx, all_k, {0, 2, 1, 3});
-        auto all_v_heads = permute_tensor(ctx, all_v, {0, 2, 1, 3});
+        core::TensorValue all_k_heads;
+        core::TensorValue all_v_heads;
+        int64_t prefix_steps = 0;
+        if (config_.prefix_cache_layout == AttentionPrefixCacheLayout::HeadsSequence) {
+            prefix_steps = prefix_key->shape.dims[2];
+            all_k_heads = ConcatModule({2}).build(ctx, *prefix_key, k_heads);
+            all_v_heads = ConcatModule({2}).build(ctx, *prefix_value, v_heads);
+        } else {
+            prefix_steps = prefix_key->shape.dims[1];
+            auto all_k = concat_sequence_axis(ctx, prefix_key, k);
+            auto all_v = concat_sequence_axis(ctx, prefix_value, v);
+            all_k_heads = permute_tensor(ctx, all_k, {0, 2, 1, 3});
+            all_v_heads = permute_tensor(ctx, all_v, {0, 2, 1, 3});
+        }
         auto k_transposed = permute_tensor(ctx, all_k_heads, {0, 1, 3, 2});
         auto scores = matmul.build(ctx, q_heads, k_transposed);
+        if (config_.attention_precision != GGML_PREC_DEFAULT) {
+            ggml_mul_mat_set_prec(scores.tensor, config_.attention_precision);
+        }
         core::TensorValue attn;
         if (attention_mask.has_value()) {
             attn = core::wrap_tensor(
@@ -96,15 +116,21 @@ StreamingAttentionOutputs StreamingSelfAttentionModule::build(
         } else {
             scores = core::wrap_tensor(ggml_scale(ctx.ggml, scores.tensor, scale), scores.shape, GGML_TYPE_F32);
             scores = core::wrap_tensor(
-                ggml_diag_mask_inf(ctx.ggml, scores.tensor, static_cast<int>(prefix_key->shape.dims[1])),
+                ggml_diag_mask_inf(ctx.ggml, scores.tensor, static_cast<int>(prefix_steps)),
                 scores.shape,
                 GGML_TYPE_F32);
             attn = core::wrap_tensor(ggml_soft_max(ctx.ggml, ensure_contiguous_layout(ctx, scores).tensor), scores.shape, GGML_TYPE_F32);
         }
         context = matmul.build(ctx, attn, all_v_heads);
+        if (config_.attention_precision != GGML_PREC_DEFAULT) {
+            ggml_mul_mat_set_prec(context.tensor, config_.attention_precision);
+        }
     } else {
         auto k_transposed = permute_tensor(ctx, k_heads, {0, 1, 3, 2});
         auto scores = matmul.build(ctx, q_heads, k_transposed);
+        if (config_.attention_precision != GGML_PREC_DEFAULT) {
+            ggml_mul_mat_set_prec(scores.tensor, config_.attention_precision);
+        }
         core::TensorValue attn;
         if (attention_mask.has_value()) {
             attn = core::wrap_tensor(
@@ -117,6 +143,9 @@ StreamingAttentionOutputs StreamingSelfAttentionModule::build(
             attn = core::wrap_tensor(ggml_soft_max(ctx.ggml, ensure_contiguous_layout(ctx, scores).tensor), scores.shape, GGML_TYPE_F32);
         }
         context = matmul.build(ctx, attn, v_heads);
+        if (config_.attention_precision != GGML_PREC_DEFAULT) {
+            ggml_mul_mat_set_prec(context.tensor, config_.attention_precision);
+        }
     }
 
     context = permute_tensor(ctx, context, {0, 2, 1, 3});
@@ -124,6 +153,13 @@ StreamingAttentionOutputs StreamingSelfAttentionModule::build(
     context = core::reshape_tensor(ctx, context, core::TensorShape::from_dims({input.shape.dims[0], input.shape.dims[1], config_.hidden_size}));
 
     auto output = out_proj.build(ctx, context, make_linear_weights(weights.out_weight, weights.out_bias));
+    if (config_.prefix_cache_layout == AttentionPrefixCacheLayout::HeadsSequence) {
+        return {
+            output,
+            ensure_contiguous_layout(ctx, k_heads),
+            ensure_contiguous_layout(ctx, v_heads),
+        };
+    }
     return {output, k, v};
 }
 

--- a/src/framework/modules/attention/transformer_blocks.cpp
+++ b/src/framework/modules/attention/transformer_blocks.cpp
@@ -28,10 +28,22 @@ core::TensorValue TransformerEncoderBlockModule::build(
     validate_sequence_input(input, config_.hidden_size, "input");
 
     const LayerNormModule norm1(make_norm_config(config_.hidden_size, config_.eps));
-    const SelfAttentionModule self_attention({config_.hidden_size, config_.num_heads, config_.use_bias});
+    const SelfAttentionModule self_attention({
+        config_.hidden_size,
+        config_.num_heads,
+        config_.use_bias,
+        config_.projection_precision,
+        config_.attention_precision,
+        config_.prefix_cache_layout,
+    });
     const LayerNormModule norm2(make_norm_config(config_.hidden_size, config_.eps));
-    const FeedForwardModule feed_forward(
-        {config_.hidden_size, config_.intermediate_size, config_.use_bias, GeluApproximation::ExactErf});
+    const FeedForwardModule feed_forward({
+        config_.hidden_size,
+        config_.intermediate_size,
+        config_.use_bias,
+        GeluApproximation::ExactErf,
+        config_.projection_precision,
+    });
     const ResidualAddModule add;
 
     auto cur = norm1.build(ctx, input, weights.norm1);
@@ -77,10 +89,22 @@ StreamingTransformerEncoderBlockOutputs StreamingTransformerEncoderBlockModule::
     validate_sequence_input(input, config_.hidden_size, "input");
 
     const LayerNormModule norm1(make_norm_config(config_.hidden_size, config_.eps));
-    const StreamingSelfAttentionModule self_attention({config_.hidden_size, config_.num_heads, config_.use_bias});
+    const StreamingSelfAttentionModule self_attention({
+        config_.hidden_size,
+        config_.num_heads,
+        config_.use_bias,
+        config_.projection_precision,
+        config_.attention_precision,
+        config_.prefix_cache_layout,
+    });
     const LayerNormModule norm2(make_norm_config(config_.hidden_size, config_.eps));
-    const FeedForwardModule feed_forward(
-        {config_.hidden_size, config_.intermediate_size, config_.use_bias, GeluApproximation::ExactErf});
+    const FeedForwardModule feed_forward({
+        config_.hidden_size,
+        config_.intermediate_size,
+        config_.use_bias,
+        GeluApproximation::ExactErf,
+        config_.projection_precision,
+    });
     const ResidualAddModule add;
 
     auto attn_in = norm1.build(ctx, input, weights.norm1);
@@ -134,6 +158,9 @@ StreamingTransformerStackOutputs StreamingTransformerStackModule::build(
             config_.intermediate_size,
             config_.eps,
             config_.use_bias,
+            config_.projection_precision,
+            config_.attention_precision,
+            config_.prefix_cache_layout,
         }).build(
             ctx,
             output,
@@ -173,7 +200,8 @@ core::TensorValue ProjectedTransformerModule::build(
     auto x = permute_tensor(ctx, input_bct, {0, 2, 1});
     x = ensure_contiguous_layout(ctx, x);
     if (weights.input_projection.has_value()) {
-        x = LinearModule({config_.input_dimension, config_.hidden_size, config_.use_bias}).build(ctx, x, *weights.input_projection);
+        x = LinearModule({config_.input_dimension, config_.hidden_size, config_.use_bias, config_.projection_precision})
+                .build(ctx, x, *weights.input_projection);
     }
     TransformerStackWeights transformer_weights{weights.transformer_layers};
     x = TransformerStackModule({
@@ -183,9 +211,13 @@ core::TensorValue ProjectedTransformerModule::build(
         config_.layers,
         config_.eps,
         config_.use_bias,
+        config_.projection_precision,
+        config_.attention_precision,
+        config_.prefix_cache_layout,
     }).build(ctx, x, transformer_weights);
     if (weights.output_projection.has_value()) {
-        x = LinearModule({config_.hidden_size, config_.output_dimension, config_.use_bias}).build(ctx, x, *weights.output_projection);
+        x = LinearModule({config_.hidden_size, config_.output_dimension, config_.use_bias, config_.projection_precision})
+                .build(ctx, x, *weights.output_projection);
     }
     return permute_tensor(ctx, x, {0, 2, 1});
 }
@@ -218,7 +250,8 @@ StreamingProjectedTransformerOutputs StreamingProjectedTransformerModule::build(
     auto x = permute_tensor(ctx, input_bct, {0, 2, 1});
     x = ensure_contiguous_layout(ctx, x);
     if (weights.input_projection.has_value()) {
-        x = LinearModule({config_.input_dimension, config_.hidden_size, config_.use_bias}).build(ctx, x, *weights.input_projection);
+        x = LinearModule({config_.input_dimension, config_.hidden_size, config_.use_bias, config_.projection_precision})
+                .build(ctx, x, *weights.input_projection);
     }
     StreamingTransformerStackWeights transformer_weights{weights.transformer_layers};
     auto stack_outputs = StreamingTransformerStackModule({
@@ -228,10 +261,14 @@ StreamingProjectedTransformerOutputs StreamingProjectedTransformerModule::build(
         config_.layers,
         config_.eps,
         config_.use_bias,
+        config_.projection_precision,
+        config_.attention_precision,
+        config_.prefix_cache_layout,
     }).build(ctx, x, positions, transformer_weights, prefix_state, attention_mask);
     x = stack_outputs.output;
     if (weights.output_projection.has_value()) {
-        x = LinearModule({config_.hidden_size, config_.output_dimension, config_.use_bias}).build(ctx, x, *weights.output_projection);
+        x = LinearModule({config_.hidden_size, config_.output_dimension, config_.use_bias, config_.projection_precision})
+                .build(ctx, x, *weights.output_projection);
     }
     return {permute_tensor(ctx, x, {0, 2, 1}), std::move(stack_outputs.state)};
 }
@@ -262,6 +299,9 @@ core::TensorValue TransformerStackModule::build(
             config_.intermediate_size,
             config_.eps,
             config_.use_bias,
+            config_.projection_precision,
+            config_.attention_precision,
+            config_.prefix_cache_layout,
         }).build(ctx, output, layer_weights);
     }
     return output;

--- a/src/framework/modules/norm_modules.cpp
+++ b/src/framework/modules/norm_modules.cpp
@@ -173,8 +173,10 @@ core::TensorValue build_norm(
     }
     core::validate_rank_between(input, 1, core::kMaxTensorRank, "input");
     core::validate_last_dim(input, config.hidden_size, "input");
-    const auto input_contiguous = tensor_layout::ensure_contiguous_layout_if_needed(ctx, input);
-    core::TensorValue normalized = core::wrap_tensor(fn(ctx.ggml, input_contiguous.tensor, config.eps), input.shape, GGML_TYPE_F32);
+    const auto norm_input = config.preserve_input_layout
+        ? input
+        : tensor_layout::ensure_contiguous_layout_if_needed(ctx, input);
+    core::TensorValue normalized = core::wrap_tensor(fn(ctx.ggml, norm_input.tensor, config.eps), input.shape, GGML_TYPE_F32);
     return apply_affine(ctx, normalized, config, weights);
 }
 

--- a/src/framework/modules/transformers/qwen_causal_decoder.cpp
+++ b/src/framework/modules/transformers/qwen_causal_decoder.cpp
@@ -61,13 +61,20 @@ QwenCausalDecoderOutputs QwenCausalDecoderModule::build(
         hidden = SliceModule({1, steps - 1, 1}).build(ctx, hidden_sequence);
     }
 
+    auto logits_input = hidden;
+    if (config_.lm_head_input_type.has_value() && logits_input.type != *config_.lm_head_input_type) {
+        logits_input = core::wrap_tensor(
+            ggml_cast(ctx.ggml, logits_input.tensor, *config_.lm_head_input_type),
+            logits_input.shape,
+            *config_.lm_head_input_type);
+    }
     const auto logits = LinearModule({
                             config_.stack.hidden_size,
                             config_.logits_size,
                             config_.use_lm_head_bias,
                             config_.lm_head_precision,
                         })
-                            .build(ctx, hidden, weights.lm_head);
+                            .build(ctx, logits_input, weights.lm_head);
     return {std::move(stack.output), hidden, logits, std::move(stack.state)};
 }
 
@@ -126,13 +133,20 @@ QwenCausalDecoderStaticCacheOutputs QwenCausalDecoderModule::build_static_cache_
 
     auto hidden = RMSNormModule({config_.stack.hidden_size, config_.stack.rms_norm_eps, true, false})
                       .build(ctx, x, weights.final_norm);
+    auto logits_input = hidden;
+    if (config_.lm_head_input_type.has_value() && logits_input.type != *config_.lm_head_input_type) {
+        logits_input = core::wrap_tensor(
+            ggml_cast(ctx.ggml, logits_input.tensor, *config_.lm_head_input_type),
+            logits_input.shape,
+            *config_.lm_head_input_type);
+    }
     const auto logits = LinearModule({
                             config_.stack.hidden_size,
                             config_.logits_size,
                             config_.use_lm_head_bias,
                             config_.lm_head_precision,
                         })
-                            .build(ctx, hidden, weights.lm_head);
+                            .build(ctx, logits_input, weights.lm_head);
     return {
         std::move(x),
         hidden,

--- a/src/framework/runtime/bounded_static_kv_decode.cpp
+++ b/src/framework/runtime/bounded_static_kv_decode.cpp
@@ -41,6 +41,15 @@ void BoundedStaticKVDecodeCursor::import_state(const TransformerKVState & state,
     cache_steps_ = cache_steps;
 }
 
+void BoundedStaticKVDecodeCursor::reset_to_empty(int64_t cache_steps) {
+    if (cache_steps <= 0) {
+        throw std::runtime_error("BoundedStaticKVDecodeCursor requires positive cache_steps");
+    }
+    valid_steps_ = 0;
+    absolute_end_ = 0;
+    cache_steps_ = cache_steps;
+}
+
 BoundedStaticKVDecodeStep BoundedStaticKVDecodeCursor::next_step() const {
     if (cache_steps_ <= 0) {
         throw std::runtime_error("BoundedStaticKVDecodeCursor requires imported state before decode");

--- a/tests/unittests/test_midi_file.cpp
+++ b/tests/unittests/test_midi_file.cpp
@@ -1,0 +1,228 @@
+#include "engine/framework/midi/midi_file.h"
+
+#include "test_assert.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+using engine::test::require;
+using engine::test::require_eq;
+
+struct ParsedEvent {
+    uint32_t tick = 0;
+    uint8_t status = 0;
+    uint8_t a = 0;
+    uint8_t b = 0;
+};
+
+struct ParsedTrack {
+    std::string name;
+    int program = -1;
+    int channel = -1;
+    std::vector<ParsedEvent> events;
+};
+
+uint8_t byte_at(const std::vector<std::byte> & bytes, size_t offset) {
+    if (offset >= bytes.size()) {
+        throw std::runtime_error("MIDI parse offset out of range");
+    }
+    return static_cast<uint8_t>(bytes[offset]);
+}
+
+uint16_t read_u16_be(const std::vector<std::byte> & bytes, size_t offset) {
+    return static_cast<uint16_t>((byte_at(bytes, offset) << 8) | byte_at(bytes, offset + 1));
+}
+
+uint32_t read_u32_be(const std::vector<std::byte> & bytes, size_t offset) {
+    return (static_cast<uint32_t>(byte_at(bytes, offset)) << 24) |
+        (static_cast<uint32_t>(byte_at(bytes, offset + 1)) << 16) |
+        (static_cast<uint32_t>(byte_at(bytes, offset + 2)) << 8) |
+        static_cast<uint32_t>(byte_at(bytes, offset + 3));
+}
+
+std::string read_ascii(const std::vector<std::byte> & bytes, size_t offset, size_t size) {
+    std::string out;
+    out.reserve(size);
+    for (size_t i = 0; i < size; ++i) {
+        out.push_back(static_cast<char>(byte_at(bytes, offset + i)));
+    }
+    return out;
+}
+
+uint32_t read_varlen(const std::vector<std::byte> & bytes, size_t & offset, size_t end) {
+    uint32_t value = 0;
+    for (int i = 0; i < 4; ++i) {
+        if (offset >= end) {
+            throw std::runtime_error("truncated MIDI variable length value");
+        }
+        const uint8_t ch = byte_at(bytes, offset++);
+        value = (value << 7) | (ch & 0x7f);
+        if ((ch & 0x80) == 0) {
+            return value;
+        }
+    }
+    throw std::runtime_error("MIDI variable length value is too long");
+}
+
+ParsedTrack parse_track(const std::vector<std::byte> & bytes, size_t offset, size_t size) {
+    ParsedTrack out;
+    const size_t end = offset + size;
+    uint32_t tick = 0;
+    while (offset < end) {
+        tick += read_varlen(bytes, offset, end);
+        const uint8_t status = byte_at(bytes, offset++);
+        if (status == 0xff) {
+            const uint8_t meta_type = byte_at(bytes, offset++);
+            const uint32_t meta_size = read_varlen(bytes, offset, end);
+            if (meta_type == 0x03) {
+                out.name = read_ascii(bytes, offset, meta_size);
+            }
+            offset += meta_size;
+            continue;
+        }
+        const uint8_t type = status & 0xf0;
+        const uint8_t channel = status & 0x0f;
+        if (type == 0xc0) {
+            out.channel = channel;
+            out.program = byte_at(bytes, offset++);
+            continue;
+        }
+        if (type == 0x90 || type == 0x80) {
+            ParsedEvent event;
+            event.tick = tick;
+            event.status = status;
+            event.a = byte_at(bytes, offset++);
+            event.b = byte_at(bytes, offset++);
+            out.events.push_back(event);
+            continue;
+        }
+        throw std::runtime_error("unexpected MIDI event status");
+    }
+    return out;
+}
+
+std::vector<ParsedTrack> parse_midi(const std::vector<std::byte> & bytes) {
+    require_eq(read_ascii(bytes, 0, 4), std::string("MThd"), "MIDI header chunk");
+    require_eq(read_u32_be(bytes, 4), uint32_t{6}, "MIDI header length");
+    require_eq(read_u16_be(bytes, 8), uint16_t{1}, "MIDI format");
+    require_eq(read_u16_be(bytes, 12), uint16_t{480}, "MIDI ticks per beat");
+    const uint16_t track_count = read_u16_be(bytes, 10);
+    std::vector<ParsedTrack> tracks;
+    size_t offset = 14;
+    for (uint16_t track = 0; track < track_count; ++track) {
+        require_eq(read_ascii(bytes, offset, 4), std::string("MTrk"), "MIDI track chunk");
+        const uint32_t size = read_u32_be(bytes, offset + 4);
+        offset += 8;
+        tracks.push_back(parse_track(bytes, offset, size));
+        offset += size;
+    }
+    require_eq(offset, bytes.size(), "MIDI parsed byte count");
+    return tracks;
+}
+
+std::vector<std::byte> bytes_from_hex(const std::string & hex) {
+    require(hex.size() % 2 == 0, "hex fixture length must be even");
+    std::vector<std::byte> out;
+    out.reserve(hex.size() / 2);
+    auto nibble = [](char ch) -> uint8_t {
+        if (ch >= '0' && ch <= '9') {
+            return static_cast<uint8_t>(ch - '0');
+        }
+        if (ch >= 'a' && ch <= 'f') {
+            return static_cast<uint8_t>(ch - 'a' + 10);
+        }
+        if (ch >= 'A' && ch <= 'F') {
+            return static_cast<uint8_t>(ch - 'A' + 10);
+        }
+        throw std::runtime_error("invalid hex fixture");
+    };
+    for (size_t i = 0; i < hex.size(); i += 2) {
+        out.push_back(static_cast<std::byte>((nibble(hex[i]) << 4) | nibble(hex[i + 1])));
+    }
+    return out;
+}
+
+void require_bytes_eq(
+    const std::vector<std::byte> & actual,
+    const std::vector<std::byte> & expected,
+    const std::string & label) {
+    require_eq(actual.size(), expected.size(), label + " size");
+    for (size_t i = 0; i < actual.size(); ++i) {
+        if (actual[i] != expected[i]) {
+            throw std::runtime_error(label + " byte mismatch at " + std::to_string(i));
+        }
+    }
+}
+
+void test_empty_midi_has_header_and_tempo_track() {
+    const auto midi = engine::midi::write_standard_midi_file({});
+    const auto tracks = parse_midi(midi);
+    require_eq(tracks.size(), size_t{1}, "empty MIDI track count");
+    require(tracks.front().events.empty(), "tempo track should not contain note events");
+}
+
+void test_multi_track_notes_and_drums() {
+    const auto midi = engine::midi::write_standard_midi_file({
+        {false, 0, 0.0, 0.5, 60, "acoustic piano"},
+        {true, engine::midi::kDrumProgram, 0.25, 0.25, 36, "drums"},
+    });
+    const auto mido_golden = bytes_from_hex(
+        "4d546864000000060001000301e0"
+        "4d54726b0000000b00ff510307a12000ff2f00"
+        "4d54726b0000002200ff030e61636f7573746963207069616e6f00c00000903c648360803c0000ff2f00"
+        "4d54726b0000001900ff03056472756d7300c90081709924640a89240000ff2f00");
+    require_bytes_eq(midi, mido_golden, "MIDI bytes from Python mido fixture");
+    const auto tracks = parse_midi(midi);
+    require_eq(tracks.size(), size_t{3}, "piano plus drums track count");
+    require_eq(tracks[1].name, std::string("acoustic piano"), "piano track name");
+    require_eq(tracks[1].channel, 0, "piano channel");
+    require_eq(tracks[1].program, 0, "piano program");
+    require_eq(tracks[1].events.size(), size_t{2}, "piano event count");
+    require_eq(tracks[1].events[0].tick, uint32_t{0}, "piano note on tick");
+    require_eq(tracks[1].events[0].status, uint8_t{0x90}, "piano note on status");
+    require_eq(tracks[1].events[1].tick, uint32_t{480}, "piano note off tick");
+    require_eq(tracks[1].events[1].status, uint8_t{0x80}, "piano note off status");
+
+    require_eq(tracks[2].name, std::string("drums"), "drum track name");
+    require_eq(tracks[2].channel, 9, "drum channel");
+    require_eq(tracks[2].program, 0, "drum program change");
+    require_eq(tracks[2].events.size(), size_t{2}, "drum event count");
+    require_eq(tracks[2].events[0].tick, uint32_t{240}, "drum note on tick");
+    require_eq(tracks[2].events[1].tick, uint32_t{250}, "drum note off tick");
+}
+
+void test_overlap_is_trimmed_before_serializing() {
+    const auto midi = engine::midi::write_standard_midi_file({
+        {false, 40, 0.0, 1.0, 69, "violin"},
+        {false, 40, 0.25, 0.3, 70, "violin"},
+        {false, 40, 0.5, 0.75, 69, "violin"},
+    });
+    const auto tracks = parse_midi(midi);
+    require_eq(tracks.size(), size_t{2}, "overlap MIDI track count");
+    require_eq(tracks[1].events.size(), size_t{6}, "overlap note event count");
+    require_eq(tracks[1].events[3].tick, uint32_t{480}, "trimmed first note off tick");
+    require_eq(tracks[1].events[3].status, uint8_t{0x80}, "trimmed first note off status");
+    require_eq(tracks[1].events[4].tick, uint32_t{480}, "second note on tick");
+    require_eq(tracks[1].events[4].status, uint8_t{0x90}, "second note on status");
+}
+
+}  // namespace
+
+int main() {
+    try {
+        test_empty_midi_has_header_and_tempo_track();
+        test_multi_track_notes_and_drums();
+        test_overlap_is_trimmed_before_serializing();
+    } catch (const std::exception & ex) {
+        std::cerr << "midi_file_test failed: " << ex.what() << "\n";
+        return 1;
+    }
+    std::cout << "midi_file_test passed\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- promote reusable cached decode and Mimi codec runtime pieces from preview model work
- add framework MIDI file writing plus CLI artifact output support for `.mid` payloads
- add `NormConfig::preserve_input_layout` for layout-sensitive norm callsites
- add CPU-specific SDPA lowering (`ExplicitCpuPerHead`) and optional Qwen LM-head input cast type
- add a framework MIDI unit test with exact MIDI byte coverage

## Validation
- cmake --build build/debug -j 16 --target audiocpp_cli
- cmake --build build/debug -j 16 --target midi_file_test
- ./build/debug/bin/midi_file_test

This PR intentionally excludes PersonaPlex, MuScriptor, NeuTTS, and DramaBox release files so reusable framework pieces can land first.