### PR TITLE
Fix CUDA BF16 cuBLAS output on Ampere

### DIFF
--- a/external/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/external/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -1784,7 +1784,7 @@ static void ggml_cuda_op_mul_mat_cublas(
                                  src1_ptr,       CUDA_R_16BF, ne10,
                     &beta_f32,   dst_dd_i,       CUDA_R_32F,  ldc,
                     CUBLAS_COMPUTE_32F,
-                    CUBLAS_GEMM_DEFAULT));
+                    CUBLAS_GEMM_DEFAULT_TENSOR_OP));
 #endif // defined(GGML_USE_HIP) && defined(GGML_HIP_USE_HIPBLASLT)
     } else if (fast_fp16_hardware_available(cc) && use_fp16) {
         // convert src0 and src1 to fp16, multiply as fp16, convert dst to fp32

--- a/external/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/external/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -1739,7 +1739,8 @@ static void ggml_cuda_op_mul_mat_cublas(
 
     const int cc = ggml_cuda_info().devices[id].cc;
 
-    const bool supports_bf16 = GGML_CUDA_CC_IS_NVIDIA(cc) || GGML_CUDA_CC_IS_AMD(cc) ||
+    const bool supports_bf16 =
+        (GGML_CUDA_CC_IS_NVIDIA(cc) && cc >= GGML_CUDA_CC_AMPERE) || GGML_CUDA_CC_IS_AMD(cc) ||
         (GGML_CUDA_CC_IS_MTHREADS(cc) && cc >= GGML_CUDA_CC_QY2);
 
     const bool use_fp16 =
@@ -1760,18 +1761,19 @@ static void ggml_cuda_op_mul_mat_cublas(
         }
         const nv_bfloat16 * src1_ptr = src1->type == GGML_TYPE_BF16 ? (const nv_bfloat16 *) src1_ddf_i : src1_as_bf16.get();
         const nv_bfloat16 * src0_ptr = (const nv_bfloat16 *)src0_dd_i;
-        ggml_cuda_pool_alloc<nv_bfloat16> dst_bf16(ctx.pool(id), row_diff*src1_ncols);
-
         const float alpha_f32 = 1.0f;
         const float beta_f32  = 0.0f;
 
 #if defined(GGML_USE_HIP) && defined(GGML_HIP_USE_HIPBLASLT)
+        ggml_cuda_pool_alloc<nv_bfloat16> dst_bf16(ctx.pool(id), row_diff*src1_ncols);
         ggml_hipblaslt_gemm(ctx, stream,
                 row_diff, src1_ncols, ne10,
                 src0_ptr,       CUDA_R_16BF, ne00, 0,
                 src1_ptr,       CUDA_R_16BF, ne10, 0,
                 dst_bf16.get(), CUDA_R_16BF, ldc,  0,
                 1);
+        const to_fp32_cuda_t to_fp32_cuda = ggml_get_to_fp32_cuda(GGML_TYPE_BF16);
+        to_fp32_cuda(dst_bf16.get(), dst_dd_i, row_diff*src1_ncols, stream);
         GGML_UNUSED_VARS(alpha_f32, beta_f32);
 #else
         CUBLAS_CHECK(cublasSetStream(ctx.cublas_handle(id), stream));
@@ -1780,13 +1782,10 @@ static void ggml_cuda_op_mul_mat_cublas(
                     row_diff, src1_ncols, ne10,
                     &alpha_f32,  src0_ptr,       CUDA_R_16BF, ne00,
                                  src1_ptr,       CUDA_R_16BF, ne10,
-                    &beta_f32,   dst_bf16.get(), CUDA_R_16BF, ldc,
+                    &beta_f32,   dst_dd_i,       CUDA_R_32F,  ldc,
                     CUBLAS_COMPUTE_32F,
-                    CUBLAS_GEMM_DEFAULT_TENSOR_OP));
+                    CUBLAS_GEMM_DEFAULT));
 #endif // defined(GGML_USE_HIP) && defined(GGML_HIP_USE_HIPBLASLT)
-
-        const to_fp32_cuda_t to_fp32_cuda = ggml_get_to_fp32_cuda(GGML_TYPE_BF16);
-        to_fp32_cuda(dst_bf16.get(), dst_dd_i, row_diff*src1_ncols, stream);
     } else if (fast_fp16_hardware_available(cc) && use_fp16) {
         // convert src0 and src1 to fp16, multiply as fp16, convert dst to fp32
         ggml_cuda_pool_alloc<half> src0_as_f16(ctx.pool(id));


### PR DESCRIPTION
## Problem

The embedded GGML BF16 cuBLAS path wrote BF16 inputs directly into a BF16 destination with CUBLAS_GEMM_DEFAULT_TENSOR_OP. On an RTX 3090 (SM 8.6, CUDA 12.4), MiniMax-H3 prompt encoding aborted the server with:

`
CUDA error: the requested functionality is not supported
in ggml_cuda_op_mul_mat_cublas
cublasGemmEx(... CUDA_R_16BF ... CUDA_R_16BF ... CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT_TENSOR_OP)
`

This made the native WebUI report only Failed to fetch because the CUDA failure terminated the server process.

## Fix

- Require Ampere or newer before selecting native NVIDIA BF16 GEMM.
- Keep BF16 input operands and FP32 accumulation.
- Write NVIDIA cuBLAS results directly to the existing FP32 destination.
- Use CUBLAS_GEMM_DEFAULT, matching the direction of current upstream GGML behavior.
- Preserve the existing HIP/hipBLASLt BF16-output path and its BF16-to-FP32 conversion.

This avoids a BF16-to-FP16 fallback and therefore does not introduce an unnecessary precision reduction.

## Impact

Ampere CUDA devices such as RTX 30-series cards can execute compatible BF16 matrix multiplications without the unsupported cuBLAS configuration. Ada and newer devices retain native BF16 inputs with FP32 output. HIP behavior is unchanged.

## Validation

- Windows 11
- NVIDIA RTX 3090, compute capability 8.6
- CUDA Toolkit 12.4
- CMAKE_CUDA_ARCHITECTURES=86-real
- Release CUDA build of udiocpp_server: passed
- MiniMax-H3 BF16 prompt-encoder reproducer: passed the former failing cuBLAS operation
- Full 12-step/241-frame CUDA generation, with the separate model-side SM 8.6 attention fallback applied locally:
  - GGUF Q4: 14.74 s, complete 1,728,060-character audio payload
  - GGUF Q4 ConvRot: 14.55 s, complete 1,728,060-character audio payload

The MiniMax SAGE-attention architecture selection is intentionally excluded from this GGML-only PR and will be submitted separately.