### PR TITLE
vulkan: disable integer dot product on AMD proprietary driver without…

### DIFF
--- a/external/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/external/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -395,6 +395,19 @@ static vk_device_architecture get_device_architecture(const vk::PhysicalDevice& 
     return vk_device_architecture::OTHER;
 }
 
+// Workaround for the AMD proprietary driver advertising
+// integerDotProduct4x8BitPackedSignedAccelerated on GPUs without native dot4
+// hardware (GCN/RDNA1/RDNA2): the emulated integer dot product path silently
+// produces incorrect quantized matmul results
+// (https://github.com/0xShug0/audio.cpp/issues/192). RADV reports
+// accelerated=false on the same hardware, and RDNA3+ has native dot4 support.
+static bool ggml_vk_amd_proprietary_emulated_int_dot(uint32_t vendor_id, vk::DriverId driver_id, vk_device_architecture architecture) {
+    return vendor_id == VK_VENDOR_ID_AMD && driver_id == vk::DriverId::eAmdProprietary &&
+           (architecture == vk_device_architecture::AMD_GCN ||
+            architecture == vk_device_architecture::AMD_RDNA1 ||
+            architecture == vk_device_architecture::AMD_RDNA2);
+}
+
 enum vk_conv_shapes {
     CONV_SHAPE_128x128,
     CONV_SHAPE_64x32,
@@ -5286,6 +5299,10 @@ static vk_device ggml_vk_get_device(size_t idx) {
 
         device->integer_dot_product = device->integer_dot_product && shader_integer_dot_product_props.integerDotProduct4x8BitPackedSignedAccelerated;
 
+        if (ggml_vk_amd_proprietary_emulated_int_dot(device->vendor_id, device->driver_id, device->architecture)) {
+            device->integer_dot_product = false;
+        }
+
         device->min_imported_host_pointer_alignment = external_memory_host_props.minImportedHostPointerAlignment;
 
         device->max_workgroup_size_log2 = uint32_t(log2f(float(device->properties.limits.maxComputeWorkGroupInvocations)));
@@ -5947,6 +5964,10 @@ static void ggml_vk_print_gpu_info(size_t idx) {
     integer_dot_product = integer_dot_product
                        && shader_integer_dot_product_props.integerDotProduct4x8BitPackedSignedAccelerated
                        && shader_integer_dot_product_features.shaderIntegerDotProduct;
+
+    if (ggml_vk_amd_proprietary_emulated_int_dot(props2.properties.vendorID, driver_props.driverID, device_architecture)) {
+        integer_dot_product = false;
+    }
 
     coopmat_support = coopmat_support
 #if defined(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT)


### PR DESCRIPTION
Fix: #192
On AMD GPUs without native dot4 hardware (GCN/RDNA1/RDNA2, e.g. RX 6800), the AMD proprietary Windows driver advertises integerDotProduct4x8BitPackedSignedAccelerated=true, so ggml-vulkan routes q8_0 matmuls through the integer-dot path (dotPacked4x8EXT). That path silently produces wrong results there — with the default q8_0 Irodori-TTS package the output WAV is saturated to a constant +32767 with no error or abnormal metric. RADV reports accelerated=false on the same hardware, and RDNA3+ has native dot4. Same signature reported in [ollama#13108](https://github.com/ollama/ollama/issues/13108) (RX 6650 XT).

**Fix**
- Force integer_dot_product=false for the affected combination (AMD vendor + eAmdProprietary + GCN/RDNA1/RDNA2), mirroring the existing old_amd_windows quirk condition. Equivalent to the known workaround GGML_VK_DISABLE_INTEGER_DOT_PRODUCT=1, applied automatically; also covers MUL_MAT_ID and flash-attention MMQ paths. The device-info path is adjusted too so the int dot log line stays truthful. RDNA3+, RADV, NVIDIA, Intel are unaffected.

**Verification**
- Reporter confirmed on the affected RX 6800: device now reports int dot: 0, q8_0/Vulkan output is bit-identical to the env-var workaround (25,462 distinct samples, RMS 0.1291), f16 unchanged, no measurable perf cost, test-backend-ops still 13,641/13,641.
- ggml-vulkan target compiles cleanly (MSVC 19.44, Vulkan SDK 1.4.350).


AI usage: Kimi K3 helped me find the issue and performed a fix.
