### PR TITLE
server: accept base64-encoded voice reference in speech requests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1399,6 +1399,7 @@ configure_file(
 
 add_executable(audiocpp_server
     app/server/main.cpp
+    app/server/base64.cpp
     app/server/config.cpp
     app/server/http.cpp
     app/server/model_installer.cpp
@@ -2143,6 +2144,17 @@ if (ENGINE_BUILD_TESTS)
     add_test(
         NAME server_multipart_test
         COMMAND server_multipart_test
+    )
+
+    add_executable(server_base64_test
+        tests/unittests/test_server_base64.cpp
+        app/server/base64.cpp
+    )
+    target_include_directories(server_base64_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/app/server)
+
+    add_test(
+        NAME server_base64_test
+        COMMAND server_base64_test
     )
 
     add_executable(server_busy_guard_test

--- a/app/server/README.md
+++ b/app/server/README.md
@@ -223,7 +223,7 @@ Relative `voice_dir` paths resolve against the config file's directory. When a r
 
 Resolution precedence for a TTS request's voice fields:
 
-1. `voice_ref` / `voice_ref_b64` — always wins.
+1. `voice_ref` — always wins.
 2. `voice` matching a configured model preset — preset wins.
 3. `voice` matching a wav basename in `voice_dir` — voice-library clone.
 4. Otherwise — `voice` is used as the model-native cached voice id (previous behavior).
@@ -274,7 +274,13 @@ option parsing.
 
 If no request voice is provided and the configured model has `default_voice_preset`, the server injects that preset automatically. Request-level `voice`, `voice_ref`, and `reference_text` override the configured default.
 
-`voice_ref` takes a server-side file path. To clone from audio the server has never seen, send `voice_ref_b64` instead: a base64-encoded WAV payload (a `data:audio/wav;base64,...` URI is also accepted), so no file has to land on the server first. `voice_ref` and `voice_ref_b64` are mutually exclusive in one request.
+`voice_ref` accepts either a plain path string (server-side file) or an object with a `type`:
+
+```json
+"voice_ref": { "type": "path", "path": "voices/alice.wav" }
+```
+
+With `"type": "base64"`, the `data` field carries a base64-encoded WAV payload (a `data:audio/wav;base64,...` URI is also accepted), so cloning clients can inline the reference audio instead of staging a file on the server first:
 
 ```bash
 curl http://127.0.0.1:8080/v1/audio/speech \
@@ -283,7 +289,7 @@ curl http://127.0.0.1:8080/v1/audio/speech \
   -d '{
     "model": "indextts2",
     "input": "Cloned from an inline reference.",
-    "voice_ref_b64": "UklGRh...",
+    "voice_ref": { "type": "base64", "data": "UklGRh..." },
     "reference_text": "Transcript of the reference audio."
   }'
 ```

--- a/app/server/README.md
+++ b/app/server/README.md
@@ -223,7 +223,7 @@ Relative `voice_dir` paths resolve against the config file's directory. When a r
 
 Resolution precedence for a TTS request's voice fields:
 
-1. `voice_ref` — always wins.
+1. `voice_ref` / `voice_ref_b64` — always wins.
 2. `voice` matching a configured model preset — preset wins.
 3. `voice` matching a wav basename in `voice_dir` — voice-library clone.
 4. Otherwise — `voice` is used as the model-native cached voice id (previous behavior).
@@ -273,6 +273,20 @@ below `2^53` are accepted, but larger JSON numbers may lose precision before
 option parsing.
 
 If no request voice is provided and the configured model has `default_voice_preset`, the server injects that preset automatically. Request-level `voice`, `voice_ref`, and `reference_text` override the configured default.
+
+`voice_ref` takes a server-side file path. To clone from audio the server has never seen, send `voice_ref_b64` instead: a base64-encoded WAV payload (a `data:audio/wav;base64,...` URI is also accepted), so no file has to land on the server first. `voice_ref` and `voice_ref_b64` are mutually exclusive in one request.
+
+```bash
+curl http://127.0.0.1:8080/v1/audio/speech \
+  -H 'Content-Type: application/json' \
+  -o out.wav \
+  -d '{
+    "model": "indextts2",
+    "input": "Cloned from an inline reference.",
+    "voice_ref_b64": "UklGRh...",
+    "reference_text": "Transcript of the reference audio."
+  }'
+```
 
 Set `"response_format": "json"` to receive base64 WAV in a JSON response.
 

--- a/app/server/README.md
+++ b/app/server/README.md
@@ -280,7 +280,7 @@ If no request voice is provided and the configured model has `default_voice_pres
 "voice_ref": { "type": "path", "path": "voices/alice.wav" }
 ```
 
-With `"type": "base64"`, the `data` field carries a base64-encoded WAV payload (a `data:audio/wav;base64,...` URI is also accepted), so cloning clients can inline the reference audio instead of staging a file on the server first:
+With `"type": "base64"`, the `data` field carries a base64-encoded WAV payload (a `data:audio/wav;base64,...` URI is also accepted), so cloning clients can inline the reference audio instead of staging a file on the server first. The decoded payload is limited to 5 MiB; larger references must use a path:
 
 ```bash
 curl http://127.0.0.1:8080/v1/audio/speech \

--- a/app/server/base64.cpp
+++ b/app/server/base64.cpp
@@ -1,0 +1,101 @@
+#include "base64.h"
+
+#include <stdexcept>
+
+namespace minitts::server {
+
+namespace {
+
+constexpr char kAlphabet[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+int decode_char(char c) {
+    if (c >= 'A' && c <= 'Z') {
+        return c - 'A';
+    }
+    if (c >= 'a' && c <= 'z') {
+        return c - 'a' + 26;
+    }
+    if (c >= '0' && c <= '9') {
+        return c - '0' + 52;
+    }
+    if (c == '+') {
+        return 62;
+    }
+    if (c == '/') {
+        return 63;
+    }
+    return -1;
+}
+
+}  // namespace
+
+std::string base64_encode(const uint8_t * data, size_t size) {
+    std::string out;
+    out.reserve(((size + 2) / 3) * 4);
+    for (size_t i = 0; i < size; i += 3) {
+        const uint32_t b0 = data[i];
+        const uint32_t b1 = i + 1 < size ? data[i + 1] : 0;
+        const uint32_t b2 = i + 2 < size ? data[i + 2] : 0;
+        const uint32_t chunk = (b0 << 16) | (b1 << 8) | b2;
+        out.push_back(kAlphabet[(chunk >> 18) & 0x3f]);
+        out.push_back(kAlphabet[(chunk >> 12) & 0x3f]);
+        out.push_back(i + 1 < size ? kAlphabet[(chunk >> 6) & 0x3f] : '=');
+        out.push_back(i + 2 < size ? kAlphabet[chunk & 0x3f] : '=');
+    }
+    return out;
+}
+
+std::string base64_encode(const std::vector<uint8_t> & bytes) {
+    return base64_encode(bytes.data(), bytes.size());
+}
+
+std::string base64_encode(const std::vector<std::byte> & bytes) {
+    return base64_encode(reinterpret_cast<const uint8_t *>(bytes.data()), bytes.size());
+}
+
+std::vector<uint8_t> base64_decode(std::string_view input) {
+    if (input.rfind("data:", 0) == 0) {
+        const auto comma = input.find(',');
+        if (comma == std::string_view::npos || input.find(";base64") == std::string_view::npos) {
+            throw std::runtime_error("malformed base64 data URI");
+        }
+        input = input.substr(comma + 1);
+    }
+
+    std::vector<uint8_t> out;
+    out.reserve((input.size() / 4) * 3);
+    uint32_t buffer = 0;
+    int bits = 0;
+    int padding = 0;
+    for (const char c : input) {
+        if (c == ' ' || c == '\t' || c == '\r' || c == '\n') {
+            continue;
+        }
+        if (c == '=') {
+            ++padding;
+            if (padding > 2) {
+                throw std::runtime_error("malformed base64 payload: excess padding");
+            }
+            continue;
+        }
+        if (padding > 0) {
+            throw std::runtime_error("malformed base64 payload: data after padding");
+        }
+        const int value = decode_char(c);
+        if (value < 0) {
+            throw std::runtime_error("malformed base64 payload: invalid character");
+        }
+        buffer = (buffer << 6) | static_cast<uint32_t>(value);
+        bits += 6;
+        if (bits >= 8) {
+            bits -= 8;
+            out.push_back(static_cast<uint8_t>((buffer >> bits) & 0xff));
+        }
+    }
+    if (bits >= 6) {
+        throw std::runtime_error("malformed base64 payload: truncated quartet");
+    }
+    return out;
+}
+
+}  // namespace minitts::server

--- a/app/server/base64.h
+++ b/app/server/base64.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace minitts::server {
+
+std::string base64_encode(const uint8_t * data, size_t size);
+std::string base64_encode(const std::vector<uint8_t> & bytes);
+std::string base64_encode(const std::vector<std::byte> & bytes);
+
+// Decodes a base64 payload. Accepts an optional "data:<mime>;base64," prefix so
+// clients can send data URIs verbatim. Throws std::runtime_error on malformed input.
+std::vector<uint8_t> base64_decode(std::string_view input);
+
+}  // namespace minitts::server

--- a/app/server/runtime.cpp
+++ b/app/server/runtime.cpp
@@ -1625,9 +1625,21 @@ engine::runtime::TaskRequest ServerState::build_speech_request(const LoadedModel
                 voice.speaker->audio = minitts::cli::read_audio_buffer(
                     resolve_path(request_base_, engine::io::json::require_string(*value, "path")));
             } else if (type == "base64") {
-                const auto bytes = base64_decode(engine::io::json::require_string(*value, "data"));
+                // Bound the inline reference audio so a huge base64 payload cannot
+                // blow up host RAM through decode + f32 expansion (~3x its size).
+                constexpr size_t kMaxVoiceRefBytes = size_t{5} * 1024 * 1024;
+                // 4/3 expansion plus slack for a data URI prefix and whitespace.
+                constexpr size_t kMaxVoiceRefB64Length = ((kMaxVoiceRefBytes + 2) / 3) * 4 + 4096;
+                const auto & data = engine::io::json::require_string(*value, "data");
+                if (data.size() > kMaxVoiceRefB64Length) {
+                    throw std::runtime_error("voice_ref base64 data exceeds the 5 MiB limit");
+                }
+                const auto bytes = base64_decode(data);
                 if (bytes.empty()) {
                     throw std::runtime_error("voice_ref base64 data decoded to an empty payload");
+                }
+                if (bytes.size() > kMaxVoiceRefBytes) {
+                    throw std::runtime_error("voice_ref base64 data exceeds the 5 MiB limit");
                 }
                 voice.speaker->audio = minitts::cli::read_audio_buffer(
                     std::string_view(reinterpret_cast<const char *>(bytes.data()), bytes.size()));

--- a/app/server/runtime.cpp
+++ b/app/server/runtime.cpp
@@ -1529,7 +1529,7 @@ const ServerState::LoadedModel::RuntimeVoicePreset * ServerState::select_voice_p
         }
         return nullptr;
     }
-    if (body.find("voice_ref") != nullptr || body.find("voice_ref_b64") != nullptr) {
+    if (body.find("voice_ref") != nullptr) {
         return nullptr;
     }
     return model.default_voice_preset.has_value() ? &*model.default_voice_preset : nullptr;
@@ -1583,8 +1583,7 @@ engine::runtime::TaskRequest ServerState::build_speech_request(const LoadedModel
             request.options["reference_text"] = *preset->reference_text;
         }
     }
-    const bool has_explicit_voice_ref =
-        body.find("voice_ref") != nullptr || body.find("voice_ref_b64") != nullptr;
+    const bool has_explicit_voice_ref = body.find("voice_ref") != nullptr;
     if (const auto * value = body.find("voice"); value != nullptr && !voice_field_is_preset) {
         // Voice library: "voice" may name a wav in the configured voice_dir. When it
         // does, that audio becomes the cloning reference and the transcript from
@@ -1614,26 +1613,30 @@ engine::runtime::TaskRequest ServerState::build_speech_request(const LoadedModel
             has_voice = true;
         }
     }
-    if (const auto * value = body.find("voice_ref_b64")) {
-        if (body.find("voice_ref") != nullptr) {
-            throw std::runtime_error("voice_ref and voice_ref_b64 are mutually exclusive");
-        }
-        if (!voice.speaker.has_value()) {
-            voice.speaker = engine::runtime::VoiceReference{};
-        }
-        const auto bytes = base64_decode(value->as_string());
-        if (bytes.empty()) {
-            throw std::runtime_error("voice_ref_b64 decoded to an empty payload");
-        }
-        voice.speaker->audio = minitts::cli::read_audio_buffer(
-            std::string_view(reinterpret_cast<const char *>(bytes.data()), bytes.size()));
-        has_voice = true;
-    }
     if (const auto * value = body.find("voice_ref")) {
         if (!voice.speaker.has_value()) {
             voice.speaker = engine::runtime::VoiceReference{};
         }
-        voice.speaker->audio = minitts::cli::read_audio_buffer(resolve_path(request_base_, value->as_string()));
+        if (value->is_string()) {
+            voice.speaker->audio = minitts::cli::read_audio_buffer(resolve_path(request_base_, value->as_string()));
+        } else if (value->is_object()) {
+            const auto & type = engine::io::json::require_string(*value, "type");
+            if (type == "path") {
+                voice.speaker->audio = minitts::cli::read_audio_buffer(
+                    resolve_path(request_base_, engine::io::json::require_string(*value, "path")));
+            } else if (type == "base64") {
+                const auto bytes = base64_decode(engine::io::json::require_string(*value, "data"));
+                if (bytes.empty()) {
+                    throw std::runtime_error("voice_ref base64 data decoded to an empty payload");
+                }
+                voice.speaker->audio = minitts::cli::read_audio_buffer(
+                    std::string_view(reinterpret_cast<const char *>(bytes.data()), bytes.size()));
+            } else {
+                throw std::runtime_error("voice_ref type must be \"path\" or \"base64\"");
+            }
+        } else {
+            throw std::runtime_error("voice_ref must be a path string or an object with type \"path\" or \"base64\"");
+        }
         has_voice = true;
     }
     if (const auto * value = body.find("reference_text")) {

--- a/app/server/runtime.cpp
+++ b/app/server/runtime.cpp
@@ -1,5 +1,6 @@
 #include "runtime.h"
 
+#include "base64.h"
 #include "multipart.h"
 #include "ui_assets.h"
 
@@ -299,31 +300,6 @@ std::vector<uint8_t> encode_pcm16_samples(const engine::runtime::AudioBuffer & a
         append_bytes(&pcm, sizeof(pcm));
     }
     return out;
-}
-
-std::string base64_encode(const uint8_t * data, size_t size) {
-    constexpr char kAlphabet[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    std::string out;
-    out.reserve(((size + 2) / 3) * 4);
-    for (size_t i = 0; i < size; i += 3) {
-        const uint32_t b0 = data[i];
-        const uint32_t b1 = i + 1 < size ? data[i + 1] : 0;
-        const uint32_t b2 = i + 2 < size ? data[i + 2] : 0;
-        const uint32_t chunk = (b0 << 16) | (b1 << 8) | b2;
-        out.push_back(kAlphabet[(chunk >> 18) & 0x3f]);
-        out.push_back(kAlphabet[(chunk >> 12) & 0x3f]);
-        out.push_back(i + 1 < size ? kAlphabet[(chunk >> 6) & 0x3f] : '=');
-        out.push_back(i + 2 < size ? kAlphabet[chunk & 0x3f] : '=');
-    }
-    return out;
-}
-
-std::string base64_encode(const std::vector<uint8_t> & bytes) {
-    return base64_encode(bytes.data(), bytes.size());
-}
-
-std::string base64_encode(const std::vector<std::byte> & bytes) {
-    return base64_encode(reinterpret_cast<const uint8_t *>(bytes.data()), bytes.size());
 }
 
 void write_sse(HttpStreamWriter & writer, const std::string & json) {
@@ -1553,7 +1529,7 @@ const ServerState::LoadedModel::RuntimeVoicePreset * ServerState::select_voice_p
         }
         return nullptr;
     }
-    if (body.find("voice_ref") != nullptr) {
+    if (body.find("voice_ref") != nullptr || body.find("voice_ref_b64") != nullptr) {
         return nullptr;
     }
     return model.default_voice_preset.has_value() ? &*model.default_voice_preset : nullptr;
@@ -1607,7 +1583,8 @@ engine::runtime::TaskRequest ServerState::build_speech_request(const LoadedModel
             request.options["reference_text"] = *preset->reference_text;
         }
     }
-    const bool has_explicit_voice_ref = body.find("voice_ref") != nullptr;
+    const bool has_explicit_voice_ref =
+        body.find("voice_ref") != nullptr || body.find("voice_ref_b64") != nullptr;
     if (const auto * value = body.find("voice"); value != nullptr && !voice_field_is_preset) {
         // Voice library: "voice" may name a wav in the configured voice_dir. When it
         // does, that audio becomes the cloning reference and the transcript from
@@ -1636,6 +1613,21 @@ engine::runtime::TaskRequest ServerState::build_speech_request(const LoadedModel
             voice.speaker->cached_voice_id = value->as_string();
             has_voice = true;
         }
+    }
+    if (const auto * value = body.find("voice_ref_b64")) {
+        if (body.find("voice_ref") != nullptr) {
+            throw std::runtime_error("voice_ref and voice_ref_b64 are mutually exclusive");
+        }
+        if (!voice.speaker.has_value()) {
+            voice.speaker = engine::runtime::VoiceReference{};
+        }
+        const auto bytes = base64_decode(value->as_string());
+        if (bytes.empty()) {
+            throw std::runtime_error("voice_ref_b64 decoded to an empty payload");
+        }
+        voice.speaker->audio = minitts::cli::read_audio_buffer(
+            std::string_view(reinterpret_cast<const char *>(bytes.data()), bytes.size()));
+        has_voice = true;
     }
     if (const auto * value = body.find("voice_ref")) {
         if (!voice.speaker.has_value()) {

--- a/tests/unittests/test_server_base64.cpp
+++ b/tests/unittests/test_server_base64.cpp
@@ -1,0 +1,74 @@
+#include "base64.h"
+
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+using minitts::server::base64_decode;
+using minitts::server::base64_encode;
+
+void require(bool condition, const std::string & message) {
+    if (!condition) {
+        throw std::runtime_error(message);
+    }
+}
+
+bool decode_throws(const std::string & input) {
+    try {
+        (void)base64_decode(input);
+    } catch (const std::runtime_error &) {
+        return true;
+    }
+    return false;
+}
+
+void test_roundtrip() {
+    for (size_t size = 0; size <= 64; ++size) {
+        std::vector<uint8_t> bytes(size);
+        for (size_t i = 0; i < size; ++i) {
+            bytes[i] = static_cast<uint8_t>(i * 37 + size);
+        }
+        const auto decoded = base64_decode(base64_encode(bytes));
+        require(decoded == bytes, "roundtrip size " + std::to_string(size));
+    }
+}
+
+void test_known_vectors() {
+    const auto hello = base64_decode("aGVsbG8=");
+    require(std::string(hello.begin(), hello.end()) == "hello", "known vector hello");
+    require(base64_decode("").empty(), "empty input decodes to empty");
+    require(base64_decode("Zg==").size() == 1, "single byte with double padding");
+    require(base64_decode("Zm8=").size() == 2, "two bytes with single padding");
+}
+
+void test_whitespace_and_data_uri() {
+    const auto spaced = base64_decode("aGVs\nbG8=");
+    require(std::string(spaced.begin(), spaced.end()) == "hello", "whitespace tolerated");
+    const auto uri = base64_decode("data:audio/wav;base64,aGVsbG8=");
+    require(std::string(uri.begin(), uri.end()) == "hello", "data URI prefix stripped");
+    const auto charset_uri = base64_decode("data:audio/wav;charset=utf-8;base64,aGVsbG8=");
+    require(std::string(charset_uri.begin(), charset_uri.end()) == "hello", "data URI with extra params");
+}
+
+void test_malformed_inputs() {
+    require(decode_throws("aGVsbG8*"), "invalid character rejected");
+    require(decode_throws("aGVsbG8=== "), "excess padding rejected");
+    require(decode_throws("aG==bG8="), "data after padding rejected");
+    require(decode_throws("a"), "single leftover character rejected");
+    require(decode_throws("data:audio/wav,aGVsbG8="), "data URI without base64 marker rejected");
+    require(decode_throws("data:audio/wav;base64"), "data URI without payload rejected");
+}
+
+}  // namespace
+
+int main() {
+    test_roundtrip();
+    test_known_vectors();
+    test_whitespace_and_data_uri();
+    test_malformed_inputs();
+    std::cout << "server_base64_test passed\n";
+    return 0;
+}


### PR DESCRIPTION

Add base64 support to the speech API. During use, I noticed that every time I clone a voice, I have to upload the audio file to the server first, and then use the file path for audiocpp_server to read it—which is quite inflexible. Therefore, I plan to add this feature so that clients can directly upload audio files encoded in base64.

Move base64 helpers into app/server/base64.{h,cpp}, add a strict decoder, and cover it with a server_base64_test unittest.

The maximum file size needs to be considered—I'm concerned that users might inadvertently upload extremely large audio files, causing machines with limited memory to run out of memory (OOM) directly.

What do you think?

