### PR TITLE
Optimize Metal copy kernels

### DIFF
--- a/docs/reports/metal_copy_optimization_performance.md
+++ b/docs/reports/metal_copy_optimization_performance.md
@@ -1,0 +1,18 @@
+# Metal Copy Optimization Performance
+
+Measured on Apple M4 Pro with the Metal backend and 8 CPU threads. Baseline is clean `dev` at `3b1bbae`; optimized is the same tree with the Metal copy fast-path patch.
+
+| Model | Request | RTF before | RTF after | Improvement |
+|---|---|---:|---:|---:|
+| DotTTS SOAR Q8_0 | Request 1 | 2.15469 | 1.62996 | 24.35% |
+| DramaBox Q8_0 | Request 1 | 15.5369 | 11.0525 | 28.86% |
+| DramaBox Q8_0 | Request 2 | 31.8510 | 18.0591 | 43.30% |
+| PocketTTS Q8_0 | Request 1 | 0.072414 | 0.052740 | 27.17% |
+| PocketTTS Q8_0 | Request 2 | 0.074366 | 0.054182 | 27.14% |
+| OmniVoice Q8_0 | Request 1 | 0.358067 | 0.310377 | 13.32% |
+| OmniVoice Q8_0 | Request 2 | 0.396263 | 0.346676 | 12.51% |
+| Qwen3-TTS VoiceDesign Q8_0 | Request 1 | 0.543776 | 0.537302 | 1.19% |
+| Qwen3-TTS VoiceDesign Q8_0 | Request 2 | 0.546709 | 0.512593 | 6.24% |
+| Qwen3-TTS Base Voice Clone Q8_0 | Request 1 | 1.19203 | 1.14700 | 3.78% |
+| Qwen3-TTS Base Voice Clone Q8_0 | Request 2 | 0.929893 | 0.863321 | 7.16% |
+| IndexTTS2 Q8_0 | Request 1 | 2.337110 | 2.183560 | 6.57% |

--- a/external/ggml/src/ggml-metal/ggml-metal-device.cpp
+++ b/external/ggml/src/ggml-metal/ggml-metal-device.cpp
@@ -96,6 +96,60 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_cpy(ggml_metal_l
     return res;
 }
 
+ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_cpy_contig(ggml_metal_library_t lib, ggml_type tsrc, ggml_type tdst) {
+    char base[256];
+    char name[256];
+
+    snprintf(base, 256, "kernel_cpy_contig_%s_%s", ggml_type_name(tsrc), ggml_type_name(tdst));
+    snprintf(name, 256, "%s", base);
+
+    ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);
+    if (!res.pipeline) {
+        res = ggml_metal_library_compile_pipeline(lib, base, name, nullptr);
+    }
+
+    return res;
+}
+
+ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_cpy_2d(ggml_metal_library_t lib, ggml_type type) {
+    char base[256];
+    char name[256];
+
+    snprintf(base, 256, "kernel_cpy_2d_%s", ggml_type_name(type));
+    snprintf(name, 256, "%s", base);
+
+    ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);
+    if (!res.pipeline) {
+        res = ggml_metal_library_compile_pipeline(lib, base, name, nullptr);
+    }
+
+    return res;
+}
+
+ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_cpy_row_f32(ggml_metal_library_t lib) {
+    const char * base = "kernel_cpy_row_f32";
+    const char * name = "kernel_cpy_row_f32";
+
+    ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);
+    if (!res.pipeline) {
+        res = ggml_metal_library_compile_pipeline(lib, base, name, nullptr);
+    }
+
+    return res;
+}
+
+ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_cpy_transpose_f32(ggml_metal_library_t lib) {
+    const char * base = "kernel_cpy_transpose_f32";
+    const char * name = "kernel_cpy_transpose_f32";
+
+    ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);
+    if (!res.pipeline) {
+        res = ggml_metal_library_compile_pipeline(lib, base, name, nullptr);
+    }
+
+    return res;
+}
+
 ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_pool_1d(ggml_metal_library_t lib, const ggml_tensor * op, ggml_op_pool op_pool) {
     GGML_ASSERT(ggml_is_contiguous(op->src[0]));
     GGML_ASSERT(op->src[0]->type == GGML_TYPE_F32 && op->src[0]->type == op->type);

--- a/external/ggml/src/ggml-metal/ggml-metal-device.h
+++ b/external/ggml/src/ggml-metal/ggml-metal-device.h
@@ -109,6 +109,10 @@ struct ggml_metal_pipeline_with_params ggml_metal_library_compile_pipeline(ggml_
 
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_base              (ggml_metal_library_t lib, enum ggml_op op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_cpy               (ggml_metal_library_t lib, enum ggml_type tsrc, enum ggml_type tdst);
+struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_cpy_contig        (ggml_metal_library_t lib, enum ggml_type tsrc, enum ggml_type tdst);
+struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_cpy_2d            (ggml_metal_library_t lib, enum ggml_type type);
+struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_cpy_row_f32       (ggml_metal_library_t lib);
+struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_cpy_transpose_f32 (ggml_metal_library_t lib);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_pool_1d           (ggml_metal_library_t lib, const struct ggml_tensor * op, enum ggml_op_pool op_pool);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_pool_2d           (ggml_metal_library_t lib, const struct ggml_tensor * op, enum ggml_op_pool op_pool);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_get_rows          (ggml_metal_library_t lib, enum ggml_type tsrc);

--- a/external/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/external/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -68,6 +68,49 @@ static bool ggml_metal_op_pad_left_supported(const ggml_tensor * op) {
 
 static int ggml_metal_op_pad_left(ggml_metal_op_t ctx, int idx);
 
+static bool ggml_metal_cpy_scalar_type_supported(ggml_type type) {
+    return type == GGML_TYPE_F32 ||
+        type == GGML_TYPE_F16 ||
+        type == GGML_TYPE_I32 ||
+        type == GGML_TYPE_BF16;
+}
+
+static bool ggml_metal_cpy_contig_fast_supported(const ggml_tensor * op) {
+    return ggml_is_contiguous(op->src[0]) &&
+        ggml_is_contiguous(op) &&
+        ggml_metal_cpy_scalar_type_supported(op->src[0]->type) &&
+        ggml_metal_cpy_scalar_type_supported(op->type);
+}
+
+static bool ggml_metal_cpy_2d_fast_supported(const ggml_tensor * op) {
+    return op->src[0]->type == op->type &&
+        ggml_metal_cpy_scalar_type_supported(op->type) &&
+        ggml_are_same_shape(op->src[0], op) &&
+        ggml_is_contiguous(op) &&
+        op->src[0]->ne[0] > 1 &&
+        op->src[0]->ne[1] > 1;
+}
+
+static bool ggml_metal_cpy_row_f32_supported(const ggml_tensor * op) {
+    return op->src[0]->type == GGML_TYPE_F32 &&
+        op->type == GGML_TYPE_F32 &&
+        ggml_are_same_shape(op->src[0], op) &&
+        ggml_is_contiguous(op) &&
+        op->src[0]->nb[0] == sizeof(float) &&
+        op->nb[0] == sizeof(float);
+}
+
+static bool ggml_metal_cpy_transpose_f32_supported(const ggml_tensor * op) {
+    return op->src[0]->type == GGML_TYPE_F32 &&
+        op->type == GGML_TYPE_F32 &&
+        ggml_are_same_shape(op->src[0], op) &&
+        ggml_is_contiguous(op) &&
+        op->src[0]->nb[1] == sizeof(float) &&
+        op->nb[0] == sizeof(float) &&
+        op->src[0]->ne[0] > 1 &&
+        op->src[0]->ne[1] > 1;
+}
+
 struct ggml_metal_op {
     ggml_metal_op(
         ggml_metal_device_t dev,
@@ -1980,25 +2023,6 @@ int ggml_metal_op_cpy(ggml_metal_op_t ctx, int idx) {
         nk0 = ne00/ggml_blck_size(op->type);
     }
 
-    int nth = std::min<int>(nk0, ggml_metal_pipeline_max_theads_per_threadgroup(pipeline));
-
-    // when rows are small, we can batch them together in a single threadgroup
-    int nrptg = 1;
-
-    // TODO: relax this constraint in the future
-    if (ggml_blck_size(op->src[0]->type) == 1 && ggml_blck_size(op->type) == 1) {
-        if (nth > nk0) {
-            nrptg = (nth + nk0 - 1)/nk0;
-            nth   = nk0;
-
-            if (nrptg*nth > ggml_metal_pipeline_max_theads_per_threadgroup(pipeline)) {
-                nrptg--;
-            }
-        }
-    }
-
-    nth = std::min<int>(nth, nk0);
-
     ggml_metal_kargs_cpy args = {
         /*.nk0  =*/ nk0,
         /*.ne00 =*/ ne00,
@@ -2018,6 +2042,81 @@ int ggml_metal_op_cpy(ggml_metal_op_t ctx, int idx) {
         /*.nb2  =*/ nb2,
         /*.nb3  =*/ nb3,
     };
+
+    if (ggml_metal_cpy_contig_fast_supported(op)) {
+        auto pipeline_contig = ggml_metal_library_get_pipeline_cpy_contig(lib, op->src[0]->type, op->type);
+        const int64_t nelements = ggml_nelements(op);
+        const int nth = std::min<int>(ggml_metal_pipeline_max_theads_per_threadgroup(pipeline_contig), 256);
+        args.nk0 = nelements;
+
+        ggml_metal_encoder_set_pipeline(enc, pipeline_contig);
+        ggml_metal_encoder_set_bytes   (enc, &args, sizeof(args), 0);
+        ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[0]), 1);
+        ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op),         2);
+
+        ggml_metal_encoder_dispatch_threadgroups(enc, (nelements + nth - 1)/nth, 1, 1, nth, 1, 1);
+
+        return 1;
+    }
+
+    if (ggml_metal_cpy_row_f32_supported(op)) {
+        auto pipeline_row = ggml_metal_library_get_pipeline_cpy_row_f32(lib);
+
+        ggml_metal_encoder_set_pipeline(enc, pipeline_row);
+        ggml_metal_encoder_set_bytes   (enc, &args, sizeof(args), 0);
+        ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[0]), 1);
+        ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op),         2);
+
+        ggml_metal_encoder_dispatch_threadgroups(enc, (ne00 + 63)/64, (ne01 + 15)/16, (ne02*ne03 + 3)/4, 16, 8, 1);
+
+        return 1;
+    }
+
+    if (ggml_metal_cpy_transpose_f32_supported(op)) {
+        auto pipeline_transpose = ggml_metal_library_get_pipeline_cpy_transpose_f32(lib);
+
+        ggml_metal_encoder_set_pipeline(enc, pipeline_transpose);
+        ggml_metal_encoder_set_bytes   (enc, &args, sizeof(args), 0);
+        ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[0]), 1);
+        ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op),         2);
+        ggml_metal_encoder_set_threadgroup_memory_size(enc, 32*(32 + 1)*sizeof(float), 0);
+
+        ggml_metal_encoder_dispatch_threadgroups(enc, (ne00 + 31)/32, (ne01 + 31)/32, ne02*ne03, 32, 8, 1);
+
+        return 1;
+    }
+
+    if (ggml_metal_cpy_2d_fast_supported(op)) {
+        auto pipeline_2d = ggml_metal_library_get_pipeline_cpy_2d(lib, op->type);
+
+        ggml_metal_encoder_set_pipeline(enc, pipeline_2d);
+        ggml_metal_encoder_set_bytes   (enc, &args, sizeof(args), 0);
+        ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[0]), 1);
+        ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op),         2);
+
+        ggml_metal_encoder_dispatch_threadgroups(enc, (ne00 + 15)/16, (ne01 + 15)/16, ne02*ne03, 16, 16, 1);
+
+        return 1;
+    }
+
+    int nth = std::min<int>(ggml_metal_pipeline_max_theads_per_threadgroup(pipeline), 256);
+
+    // when rows are small, we can batch them together in a single threadgroup
+    int nrptg = 1;
+
+    // TODO: relax this constraint in the future
+    if (ggml_blck_size(op->src[0]->type) == 1 && ggml_blck_size(op->type) == 1) {
+        if (nth > nk0) {
+            nrptg = (nth + nk0 - 1)/nk0;
+            nth   = nk0;
+
+            if (nrptg*nth > ggml_metal_pipeline_max_theads_per_threadgroup(pipeline)) {
+                nrptg--;
+            }
+        }
+    }
+
+    nth = std::min<int>(nth, nk0);
 
     const int nw0 = nrptg == 1 ? (nk0 + nth - 1)/nth : 1;
 

