### PR TITLE
Fix HIP build without Sage Attention 2

### DIFF
--- a/external/ggml/src/ggml-cuda/sage-attn2.cuh
+++ b/external/ggml/src/ggml-cuda/sage-attn2.cuh
@@ -1,6 +1,26 @@
+#pragma once
+
 #include "common.cuh"
 
-#ifdef GGML_CUDA_SAGE_ATTN2_ENABLED
+#if defined(GGML_USE_HIP)
+
+static inline void ggml_cuda_sage_attn2(ggml_backend_cuda_context &, ggml_tensor *) {
+    GGML_ABORT("SAGE_ATTN2 is not supported by the HIP backend");
+}
+
+static inline void ggml_cuda_sage_attn2_i8(ggml_backend_cuda_context &, ggml_tensor *) {
+    GGML_ABORT("SAGE_ATTN2_I8 is not supported by the HIP backend");
+}
+
+static inline bool ggml_cuda_sage_attn2_supported(int, const ggml_tensor *) {
+    return false;
+}
+
+static inline bool ggml_cuda_sage_attn2_i8_supported(int, const ggml_tensor *) {
+    return false;
+}
+
+#elif defined(GGML_CUDA_SAGE_ATTN2_ENABLED)
 
 void ggml_cuda_sage_attn2(ggml_backend_cuda_context & ctx, ggml_tensor * dst);
 

--- a/external/ggml/src/ggml-hip/CMakeLists.txt
+++ b/external/ggml/src/ggml-hip/CMakeLists.txt
@@ -73,6 +73,7 @@ file(GLOB   GGML_HEADERS_ROCM "../ggml-cuda/*.cuh")
 list(APPEND GGML_HEADERS_ROCM "../../include/ggml-cuda.h")
 
 file(GLOB   GGML_SOURCES_ROCM "../ggml-cuda/*.cu")
+list(FILTER GGML_SOURCES_ROCM EXCLUDE REGEX "/sage-attn2\\.cu$")
 file(GLOB   SRCS "../ggml-cuda/template-instances/fattn-tile*.cu")
 list(APPEND GGML_SOURCES_ROCM ${SRCS})
 file(GLOB   SRCS "../ggml-cuda/template-instances/fattn-mma*.cu")


### PR DESCRIPTION
## Summary
- exclude CUDA-only `sage-attn2.cu` from the HIP backend source list
- make the shared Sage Attention 2 header return unsupported stubs for HIP builds
- keep the CUDA Sage Attention 2 path unchanged

Fixes #216.

## Validation
- `git diff --check`
- `cmake --build build/debug -j 16 --target audiocpp_cli`
- `cmake --build build/debug -j 16 --target audiocpp_server`

Note: ROCm/HIP is not installed on this local machine, so the local compile validation was CUDA/Vulkan. The fix targets the HIP compile source selection that triggered the reported `cuda_bf16.h` failure.