### PR TITLE
Add Irodori codec backend selection

### DIFF
--- a/include/engine/models/irodori_tts/session.h
+++ b/include/engine/models/irodori_tts/session.h
@@ -73,6 +73,7 @@ private:
   assets::TensorStorageType codec_weight_storage_type_ =
       assets::TensorStorageType::Native;
   bool mem_saver_ = true;
+  std::unique_ptr<engine::core::ExecutionContext> codec_execution_context_;
   std::unique_ptr<IrodoriConditionEncoder> condition_encoder_;
   std::unique_ptr<IrodoriRfSampler> rf_sampler_;
   std::unique_ptr<IrodoriCodec> codec_;

--- a/model_specs/irodori_tts.json
+++ b/model_specs/irodori_tts.json
@@ -195,6 +195,17 @@
         "default": "native"
       },
       {
+        "name": "codec_backend",
+        "type": "enum",
+        "description": "DACVAE codec execution backend. Use cpu as an opt-in workaround for backend-specific codec decoder issues; default same.",
+        "values": [
+          "same",
+          "cpu"
+        ],
+        "required": false,
+        "default": "same"
+      },
+      {
         "name": "condition_graph_arena_mb",
         "type": "int",
         "description": "Condition encoder graph arena size in MiB; default 256.",

--- a/src/models/irodori_tts/session.cpp
+++ b/src/models/irodori_tts/session.cpp
@@ -29,6 +29,11 @@ namespace {
 using Clock = std::chrono::steady_clock;
 constexpr const char *kFamily = "irodori_tts";
 
+enum class IrodoriCodecBackend {
+  Same,
+  Cpu,
+};
+
 std::shared_ptr<const IrodoriTTSAssets>
 require_assets(std::shared_ptr<const IrodoriTTSAssets> assets) {
   if (assets == nullptr) {
@@ -43,6 +48,20 @@ std::shared_ptr<const engine::model_spec::ModelContract> require_contract(
     throw std::runtime_error("Irodori-TTS session requires a model contract");
   }
   return contract;
+}
+
+IrodoriCodecBackend parse_codec_backend(const runtime::SessionOptions & options) {
+  if (const auto value =
+          runtime::find_option(options.options, {"irodori_tts.codec_backend"})) {
+    if (*value == "same") {
+      return IrodoriCodecBackend::Same;
+    }
+    if (*value == "cpu") {
+      return IrodoriCodecBackend::Cpu;
+    }
+    throw std::runtime_error("Invalid irodori_tts.codec_backend: " + *value);
+  }
+  return IrodoriCodecBackend::Same;
 }
 
 runtime::SessionOptions normalize_session_options(runtime::SessionOptions options) {
@@ -60,8 +79,15 @@ runtime::SessionOptions require_supported_session_options(
     const std::shared_ptr<const engine::model_spec::ModelContract> &contract) {
   options = normalize_session_options(std::move(options));
   const auto checked_contract = require_contract(contract);
+  auto validation_options = options;
+  // Older standalone GGUF packages embed a v1 contract that predates this
+  // workaround option; keep them usable while still validating the value below.
+  if (checked_contract->session_option_keys.find("irodori_tts.codec_backend") ==
+      checked_contract->session_option_keys.end()) {
+    validation_options.options.erase("irodori_tts.codec_backend");
+  }
   runtime::validate_spec_backed_session_options(
-      options, *checked_contract, kFamily, "Irodori-TTS");
+      validation_options, *checked_contract, kFamily, "Irodori-TTS");
   return options;
 }
 
@@ -376,6 +402,16 @@ IrodoriTTSSession::IrodoriTTSSession(
     throw std::runtime_error(
         "Irodori-TTS supports only TTS, voice-cloning, and voice-design offline tasks");
   }
+  const auto codec_backend = parse_codec_backend(this->options());
+  engine::core::ExecutionContext * codec_execution = &execution_context();
+  if (codec_backend == IrodoriCodecBackend::Cpu) {
+    auto codec_backend_config = this->options().backend;
+    codec_backend_config.type = engine::core::BackendType::Cpu;
+    codec_backend_config.device = 0;
+    codec_execution_context_ =
+        std::make_unique<engine::core::ExecutionContext>(codec_backend_config);
+    codec_execution = codec_execution_context_.get();
+  }
   condition_encoder_ = std::make_unique<IrodoriConditionEncoder>(
       assets_, execution_context(), condition_graph_arena_bytes_,
       condition_weight_context_bytes_, weight_storage_type_);
@@ -383,7 +419,7 @@ IrodoriTTSSession::IrodoriTTSSession(
       assets_, execution_context(), rf_graph_arena_bytes_,
       rf_weight_context_bytes_, weight_storage_type_, mem_saver_);
   codec_ = std::make_unique<IrodoriCodec>(
-      assets_, execution_context(), codec_graph_arena_bytes_,
+      assets_, *codec_execution, codec_graph_arena_bytes_,
       codec_weight_context_bytes_, codec_weight_storage_type_);
   assets_->model_weights->release_storage();
   assets_->codec_weights->release_storage();
@@ -397,6 +433,10 @@ IrodoriTTSSession::IrodoriTTSSession(
                           assets_->config.max_text_len);
   debug::trace_log_scalar("irodori_tts.config.max_caption_len",
                           assets_->config.max_caption_len);
+  debug::trace_log_scalar(
+      "irodori_tts.codec.backend",
+      std::string_view(codec_backend == IrodoriCodecBackend::Cpu ? "cpu"
+                                                                  : "same"));
 }
 
 IrodoriTTSSession::~IrodoriTTSSession() = default;


### PR DESCRIPTION
## Summary
- add `irodori_tts.codec_backend=same|cpu` as an Irodori-only session option
- keep condition encoder and RF sampler on the requested backend while allowing the DACVAE codec decode to run on CPU
- keep old standalone GGUF packages usable when their embedded spec predates this option

## Validation
- `cmake --build build/debug -j 16 --target audiocpp_cli`
- Vulkan default path logs `irodori_tts.codec.backend same`
- Vulkan + `--session-option irodori_tts.codec_backend=cpu` logs `irodori_tts.codec.backend cpu` and produces valid audio
- invalid value rejects with `Invalid irodori_tts.codec_backend: bad`
- Qwen3-ASR on the CPU-codec output produced largely matching Japanese text
