### PR TITLE
Add  voice library folder (`voice_dir`) support for name-based voice cloning for OpenAI API (audiocpp_server)

### DIFF
--- a/app/server/README.md
+++ b/app/server/README.md
@@ -193,6 +193,43 @@ Define `voice_presets` once and put every named preset inside that object. Dupli
 
 When a request sends `"voice": "assistant"`, the server uses that configured preset. When `"voice"` does not match a configured preset, it is passed through as the model-native cached voice id, preserving the previous behavior.
 
+### Voice library (`voice_dir`)
+
+Set server-level `"voice_dir"` to a directory of built-in voice wav files plus a `prompt_text` mapping file, so a request `"voice": "demo_01_man"` clones `voice_dir/demo_01_man.wav` the same way the WebUI's voice tab does — no `voice_ref` / `reference_text` needed from the caller:
+
+```json
+{
+  "voice_dir": "/absolute/path/to/voice",
+  "models": [
+    {
+      "id": "qwen3-tts",
+      "family": "qwen3_tts",
+      "path": "/absolute/path/to/models/Qwen3-TTS",
+      "task": "tts",
+      "mode": "offline"
+    }
+  ]
+}
+```
+
+The directory holds one `.wav` per built-in voice ('demo_01_man.wav', 'demo_02_woman.wav'...) and a `prompt_text` file with one `<basename-without-extension>|<transcript>` line per voice:
+
+```
+demo_01_man|okay,I'm Cemo and what you just heard wasn't a human voice.
+demo_02_woman|以前我对这句话一知半解，现在好像有点懂了。因为你我开始留意很多以前不曾关心的事，开始对这个世界有了更多的好奇和善意。
+```
+
+Relative `voice_dir` paths resolve against the config file's directory. When a request sends `"voice"` that is not a configured model preset, the server checks `<voice_dir>/<name>.wav`; if the file exists it is loaded as the cloning reference, and the `<name>` transcript from `prompt_text` is injected as `reference_text` unless the request already provides one.
+
+Resolution precedence for a TTS request's voice fields:
+
+1. `voice_ref` — always wins.
+2. `voice` matching a configured model preset — preset wins.
+3. `voice` matching a wav basename in `voice_dir` — voice-library clone.
+4. Otherwise — `voice` is used as the model-native cached voice id (previous behavior).
+
+`GET /v1/audio/voices` also lists the `voice_dir` wav basenames (deduplicated against preset names). If `voice_dir` is unset, behavior is exactly as before.
+
 ## Start
 
 ```bash
@@ -370,7 +407,7 @@ A browser cannot drive it: `fetch()` request streaming requires HTTP/2 and is ha
 
 ### `GET /v1/audio/voices?model=<id>`
 
-Lists the cached voice ids and configured server voice preset names available for a TTS model, so a client can populate a voice picker instead of guessing generic names. For families that keep voice presets under `model_root/embeddings/*.safetensors` (`pocket_tts` today), this returns those ids too. If `model` is omitted and the server has exactly one configured model, that model is used; if multiple models are configured, omit `model` only when an empty list is acceptable.
+Lists the cached voice ids, configured server voice preset names, and voice-library (`voice_dir`) wav names available for a TTS model, so a client can populate a voice picker instead of guessing generic names. For families that keep voice presets under `model_root/embeddings/*.safetensors` (`pocket_tts` today), this returns those ids too. If `model` is omitted and the server has exactly one configured model, that model is used; if multiple models are configured, omit `model` only when an empty list is acceptable.
 
 ```bash
 curl 'http://127.0.0.1:8080/v1/audio/voices?model=pocket-tts'

--- a/app/server/config.cpp
+++ b/app/server/config.cpp
@@ -240,6 +240,12 @@ ServerConfig load_server_config(const std::filesystem::path & path) {
     if (const auto * value = root.find("model_spec_override")) {
         config.model_spec_override = resolve_path(base, value->as_string());
     }
+    if (const auto * value = root.find("voice_dir")) {
+        if (!value->is_string()) {
+            throw std::runtime_error("server voice_dir must be a string");
+        }
+        config.voice_dir = resolve_path(base, value->as_string());
+    }
     if (config.port <= 0 || config.port > 65535) {
         throw std::runtime_error("server port must be in 1..65535");
     }

--- a/app/server/config.h
+++ b/app/server/config.h
@@ -87,6 +87,10 @@ struct ServerConfig {
     // in LiveIngestLimits; a model entry may override any subset of them.
     LiveIngestLimits live_ingest;
     std::optional<std::filesystem::path> model_spec_override;
+    // Voice library shared across all TTS models: *.wav files plus a `prompt_text`
+    // mapping file (<basename>|<transcript>). A request `voice` name that is not a
+    // model preset resolves to <voice_dir>/<name>.wav as the cloning reference.
+    std::optional<std::filesystem::path> voice_dir;
     std::vector<ServerModelConfig> models;
 };
 

--- a/app/server/runtime.cpp
+++ b/app/server/runtime.cpp
@@ -59,6 +59,48 @@ std::filesystem::path resolve_path(const std::filesystem::path & base, const std
     return path.is_absolute() ? path : base / path;
 }
 
+// Looks up `<voice_name>` in `<voice_dir>/prompt_text`, a mapping file with one
+// `<basename>|<transcript>` line per built-in voice (same format the webui uses).
+std::optional<std::string> load_voice_library_text(
+    const std::filesystem::path & voice_dir, const std::string & voice_name) {
+    std::ifstream f(voice_dir / "prompt_text");
+    std::string line;
+    while (std::getline(f, line)) {
+        const auto sep = line.find('|');
+        if (sep == std::string::npos) continue;
+        std::string name = line.substr(0, sep);
+        // trim trailing whitespace from name
+        while (!name.empty() && std::isspace(static_cast<unsigned char>(name.back()))) {
+            name.pop_back();
+        }
+        if (name == voice_name) {
+            return line.substr(sep + 1);
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<std::filesystem::path> resolve_voice_library_wav(
+    const std::filesystem::path & voice_dir,
+    const std::string & voice_name) {
+    const std::filesystem::path name_path(voice_name);
+    if (voice_name.empty() ||
+        name_path.has_root_name() ||
+        name_path.has_root_directory() ||
+        name_path.has_parent_path() ||
+        name_path.filename().string() != voice_name ||
+        voice_name == "." ||
+        voice_name == "..") {
+        return std::nullopt;
+    }
+    const auto wav = voice_dir / (voice_name + ".wav");
+    std::error_code ec;
+    if (!std::filesystem::is_regular_file(wav, ec)) {
+        return std::nullopt;
+    }
+    return wav;
+}
+
 std::unordered_map<std::string, std::string> options_from_object(const Value * value);
 
 std::string safe_upload_name(std::string value) {
@@ -1439,12 +1481,35 @@ engine::runtime::TaskRequest ServerState::build_speech_request(const LoadedModel
             request.options["reference_text"] = *preset->reference_text;
         }
     }
+    const bool has_explicit_voice_ref = body.find("voice_ref") != nullptr;
     if (const auto * value = body.find("voice"); value != nullptr && !voice_field_is_preset) {
-        if (!voice.speaker.has_value()) {
-            voice.speaker = engine::runtime::VoiceReference{};
+        // Voice library: "voice" may name a wav in the configured voice_dir. When it
+        // does, that audio becomes the cloning reference and the transcript from
+        // prompt_text is injected unless the request already sets reference_text.
+        bool voice_library_resolved = false;
+        if (config_.voice_dir.has_value() && !has_explicit_voice_ref) {
+            const std::string voice_name = value->as_string();
+            if (const auto wav = resolve_voice_library_wav(*config_.voice_dir, voice_name)) {
+                voice.speaker = engine::runtime::VoiceReference{};
+                voice.speaker->audio = minitts::cli::read_audio_buffer(*wav);
+                has_voice = true;
+                voice_library_resolved = true;
+                if (request.options.find("reference_text") == request.options.end()) {
+                    auto text = load_voice_library_text(*config_.voice_dir, voice_name);
+                    if (text.has_value()) {
+                        request.options["reference_text"] = *text;
+                    }
+                }
+            }
         }
-        voice.speaker->cached_voice_id = value->as_string();
-        has_voice = true;
+        // Names that do not resolve to a wav keep the cached_voice_id behavior.
+        if (!voice_library_resolved) {
+            if (!voice.speaker.has_value()) {
+                voice.speaker = engine::runtime::VoiceReference{};
+            }
+            voice.speaker->cached_voice_id = value->as_string();
+            has_voice = true;
+        }
     }
     if (const auto * value = body.find("voice_ref")) {
         if (!voice.speaker.has_value()) {
@@ -2052,6 +2117,16 @@ HttpResponse ServerState::handle_voices(const HttpRequest & request) const {
         if (std::filesystem::is_directory(embeddings_dir, ec)) {
             for (const auto & entry : std::filesystem::directory_iterator(embeddings_dir, ec)) {
                 if (entry.is_regular_file() && entry.path().extension() == ".safetensors") {
+                    voices.push_back(entry.path().stem().string());
+                }
+            }
+        }
+    }
+    if (config_.voice_dir.has_value()) {
+        std::error_code ec;
+        if (std::filesystem::is_directory(*config_.voice_dir, ec)) {
+            for (const auto & entry : std::filesystem::directory_iterator(*config_.voice_dir, ec)) {
+                if (entry.is_regular_file() && entry.path().extension() == ".wav") {
                     voices.push_back(entry.path().stem().string());
                 }
             }

--- a/examples/voice_dir_example.json
+++ b/examples/voice_dir_example.json
@@ -1,0 +1,18 @@
+{
+  "host": "127.0.0.1",
+  "port": 8020,
+  "backend": "cuda",
+  "device": 0,
+  "threads": 1,
+  "lazy_load": true,
+  "voice_dir": "../../webui/voice",
+  "models": [
+    {
+      "id": "qwen3-tts",
+      "family": "qwen3_tts",
+      "path": "../../models/Qwen3-TTS-12Hz-0.6B-Base",
+      "task": "tts",
+      "mode": "offline"
+    }
+  ]
+}

--- a/webui/webui.py
+++ b/webui/webui.py
@@ -2128,7 +2128,7 @@ def _write_temp_config(entry):
         if entry.get(key) is not None:
             model[key] = entry[key]
     cfg = {"host": HOST, "port": PORT, "backend": SERVER_BACKEND, "device": DEVICE,
-           "threads": THREADS, "models": [model]}
+           "threads": THREADS, "voice_dir": VOICE_DIR, "models": [model]}
     fd, path = tempfile.mkstemp(prefix="audiocpp_webui_cfg_", suffix=".json")
     with os.fdopen(fd, "w", encoding="utf-8") as f:
         json.dump(cfg, f)
@@ -2438,6 +2438,15 @@ curl {SERVER}/v1/audio/speech -H "Content-Type: application/json" -o out.wav \\
   -d '{{"model":"qwen3-tts","input":"Hello from audio.cpp."}}'
 ```
 
+Built-in voices from this WebUI's voice folder can be cloned by name: pass the voice
+basename as `"voice"`, e.g. `"voice": "demo_01_man"` loads `voice/demo_01_man.wav` and its transcript
+from `voice/prompt_text` automatically.
+
+```bash
+curl {SERVER}/v1/audio/speech -H "Content-Type: application/json" -o out.wav \\
+  -d '{{"model":"qwen3-tts","input":"Hello from audio.cpp.","voice":"jenny"}}'
+```
+
 The server stays running while the WebUI command window is open.
 """
     content = f"""
@@ -2458,6 +2467,9 @@ curl {SERVER}/v1/audio/speech -H "Content-Type: application/json" -o out.wav \\
 - **ASR 请求示例**：`-d '{{"model": "qwen3-asr", "audio": "D:/audio/in.wav"}}'`；
   可选 `"language"`（强制语种，如 `"Chinese"`）和 `"context"`（人名/术语偏置提示），仅 qwen3-asr 生效。
   注意 `voice_ref` / `audio` 填的都是 **server 所在机器上的文件路径**（不是浏览器上传）。
+- **按名字克隆内置音色**：本 WebUI voice 文件夹里的内置音色可以只填 `"voice": "<名字>"` 克隆，
+  例如 `"voice": "jenny"` 会自动加载 `voice/jenny.wav` 并从 `voice/prompt_text` 取参考文本：
+  `-d '{{"model": "qwen3-tts", "input": "你好，audio.cpp。", "voice": "jenny"}}'`。
 - **音乐生成（gen 模型）**：走通用路由 `POST {SERVER}/v1/tasks/run`，body 形如
   `{{"model": "ace-step", "request": {{"text": "提示词", "lyrics": "歌词", "duration_seconds": 30,
   "options": {{"tags": "pop,bright"}}}}}}`，响应 JSON 的 `audio` 字段是 base64 WAV。


### PR DESCRIPTION

**Status:** Ready for review
**Branch base:** `main`
**Files changed:** 6 (5 modified, 1 added)
---

## Summary

The WebUI's TTS/Voice Cloning tab lets a user pick a built-in voice from `webui/voice/`
(a `.wav` file plus its reference transcription in `webui/voice/prompt_text`) and clone
that voice. Today this works only because the **Python client** resolves the dropdown
name into a server-side file path (`voice_ref`) plus a transcription (`reference_text`)
and sends both to `POST /v1/audio/speech`.

A third-party OpenAI-compatible client cannot clone by **name**: sending the standard
OpenAI field `"voice": "jenny"` does not clone `webui/voice/jenny.wav`, because the
C++ server has no knowledge of the webui voice library.

This PR teaches `audiocpp_server` to resolve a `voice` name against a configured voice
library directory (`voice_dir`) containing `.wav` files and a `prompt_text` mapping file,
so `{"voice": "jenny"}` performs the same voice cloning as the WebUI tab — with no
`voice_ref` / `reference_text` required from the caller.

## Changes

### `app/server/config.h` — new config field

```cpp
// Voice library shared across all TTS models: *.wav files plus a `prompt_text`
// mapping file (<basename>|<transcript>). A request `voice` name that is not a
// model preset resolves to <voice_dir>/<name>.wav as the cloning reference.
std::optional<std::filesystem::path> voice_dir;
```

### `app/server/config.cpp` — parse and resolve `voice_dir`

Parses the server-level `voice_dir` key (must be a string). Relative paths resolve
against the config file's directory, same as `model_spec_override` / model paths.

### `app/server/runtime.cpp` — voice-library resolution

- **`build_speech_request()`**: when `voice` is not a configured model preset, the
  server checks `<voice_dir>/<name>.wav`. If the file exists, it is loaded as the
  cloning reference (`voice.speaker->audio`) and the matching transcript from
  `prompt_text` is injected as `reference_text` — but only if the request does not
  already set `reference_text`.
- **`load_voice_library_text()`**: file-local helper parsing `prompt_text` (one
  `<basename>|<transcript>` line per voice, split on first `|`, name trimmed).
- **`handle_voices()`**: `GET /v1/audio/voices` now also lists `voice_dir/*.wav`
  basenames (deduplicated against preset names by the existing sort+unique).

### `webui/webui.py` — wire the library into the managed server

- **`_write_temp_config()`**: the temp server config now emits
  `"voice_dir": VOICE_DIR` (absolute path), so a webui-launched server exposes the
  same voices the tab offers to third-party OpenAI-compatible clients.
- **API help text** (EN + zh): documents cloning by name, e.g. `"voice": "jenny"`.

### `app/server/README.md` — documentation

New "Voice library (`voice_dir`)" section documenting the config, the `prompt_text`
format, and the voice resolution precedence.

### `examples/voice_dir_example.json` — runnable example config (new)

Minimal config demonstrating `voice_dir` with a TTS model.

## Voice resolution precedence (unchanged semantics + new step)

1. `voice_ref` present → load that file. **Always wins.**
2. `voice` matches a configured model `voice_presets` preset → preset wins.
3. `voice` matches `<voice_dir>/<name>.wav` → voice-library clone (new).
4. Otherwise → `voice` used as model-native cached voice id (previous behavior).

> Implementation note: the library lookup is merged into the existing `voice` →
> `cached_voice_id` block (gating the fallback on `!voice_library_resolved`) rather
> than inserted as a separate preceding block. As originally sketched, the untouched
> `cached_voice_id` block would still run after a successful library hit and set
> `cached_voice_id` alongside `audio` — pocket_tts hard-errors when both a preset
> name and clone audio are set. The merge preserves the intended precedence exactly:
> a name that resolves to a wav clones; anything else falls through unchanged.

## Usage

### 1. Configure the voice library

Add `voice_dir` to your server config:

```json
{
  "host": "127.0.0.1",
  "port": 8020,
  "backend": "cuda",
  "device": 0,
  "threads": 1,
  "lazy_load": true,
  "voice_dir": "/absolute/path/to/webui/voice",
  "models": [
    {
      "id": "qwen3-tts",
      "family": "qwen3_tts",
      "path": "/absolute/path/to/models/Qwen3-TTS",
      "task": "tts",
      "mode": "offline"
    }
  ]
}
```

The directory holds one `.wav` per built-in voice and a `prompt_text` file with one
`<basename-without-extension>|<transcript>` line per voice:

```
jenny|This is the longer voice from Jenny Neutral.
原神-甘雨|但只要最后落在具体的「人」身上，那，我可以想办法。
```

See `examples/voice_dir_example.json` for a complete runnable example (paths relative
to `examples/`, so `../../webui/voice` resolves to the repo's voice folder).

### 2. List available voices

```bash
curl 'http://127.0.0.1:8020/v1/audio/voices?model=qwen3-tts'
# {"voices": ["ana", "andrew", "aria", "demo_01_man", "jenny", ..., "原神-甘雨", ...]}
```

### 3. Clone by name (the core fix)

```bash
curl http://127.0.0.1:8020/v1/audio/speech -H "Content-Type: application/json" -o out.wav \
  -d '{"model": "qwen3-tts", "input": "Hello from audio.cpp.", "voice": "jenny"}'
```

No `voice_ref` / `reference_text` needed — the transcript is injected from
`prompt_text` automatically. Non-ASCII names work too:

```bash
curl http://127.0.0.1:8020/v1/audio/speech -H "Content-Type: application/json" -o out.wav \
  -d '{"model": "qwen3-tts", "input": "你好，audio.cpp。", "voice": "原神-甘雨"}'
```

## Verification (performed)

Built with `cmake -S . -B build -DENGINE_ENABLE_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=61`
and `cmake --build build --config Release -j` — clean, `audiocpp_server` links.

| Check | Result |
|---|---|
| `GET /v1/audio/voices?model=qwen3-tts` lists library voices | 25 voices incl. `jenny`, `andrew`, `原神-甘雨` |
| `voice` + `voice_ref` both present | `voice_ref` wins (unchanged) |
| Explicit `reference_text` in request | overrides the library transcript |
| Unknown `voice` name (no wav) | falls through to cached voice id (unchanged) |
| `voice_dir` unset | behavior exactly as before |
| WebUI regression (sends `voice_ref`+`reference_text`) | unchanged path |
