### PR TITLE
Reusable framework runtimes for release 0.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -357,6 +357,7 @@ add_library(engine_core OBJECT
     src/framework/modules/attention/transformer_blocks.cpp
     src/framework/modules/conditioning_modules.cpp
     src/framework/modules/conformer_modules.cpp
+    src/framework/modules/flow_sampler_runtime.cpp
     src/framework/modules/predictor_modules.cpp
     src/framework/modules/positional_modules.cpp
     src/framework/modules/text_encoders/t5_base_encoder.cpp
@@ -387,6 +388,7 @@ add_library(engine_core OBJECT
     src/framework/audio/wav_reader.cpp
     src/framework/audio/wav_writer.cpp
     src/framework/audio/zipenhancer.cpp
+    src/framework/runtime/flow_kv_cache.cpp
     src/framework/modules/speaker_encoders/ecapa_tdnn_runtime.cpp
     src/framework/modules/speaker_encoders/titanet_runtime.cpp
     src/framework/codecs/fsq_audio_codec_runtime.cpp

--- a/include/engine/framework/audio/kaldi_fbank.h
+++ b/include/engine/framework/audio/kaldi_fbank.h
@@ -7,11 +7,17 @@
 
 namespace engine::audio {
 
+enum class KaldiFbankWindowType {
+  Hamming,
+  Povey,
+};
+
 struct KaldiFbankOptions {
   int sample_rate = 16000;
   int num_mels = 80;
   float frame_length_ms = 25.0F;
   float frame_shift_ms = 10.0F;
+  KaldiFbankWindowType window_type = KaldiFbankWindowType::Hamming;
   int lfr_m = 7;
   int lfr_n = 6;
   float preemphasis = 0.97F;

--- a/include/engine/framework/core/backend.h
+++ b/include/engine/framework/core/backend.h
@@ -5,6 +5,7 @@
 #include "ggml.h"
 #include "ggml-backend.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -86,6 +87,9 @@ void write_tensor_f16(const TensorValue & tensor, const float * values, size_t c
 void write_tensor_f16(const TensorValue & tensor, const std::vector<float> & values);
 void write_tensor_bf16(const TensorValue & tensor, const float * values, size_t count);
 void write_tensor_bf16(const TensorValue & tensor, const std::vector<float> & values);
+void write_tensor_float(const TensorValue & tensor, const float * values, size_t count);
+void write_tensor_float(const TensorValue & tensor, const std::vector<float> & values);
+void write_tensor_bytes(const TensorValue & tensor, const std::vector<std::byte> & bytes);
 void round_f32_to_bf16_in_place(float * values, size_t count);
 void round_f32_to_bf16_in_place(std::vector<float> & values);
 void write_tensor_i32(const TensorValue & tensor, const int32_t * values, size_t count);
@@ -96,6 +100,10 @@ void read_tensor_f16_into(const ggml_tensor * tensor, std::vector<float> & value
 std::vector<float> read_tensor_f16(const ggml_tensor * tensor);
 void read_tensor_bf16_into(const ggml_tensor * tensor, std::vector<float> & values);
 std::vector<float> read_tensor_bf16(const ggml_tensor * tensor);
+void read_tensor_float_into(const ggml_tensor * tensor, std::vector<float> & values);
+std::vector<float> read_tensor_float(const ggml_tensor * tensor);
+void read_tensor_bytes_into(const ggml_tensor * tensor, std::vector<std::byte> & bytes);
+std::vector<std::byte> read_tensor_bytes(const ggml_tensor * tensor);
 void read_tensor_i32_into(const ggml_tensor * tensor, std::vector<int32_t> & values);
 std::vector<int32_t> read_tensor_i32(const ggml_tensor * tensor);
 

--- a/include/engine/framework/modules/flow_sampler_runtime.h
+++ b/include/engine/framework/modules/flow_sampler_runtime.h
@@ -1,0 +1,263 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace engine::modules {
+
+struct FlowSamplerScheduleStep {
+    int64_t index = 0;
+    float t = 0.0F;
+    float t_next = 0.0F;
+    float sigma = 0.0F;
+    float sigma_next = 0.0F;
+};
+
+struct FlowSamplerBranchSpec {
+    std::string name;
+    float weight = 1.0F;
+};
+
+struct FlowSamplerCacheSpec {
+    std::string name;
+    std::string mode;
+    bool reset_on_sequence_begin = true;
+};
+
+struct FlowSamplerCacheKey {
+    std::string name;
+    std::string mode;
+
+    bool operator==(const FlowSamplerCacheKey & other) const;
+    bool operator!=(const FlowSamplerCacheKey & other) const {
+        return !(*this == other);
+    }
+};
+
+struct FlowSamplerCacheState {
+    std::string name;
+    std::string mode;
+    int64_t revision = 0;
+    bool initialized = false;
+
+    bool operator==(const FlowSamplerCacheState & other) const;
+    bool operator!=(const FlowSamplerCacheState & other) const {
+        return !(*this == other);
+    }
+};
+
+enum class FlowSamplerCacheUpdateKind {
+    Unchanged,
+    Updated,
+    Reset,
+};
+
+struct FlowSamplerCacheUpdate {
+    std::string name;
+    FlowSamplerCacheUpdateKind kind = FlowSamplerCacheUpdateKind::Unchanged;
+};
+
+enum class FlowSamplerPredictionType {
+    Velocity,
+};
+
+enum class FlowSamplerUpdateRule {
+    Euler,
+    Custom,
+};
+
+enum class FlowSamplerGuidanceMode {
+    None,
+    ClassifierFree,
+};
+
+struct FlowSamplerGuidanceConfig {
+    FlowSamplerGuidanceMode mode = FlowSamplerGuidanceMode::None;
+    std::string cond_branch;
+    std::string uncond_branch;
+    float scale = 1.0F;
+};
+
+struct FlowSamplerPrefixPolicy {
+    std::vector<float> preserve_mask;
+};
+
+struct FlowSamplerGraphKey {
+    std::vector<int64_t> latent_shape;
+    int64_t branch_count = 0;
+    int64_t schedule_steps = 0;
+    std::string sampler_mode;
+    std::vector<FlowSamplerCacheKey> caches;
+    int64_t modulation_revision = 0;
+
+    bool operator==(const FlowSamplerGraphKey & other) const;
+    bool operator!=(const FlowSamplerGraphKey & other) const {
+        return !(*this == other);
+    }
+};
+
+struct FlowSamplerRuntimeConfig {
+    std::string label = "flow_sampler";
+    std::vector<int64_t> latent_shape;
+    std::vector<float> initial_latent;
+    std::vector<FlowSamplerScheduleStep> schedule;
+    std::vector<FlowSamplerBranchSpec> branches;
+    std::vector<FlowSamplerCacheSpec> caches;
+    FlowSamplerPredictionType prediction_type = FlowSamplerPredictionType::Velocity;
+    FlowSamplerUpdateRule update_rule = FlowSamplerUpdateRule::Euler;
+    FlowSamplerGuidanceConfig guidance;
+    FlowSamplerPrefixPolicy prefix;
+    bool release_graph_after_sequence = false;
+    bool require_complete_graph_key = true;
+};
+
+struct FlowSamplerStepState {
+    int64_t sequence_index = 0;
+    FlowSamplerScheduleStep schedule;
+    std::vector<FlowSamplerBranchSpec> branches;
+    std::vector<FlowSamplerCacheState> caches;
+    FlowSamplerGraphKey graph_key;
+};
+
+struct FlowSamplerSequenceState {
+    std::vector<int64_t> latent_shape;
+    std::vector<FlowSamplerScheduleStep> schedule;
+    std::vector<FlowSamplerBranchSpec> branches;
+    std::vector<FlowSamplerCacheState> caches;
+};
+
+struct FlowSamplerDenoiserInput {
+    FlowSamplerStepState state;
+    const std::vector<float> & latent;
+};
+
+struct FlowSamplerBranchPrediction {
+    std::string branch;
+    std::vector<float> values;
+};
+
+struct FlowSamplerDenoiserOutput {
+    std::vector<FlowSamplerBranchPrediction> predictions;
+    std::vector<FlowSamplerCacheUpdate> cache_updates;
+};
+
+struct FlowSamplerUpdateInput {
+    FlowSamplerStepState state;
+    const std::vector<float> & prediction;
+    std::vector<float> & latent;
+};
+
+class FlowSamplerUpdateRuntime {
+public:
+    virtual ~FlowSamplerUpdateRuntime();
+
+    virtual void update_latent(const FlowSamplerUpdateInput & input) = 0;
+};
+
+std::unique_ptr<FlowSamplerUpdateRuntime> make_flow_sampler_euler_update();
+
+class FlowSamplerDenoiserRuntime {
+public:
+    virtual ~FlowSamplerDenoiserRuntime();
+
+    virtual void reset_sampler_caches(const std::vector<FlowSamplerCacheState> & caches) = 0;
+    virtual std::vector<FlowSamplerCacheUpdate> begin_sampler_sequence(const FlowSamplerSequenceState & state) = 0;
+    virtual FlowSamplerGraphKey sampler_graph_key(const FlowSamplerStepState & state) = 0;
+    virtual void rebuild_sampler_graph(
+        const FlowSamplerGraphKey & key,
+        const FlowSamplerStepState & state) = 0;
+    virtual FlowSamplerDenoiserOutput run_sampler_denoiser(const FlowSamplerDenoiserInput & input) = 0;
+    virtual void release_sampler_graphs() = 0;
+};
+
+struct FlowSamplerSingleBranchDenoiserConfig {
+    std::string label = "flow_sampler.denoiser";
+    std::string branch_name = "velocity";
+    std::function<void(const std::vector<FlowSamplerCacheState> &)> reset_caches;
+    std::function<std::vector<FlowSamplerCacheUpdate>(const FlowSamplerSequenceState &)> begin_sequence;
+    std::function<std::string(const FlowSamplerStepState &)> sampler_mode;
+    std::function<int64_t(const FlowSamplerStepState &)> modulation_revision;
+    std::function<void(const FlowSamplerGraphKey &, const FlowSamplerStepState &)> rebuild_graph;
+    std::function<std::vector<float>(const FlowSamplerDenoiserInput &)> predict;
+    std::function<void()> release_graphs;
+};
+
+std::unique_ptr<FlowSamplerDenoiserRuntime>
+make_flow_sampler_single_branch_denoiser(FlowSamplerSingleBranchDenoiserConfig config);
+
+struct FlowSamplerSingleBranchDenoiserRuntimeConfig {
+    std::string label = "flow_sampler.denoiser";
+    std::string branch_name = "velocity";
+};
+
+class FlowSamplerSingleBranchDenoiserRuntime : public FlowSamplerDenoiserRuntime {
+public:
+    explicit FlowSamplerSingleBranchDenoiserRuntime(
+        FlowSamplerSingleBranchDenoiserRuntimeConfig config);
+    ~FlowSamplerSingleBranchDenoiserRuntime() override;
+
+    void reset_sampler_caches(const std::vector<FlowSamplerCacheState> & caches) override;
+    std::vector<FlowSamplerCacheUpdate> begin_sampler_sequence(
+        const FlowSamplerSequenceState & state) override;
+    FlowSamplerGraphKey sampler_graph_key(const FlowSamplerStepState & state) override;
+    void rebuild_sampler_graph(
+        const FlowSamplerGraphKey & key,
+        const FlowSamplerStepState & state) override;
+    FlowSamplerDenoiserOutput run_sampler_denoiser(const FlowSamplerDenoiserInput & input) override;
+    void release_sampler_graphs() override;
+
+protected:
+    virtual void reset_sequence_caches(const std::vector<FlowSamplerCacheState> & caches);
+    virtual std::vector<FlowSamplerCacheUpdate> begin_sequence(
+        const FlowSamplerSequenceState & state);
+    virtual std::string sampler_mode(const FlowSamplerStepState & state) const = 0;
+    virtual int64_t modulation_revision(const FlowSamplerStepState & state) const;
+    virtual void rebuild_graph(
+        const FlowSamplerGraphKey & key,
+        const FlowSamplerStepState & state) = 0;
+    virtual std::vector<float> predict_branch(const FlowSamplerDenoiserInput & input) = 0;
+    virtual void release_runtime_graphs();
+
+    const FlowSamplerSingleBranchDenoiserRuntimeConfig & config() const noexcept;
+
+private:
+    FlowSamplerSingleBranchDenoiserRuntimeConfig config_;
+    std::vector<int64_t> sequence_latent_shape_;
+    int64_t sequence_schedule_steps_ = 0;
+};
+
+class FlowSamplerRuntime {
+public:
+    FlowSamplerRuntime(
+        FlowSamplerRuntimeConfig config,
+        std::unique_ptr<FlowSamplerDenoiserRuntime> denoiser);
+    FlowSamplerRuntime(
+        FlowSamplerRuntimeConfig config,
+        std::unique_ptr<FlowSamplerDenoiserRuntime> denoiser,
+        std::unique_ptr<FlowSamplerUpdateRuntime> updater);
+    ~FlowSamplerRuntime();
+
+    FlowSamplerRuntime(const FlowSamplerRuntime &) = delete;
+    FlowSamplerRuntime & operator=(const FlowSamplerRuntime &) = delete;
+
+    void run_sequence();
+    void run_sequence(const std::vector<float> & initial_latent);
+    void release_runtime_graphs();
+    void reset_graph_reuse_state();
+    void reset_runtime_caches();
+
+    const std::vector<float> & latent() const noexcept;
+    const FlowSamplerRuntimeConfig & config() const noexcept;
+    const std::optional<FlowSamplerGraphKey> & active_graph_key() const noexcept;
+    const std::vector<FlowSamplerCacheState> & cache_states() const noexcept;
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace engine::modules

--- a/include/engine/framework/modules/speaker_encoders/ecapa_tdnn_speaker.h
+++ b/include/engine/framework/modules/speaker_encoders/ecapa_tdnn_speaker.h
@@ -2,6 +2,7 @@
 
 #include "engine/framework/assets/tensor_source.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <filesystem>
 #include <memory>
@@ -10,6 +11,16 @@
 #include <vector>
 
 namespace engine::modules::ecapa_tdnn {
+
+enum class Conv1dPaddingMode {
+    Zero,
+    Reflect,
+};
+
+enum class AttentivePoolingKind {
+    GlobalContext,
+    Simple,
+};
 
 struct BatchNorm1dWeights {
     std::vector<float> weight;
@@ -28,6 +39,7 @@ struct Conv1dWeights {
     int64_t padding = 0;
     int64_t dilation = 1;
     bool use_bias = true;
+    Conv1dPaddingMode padding_mode = Conv1dPaddingMode::Reflect;
     std::optional<std::string> bias_name;
 };
 
@@ -40,6 +52,7 @@ struct Res2NetBlockWeights {
     std::vector<TDNNBlockWeights> blocks;
     int64_t scale = 8;
     int64_t width = 0;
+    bool first_chunk_passthrough = true;
 };
 
 struct SEBlockWeights {
@@ -59,13 +72,21 @@ struct SERes2NetBlockWeights {
 struct AspWeights {
     TDNNBlockWeights tdnn;
     Conv1dWeights conv;
+    AttentivePoolingKind kind = AttentivePoolingKind::GlobalContext;
+    bool tdnn_use_batch_norm = true;
 };
 
 struct EcapaWeights {
     std::shared_ptr<const assets::TensorSource> source;
+    int64_t feature_dim = 80;
+    int64_t embedding_dim = 192;
+    float stats_eps = 1.0e-12f;
+    size_t weight_context_bytes = 256ull * 1024ull * 1024ull;
+    size_t graph_context_bytes = 256ull * 1024ull * 1024ull;
     TDNNBlockWeights block0;
     std::vector<SERes2NetBlockWeights> se_blocks;
     TDNNBlockWeights mfa;
+    bool mfa_use_batch_norm = true;
     AspWeights asp;
     BatchNorm1dWeights asp_bn;
     Conv1dWeights fc;

--- a/include/engine/framework/modules/speech_encoders/wavlm_encoder.h
+++ b/include/engine/framework/modules/speech_encoders/wavlm_encoder.h
@@ -29,6 +29,9 @@ struct WavlmEncoderConfig {
     std::vector<int64_t> conv_kernel{10, 3, 3, 3, 3, 2, 2};
     std::vector<int64_t> conv_stride{5, 2, 2, 2, 2, 2, 2};
     float layer_norm_eps = 1.0e-5F;
+    bool normalize_input = false;
+    bool conv_feature_layer_norm = false;
+    bool transformer_layer_norm_first = false;
     assets::TensorStorageType weight_storage_type = assets::TensorStorageType::Native;
 };
 

--- a/include/engine/framework/runtime/flow_kv_cache.h
+++ b/include/engine/framework/runtime/flow_kv_cache.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "ggml.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace engine::runtime {
+
+struct FlowKVLayerCache {
+    ggml_type type = GGML_TYPE_F32;
+    std::vector<std::byte> key_bytes;
+    std::vector<std::byte> value_bytes;
+    int64_t valid_steps = 0;
+    int64_t capacity_steps = 0;
+    int64_t step_values = 0;
+    size_t step_bytes = 0;
+};
+
+class RollingFlowKVCache {
+public:
+    RollingFlowKVCache() = default;
+
+    RollingFlowKVCache(
+        const std::vector<int64_t> & layer_capacities,
+        int64_t step_values);
+    RollingFlowKVCache(
+        const std::vector<int64_t> & layer_capacities,
+        int64_t step_values,
+        ggml_type type);
+
+    void reset(
+        const std::vector<int64_t> & layer_capacities,
+        int64_t step_values);
+    void reset(
+        const std::vector<int64_t> & layer_capacities,
+        int64_t step_values,
+        ggml_type type);
+
+    void clear_valid_steps();
+
+    size_t layers() const noexcept {
+        return layers_.size();
+    }
+
+    const FlowKVLayerCache & layer(size_t index) const;
+    FlowKVLayerCache & layer(size_t index);
+
+    void append_tail(
+        size_t layer_index,
+        const std::vector<float> & current_key,
+        const std::vector<float> & current_value,
+        int64_t current_steps,
+        int64_t append_steps,
+        const std::string & label);
+    void append_tail_bytes(
+        size_t layer_index,
+        const std::vector<std::byte> & current_key,
+        const std::vector<std::byte> & current_value,
+        int64_t current_steps,
+        int64_t append_steps,
+        const std::string & label);
+
+private:
+    std::vector<FlowKVLayerCache> layers_;
+};
+
+}  // namespace engine::runtime

--- a/src/framework/audio/kaldi_fbank.cpp
+++ b/src/framework/audio/kaldi_fbank.cpp
@@ -277,7 +277,9 @@ KaldiFbankFeatures extract_kaldi_fbank(const std::vector<float> &audio,
   const int fft_size = next_power_of_two(window_size);
   const int spectrum_bins = fft_size / 2 + 1;
   const float sample_scale = options.upscale_samples ? 32768.0F : 1.0F;
-  const auto window = make_hamming_window(window_size);
+  const auto window = options.window_type == KaldiFbankWindowType::Povey
+                          ? cached_kaldi_povey_window(window_size)
+                          : make_hamming_window(window_size);
   const auto filters =
       make_mel_filterbank(options.sample_rate, fft_size, options.num_mels,
                           options.low_frequency, options.high_frequency);

--- a/src/framework/core/backend.cpp
+++ b/src/framework/core/backend.cpp
@@ -522,6 +522,41 @@ void write_tensor_bf16(const TensorValue & tensor, const std::vector<float> & va
     write_tensor_bf16(tensor, values.data(), values.size());
 }
 
+void write_tensor_float(const TensorValue & tensor, const float * values, size_t count) {
+    switch (tensor.type) {
+        case GGML_TYPE_F32:
+            write_tensor_f32(tensor, values, count);
+            return;
+        case GGML_TYPE_F16:
+            write_tensor_f16(tensor, values, count);
+            return;
+        case GGML_TYPE_BF16:
+            write_tensor_bf16(tensor, values, count);
+            return;
+        default:
+            throw std::runtime_error("write_tensor_float supports only f32/f16/bf16 tensors");
+    }
+}
+
+void write_tensor_float(const TensorValue & tensor, const std::vector<float> & values) {
+    write_tensor_float(tensor, values.data(), values.size());
+}
+
+void write_tensor_bytes(const TensorValue & tensor, const std::vector<std::byte> & bytes) {
+    if (tensor.tensor == nullptr) {
+        throw std::runtime_error("write_tensor_bytes requires non-null tensor");
+    }
+    const size_t expected = static_cast<size_t>(ggml_nbytes(tensor.tensor));
+    if (bytes.size() != expected) {
+        throw std::runtime_error(
+            "write_tensor_bytes byte count does not match tensor '" +
+            std::string(tensor.tensor->name) +
+            "': expected " + std::to_string(expected) +
+            ", got " + std::to_string(bytes.size()));
+    }
+    ggml_backend_tensor_set(tensor.tensor, bytes.data(), 0, bytes.size());
+}
+
 void round_f32_to_bf16_in_place(float * values, size_t count) {
     if (count == 0) {
         return;
@@ -618,6 +653,43 @@ std::vector<float> read_tensor_bf16(const ggml_tensor * tensor) {
     std::vector<float> values;
     read_tensor_bf16_into(tensor, values);
     return values;
+}
+
+void read_tensor_float_into(const ggml_tensor * tensor, std::vector<float> & values) {
+    switch (tensor->type) {
+        case GGML_TYPE_F32:
+            read_tensor_f32_into(tensor, values);
+            return;
+        case GGML_TYPE_F16:
+            read_tensor_f16_into(tensor, values);
+            return;
+        case GGML_TYPE_BF16:
+            read_tensor_bf16_into(tensor, values);
+            return;
+        default:
+            throw std::runtime_error("read_tensor_float supports only f32/f16/bf16 tensors");
+    }
+}
+
+std::vector<float> read_tensor_float(const ggml_tensor * tensor) {
+    std::vector<float> values;
+    read_tensor_float_into(tensor, values);
+    return values;
+}
+
+void read_tensor_bytes_into(const ggml_tensor * tensor, std::vector<std::byte> & bytes) {
+    if (tensor == nullptr) {
+        throw std::runtime_error("read_tensor_bytes requires non-null tensor");
+    }
+    const size_t byte_count = static_cast<size_t>(ggml_nbytes(tensor));
+    bytes.resize(byte_count);
+    ggml_backend_tensor_get(tensor, bytes.data(), 0, byte_count);
+}
+
+std::vector<std::byte> read_tensor_bytes(const ggml_tensor * tensor) {
+    std::vector<std::byte> bytes;
+    read_tensor_bytes_into(tensor, bytes);
+    return bytes;
 }
 
 void read_tensor_i32_into(const ggml_tensor * tensor, std::vector<int32_t> & values) {

--- a/src/framework/modules/flow_sampler_runtime.cpp
+++ b/src/framework/modules/flow_sampler_runtime.cpp
@@ -1,0 +1,674 @@
+#include "engine/framework/modules/flow_sampler_runtime.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <stdexcept>
+#include <utility>
+
+namespace engine::modules {
+namespace {
+
+int64_t element_count(const std::vector<int64_t> & shape) {
+    if (shape.empty()) {
+        return 0;
+    }
+    int64_t count = 1;
+    for (const int64_t dim : shape) {
+        if (dim <= 0) {
+            return 0;
+        }
+        count *= dim;
+    }
+    return count;
+}
+
+bool has_duplicate_cache_name(const std::vector<FlowSamplerCacheSpec> & values) {
+    for (size_t i = 0; i < values.size(); ++i) {
+        for (size_t j = i + 1; j < values.size(); ++j) {
+            if (values[i].name == values[j].name) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+bool has_duplicate_branch_name(const std::vector<FlowSamplerBranchSpec> & values) {
+    for (size_t i = 0; i < values.size(); ++i) {
+        for (size_t j = i + 1; j < values.size(); ++j) {
+            if (values[i].name == values[j].name) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+bool has_duplicate_prediction(const std::vector<FlowSamplerBranchPrediction> & values) {
+    for (size_t i = 0; i < values.size(); ++i) {
+        for (size_t j = i + 1; j < values.size(); ++j) {
+            if (values[i].branch == values[j].branch) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+bool has_duplicate_cache_update(const std::vector<FlowSamplerCacheUpdate> & values) {
+    for (size_t i = 0; i < values.size(); ++i) {
+        for (size_t j = i + 1; j < values.size(); ++j) {
+            if (values[i].name == values[j].name) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+bool cache_key_matches_config(
+    const std::vector<FlowSamplerCacheKey> & key,
+    const std::vector<FlowSamplerCacheSpec> & config) {
+    if (key.size() != config.size()) {
+        return false;
+    }
+    for (const auto & spec : config) {
+        const auto it = std::find_if(key.begin(), key.end(), [&](const FlowSamplerCacheKey & state) {
+            return state.name == spec.name && state.mode == spec.mode;
+        });
+        if (it == key.end()) {
+            return false;
+        }
+    }
+    return true;
+}
+
+const FlowSamplerBranchPrediction & require_prediction(
+    const std::vector<FlowSamplerBranchPrediction> & predictions,
+    const std::string & branch,
+    const std::string & label) {
+    const auto it = std::find_if(predictions.begin(), predictions.end(), [&](const FlowSamplerBranchPrediction & pred) {
+        return pred.branch == branch;
+    });
+    if (it == predictions.end()) {
+        throw std::runtime_error(label + " missing prediction for branch '" + branch + "'");
+    }
+    return *it;
+}
+
+}  // namespace
+
+bool FlowSamplerCacheKey::operator==(const FlowSamplerCacheKey & other) const {
+    return name == other.name && mode == other.mode;
+}
+
+bool FlowSamplerCacheState::operator==(const FlowSamplerCacheState & other) const {
+    return name == other.name &&
+           mode == other.mode &&
+           revision == other.revision &&
+           initialized == other.initialized;
+}
+
+bool FlowSamplerGraphKey::operator==(const FlowSamplerGraphKey & other) const {
+    return latent_shape == other.latent_shape &&
+           branch_count == other.branch_count &&
+           schedule_steps == other.schedule_steps &&
+           sampler_mode == other.sampler_mode &&
+           caches == other.caches &&
+           modulation_revision == other.modulation_revision;
+}
+
+FlowSamplerDenoiserRuntime::~FlowSamplerDenoiserRuntime() = default;
+
+FlowSamplerUpdateRuntime::~FlowSamplerUpdateRuntime() = default;
+
+class FlowSamplerEulerUpdate final : public FlowSamplerUpdateRuntime {
+public:
+    void update_latent(const FlowSamplerUpdateInput & input) override {
+        const float dt = input.state.schedule.t_next - input.state.schedule.t;
+        if (input.prediction.size() != input.latent.size()) {
+            throw std::runtime_error("FlowSampler Euler update prediction shape mismatch");
+        }
+        for (size_t i = 0; i < input.latent.size(); ++i) {
+            input.latent[i] += dt * input.prediction[i];
+        }
+    }
+};
+
+std::unique_ptr<FlowSamplerUpdateRuntime> make_flow_sampler_euler_update() {
+    return std::make_unique<FlowSamplerEulerUpdate>();
+}
+
+FlowSamplerSingleBranchDenoiserRuntime::FlowSamplerSingleBranchDenoiserRuntime(
+    FlowSamplerSingleBranchDenoiserRuntimeConfig config)
+    : config_(std::move(config)) {
+    if (config_.label.empty()) {
+        throw std::runtime_error("FlowSampler single-branch denoiser requires label");
+    }
+    if (config_.branch_name.empty()) {
+        throw std::runtime_error(config_.label + " requires branch name");
+    }
+}
+
+FlowSamplerSingleBranchDenoiserRuntime::~FlowSamplerSingleBranchDenoiserRuntime() = default;
+
+void FlowSamplerSingleBranchDenoiserRuntime::reset_sampler_caches(
+    const std::vector<FlowSamplerCacheState> & caches) {
+    reset_sequence_caches(caches);
+}
+
+std::vector<FlowSamplerCacheUpdate>
+FlowSamplerSingleBranchDenoiserRuntime::begin_sampler_sequence(
+    const FlowSamplerSequenceState & state) {
+    sequence_latent_shape_ = state.latent_shape;
+    sequence_schedule_steps_ = static_cast<int64_t>(state.schedule.size());
+    return begin_sequence(state);
+}
+
+FlowSamplerGraphKey FlowSamplerSingleBranchDenoiserRuntime::sampler_graph_key(
+    const FlowSamplerStepState & state) {
+    FlowSamplerGraphKey key;
+    key.latent_shape = sequence_latent_shape_;
+    key.branch_count = static_cast<int64_t>(state.branches.size());
+    key.schedule_steps = sequence_schedule_steps_;
+    key.sampler_mode = sampler_mode(state);
+    for (const auto & cache : state.caches) {
+        key.caches.push_back({cache.name, cache.mode});
+    }
+    key.modulation_revision = modulation_revision(state);
+    return key;
+}
+
+void FlowSamplerSingleBranchDenoiserRuntime::rebuild_sampler_graph(
+    const FlowSamplerGraphKey & key,
+    const FlowSamplerStepState & state) {
+    rebuild_graph(key, state);
+}
+
+FlowSamplerDenoiserOutput FlowSamplerSingleBranchDenoiserRuntime::run_sampler_denoiser(
+    const FlowSamplerDenoiserInput & input) {
+    FlowSamplerDenoiserOutput output;
+    output.predictions.push_back({config_.branch_name, predict_branch(input)});
+    return output;
+}
+
+void FlowSamplerSingleBranchDenoiserRuntime::release_sampler_graphs() {
+    release_runtime_graphs();
+}
+
+void FlowSamplerSingleBranchDenoiserRuntime::reset_sequence_caches(
+    const std::vector<FlowSamplerCacheState> & caches) {
+    if (!caches.empty()) {
+        throw std::runtime_error(config_.label + " does not define cache reset handling");
+    }
+}
+
+std::vector<FlowSamplerCacheUpdate>
+FlowSamplerSingleBranchDenoiserRuntime::begin_sequence(
+    const FlowSamplerSequenceState & state) {
+    if (!state.caches.empty()) {
+        throw std::runtime_error(config_.label + " does not define cache sequence handling");
+    }
+    return {};
+}
+
+int64_t FlowSamplerSingleBranchDenoiserRuntime::modulation_revision(
+    const FlowSamplerStepState &) const {
+    return 0;
+}
+
+void FlowSamplerSingleBranchDenoiserRuntime::release_runtime_graphs() {}
+
+const FlowSamplerSingleBranchDenoiserRuntimeConfig &
+FlowSamplerSingleBranchDenoiserRuntime::config() const noexcept {
+    return config_;
+}
+
+class SingleBranchFlowSamplerDenoiser final : public FlowSamplerSingleBranchDenoiserRuntime {
+public:
+    explicit SingleBranchFlowSamplerDenoiser(FlowSamplerSingleBranchDenoiserConfig config)
+        : FlowSamplerSingleBranchDenoiserRuntime({config.label, config.branch_name}),
+          config_(std::move(config)) {
+        if (!config_.sampler_mode) {
+            throw std::runtime_error(config_.label + " requires sampler mode callback");
+        }
+        if (!config_.predict) {
+            throw std::runtime_error(config_.label + " requires prediction callback");
+        }
+    }
+
+private:
+    void reset_sequence_caches(const std::vector<FlowSamplerCacheState> & caches) override {
+        if (config_.reset_caches) {
+            config_.reset_caches(caches);
+            return;
+        }
+        if (!caches.empty()) {
+            throw std::runtime_error(config_.label + " does not define cache reset handling");
+        }
+    }
+
+    std::vector<FlowSamplerCacheUpdate> begin_sequence(
+        const FlowSamplerSequenceState & state) override {
+        if (config_.begin_sequence) {
+            return config_.begin_sequence(state);
+        }
+        if (!state.caches.empty()) {
+            throw std::runtime_error(config_.label + " does not define cache sequence handling");
+        }
+        return {};
+    }
+
+    std::string sampler_mode(const FlowSamplerStepState & state) const override {
+        return config_.sampler_mode(state);
+    }
+
+    int64_t modulation_revision(const FlowSamplerStepState & state) const override {
+        if (config_.modulation_revision) {
+            return config_.modulation_revision(state);
+        }
+        return 0;
+    }
+
+    void rebuild_graph(
+        const FlowSamplerGraphKey & key,
+        const FlowSamplerStepState & state) override {
+        if (config_.rebuild_graph) {
+            config_.rebuild_graph(key, state);
+        }
+    }
+
+    std::vector<float> predict_branch(const FlowSamplerDenoiserInput & input) override {
+        return config_.predict(input);
+    }
+
+    void release_runtime_graphs() override {
+        if (config_.release_graphs) {
+            config_.release_graphs();
+        }
+    }
+
+    FlowSamplerSingleBranchDenoiserConfig config_;
+};
+
+std::unique_ptr<FlowSamplerDenoiserRuntime>
+make_flow_sampler_single_branch_denoiser(FlowSamplerSingleBranchDenoiserConfig config) {
+    return std::make_unique<SingleBranchFlowSamplerDenoiser>(std::move(config));
+}
+
+class FlowSamplerRuntime::Impl {
+public:
+    Impl(
+        FlowSamplerRuntimeConfig config,
+        std::unique_ptr<FlowSamplerDenoiserRuntime> denoiser,
+        std::unique_ptr<FlowSamplerUpdateRuntime> updater,
+        bool default_euler_updater)
+        : config_(std::move(config)),
+          denoiser_(std::move(denoiser)),
+          updater_(std::move(updater)) {
+        validate_config();
+        if (denoiser_ == nullptr) {
+            throw std::runtime_error(config_.label + " requires denoiser runtime");
+        }
+        if (updater_ == nullptr) {
+            throw std::runtime_error(config_.label + " requires latent update runtime");
+        }
+        if (default_euler_updater && config_.update_rule == FlowSamplerUpdateRule::Custom) {
+            throw std::runtime_error(config_.label + " custom update rule requires explicit latent update runtime");
+        }
+        latent_ = config_.initial_latent;
+        preserved_latent_ = config_.initial_latent;
+        cache_states_.reserve(config_.caches.size());
+        for (const auto & cache : config_.caches) {
+            cache_states_.push_back({cache.name, cache.mode, 0, false});
+        }
+    }
+
+    ~Impl() {
+        release_runtime_graphs();
+    }
+
+    void run_sequence() {
+        if (config_.initial_latent.empty()) {
+            throw std::runtime_error(config_.label + " requires initial latent input");
+        }
+        run_sequence(config_.initial_latent);
+    }
+
+    void run_sequence(const std::vector<float> & initial_latent) {
+        validate_initial_latent(initial_latent);
+        reset_sequence_caches();
+        const auto begin_updates = denoiser_->begin_sampler_sequence(make_sequence_state());
+        apply_cache_updates(begin_updates);
+        latent_ = initial_latent;
+        preserved_latent_ = initial_latent;
+        for (int64_t i = 0; i < static_cast<int64_t>(config_.schedule.size()); ++i) {
+            auto state = make_step_state(i);
+            ensure_graph(state);
+            auto output = denoiser_->run_sampler_denoiser({state, latent_});
+            validate_denoiser_output(state, output);
+            const auto combined = combine_predictions(output.predictions);
+            apply_update(state, combined);
+            preserve_prefix();
+            apply_cache_updates(output.cache_updates);
+        }
+        if (config_.release_graph_after_sequence) {
+            release_runtime_graphs();
+        }
+    }
+
+    void release_runtime_graphs() {
+        if (denoiser_ != nullptr) {
+            denoiser_->release_sampler_graphs();
+        }
+        active_graph_key_.reset();
+    }
+
+    void reset_graph_reuse_state() {
+        active_graph_key_.reset();
+    }
+
+    void reset_runtime_caches() {
+        for (auto & state : cache_states_) {
+            ++state.revision;
+            state.initialized = false;
+        }
+        denoiser_->reset_sampler_caches(cache_states_);
+        reset_graph_reuse_state();
+    }
+
+    const std::vector<float> & latent() const noexcept {
+        return latent_;
+    }
+
+    const FlowSamplerRuntimeConfig & config() const noexcept {
+        return config_;
+    }
+
+    const std::optional<FlowSamplerGraphKey> & active_graph_key() const noexcept {
+        return active_graph_key_;
+    }
+
+    const std::vector<FlowSamplerCacheState> & cache_states() const noexcept {
+        return cache_states_;
+    }
+
+private:
+    void validate_config() const {
+        const int64_t latent_values = element_count(config_.latent_shape);
+        if (config_.label.empty()) {
+            throw std::runtime_error("FlowSamplerRuntime requires label");
+        }
+        if (latent_values <= 0) {
+            throw std::runtime_error(config_.label + " requires positive latent shape");
+        }
+        if (!config_.initial_latent.empty() &&
+            config_.initial_latent.size() != static_cast<size_t>(latent_values)) {
+            throw std::runtime_error(config_.label + " initial latent shape mismatch");
+        }
+        if (!config_.prefix.preserve_mask.empty() &&
+            config_.prefix.preserve_mask.size() != static_cast<size_t>(latent_values)) {
+            throw std::runtime_error(config_.label + " prefix preserve mask shape mismatch");
+        }
+        if (config_.schedule.empty()) {
+            throw std::runtime_error(config_.label + " requires non-empty schedule");
+        }
+        if (config_.branches.empty()) {
+            throw std::runtime_error(config_.label + " requires at least one branch");
+        }
+        if (has_duplicate_branch_name(config_.branches)) {
+            throw std::runtime_error(config_.label + " branch names must be unique");
+        }
+        for (const auto & branch : config_.branches) {
+            if (branch.name.empty()) {
+                throw std::runtime_error(config_.label + " branch name must not be empty");
+            }
+        }
+        if (config_.guidance.mode == FlowSamplerGuidanceMode::ClassifierFree) {
+            if (config_.guidance.cond_branch.empty() || config_.guidance.uncond_branch.empty()) {
+                throw std::runtime_error(config_.label + " CFG requires cond and uncond branches");
+            }
+        }
+        if (has_duplicate_cache_name(config_.caches)) {
+            throw std::runtime_error(config_.label + " cache names must be unique");
+        }
+        for (const auto & cache : config_.caches) {
+            if (cache.name.empty()) {
+                throw std::runtime_error(config_.label + " cache name must not be empty");
+            }
+            if (cache.mode.empty()) {
+                throw std::runtime_error(config_.label + " cache mode must not be empty");
+            }
+        }
+    }
+
+    void validate_initial_latent(const std::vector<float> & initial_latent) const {
+        const int64_t latent_values = element_count(config_.latent_shape);
+        if (initial_latent.size() != static_cast<size_t>(latent_values)) {
+            throw std::runtime_error(config_.label + " initial latent shape mismatch");
+        }
+    }
+
+    void validate_graph_key(const FlowSamplerGraphKey & key) const {
+        if (!config_.require_complete_graph_key) {
+            return;
+        }
+        if (key.latent_shape != config_.latent_shape) {
+            throw std::runtime_error(config_.label + " graph key latent shape mismatch");
+        }
+        if (key.branch_count != static_cast<int64_t>(config_.branches.size())) {
+            throw std::runtime_error(config_.label + " graph key branch count mismatch");
+        }
+        if (key.schedule_steps != static_cast<int64_t>(config_.schedule.size())) {
+            throw std::runtime_error(config_.label + " graph key schedule length mismatch");
+        }
+        if (key.sampler_mode.empty()) {
+            throw std::runtime_error(config_.label + " graph key requires sampler mode");
+        }
+        if (!cache_key_matches_config(key.caches, config_.caches)) {
+            throw std::runtime_error(config_.label + " graph key cache state mismatch");
+        }
+    }
+
+    FlowSamplerStepState make_step_state(int64_t sequence_index) const {
+        FlowSamplerStepState state;
+        state.sequence_index = sequence_index;
+        state.schedule = config_.schedule[static_cast<size_t>(sequence_index)];
+        state.branches = config_.branches;
+        state.caches = cache_states_;
+        return state;
+    }
+
+    FlowSamplerSequenceState make_sequence_state() const {
+        FlowSamplerSequenceState state;
+        state.latent_shape = config_.latent_shape;
+        state.schedule = config_.schedule;
+        state.branches = config_.branches;
+        state.caches = cache_states_;
+        return state;
+    }
+
+    void ensure_graph(FlowSamplerStepState & state) {
+        state.graph_key = denoiser_->sampler_graph_key(state);
+        validate_graph_key(state.graph_key);
+        if (!active_graph_key_.has_value() || *active_graph_key_ != state.graph_key) {
+            denoiser_->rebuild_sampler_graph(state.graph_key, state);
+            active_graph_key_ = state.graph_key;
+        }
+    }
+
+    void validate_denoiser_output(
+        const FlowSamplerStepState & state,
+        const FlowSamplerDenoiserOutput & output) const {
+        if (output.predictions.size() != state.branches.size()) {
+            throw std::runtime_error(config_.label + " denoiser branch count mismatch");
+        }
+        if (has_duplicate_prediction(output.predictions)) {
+            throw std::runtime_error(config_.label + " denoiser output contains duplicate branches");
+        }
+        for (const auto & prediction : output.predictions) {
+            const auto branch = std::find_if(state.branches.begin(), state.branches.end(), [&](const FlowSamplerBranchSpec & spec) {
+                return spec.name == prediction.branch;
+            });
+            if (branch == state.branches.end()) {
+                throw std::runtime_error(config_.label + " denoiser output references unknown branch '" + prediction.branch + "'");
+            }
+            if (prediction.values.size() != latent_.size()) {
+                throw std::runtime_error(config_.label + " denoiser prediction shape mismatch");
+            }
+        }
+        if (has_duplicate_cache_update(output.cache_updates)) {
+            throw std::runtime_error(config_.label + " denoiser output contains duplicate cache updates");
+        }
+        for (const auto & update : output.cache_updates) {
+            const auto it = std::find_if(config_.caches.begin(), config_.caches.end(), [&](const FlowSamplerCacheSpec & spec) {
+                return spec.name == update.name;
+            });
+            if (it == config_.caches.end()) {
+                throw std::runtime_error(config_.label + " denoiser output references unknown cache '" + update.name + "'");
+            }
+        }
+    }
+
+    std::vector<float> combine_predictions(const std::vector<FlowSamplerBranchPrediction> & predictions) const {
+        if (config_.guidance.mode == FlowSamplerGuidanceMode::None) {
+            if (predictions.size() != 1) {
+                throw std::runtime_error(config_.label + " unguided sampler expects exactly one prediction");
+            }
+            return predictions.front().values;
+        }
+        if (config_.guidance.mode == FlowSamplerGuidanceMode::ClassifierFree) {
+            const auto & cond = require_prediction(predictions, config_.guidance.cond_branch, config_.label);
+            const auto & uncond = require_prediction(predictions, config_.guidance.uncond_branch, config_.label);
+            std::vector<float> out(cond.values.size(), 0.0F);
+            for (size_t i = 0; i < out.size(); ++i) {
+                out[i] = uncond.values[i] + config_.guidance.scale * (cond.values[i] - uncond.values[i]);
+            }
+            return out;
+        }
+        throw std::runtime_error(config_.label + " unsupported guidance mode");
+    }
+
+    void apply_update(
+        const FlowSamplerStepState & state,
+        const std::vector<float> & prediction) {
+        if (config_.prediction_type != FlowSamplerPredictionType::Velocity) {
+            throw std::runtime_error(config_.label + " unsupported flow update");
+        }
+        if (config_.update_rule != FlowSamplerUpdateRule::Euler &&
+            config_.update_rule != FlowSamplerUpdateRule::Custom) {
+            throw std::runtime_error(config_.label + " unsupported flow update rule");
+        }
+        updater_->update_latent({state, prediction, latent_});
+    }
+
+    void preserve_prefix() {
+        if (config_.prefix.preserve_mask.empty()) {
+            return;
+        }
+        for (size_t i = 0; i < latent_.size(); ++i) {
+            if (config_.prefix.preserve_mask[i] != 0.0F) {
+                latent_[i] = preserved_latent_[i];
+            }
+        }
+    }
+
+    void reset_sequence_caches() {
+        for (size_t i = 0; i < config_.caches.size(); ++i) {
+            if (config_.caches[i].reset_on_sequence_begin) {
+                ++cache_states_[i].revision;
+                cache_states_[i].initialized = false;
+            }
+        }
+    }
+
+    void apply_cache_updates(const std::vector<FlowSamplerCacheUpdate> & updates) {
+        for (const auto & update : updates) {
+            auto it = std::find_if(cache_states_.begin(), cache_states_.end(), [&](const FlowSamplerCacheState & state) {
+                return state.name == update.name;
+            });
+            if (it == cache_states_.end()) {
+                throw std::runtime_error(config_.label + " received update for unknown cache '" + update.name + "'");
+            }
+            switch (update.kind) {
+                case FlowSamplerCacheUpdateKind::Unchanged:
+                    break;
+                case FlowSamplerCacheUpdateKind::Updated:
+                    ++it->revision;
+                    it->initialized = true;
+                    break;
+                case FlowSamplerCacheUpdateKind::Reset:
+                    ++it->revision;
+                    it->initialized = false;
+                    break;
+            }
+        }
+    }
+
+    FlowSamplerRuntimeConfig config_;
+    std::unique_ptr<FlowSamplerDenoiserRuntime> denoiser_;
+    std::unique_ptr<FlowSamplerUpdateRuntime> updater_;
+    std::optional<FlowSamplerGraphKey> active_graph_key_;
+    std::vector<FlowSamplerCacheState> cache_states_;
+    std::vector<float> latent_;
+    std::vector<float> preserved_latent_;
+};
+
+FlowSamplerRuntime::FlowSamplerRuntime(
+    FlowSamplerRuntimeConfig config,
+    std::unique_ptr<FlowSamplerDenoiserRuntime> denoiser)
+    : impl_(std::make_unique<Impl>(
+          std::move(config),
+          std::move(denoiser),
+          make_flow_sampler_euler_update(),
+          true)) {}
+
+FlowSamplerRuntime::FlowSamplerRuntime(
+    FlowSamplerRuntimeConfig config,
+    std::unique_ptr<FlowSamplerDenoiserRuntime> denoiser,
+    std::unique_ptr<FlowSamplerUpdateRuntime> updater)
+    : impl_(std::make_unique<Impl>(
+          std::move(config),
+          std::move(denoiser),
+          std::move(updater),
+          false)) {}
+
+FlowSamplerRuntime::~FlowSamplerRuntime() = default;
+
+void FlowSamplerRuntime::run_sequence() {
+    impl_->run_sequence();
+}
+
+void FlowSamplerRuntime::run_sequence(const std::vector<float> & initial_latent) {
+    impl_->run_sequence(initial_latent);
+}
+
+void FlowSamplerRuntime::release_runtime_graphs() {
+    impl_->release_runtime_graphs();
+}
+
+void FlowSamplerRuntime::reset_graph_reuse_state() {
+    impl_->reset_graph_reuse_state();
+}
+
+void FlowSamplerRuntime::reset_runtime_caches() {
+    impl_->reset_runtime_caches();
+}
+
+const std::vector<float> & FlowSamplerRuntime::latent() const noexcept {
+    return impl_->latent();
+}
+
+const FlowSamplerRuntimeConfig & FlowSamplerRuntime::config() const noexcept {
+    return impl_->config();
+}
+
+const std::optional<FlowSamplerGraphKey> & FlowSamplerRuntime::active_graph_key() const noexcept {
+    return impl_->active_graph_key();
+}
+
+const std::vector<FlowSamplerCacheState> & FlowSamplerRuntime::cache_states() const noexcept {
+    return impl_->cache_states();
+}
+
+}  // namespace engine::modules

--- a/src/framework/modules/speaker_encoders/ecapa_tdnn_runtime.cpp
+++ b/src/framework/modules/speaker_encoders/ecapa_tdnn_runtime.cpp
@@ -36,6 +36,7 @@ struct BackendConv1dWeights {
     int64_t padding = 0;
     int64_t dilation = 1;
     bool use_bias = true;
+    Conv1dPaddingMode padding_mode = Conv1dPaddingMode::Reflect;
     modules::Conv1dWeights conv;
 };
 
@@ -49,6 +50,7 @@ struct BackendRes2NetBlockWeights {
     std::vector<BackendTDNNBlockWeights> blocks;
     int64_t scale = 8;
     int64_t width = 0;
+    bool first_chunk_passthrough = true;
 };
 
 struct BackendSEBlockWeights {
@@ -70,6 +72,8 @@ struct BackendAspWeights {
     modules::BatchNorm1dEvalWeights tdnn_norm;
     int64_t tdnn_norm_channels = 0;
     BackendConv1dWeights conv;
+    AttentivePoolingKind kind = AttentivePoolingKind::GlobalContext;
+    bool tdnn_use_batch_norm = true;
 };
 
 struct EcapaBackendWeights {
@@ -77,11 +81,15 @@ struct EcapaBackendWeights {
     BackendTDNNBlockWeights block0;
     std::vector<BackendSERes2NetBlockWeights> se_blocks;
     BackendTDNNBlockWeights mfa;
+    bool mfa_use_batch_norm = true;
     BackendAspWeights asp;
     modules::BatchNorm1dEvalWeights asp_bn;
     int64_t asp_bn_channels = 0;
     BackendConv1dWeights fc;
     core::TensorValue stats_eps;
+    int64_t feature_dim = 80;
+    int64_t embedding_dim = 192;
+    size_t graph_context_bytes = 256ull * 1024ull * 1024ull;
 };
 
 namespace {
@@ -110,26 +118,6 @@ struct GgmlContextDeleter {
     }
 };
 
-core::TensorValue store_weight(
-    core::BackendWeightStore & store,
-    const assets::TensorSource & source,
-    const Conv1dWeights & tensor,
-    assets::TensorStorageType storage_type) {
-    return store.load_tensor_as_shape(
-        source,
-        tensor.weight_name,
-        storage_type,
-        tensor.weight_source_shape,
-        core::TensorShape::from_dims({tensor.out_channels, tensor.in_channels, tensor.kernel}));
-}
-
-core::TensorValue store_f32(
-    core::BackendWeightStore & store,
-    const core::TensorShape & shape,
-    const std::vector<float> & values) {
-    return store.make_f32(shape, values);
-}
-
 BackendConv1dWeights make_backend_conv(
     core::BackendWeightStore & store,
     const assets::TensorSource & source,
@@ -143,7 +131,13 @@ BackendConv1dWeights make_backend_conv(
     weights.padding = conv.padding;
     weights.dilation = conv.dilation;
     weights.use_bias = conv.use_bias;
-    weights.conv.weight = store_weight(store, source, conv, storage_type);
+    weights.padding_mode = conv.padding_mode;
+    weights.conv.weight = store.load_tensor_as_shape(
+        source,
+        conv.weight_name,
+        storage_type,
+        conv.weight_source_shape,
+        core::TensorShape::from_dims({conv.out_channels, conv.in_channels, conv.kernel}));
     if (conv.use_bias) {
         weights.conv.bias = store.load_f32_tensor(source, *conv.bias_name, {conv.out_channels});
     }
@@ -228,13 +222,14 @@ modules::BatchNorm1dEvalWeights bind_batch_norm_weights(
     std::vector<float> scale(static_cast<size_t>(channels), 0.0f);
     std::vector<float> bias(static_cast<size_t>(channels), 0.0f);
     for (int64_t i = 0; i < channels; ++i) {
-        const float inv_std = 1.0f / std::sqrt(bn.running_var[static_cast<size_t>(i)] + kBatchNormEps);
-        scale[static_cast<size_t>(i)] = bn.weight[static_cast<size_t>(i)] * inv_std;
-        bias[static_cast<size_t>(i)] = bn.bias[static_cast<size_t>(i)] - bn.running_mean[static_cast<size_t>(i)] * scale[static_cast<size_t>(i)];
+        scale[static_cast<size_t>(i)] =
+            bn.weight[static_cast<size_t>(i)] / std::sqrt(bn.running_var[static_cast<size_t>(i)] + kBatchNormEps);
+        bias[static_cast<size_t>(i)] =
+            bn.bias[static_cast<size_t>(i)] - bn.running_mean[static_cast<size_t>(i)] * scale[static_cast<size_t>(i)];
     }
     return {
-        store_f32(store, core::TensorShape::from_dims({channels}), scale),
-        store_f32(store, core::TensorShape::from_dims({channels}), bias),
+        store.make_f32(core::TensorShape::from_dims({channels}), scale),
+        store.make_f32(core::TensorShape::from_dims({channels}), bias),
     };
 }
 
@@ -257,7 +252,10 @@ std::shared_ptr<const EcapaBackendWeights> load_backend_weights(
     assets::TensorStorageType storage_type) {
     auto out = std::make_shared<EcapaBackendWeights>();
     out->store = std::make_shared<core::BackendWeightStore>(
-        backend, backend_type, "ecapa_tdnn_spk.weights", 256ull * 1024ull * 1024ull);
+        backend, backend_type, "ecapa_tdnn_spk.weights", weights.weight_context_bytes);
+    out->feature_dim = weights.feature_dim;
+    out->embedding_dim = weights.embedding_dim;
+    out->graph_context_bytes = weights.graph_context_bytes;
     auto & store = *out->store;
     if (weights.source == nullptr) {
         throw std::runtime_error("ECAPA weights require a tensor source");
@@ -270,6 +268,7 @@ std::shared_ptr<const EcapaBackendWeights> load_backend_weights(
         dst.tdnn1 = make_backend_tdnn(store, source, block.tdnn1, storage_type);
         dst.res2net.scale = block.res2net.scale;
         dst.res2net.width = block.res2net.width;
+        dst.res2net.first_chunk_passthrough = block.res2net.first_chunk_passthrough;
         dst.res2net.blocks.reserve(block.res2net.blocks.size());
         for (const auto & res2 : block.res2net.blocks) {
             dst.res2net.blocks.push_back(make_backend_tdnn(store, source, res2, storage_type));
@@ -279,8 +278,15 @@ std::shared_ptr<const EcapaBackendWeights> load_backend_weights(
         dst.se.conv2 = make_backend_conv(store, source, block.se.conv2, storage_type);
         out->se_blocks.push_back(std::move(dst));
     }
-    out->mfa = make_backend_tdnn(store, source, weights.mfa, storage_type);
-    if (engine::core::uses_host_graph_plan(backend)) {
+    out->mfa.conv = make_backend_conv(store, source, weights.mfa.conv, storage_type);
+    out->mfa.norm_channels = static_cast<int64_t>(weights.mfa.norm.running_mean.size());
+    out->mfa_use_batch_norm = weights.mfa_use_batch_norm;
+    if (weights.mfa_use_batch_norm) {
+        out->mfa.norm = bind_batch_norm_weights(weights.mfa.norm, store);
+    }
+    out->asp.kind = weights.asp.kind;
+    out->asp.tdnn_use_batch_norm = weights.asp.tdnn_use_batch_norm;
+    if (weights.asp.kind == AttentivePoolingKind::GlobalContext && engine::core::uses_host_graph_plan(backend)) {
         auto [tdnn_x_conv, tdnn_stats_conv] = make_backend_split_pool_conv(
             store,
             source,
@@ -289,16 +295,24 @@ std::shared_ptr<const EcapaBackendWeights> load_backend_weights(
             storage_type);
         out->asp.tdnn_x_conv = std::move(tdnn_x_conv);
         out->asp.tdnn_stats_conv = std::move(tdnn_stats_conv);
-        out->asp.tdnn_norm = bind_batch_norm_weights(weights.asp.tdnn.norm, store);
+        if (weights.asp.tdnn_use_batch_norm) {
+            out->asp.tdnn_norm = bind_batch_norm_weights(weights.asp.tdnn.norm, store);
+        }
         out->asp.tdnn_norm_channels = static_cast<int64_t>(weights.asp.tdnn.norm.running_mean.size());
     } else {
-        out->asp.tdnn = make_backend_tdnn(store, source, weights.asp.tdnn, storage_type);
+        out->asp.tdnn.conv = make_backend_conv(store, source, weights.asp.tdnn.conv, storage_type);
+        if (weights.asp.tdnn_use_batch_norm) {
+            out->asp.tdnn.norm = bind_batch_norm_weights(weights.asp.tdnn.norm, store);
+        }
+        out->asp.tdnn.norm_channels = static_cast<int64_t>(weights.asp.tdnn.norm.running_mean.size());
     }
     out->asp.conv = make_backend_conv(store, source, weights.asp.conv, storage_type);
     out->asp_bn = bind_batch_norm_weights(weights.asp_bn, store);
     out->asp_bn_channels = static_cast<int64_t>(weights.asp_bn.running_mean.size());
     out->fc = make_backend_conv(store, source, weights.fc, storage_type);
-    out->stats_eps = store_f32(store, core::TensorShape::from_dims({1, 1, 1}), std::vector<float>{kStatsEps});
+    out->stats_eps = store.make_f32(
+        core::TensorShape::from_dims({1, 1, 1}),
+        std::vector<float>{weights.stats_eps});
     store.upload();
     weights.source->release_storage();
     return out;
@@ -311,17 +325,6 @@ std::shared_ptr<const EcapaWeights> require_weights(std::shared_ptr<const EcapaW
     return weights;
 }
 
-core::TensorValue batch_norm_1d(
-    core::ModuleBuildContext & ctx,
-    const core::TensorValue & x,
-    const modules::BatchNorm1dEvalWeights & bn,
-    int64_t channels) {
-    return modules::BatchNorm1dEvalModule({channels}).build(
-        ctx,
-        x,
-        bn);
-}
-
 core::TensorValue conv1d(
     core::ModuleBuildContext & ctx,
     core::TensorValue x,
@@ -331,15 +334,17 @@ core::TensorValue conv1d(
             "ECAPA conv1d channel mismatch: got=" + std::to_string(x.shape.dims[1]) +
             " expected=" + std::to_string(conv.in_channels));
     }
-    if (conv.padding > 0) {
+    int padding = static_cast<int>(conv.padding);
+    if (conv.padding_mode == Conv1dPaddingMode::Reflect && conv.padding > 0) {
         x = modules::ReflectPad1dModule({conv.padding, conv.padding}).build(ctx, x);
+        padding = 0;
     }
     return modules::FastConv1dModule({
         conv.in_channels,
         conv.out_channels,
         conv.kernel,
         static_cast<int>(conv.stride),
-        0,
+        padding,
         static_cast<int>(conv.dilation),
         conv.use_bias,
     }, modules::FastConv1dKind::MinittsFast1dIm2col).build(ctx, x, conv.conv);
@@ -351,30 +356,21 @@ core::TensorValue tdnn_block(
     const BackendTDNNBlockWeights & block) {
     auto y = conv1d(ctx, x, block.conv);
     y = modules::ReluModule{}.build(ctx, y);
-    y = batch_norm_1d(ctx, y, block.norm, block.norm_channels);
+    y = modules::BatchNorm1dEvalModule({block.norm_channels}).build(ctx, y, block.norm);
     return y;
 }
 
-core::TensorValue concat_channels(core::ModuleBuildContext & ctx, const core::TensorValue & a, const core::TensorValue & b) {
-    return modules::ConcatModule({1}).build(ctx, a, b);
-}
-
-core::TensorValue se_block(
+core::TensorValue tdnn_block(
     core::ModuleBuildContext & ctx,
     const core::TensorValue & x,
-    const BackendSEBlockWeights & se) {
-    return modules::SqueezeExcite1dModule({se.conv2.out_channels, se.conv1.out_channels, true}).build(
-        ctx,
-        x,
-        {se.conv1.conv, se.conv2.conv});
-}
-
-core::TensorValue view_channels(
-    core::ModuleBuildContext & ctx,
-    const core::TensorValue & x,
-    int64_t c0,
-    int64_t c1) {
-    return modules::SliceModule({1, c0, c1 - c0}).build(ctx, x);
+    const BackendTDNNBlockWeights & block,
+    bool use_batch_norm) {
+    auto y = conv1d(ctx, x, block.conv);
+    y = modules::ReluModule{}.build(ctx, y);
+    if (use_batch_norm) {
+        y = modules::BatchNorm1dEvalModule({block.norm_channels}).build(ctx, y, block.norm);
+    }
+    return y;
 }
 
 core::TensorValue se_res2net_block(
@@ -385,26 +381,65 @@ core::TensorValue se_res2net_block(
     auto y = tdnn_block(ctx, x, block.tdnn1);
     core::TensorValue merged;
     core::TensorValue prev;
-    for (int64_t i = 0; i < block.res2net.scale; ++i) {
-        auto chunk = view_channels(ctx, y, i * block.res2net.width, (i + 1) * block.res2net.width);
-        core::TensorValue out;
-        if (i == 0) {
-            out = chunk;
-        } else if (i == 1) {
-            out = tdnn_block(ctx, chunk, block.res2net.blocks[0]);
-        } else {
-            auto summed = modules::ResidualAddModule{}.build(ctx, chunk, prev);
-            out = tdnn_block(ctx, summed, block.res2net.blocks[static_cast<size_t>(i - 1)]);
+    if (block.res2net.first_chunk_passthrough) {
+        for (int64_t i = 0; i < block.res2net.scale; ++i) {
+            auto chunk = modules::SliceModule({1, i * block.res2net.width, block.res2net.width}).build(ctx, y);
+            core::TensorValue out;
+            if (i == 0) {
+                out = chunk;
+            } else if (i == 1) {
+                out = tdnn_block(ctx, chunk, block.res2net.blocks[0]);
+            } else {
+                auto summed = modules::AddModule{}.build(ctx, chunk, prev);
+                out = tdnn_block(ctx, summed, block.res2net.blocks[static_cast<size_t>(i - 1)]);
+            }
+            prev = out;
+            merged = merged.valid() ? modules::ConcatModule({1}).build(ctx, merged, out) : out;
         }
-        prev = out;
-        merged = merged.valid() ? concat_channels(ctx, merged, out) : out;
+    } else {
+        for (int64_t i = 0; i < block.res2net.scale - 1; ++i) {
+            auto chunk = modules::SliceModule({1, i * block.res2net.width, block.res2net.width}).build(ctx, y);
+            auto input = i == 0 ? chunk : modules::AddModule{}.build(ctx, chunk, prev);
+            auto out = tdnn_block(ctx, input, block.res2net.blocks[static_cast<size_t>(i)]);
+            prev = out;
+            merged = merged.valid() ? modules::ConcatModule({1}).build(ctx, merged, out) : out;
+        }
+        auto tail = modules::SliceModule({
+            1,
+            (block.res2net.scale - 1) * block.res2net.width,
+            block.res2net.width}).build(ctx, y);
+        merged = merged.valid() ? modules::ConcatModule({1}).build(ctx, merged, tail) : tail;
     }
     y = tdnn_block(ctx, merged, block.tdnn2);
-    y = se_block(ctx, y, block.se);
-    return modules::ResidualAddModule{}.build(ctx, y, residual);
+    y = modules::SqueezeExcite1dModule({block.se.conv2.out_channels, block.se.conv1.out_channels, true}).build(
+        ctx,
+        y,
+        {block.se.conv1.conv, block.se.conv2.conv});
+    return modules::AddModule{}.build(ctx, y, residual);
 }
 
-core::TensorValue attentive_statistics_pool(
+core::TensorValue simple_attentive_statistics_pool(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & x,
+    const BackendAspWeights & asp,
+    core::TensorValue eps) {
+    auto attn = conv1d(ctx, x, asp.tdnn.conv);
+    attn = modules::TanhModule{}.build(ctx, attn);
+    attn = conv1d(ctx, attn, asp.conv);
+    auto weights = modules::SoftmaxModule{}.build(ctx, attn);
+    auto weighted_x = modules::MulModule{}.build(ctx, x, weights);
+    auto mean_att = modules::ReduceSumModule({static_cast<int>(weighted_x.shape.rank - 1)}).build(ctx, weighted_x);
+    auto mean_att_rep = modules::RepeatModule({x.shape}).build(ctx, mean_att);
+    auto diff = core::wrap_tensor(ggml_sub(ctx.ggml, x.tensor, mean_att_rep.tensor), x.shape, GGML_TYPE_F32);
+    auto diff_sq = modules::MulModule{}.build(ctx, diff, diff);
+    auto weighted_var = modules::MulModule{}.build(ctx, diff_sq, weights);
+    auto var_att = modules::ReduceSumModule({static_cast<int>(weighted_var.shape.rank - 1)}).build(ctx, weighted_var);
+    auto eps_stats = modules::RepeatModule({var_att.shape}).build(ctx, eps);
+    auto std_att = modules::SqrtModule{}.build(ctx, modules::AddModule{}.build(ctx, var_att, eps_stats));
+    return modules::ConcatModule({1}).build(ctx, mean_att, std_att);
+}
+
+core::TensorValue global_context_attentive_statistics_pool(
     core::ModuleBuildContext & ctx,
     const core::TensorValue & x,
     const BackendAspWeights & asp,
@@ -418,17 +453,22 @@ core::TensorValue attentive_statistics_pool(
     auto std = modules::SqrtModule{}.build(ctx, modules::AddModule{}.build(ctx, variance, eps_stats));
     core::TensorValue attn;
     if (core::uses_host_graph_plan(ctx.backend_type)) {
-        auto stats = concat_channels(ctx, mean, std);
+        auto stats = modules::ConcatModule({1}).build(ctx, mean, std);
         attn = conv1d(ctx, x, asp.tdnn_x_conv);
         auto stats_attn = conv1d(ctx, stats, asp.tdnn_stats_conv);
         auto stats_attn_rep = modules::RepeatModule({attn.shape}).build(ctx, stats_attn);
         attn = modules::AddModule{}.build(ctx, attn, stats_attn_rep);
         attn = modules::ReluModule{}.build(ctx, attn);
-        attn = batch_norm_1d(ctx, attn, asp.tdnn_norm, asp.tdnn_norm_channels);
+        if (asp.tdnn_use_batch_norm) {
+            attn = modules::BatchNorm1dEvalModule({asp.tdnn_norm_channels}).build(ctx, attn, asp.tdnn_norm);
+        }
     } else {
         auto std_rep = modules::RepeatModule({x.shape}).build(ctx, std);
-        auto gc = concat_channels(ctx, concat_channels(ctx, x, mean_rep), std_rep);
-        attn = tdnn_block(ctx, gc, asp.tdnn);
+        auto gc = modules::ConcatModule({1}).build(
+            ctx,
+            modules::ConcatModule({1}).build(ctx, x, mean_rep),
+            std_rep);
+        attn = tdnn_block(ctx, gc, asp.tdnn, asp.tdnn_use_batch_norm);
     }
     attn = modules::TanhModule{}.build(ctx, attn);
     attn = conv1d(ctx, attn, asp.conv);
@@ -442,7 +482,18 @@ core::TensorValue attentive_statistics_pool(
     auto var_att = modules::ReduceSumModule({static_cast<int>(weighted_var.shape.rank - 1)}).build(ctx, weighted_var);
     eps_stats = modules::RepeatModule({var_att.shape}).build(ctx, eps);
     auto std_att = modules::SqrtModule{}.build(ctx, modules::AddModule{}.build(ctx, var_att, eps_stats));
-    return concat_channels(ctx, mean_att, std_att);
+    return modules::ConcatModule({1}).build(ctx, mean_att, std_att);
+}
+
+core::TensorValue attentive_statistics_pool(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & x,
+    const BackendAspWeights & asp,
+    core::TensorValue eps) {
+    if (asp.kind == AttentivePoolingKind::Simple) {
+        return simple_attentive_statistics_pool(ctx, x, asp, eps);
+    }
+    return global_context_attentive_statistics_pool(ctx, x, asp, eps);
 }
 
 core::TensorValue build_ecapa_graph(
@@ -456,11 +507,11 @@ core::TensorValue build_ecapa_graph(
         x = se_res2net_block(ctx, x, weights.se_blocks[i]);
         xl.push_back(x);
     }
-    auto cat = concat_channels(ctx, xl[1], xl[2]);
-    cat = concat_channels(ctx, cat, xl[3]);
-    x = tdnn_block(ctx, cat, weights.mfa);
+    auto cat = modules::ConcatModule({1}).build(ctx, xl[1], xl[2]);
+    cat = modules::ConcatModule({1}).build(ctx, cat, xl[3]);
+    x = tdnn_block(ctx, cat, weights.mfa, weights.mfa_use_batch_norm);
     x = attentive_statistics_pool(ctx, x, weights.asp, weights.stats_eps);
-    x = batch_norm_1d(ctx, x, weights.asp_bn, weights.asp_bn_channels);
+    x = modules::BatchNorm1dEvalModule({weights.asp_bn_channels}).build(ctx, x, weights.asp_bn);
     x = conv1d(ctx, x, weights.fc);
     return x;
 }
@@ -488,7 +539,7 @@ class EcapaRuntime::Graph {
         }
 
         ggml_init_params params{
-            /*.mem_size   =*/ 256ull * 1024ull * 1024ull,
+            /*.mem_size   =*/ backend_weights_->graph_context_bytes,
             /*.mem_buffer =*/ nullptr,
             /*.no_alloc   =*/ true,
         };
@@ -502,15 +553,19 @@ class EcapaRuntime::Graph {
             "ecapa_tdnn_spk",
             execution_context.backend_type(),
         };
-        auto input = core::make_tensor(build_ctx, GGML_TYPE_F32, core::TensorShape::from_dims({1, kFeatureDim, frames_}));
+        auto input = core::make_tensor(
+            build_ctx,
+            GGML_TYPE_F32,
+            core::TensorShape::from_dims({1, backend_weights_->feature_dim, frames_}));
         input_ = input.tensor;
         output_ = build_ecapa_graph(build_ctx, input, *backend_weights_).tensor;
         ggml_set_output(output_);
-        graph_ = ggml_new_graph_custom(ctx_.get(), 4096, false);
+        graph_ = ggml_new_graph_custom(ctx_.get(), 65536, false);
         ggml_build_forward_expand(graph_, output_);
 
-        buffer_ = ggml_backend_alloc_ctx_tensors(ctx_.get(), backend_);
-        if (buffer_ == nullptr) {
+        gallocr_ = ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend_));
+        if (gallocr_ == nullptr || !ggml_gallocr_reserve(gallocr_, graph_) ||
+            !ggml_gallocr_alloc_graph(gallocr_, graph_)) {
             throw std::runtime_error("failed to allocate ECAPA backend graph");
         }
         if (engine::core::uses_host_graph_plan(backend_)) {
@@ -530,8 +585,8 @@ class EcapaRuntime::Graph {
         if (plan_ != nullptr) {
             engine::core::free_backend_graph_plan(backend_, plan_);
         }
-        if (buffer_ != nullptr) {
-            ggml_backend_buffer_free(buffer_);
+        if (gallocr_ != nullptr) {
+            ggml_gallocr_free(gallocr_);
         }
     }
 
@@ -542,22 +597,23 @@ class EcapaRuntime::Graph {
     std::vector<float> run(const std::vector<float> & features) {
         upload_input(features);
         compute();
-        std::vector<float> embedding(static_cast<size_t>(kEmbeddingDim), 0.0f);
+        std::vector<float> embedding(static_cast<size_t>(backend_weights_->embedding_dim), 0.0f);
         ggml_backend_tensor_get(output_, embedding.data(), 0, embedding.size() * sizeof(float));
         return embedding;
     }
 
   private:
     void upload_input(const std::vector<float> & features) {
-        if (features.size() != static_cast<size_t>(frames_ * kFeatureDim)) {
+        if (features.size() != static_cast<size_t>(frames_ * backend_weights_->feature_dim)) {
             throw std::runtime_error("feature tensor size mismatch");
         }
         if (channels_first_.size() != features.size()) {
             channels_first_.resize(features.size());
         }
         for (int64_t t = 0; t < frames_; ++t) {
-            for (int64_t c = 0; c < kFeatureDim; ++c) {
-                channels_first_[static_cast<size_t>(t + frames_ * c)] = features[static_cast<size_t>(t * kFeatureDim + c)];
+            for (int64_t c = 0; c < backend_weights_->feature_dim; ++c) {
+                channels_first_[static_cast<size_t>(t + frames_ * c)] =
+                    features[static_cast<size_t>(t * backend_weights_->feature_dim + c)];
             }
         }
         ggml_backend_tensor_set(input_, channels_first_.data(), 0, channels_first_.size() * sizeof(float));
@@ -584,7 +640,7 @@ class EcapaRuntime::Graph {
     ggml_cgraph * graph_ = nullptr;
     ggml_backend_t backend_ = nullptr;
     int compute_threads_ = 1;
-    ggml_backend_buffer_t buffer_ = nullptr;
+    ggml_gallocr_t gallocr_ = nullptr;
     ggml_backend_graph_plan_t plan_ = nullptr;
     double plan_create_ms_ = 0.0;
     std::vector<float> channels_first_;
@@ -722,21 +778,23 @@ std::vector<float> compute_speechbrain_fbank(const std::vector<float> & waveform
 }
 
 std::vector<float> normalize_classifier_weights(const EcapaWeights & weights) {
-    if (weights.classifier_weight.empty() || weights.classifier_weight.size() % static_cast<size_t>(kEmbeddingDim) != 0) {
+    if (weights.classifier_weight.empty() ||
+        weights.classifier_weight.size() % static_cast<size_t>(weights.embedding_dim) != 0) {
         throw std::runtime_error("classifier weights are missing from checkpoint");
     }
     std::vector<float> normalized(weights.classifier_weight.size(), 0.0f);
-    const int64_t class_count = static_cast<int64_t>(weights.classifier_weight.size() / static_cast<size_t>(kEmbeddingDim));
+    const int64_t class_count =
+        static_cast<int64_t>(weights.classifier_weight.size() / static_cast<size_t>(weights.embedding_dim));
     for (int64_t cls = 0; cls < class_count; ++cls) {
-        const float * row = weights.classifier_weight.data() + static_cast<size_t>(cls * kEmbeddingDim);
+        const float * row = weights.classifier_weight.data() + static_cast<size_t>(cls * weights.embedding_dim);
         double norm_sq = 0.0;
-        for (int64_t i = 0; i < kEmbeddingDim; ++i) {
+        for (int64_t i = 0; i < weights.embedding_dim; ++i) {
             const double w = row[static_cast<size_t>(i)];
             norm_sq += w * w;
         }
-        const double inv_norm = 1.0 / std::sqrt(std::max(norm_sq, static_cast<double>(kStatsEps)));
-        float * dst = normalized.data() + static_cast<size_t>(cls * kEmbeddingDim);
-        for (int64_t i = 0; i < kEmbeddingDim; ++i) {
+        const double inv_norm = 1.0 / std::sqrt(std::max(norm_sq, static_cast<double>(weights.stats_eps)));
+        float * dst = normalized.data() + static_cast<size_t>(cls * weights.embedding_dim);
+        for (int64_t i = 0; i < weights.embedding_dim; ++i) {
             dst[static_cast<size_t>(i)] = static_cast<float>(static_cast<double>(row[static_cast<size_t>(i)]) * inv_norm);
         }
     }
@@ -749,27 +807,29 @@ std::vector<float> classify_embedding(
     std::vector<float> & centered,
     const std::vector<float> & embedding) {
     const auto start = Clock::now();
-    if (weights.embedding_global_mean.size() != static_cast<size_t>(kEmbeddingDim)) {
+    if (weights.embedding_global_mean.size() != static_cast<size_t>(weights.embedding_dim)) {
         throw std::runtime_error("embedding global mean is missing from checkpoint");
     }
-    if (normalized_classifier_weight.empty() || normalized_classifier_weight.size() % static_cast<size_t>(kEmbeddingDim) != 0) {
+    if (normalized_classifier_weight.empty() ||
+        normalized_classifier_weight.size() % static_cast<size_t>(weights.embedding_dim) != 0) {
         throw std::runtime_error("normalized classifier weights are missing");
     }
-    const int64_t class_count = static_cast<int64_t>(normalized_classifier_weight.size() / static_cast<size_t>(kEmbeddingDim));
-    if (centered.size() != static_cast<size_t>(kEmbeddingDim)) {
-        centered.resize(static_cast<size_t>(kEmbeddingDim));
+    const int64_t class_count =
+        static_cast<int64_t>(normalized_classifier_weight.size() / static_cast<size_t>(weights.embedding_dim));
+    if (centered.size() != static_cast<size_t>(weights.embedding_dim)) {
+        centered.resize(static_cast<size_t>(weights.embedding_dim));
     }
     float emb_norm_sq = 0.0f;
-    for (int64_t i = 0; i < kEmbeddingDim; ++i) {
+    for (int64_t i = 0; i < weights.embedding_dim; ++i) {
         centered[static_cast<size_t>(i)] = embedding[static_cast<size_t>(i)] - weights.embedding_global_mean[static_cast<size_t>(i)];
         emb_norm_sq += centered[static_cast<size_t>(i)] * centered[static_cast<size_t>(i)];
     }
-    const float inv_emb_norm = 1.0f / std::sqrt(std::max(emb_norm_sq, kStatsEps));
+    const float inv_emb_norm = 1.0f / std::sqrt(std::max(emb_norm_sq, weights.stats_eps));
     std::vector<float> logits(static_cast<size_t>(class_count), 0.0f);
     for (int64_t cls = 0; cls < class_count; ++cls) {
-        const float * row = normalized_classifier_weight.data() + static_cast<size_t>(cls * kEmbeddingDim);
+        const float * row = normalized_classifier_weight.data() + static_cast<size_t>(cls * weights.embedding_dim);
         float dot = 0.0f;
-        for (int64_t i = 0; i < kEmbeddingDim; ++i) {
+        for (int64_t i = 0; i < weights.embedding_dim; ++i) {
             dot += centered[static_cast<size_t>(i)] * row[static_cast<size_t>(i)];
         }
         logits[static_cast<size_t>(cls)] = dot * inv_emb_norm;
@@ -801,7 +861,7 @@ EcapaClassifyResult classify_runtime_audio(
     const std::vector<std::string> & labels,
     const runtime::AudioBuffer & audio) {
     const auto start = Clock::now();
-    const size_t class_count = normalized_classifier_weight.size() / static_cast<size_t>(kEmbeddingDim);
+    const size_t class_count = normalized_classifier_weight.size() / static_cast<size_t>(weights.embedding_dim);
     if (class_count == 0) {
         throw std::runtime_error("classifier weights are missing from checkpoint");
     }
@@ -835,8 +895,11 @@ EcapaRuntime::EcapaRuntime(
     : weights_(require_weights(std::move(weights))),
       backend_weights_(load_backend_weights(*weights_, execution_context.backend(), execution_context.backend_type(), weight_storage_type)),
       labels_(std::move(labels)),
-      normalized_classifier_weight_(normalize_classifier_weights(*weights_)),
-      execution_context_(&execution_context) {}
+      execution_context_(&execution_context) {
+    if (!weights_->classifier_weight.empty()) {
+        normalized_classifier_weight_ = normalize_classifier_weights(*weights_);
+    }
+}
 
 EcapaRuntime::~EcapaRuntime() = default;
 
@@ -857,7 +920,7 @@ std::vector<float> EcapaRuntime::embed_features(const std::vector<float> & featu
     if (frames <= 0) {
         throw std::runtime_error("frames must be positive");
     }
-    if (features.size() != static_cast<size_t>(frames * kFeatureDim)) {
+    if (features.size() != static_cast<size_t>(frames * weights_->feature_dim)) {
         throw std::runtime_error("feature tensor size mismatch");
     }
     return ensure_graph(frames).run(features);

--- a/src/framework/modules/speech_encoders/wavlm_encoder.cpp
+++ b/src/framework/modules/speech_encoders/wavlm_encoder.cpp
@@ -501,7 +501,7 @@ std::vector<core::TensorValue> build_wavlm_graph_layers(
     }
     int64_t max_output_layer = 0;
     for (const int64_t layer : output_layers) {
-        if (layer <= 0 || layer > config.num_hidden_layers) {
+        if (layer < 0 || layer > config.num_hidden_layers) {
             throw std::runtime_error("WavLM output layer is out of range");
         }
         max_output_layer = std::max(max_output_layer, layer);
@@ -518,7 +518,12 @@ std::vector<core::TensorValue> build_wavlm_graph_layers(
             0,
             1,
             false}).build(ctx, hidden, conv1d_weights(weights, prefix + ".conv", false));
-        if (index == 0) {
+        if (config.conv_feature_layer_norm) {
+            hidden = transpose_bct_btc(ctx, hidden);
+            hidden = LayerNormModule({config.conv_dim[index], config.layer_norm_eps, true, true})
+                         .build(ctx, hidden, norm_weights(weights, prefix + ".layer_norm"));
+            hidden = transpose_bct_btc(ctx, hidden);
+        } else if (index == 0) {
             hidden = masked_group_norm_affine(
                 ctx,
                 hidden,
@@ -545,28 +550,49 @@ std::vector<core::TensorValue> build_wavlm_graph_layers(
         conv1d_weights(weights, "encoder.pos_conv_embed.conv", true),
         config);
     hidden = add_same(ctx, hidden, transpose_bct_btc(ctx, pos));
-    hidden = LayerNormModule({config.hidden_size, config.layer_norm_eps, true, true})
-                 .build(ctx, hidden, norm_weights(weights, "encoder.layer_norm"));
+    if (!config.transformer_layer_norm_first) {
+        hidden = LayerNormModule({config.hidden_size, config.layer_norm_eps, true, true})
+                     .build(ctx, hidden, norm_weights(weights, "encoder.layer_norm"));
+    }
     hidden = MaskingModule().build(ctx, hidden, token_mask);
 
     std::vector<core::TensorValue> outputs;
     outputs.reserve(output_layers.size());
+    if (std::find(output_layers.begin(), output_layers.end(), 0) != output_layers.end()) {
+        outputs.push_back(hidden);
+    }
     for (int64_t layer = 0; layer < max_output_layer; ++layer) {
         const std::string prefix = "encoder.layers." + std::to_string(layer);
-        auto attn = build_wavlm_self_attention(ctx, hidden, position_bias, attention_mask, weights, layer);
-        hidden = add_same(ctx, hidden, attn);
-        hidden = LayerNormModule({config.hidden_size, config.layer_norm_eps, true, true})
-                     .build(ctx, hidden, norm_weights(weights, prefix + ".self_attn_layer_norm"));
-        hidden = MaskingModule().build(ctx, hidden, token_mask);
-        const auto ff_in = hidden;
-        auto ff = build_feed_forward(ctx, hidden, weights, layer);
-        hidden = add_same(ctx, ff_in, ff);
-        hidden = LayerNormModule({config.hidden_size, config.layer_norm_eps, true, true})
-                     .build(ctx, hidden, norm_weights(weights, prefix + ".final_layer_norm"));
+        if (config.transformer_layer_norm_first) {
+            const auto attn_in = LayerNormModule({config.hidden_size, config.layer_norm_eps, true, true})
+                                     .build(ctx, hidden, norm_weights(weights, prefix + ".self_attn_layer_norm"));
+            hidden = add_same(ctx, hidden, build_wavlm_self_attention(ctx, attn_in, position_bias, attention_mask, weights, layer));
+            hidden = MaskingModule().build(ctx, hidden, token_mask);
+            const auto ff_in = LayerNormModule({config.hidden_size, config.layer_norm_eps, true, true})
+                                   .build(ctx, hidden, norm_weights(weights, prefix + ".final_layer_norm"));
+            hidden = add_same(ctx, hidden, build_feed_forward(ctx, ff_in, weights, layer));
+        } else {
+            auto attn = build_wavlm_self_attention(ctx, hidden, position_bias, attention_mask, weights, layer);
+            hidden = add_same(ctx, hidden, attn);
+            hidden = LayerNormModule({config.hidden_size, config.layer_norm_eps, true, true})
+                         .build(ctx, hidden, norm_weights(weights, prefix + ".self_attn_layer_norm"));
+            hidden = MaskingModule().build(ctx, hidden, token_mask);
+            const auto ff_in = hidden;
+            auto ff = build_feed_forward(ctx, hidden, weights, layer);
+            hidden = add_same(ctx, ff_in, ff);
+            hidden = LayerNormModule({config.hidden_size, config.layer_norm_eps, true, true})
+                         .build(ctx, hidden, norm_weights(weights, prefix + ".final_layer_norm"));
+        }
         hidden = MaskingModule().build(ctx, hidden, token_mask);
         const int64_t layer_index = layer + 1;
         if (std::find(output_layers.begin(), output_layers.end(), layer_index) != output_layers.end()) {
-            outputs.push_back(hidden);
+            if (config.transformer_layer_norm_first && layer_index == config.num_hidden_layers) {
+                outputs.push_back(
+                    LayerNormModule({config.hidden_size, config.layer_norm_eps, true, true})
+                        .build(ctx, hidden, norm_weights(weights, "encoder.layer_norm")));
+            } else {
+                outputs.push_back(hidden);
+            }
         }
     }
     return outputs;
@@ -647,7 +673,25 @@ public:
         }
         auto timing_start = Clock::now();
         std::vector<float> padded_input(static_cast<size_t>(sample_capacity_), 0.0F);
-        std::copy(input_values.begin(), input_values.end(), padded_input.begin());
+        if (weights_->config.normalize_input) {
+            double mean = 0.0;
+            for (const float value : input_values) {
+                mean += static_cast<double>(value);
+            }
+            mean /= static_cast<double>(input_values.size());
+            double variance = 0.0;
+            for (const float value : input_values) {
+                const double centered = static_cast<double>(value) - mean;
+                variance += centered * centered;
+            }
+            variance /= static_cast<double>(input_values.size());
+            const float inv_std = 1.0F / std::sqrt(static_cast<float>(variance) + weights_->config.layer_norm_eps);
+            for (size_t i = 0; i < input_values.size(); ++i) {
+                padded_input[i] = (input_values[i] - static_cast<float>(mean)) * inv_std;
+            }
+        } else {
+            std::copy(input_values.begin(), input_values.end(), padded_input.begin());
+        }
         core::write_tensor_f32(input_, padded_input);
         engine::debug::timing_log_scalar("framework.wavlm.input_upload_ms", engine::debug::elapsed_ms(timing_start));
         timing_start = Clock::now();
@@ -912,6 +956,20 @@ WavlmEncoderComponent WavlmEncoderComponent::load_from_tensor_source(
             "feature_extractor.conv_layers." + std::to_string(i) + ".conv.weight",
             "feature_extractor.conv_layers." + std::to_string(i) + ".0.weight",
             {config_ref.conv_dim[static_cast<size_t>(i)], config_ref.conv_dim[static_cast<size_t>(i - 1)], config_ref.conv_kernel[static_cast<size_t>(i)]});
+        if (config_ref.conv_feature_layer_norm) {
+            load_tensor_alias(
+                *weights,
+                source,
+                "feature_extractor.conv_layers." + std::to_string(i) + ".layer_norm.weight",
+                "feature_extractor.conv_layers." + std::to_string(i) + ".2.weight",
+                {config_ref.conv_dim[static_cast<size_t>(i)]});
+            load_tensor_alias(
+                *weights,
+                source,
+                "feature_extractor.conv_layers." + std::to_string(i) + ".layer_norm.bias",
+                "feature_extractor.conv_layers." + std::to_string(i) + ".2.bias",
+                {config_ref.conv_dim[static_cast<size_t>(i)]});
+        }
     }
     load_tensor_alias(*weights, source, "feature_projection.layer_norm.weight", "layer_norm.weight", {config_ref.conv_dim.back()});
     load_tensor_alias(*weights, source, "feature_projection.layer_norm.bias", "layer_norm.bias", {config_ref.conv_dim.back()});

--- a/src/framework/runtime/flow_kv_cache.cpp
+++ b/src/framework/runtime/flow_kv_cache.cpp
@@ -1,0 +1,180 @@
+#include "engine/framework/runtime/flow_kv_cache.h"
+
+#include <algorithm>
+#include <cstring>
+#include <stdexcept>
+
+namespace engine::runtime {
+
+namespace {
+
+void validate_cache_type(ggml_type type) {
+    if (type == GGML_TYPE_F32 || type == GGML_TYPE_F16 || type == GGML_TYPE_BF16) {
+        return;
+    }
+    throw std::runtime_error("RollingFlowKVCache supports only f32/f16/bf16 cache storage");
+}
+
+std::vector<std::byte> float_values_to_bytes(const std::vector<float> & values, ggml_type type) {
+    validate_cache_type(type);
+    if (type == GGML_TYPE_F32) {
+        std::vector<std::byte> bytes(values.size() * sizeof(float));
+        std::memcpy(bytes.data(), values.data(), bytes.size());
+        return bytes;
+    }
+    if (type == GGML_TYPE_F16) {
+        std::vector<ggml_fp16_t> converted(values.size());
+        ggml_fp32_to_fp16_row(values.data(), converted.data(), static_cast<int64_t>(values.size()));
+        std::vector<std::byte> bytes(converted.size() * sizeof(ggml_fp16_t));
+        std::memcpy(bytes.data(), converted.data(), bytes.size());
+        return bytes;
+    }
+    std::vector<ggml_bf16_t> converted(values.size());
+    ggml_fp32_to_bf16_row(values.data(), converted.data(), static_cast<int64_t>(values.size()));
+    std::vector<std::byte> bytes(converted.size() * sizeof(ggml_bf16_t));
+    std::memcpy(bytes.data(), converted.data(), bytes.size());
+    return bytes;
+}
+
+}  // namespace
+
+RollingFlowKVCache::RollingFlowKVCache(
+    const std::vector<int64_t> & layer_capacities,
+    int64_t step_values) {
+    reset(layer_capacities, step_values);
+}
+
+RollingFlowKVCache::RollingFlowKVCache(
+    const std::vector<int64_t> & layer_capacities,
+    int64_t step_values,
+    ggml_type type) {
+    reset(layer_capacities, step_values, type);
+}
+
+void RollingFlowKVCache::reset(
+    const std::vector<int64_t> & layer_capacities,
+    int64_t step_values) {
+    reset(layer_capacities, step_values, GGML_TYPE_F32);
+}
+
+void RollingFlowKVCache::reset(
+    const std::vector<int64_t> & layer_capacities,
+    int64_t step_values,
+    ggml_type type) {
+    validate_cache_type(type);
+    if (step_values <= 0) {
+        throw std::runtime_error("RollingFlowKVCache requires positive step values");
+    }
+    layers_.resize(layer_capacities.size());
+    for (size_t i = 0; i < layer_capacities.size(); ++i) {
+        const int64_t capacity = layer_capacities[i];
+        if (capacity <= 0) {
+            throw std::runtime_error("RollingFlowKVCache requires positive layer capacity");
+        }
+        auto & layer = layers_[i];
+        layer.type = type;
+        layer.capacity_steps = capacity;
+        layer.step_values = step_values;
+        layer.step_bytes = static_cast<size_t>(step_values) * ggml_type_size(type);
+        layer.valid_steps = 0;
+        layer.key_bytes.assign(static_cast<size_t>(capacity) * layer.step_bytes, std::byte{0});
+        layer.value_bytes.assign(static_cast<size_t>(capacity) * layer.step_bytes, std::byte{0});
+    }
+}
+
+void RollingFlowKVCache::clear_valid_steps() {
+    for (auto & layer : layers_) {
+        std::fill(layer.key_bytes.begin(), layer.key_bytes.end(), std::byte{0});
+        std::fill(layer.value_bytes.begin(), layer.value_bytes.end(), std::byte{0});
+        layer.valid_steps = 0;
+    }
+}
+
+const FlowKVLayerCache & RollingFlowKVCache::layer(size_t index) const {
+    if (index >= layers_.size()) {
+        throw std::runtime_error("RollingFlowKVCache layer index is out of range");
+    }
+    return layers_[index];
+}
+
+FlowKVLayerCache & RollingFlowKVCache::layer(size_t index) {
+    if (index >= layers_.size()) {
+        throw std::runtime_error("RollingFlowKVCache layer index is out of range");
+    }
+    return layers_[index];
+}
+
+void RollingFlowKVCache::append_tail(
+    size_t layer_index,
+    const std::vector<float> & current_key,
+    const std::vector<float> & current_value,
+    int64_t current_steps,
+    int64_t append_steps,
+    const std::string & label) {
+    auto & cache = layer(layer_index);
+    append_tail_bytes(
+        layer_index,
+        float_values_to_bytes(current_key, cache.type),
+        float_values_to_bytes(current_value, cache.type),
+        current_steps,
+        append_steps,
+        label);
+}
+
+void RollingFlowKVCache::append_tail_bytes(
+    size_t layer_index,
+    const std::vector<std::byte> & current_key,
+    const std::vector<std::byte> & current_value,
+    int64_t current_steps,
+    int64_t append_steps,
+    const std::string & label) {
+    auto & cache = layer(layer_index);
+    if (current_steps <= 0 || append_steps <= 0 || append_steps > current_steps) {
+        throw std::runtime_error(label + " received invalid KV append size");
+    }
+    const size_t current_bytes = static_cast<size_t>(current_steps) * cache.step_bytes;
+    if (current_key.size() != current_bytes || current_value.size() != current_bytes) {
+        throw std::runtime_error(label + " current KV shape mismatch");
+    }
+
+    std::vector<std::byte> logical_key;
+    std::vector<std::byte> logical_value;
+    logical_key.reserve(static_cast<size_t>(cache.valid_steps + append_steps) * cache.step_bytes);
+    logical_value.reserve(logical_key.capacity());
+
+    const int64_t start = cache.capacity_steps - cache.valid_steps;
+    for (int64_t step = start; step < cache.capacity_steps; ++step) {
+        const auto byte_offset = static_cast<std::ptrdiff_t>(static_cast<size_t>(step) * cache.step_bytes);
+        const auto key_begin = cache.key_bytes.begin() + byte_offset;
+        logical_key.insert(logical_key.end(), key_begin, key_begin + static_cast<std::ptrdiff_t>(cache.step_bytes));
+        const auto value_begin = cache.value_bytes.begin() + byte_offset;
+        logical_value.insert(logical_value.end(), value_begin, value_begin + static_cast<std::ptrdiff_t>(cache.step_bytes));
+    }
+
+    logical_key.insert(
+        logical_key.end(),
+        current_key.begin(),
+        current_key.begin() + static_cast<std::ptrdiff_t>(static_cast<size_t>(append_steps) * cache.step_bytes));
+    logical_value.insert(
+        logical_value.end(),
+        current_value.begin(),
+        current_value.begin() + static_cast<std::ptrdiff_t>(static_cast<size_t>(append_steps) * cache.step_bytes));
+
+    const int64_t new_valid = std::min<int64_t>(
+        cache.capacity_steps,
+        static_cast<int64_t>(logical_key.size() / cache.step_bytes));
+    cache.valid_steps = new_valid;
+    std::fill(cache.key_bytes.begin(), cache.key_bytes.end(), std::byte{0});
+    std::fill(cache.value_bytes.begin(), cache.value_bytes.end(), std::byte{0});
+    const size_t copy_bytes = static_cast<size_t>(new_valid) * cache.step_bytes;
+    std::copy(
+        logical_key.end() - static_cast<std::ptrdiff_t>(copy_bytes),
+        logical_key.end(),
+        cache.key_bytes.end() - static_cast<std::ptrdiff_t>(copy_bytes));
+    std::copy(
+        logical_value.end() - static_cast<std::ptrdiff_t>(copy_bytes),
+        logical_value.end(),
+        cache.value_bytes.end() - static_cast<std::ptrdiff_t>(copy_bytes));
+}
+
+}  // namespace engine::runtime


### PR DESCRIPTION
## Summary
- add reusable framework flow sampler runtime and flow KV cache
- add framework tensor read/write helpers for native float/byte transfers
- extend Kaldi fbank, ECAPA, and WavLM framework runtime configuration used by upcoming model work
- wire new framework sources into engine_core only

## Validation
- cmake --build build/debug --target audiocpp_cli -j$(nproc)