--- a/external/ggml/src/ggml-metal/ggml-metal.metal
+++ b/external/ggml/src/ggml-metal/ggml-metal.metal
@@ -7897,6 +7897,160 @@ kernel void kernel_cpy_t_t(
 
 typedef decltype(kernel_cpy_t_t<float, float>) kernel_cpy_t;
 
+template<typename T0, typename T1>
+kernel void kernel_cpy_contig_t_t(
+        constant ggml_metal_kargs_cpy & args,
+        device  const char * src0,
+        device        char * dst,
+        uint3   tgpig[[threadgroup_position_in_grid]],
+        ushort3 tpitg[[thread_position_in_threadgroup]],
+        ushort3 ntg[[threads_per_threadgroup]]) {
+    const int64_t i = (int64_t)tgpig.x*ntg.x + tpitg.x;
+
+    if (i >= args.nk0) {
+        return;
+    }
+
+    device const T0 * src_data = (device const T0 *) src0;
+    device       T1 * dst_data = (device       T1 *) dst;
+
+    dst_data[i] = (T1) src_data[i];
+}
+
+typedef decltype(kernel_cpy_contig_t_t<float, float>) kernel_cpy_contig_t;
+
+template [[host_name("kernel_cpy_contig_f32_f32")]] kernel kernel_cpy_contig_t kernel_cpy_contig_t_t<float,   float>;
+template [[host_name("kernel_cpy_contig_f32_f16")]] kernel kernel_cpy_contig_t kernel_cpy_contig_t_t<float,   half>;
+template [[host_name("kernel_cpy_contig_f32_i32")]] kernel kernel_cpy_contig_t kernel_cpy_contig_t_t<float,   int32_t>;
+template [[host_name("kernel_cpy_contig_i32_f32")]] kernel kernel_cpy_contig_t kernel_cpy_contig_t_t<int32_t, float>;
+template [[host_name("kernel_cpy_contig_i32_i32")]] kernel kernel_cpy_contig_t kernel_cpy_contig_t_t<int32_t, int32_t>;
+#if defined(GGML_METAL_HAS_BF16)
+template [[host_name("kernel_cpy_contig_f32_bf16")]] kernel kernel_cpy_contig_t kernel_cpy_contig_t_t<float,   bfloat>;
+#endif
+template [[host_name("kernel_cpy_contig_f16_f32")]] kernel kernel_cpy_contig_t kernel_cpy_contig_t_t<half,    float>;
+template [[host_name("kernel_cpy_contig_f16_f16")]] kernel kernel_cpy_contig_t kernel_cpy_contig_t_t<half,    half>;
+#if defined(GGML_METAL_HAS_BF16)
+template [[host_name("kernel_cpy_contig_bf16_f32")]]  kernel kernel_cpy_contig_t kernel_cpy_contig_t_t<bfloat, float>;
+template [[host_name("kernel_cpy_contig_bf16_bf16")]] kernel kernel_cpy_contig_t kernel_cpy_contig_t_t<bfloat, bfloat>;
+#endif
+
+template<typename T>
+kernel void kernel_cpy_2d_t(
+        constant ggml_metal_kargs_cpy & args,
+        device  const char * src0,
+        device        char * dst,
+        uint3   tgpig[[threadgroup_position_in_grid]],
+        ushort3 tpitg[[thread_position_in_threadgroup]],
+        ushort3 ntg[[threads_per_threadgroup]]) {
+    const int64_t i0  = (int64_t)tgpig.x*ntg.x + tpitg.x;
+    const int64_t i1  = (int64_t)tgpig.y*ntg.y + tpitg.y;
+    const int64_t i23 = tgpig.z;
+    const int64_t i2  = i23 % args.ne02;
+    const int64_t i3  = i23 / args.ne02;
+
+    if (i0 >= args.ne00 || i1 >= args.ne01) {
+        return;
+    }
+
+    device const T * src_data = (device const T *) (src0 + i3*args.nb03 + i2*args.nb02 + i1*args.nb01 + i0*args.nb00);
+    device       T * dst_data = (device       T *) (dst  + i3*args.nb3  + i2*args.nb2  + i1*args.nb1  + i0*args.nb0);
+
+    dst_data[0] = src_data[0];
+}
+
+typedef decltype(kernel_cpy_2d_t<float>) kernel_cpy_2d_tmpl;
+
+template [[host_name("kernel_cpy_2d_f32")]] kernel kernel_cpy_2d_tmpl kernel_cpy_2d_t<float>;
+template [[host_name("kernel_cpy_2d_f16")]] kernel kernel_cpy_2d_tmpl kernel_cpy_2d_t<half>;
+template [[host_name("kernel_cpy_2d_i32")]] kernel kernel_cpy_2d_tmpl kernel_cpy_2d_t<int32_t>;
+#if defined(GGML_METAL_HAS_BF16)
+template [[host_name("kernel_cpy_2d_bf16")]] kernel kernel_cpy_2d_tmpl kernel_cpy_2d_t<bfloat>;
+#endif
+
+kernel void kernel_cpy_row_f32(
+        constant ggml_metal_kargs_cpy & args,
+        device  const char * src0,
+        device        char * dst,
+        uint3   tgpig[[threadgroup_position_in_grid]],
+        ushort3 tpitg[[thread_position_in_threadgroup]]) {
+    const int64_t i0 = ((int64_t)tgpig.x*16 + tpitg.x)*4;
+
+    if (i0 >= args.ne00) {
+        return;
+    }
+
+    for (int mat = 0; mat < 4; ++mat) {
+        const int64_t i23 = (int64_t)tgpig.z*4 + mat;
+        if (i23 >= args.ne02*args.ne03) {
+            continue;
+        }
+        const int64_t i2 = i23 % args.ne02;
+        const int64_t i3 = i23 / args.ne02;
+
+        for (int row = 0; row < 2; ++row) {
+            const int64_t i1 = (int64_t)tgpig.y*16 + tpitg.y + 8*row;
+            if (i1 >= args.ne01) {
+                continue;
+            }
+
+            device const char * src_row = src0 + i3*args.nb03 + i2*args.nb02 + i1*args.nb01 + i0*args.nb00;
+            device       char * dst_row = dst  + i3*args.nb3  + i2*args.nb2  + i1*args.nb1  + i0*args.nb0;
+
+            if (i0 + 3 < args.ne00) {
+                device const float4 * src4 = (device const float4 *) src_row;
+                device       float4 * dst4 = (device       float4 *) dst_row;
+                dst4[0] = src4[0];
+            } else {
+                device const float * src1 = (device const float *) src_row;
+                device       float * dst1 = (device       float *) dst_row;
+                for (int64_t i = i0; i < args.ne00; ++i) {
+                    dst1[i - i0] = src1[i - i0];
+                }
+            }
+        }
+    }
+}
+
+kernel void kernel_cpy_transpose_f32(
+        constant ggml_metal_kargs_cpy & args,
+        device  const char * src0,
+        device        char * dst,
+        threadgroup float * shmem [[threadgroup(0)]],
+        uint3   tgpig[[threadgroup_position_in_grid]],
+        ushort3 tpitg[[thread_position_in_threadgroup]]) {
+    constexpr int tile_dim = 32;
+    constexpr int block_rows = 8;
+    constexpr int tile_stride = tile_dim + 1;
+
+    const int64_t tile_col = tgpig.x;
+    const int64_t tile_row = tgpig.y;
+    const int64_t i23 = tgpig.z;
+    const int64_t i2 = i23 % args.ne02;
+    const int64_t i3 = i23 / args.ne02;
+    const int64_t tid_col = tpitg.x;
+    const int64_t tid_row = tpitg.y;
+
+    for (int y = 0; y < 4; ++y) {
+        const int64_t i0 = tile_col*tile_dim + tid_row + block_rows*y;
+        const int64_t i1 = tile_row*tile_dim + tid_col;
+        if (i0 < args.ne00 && i1 < args.ne01) {
+            device const float * src = (device const float *) (src0 + i3*args.nb03 + i2*args.nb02 + i1*args.nb01 + i0*args.nb00);
+            shmem[(tid_row + block_rows*y)*tile_stride + tid_col] = src[0];
+        }
+    }
+
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (int y = 0; y < 4; ++y) {
+        const int64_t i0 = tile_col*tile_dim + tid_col;
+        const int64_t i1 = tile_row*tile_dim + tid_row + block_rows*y;
+        if (i0 < args.ne0 && i1 < args.ne1) {
+            device float * dst_data = (device float *) (dst + i3*args.nb3 + i2*args.nb2 + i1*args.nb1 + i0*args.nb0);
+            dst_data[0] = shmem[tid_col*tile_stride + tid_row + block_rows*y];
+        }
+    }
+}
+
 template [[host_name("kernel_cpy_f32_f32")]]   kernel kernel_cpy_t kernel_cpy_t_t<float,   float>;
 template [[host_name("kernel_cpy_f32_f16")]]   kernel kernel_cpy_t kernel_cpy_t_t<float,   half>;
 template [[host_name("kernel_cpy_f32_i32")]]   kernel kernel_cpy_t kernel_cpy_t_t<float,   int32_t>;


### PR DESCRIPTION
## Summary
- Add Metal fast paths for common copy patterns.
- Record measured RTF gains in `docs/reports/metal_copy_optimization_performance.md`.

## Validation
- Ran A/B path-test CLI benchmarks listed in `docs/reports/metal_copy_optimization_performance.md`.
- Verified optimized WAV outputs match baseline for tested cases.