### PR TITLE
Fix CUDA linking on Nixos

### DIFF
--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -14,6 +14,7 @@
   python-scripts,
   config,
   version,
+  autoAddDriverRunpath,
 
   # Overridable feature flags
   cudaSupport ? config.cudaSupport or false,
@@ -38,6 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
   ]
   ++ lib.optional cudaSupport cudaPackages.cuda_nvcc
+  ++ lib.optional cudaSupport autoAddDriverRunpath
   ++ lib.optional rocmSupport rocmPackages.clr;
 
   buildInputs = [


### PR DESCRIPTION
Fixes a problem building with CUDA from the Nix flake. Without it, the build errors with:

```
$ ./result/bin/audiocpp_cli --list-devices
ggml_cuda_init: failed to initialize CUDA: CUDA driver is a stub library
available_devices=1
CPU:0 "13th Gen Intel(R) Core(TM) i7-13700" [CPU]
select with: --backend <cuda|hip|vulkan|metal|cpu> --device <index>
```

With it my GPU is detected.

Fix based on how the `llama-cpp` package in Nixos does it:
https://github.com/NixOS/nixpkgs/blob/ef33b28e97233dac04666e34f26027c44f5db08b/pkgs/by-name/ll/llama-cpp/package.nix#L115