### PR TITLE
ace_step: support the ACE-Step 1.5 XL DiT variants

### DIFF
--- a/app/gguf/main.cpp
+++ b/app/gguf/main.cpp
@@ -314,6 +314,19 @@ std::vector<std::string> validate_candidate(const PackageSpecCandidate & candida
             (void)unused;
             expected_prefixes.insert(tensor_prefix(value));
         }
+        // A namespace in `optional_tensors` is one the family's packages may or
+        // may not ship — an ACE-Step XL DiT against a turbo-only package. It
+        // cannot be required of every conversion, but a conversion that does
+        // supply it is building exactly the package the spec describes, so it
+        // is not unexpected either.
+        std::set<std::string> optional_prefixes;
+        if (const auto * optional_tensors = source.find("optional_tensors");
+            optional_tensors != nullptr && !optional_tensors->is_null()) {
+            for (const auto & [unused, value] : optional_tensors->as_object()) {
+                (void)unused;
+                optional_prefixes.insert(tensor_prefix(value));
+            }
+        }
         for (const auto & prefix : expected_prefixes) {
             if (actual_prefixes.find(prefix) == actual_prefixes.end()) {
                 errors.push_back("missing tensor namespace '" + (prefix.empty() ? std::string("<root>") : prefix) +
@@ -321,7 +334,8 @@ std::vector<std::string> validate_candidate(const PackageSpecCandidate & candida
             }
         }
         for (const auto & prefix : actual_prefixes) {
-            if (expected_prefixes.find(prefix) == expected_prefixes.end()) {
+            if (expected_prefixes.find(prefix) == expected_prefixes.end() &&
+                optional_prefixes.find(prefix) == optional_prefixes.end()) {
                 errors.push_back("unexpected tensor namespace '" + (prefix.empty() ? std::string("<root>") : prefix) +
                                  "'");
             }

--- a/docs/models/ace_step.md
+++ b/docs/models/ace_step.md
@@ -210,17 +210,21 @@ before. Selecting one that is not installed reports which directory is missing.
 The upstream snapshots ship four safetensors shards plus a
 `model.safetensors.index.json`, which the package spec points at directly.
 
-`ace_step_xl_turbo_bf16` installs the XL Turbo GGUF (14.2 GB), which is
-self-contained the way the Turbo and Base GGUFs are — XL DiT, planner LM, text
-encoder and VAE in one file:
+The two differ only in `is_turbo`: XL Turbo is guidance-distilled and ignores
+`guidance_scale`, XL SFT takes the CFG path the way `acestep-v15-base` does.
+Their dimensions, encoder group and head configuration are identical.
+
+`ace_step_xl_turbo_bf16` and `ace_step_xl_sft_bf16` install them as GGUFs
+(14.2 GB each), self-contained the way the Turbo and Base GGUFs are — XL DiT,
+planner LM, text encoder and VAE in one file:
 
 ```bash
 audiocpp_cli --task gen --family ace_step --model models/ACE-Step1.5-GGUF/xl-turbo --backend cuda --task-route text2music --text "warm lo-fi hip hop with a soft rhodes piano" --duration-seconds 60 --load-option ace_step.dit_model_path=acestep-v15-xl-turbo --out song.wav
 ```
 
-`acestep-v15-xl-sft` has no GGUF package yet; run it from a safetensors tree.
-There, `dit_weight_type=bf16` is worth passing — the XL snapshots are stored in
-float32, so `native` puts 19.9 GB of weights on the card:
+Running one from a safetensors tree instead is worth a `dit_weight_type=bf16`,
+because the XL snapshots are stored in float32 and `native` puts 19.9 GB of
+weights on the card:
 
 ```bash
 audiocpp_cli --task gen --family ace_step --model models/Ace-Step1.5 --backend cuda --task-route text2music --text "warm lo-fi hip hop with a soft rhodes piano" --duration-seconds 60 --load-option ace_step.dit_model_path=acestep-v15-xl-sft --session-option ace_step.dit_weight_type=bf16 --out song.wav
@@ -228,10 +232,10 @@ audiocpp_cli --task gen --family ace_step --model models/Ace-Step1.5 --backend c
 
 Measured on an RTX 5090, 20 s of audio, weight loading included and the weights
 warm in the page cache: 87 s from safetensors at `native`, 25 s from safetensors
-at `bf16`, 15 s from the bf16 GGUF (turbo, for reference: 11 s). Reading the
-weights off disk adds roughly 10 s either way.
+at `bf16`, 15 s from the bf16 GGUF, both variants alike (turbo, for reference:
+11 s). Reading the weights off disk adds roughly 10 s either way.
 
-Building the XL GGUF yourself needs the other variants' safetensors on hand,
+Building an XL GGUF yourself needs the other variants' safetensors on hand,
 because `audiocpp_gguf` checks the conversion against the spec's required
 namespaces; exclude them from the output:
 
@@ -249,3 +253,8 @@ audiocpp_gguf --root models/Ace-Step1.5 --family ace_step \
   --exclude-prefix dit_turbo_ --exclude-prefix dit_base_ \
   --type bf16 --output ace-step-1.5-xl-turbo-bf16.gguf
 ```
+
+Swap `dit_xl_turbo_*` for `dit_xl_sft_*` to build the SFT one. Upstream ships
+`silence_latent.pt` where the spec wants safetensors;
+`tests/ace_step/convert_silence_latent.py --input <variant>/silence_latent.pt`
+converts it.

--- a/docs/models/ace_step.md
+++ b/docs/models/ace_step.md
@@ -16,6 +16,7 @@ audiocpp_cli --task gen --family ace_step --model models/Ace-Step1.5 --backend c
 | Model directory | `models/Ace-Step1.5` |
 | Task | `gen` |
 | Default DiT | `acestep-v15-turbo` |
+| Optional DiT | `acestep-v15-xl-turbo`, `acestep-v15-xl-sft` |
 | Default LM | `acestep-5Hz-lm-1.7B` |
 | Prompt input | `--text` |
 | Lyrics input | `--lyrics` |
@@ -183,7 +184,7 @@ audiocpp_cli --task gen --family ace_step --model models/Ace-Step1.5 --backend c
 
 | Option | Values | Default | Meaning |
 |---|---|---:|---|
-| `--load-option ace_step.dit_model_path=<dir>` | `acestep-v15-turbo`, `acestep-v15-base` | `acestep-v15-turbo` | Select DiT variant inside the model root. |
+| `--load-option ace_step.dit_model_path=<dir>` | `acestep-v15-turbo`, `acestep-v15-base`, `acestep-v15-xl-turbo`, `acestep-v15-xl-sft` | `acestep-v15-turbo` | Select DiT variant inside the model root. |
 | `--session-option ace_step.dit_weight_type=<type>` | `native`, `f32`, `f16`, `bf16`, `q8_0` | `native` | DiT weight type. |
 | `--session-option ace_step.planner_weight_type=<type>` | `native`, `f32`, `f16`, `bf16`, `q8_0` | `native` | Planner LM weight type. |
 | `--session-option ace_step.mem_saver=true\|false` | bool | `false` | Release staged graph/cache state after request phases to reduce resident VRAM. Later requests may rebuild released graphs. |
@@ -191,3 +192,27 @@ audiocpp_cli --task gen --family ace_step --model models/Ace-Step1.5 --backend c
 ACE-Step GGUF packages are variant-specific. Use the Turbo GGUF for the default
 `acestep-v15-turbo` path, and pass `--load-option ace_step.dit_model_path=acestep-v15-base`
 when loading a Base GGUF package.
+
+### XL variants
+
+`acestep-v15-xl-turbo` and `acestep-v15-xl-sft` are the larger DiT: 32 layers of
+2560 against turbo's 24 of 2048, with 32 attention heads of 128 (so the attention
+width is 4096, wider than the model). The condition encoder, audio tokenizer and
+detokenizer stay at 2048 — the `encoder_hidden_size` group in the XL config — and
+the DiT's condition embedder bridges the two. The XL timbre encoder also prepends
+a CLS token to the reference frames and reads that position back, where earlier
+variants read the first audio frame.
+
+Both are **optional package resources**: they are only loadable when their
+directory is present, and a package without them loads and runs exactly as
+before. Selecting one that is not installed reports which directory is missing.
+The upstream snapshots ship four safetensors shards plus a
+`model.safetensors.index.json`, which the package spec points at directly.
+
+```bash
+audiocpp_cli --task gen --family ace_step --model models/Ace-Step1.5 --backend cuda --task-route text2music --text "warm lo-fi hip hop with a soft rhodes piano" --duration-seconds 60 --load-option ace_step.dit_model_path=acestep-v15-xl-turbo --session-option ace_step.dit_weight_type=bf16 --out song.wav
+```
+
+`dit_weight_type=bf16` is worth passing. The XL snapshots are stored in float32,
+so `native` puts 19.9 GB of weights on the card: measured on an RTX 5090, 20 s of
+audio took 87 s at `native` against 24 s at `bf16` (turbo, for reference: 11 s).

--- a/docs/models/ace_step.md
+++ b/docs/models/ace_step.md
@@ -191,7 +191,8 @@ audiocpp_cli --task gen --family ace_step --model models/Ace-Step1.5 --backend c
 
 ACE-Step GGUF packages are variant-specific. Use the Turbo GGUF for the default
 `acestep-v15-turbo` path, and pass `--load-option ace_step.dit_model_path=acestep-v15-base`
-when loading a Base GGUF package.
+when loading a Base GGUF package, or
+`--load-option ace_step.dit_model_path=acestep-v15-xl-turbo` for the XL Turbo one.
 
 ### XL variants
 
@@ -204,15 +205,47 @@ a CLS token to the reference frames and reads that position back, where earlier
 variants read the first audio frame.
 
 Both are **optional package resources**: they are only loadable when their
-directory is present, and a package without them loads and runs exactly as
+weights are present, and a package without them loads and runs exactly as
 before. Selecting one that is not installed reports which directory is missing.
 The upstream snapshots ship four safetensors shards plus a
 `model.safetensors.index.json`, which the package spec points at directly.
 
+`ace_step_xl_turbo_bf16` installs the XL Turbo GGUF (14.2 GB), which is
+self-contained the way the Turbo and Base GGUFs are — XL DiT, planner LM, text
+encoder and VAE in one file:
+
 ```bash
-audiocpp_cli --task gen --family ace_step --model models/Ace-Step1.5 --backend cuda --task-route text2music --text "warm lo-fi hip hop with a soft rhodes piano" --duration-seconds 60 --load-option ace_step.dit_model_path=acestep-v15-xl-turbo --session-option ace_step.dit_weight_type=bf16 --out song.wav
+audiocpp_cli --task gen --family ace_step --model models/ACE-Step1.5-GGUF/xl-turbo --backend cuda --task-route text2music --text "warm lo-fi hip hop with a soft rhodes piano" --duration-seconds 60 --load-option ace_step.dit_model_path=acestep-v15-xl-turbo --out song.wav
 ```
 
-`dit_weight_type=bf16` is worth passing. The XL snapshots are stored in float32,
-so `native` puts 19.9 GB of weights on the card: measured on an RTX 5090, 20 s of
-audio took 87 s at `native` against 24 s at `bf16` (turbo, for reference: 11 s).
+`acestep-v15-xl-sft` has no GGUF package yet; run it from a safetensors tree.
+There, `dit_weight_type=bf16` is worth passing — the XL snapshots are stored in
+float32, so `native` puts 19.9 GB of weights on the card:
+
+```bash
+audiocpp_cli --task gen --family ace_step --model models/Ace-Step1.5 --backend cuda --task-route text2music --text "warm lo-fi hip hop with a soft rhodes piano" --duration-seconds 60 --load-option ace_step.dit_model_path=acestep-v15-xl-sft --session-option ace_step.dit_weight_type=bf16 --out song.wav
+```
+
+Measured on an RTX 5090, 20 s of audio, weight loading included and the weights
+warm in the page cache: 87 s from safetensors at `native`, 25 s from safetensors
+at `bf16`, 15 s from the bf16 GGUF (turbo, for reference: 11 s). Reading the
+weights off disk adds roughly 10 s either way.
+
+Building the XL GGUF yourself needs the other variants' safetensors on hand,
+because `audiocpp_gguf` checks the conversion against the spec's required
+namespaces; exclude them from the output:
+
+```bash
+audiocpp_gguf --root models/Ace-Step1.5 --family ace_step \
+  --input dit_turbo_weights=models/Ace-Step1.5/acestep-v15-turbo/model.safetensors \
+  --input dit_turbo_silence_latent=models/Ace-Step1.5/acestep-v15-turbo/silence_latent.safetensors \
+  --input dit_base_weights=models/Ace-Step1.5/acestep-v15-base/model.safetensors \
+  --input dit_base_silence_latent=models/Ace-Step1.5/acestep-v15-base/silence_latent.safetensors \
+  --input dit_xl_turbo_weights=models/Ace-Step1.5/acestep-v15-xl-turbo/model.safetensors.index.json \
+  --input dit_xl_turbo_silence_latent=models/Ace-Step1.5/acestep-v15-xl-turbo/silence_latent.safetensors \
+  --input lm_weights=models/Ace-Step1.5/acestep-5Hz-lm-1.7B/model.safetensors \
+  --input text_encoder_weights=models/Ace-Step1.5/Qwen3-Embedding-0.6B/model.safetensors \
+  --input vae_weights=models/Ace-Step1.5/vae/diffusion_pytorch_model.safetensors \
+  --exclude-prefix dit_turbo_ --exclude-prefix dit_base_ \
+  --type bf16 --output ace-step-1.5-xl-turbo-bf16.gguf
+```

--- a/include/engine/models/ace_step/assets.h
+++ b/include/engine/models/ace_step/assets.h
@@ -75,6 +75,18 @@ struct AceStepDiffusionConfig {
     int64_t sliding_window = 0;
     bool use_sliding_window = false;
     bool is_turbo = true;
+    // XL packages size the condition encoder, audio tokenizer and detokenizer
+    // independently of the DiT (2048 against 2560), which upstream expresses by
+    // handing those submodules a copy of the config with the encoder_* values
+    // substituted. The same copy lives in AceStepConfig::encoder, and this flag
+    // marks the two configs as genuinely different so the code that has to
+    // bridge them — the condition embedder, the cross-attention KV — can say so.
+    bool has_separate_encoder = false;
+    // XL's timbre encoder prepends a CLS token to the reference frames and reads
+    // position 0 back as the timbre embedding; the pre-XL class carries the same
+    // parameter but leaves that line commented out, so the tensor's presence says
+    // nothing and the config has to.
+    bool timbre_special_token = false;
     float rms_norm_eps = 1.0e-6F;
     float rope_theta = 1000000.0F;
     std::vector<int64_t> fsq_input_levels;
@@ -94,7 +106,12 @@ struct AceStepVAEConfig {
 struct AceStepConfig {
     AceStepPlannerConfig planner;
     AceStepTextEncoderConfig text_encoder;
+    // The DiT itself.
     AceStepDiffusionConfig diffusion;
+    // Everything that feeds it: the condition encoder, the audio tokenizer and
+    // the detokenizer. Identical to `diffusion` except for the four attention and
+    // MLP dimensions, and identical outright on packages that do not split them.
+    AceStepDiffusionConfig encoder;
     AceStepVAEConfig vae;
 };
 

--- a/include/engine/models/ace_step/dit_weights_runtime.h
+++ b/include/engine/models/ace_step/dit_weights_runtime.h
@@ -59,6 +59,8 @@ struct AceStepConditionEncoderWeights {
     core::TensorValue timbre_embed_bias;
     std::vector<AceStepConditionEncoderLayerWeights> timbre_layers;
     core::TensorValue timbre_norm;
+    // Empty unless the variant prepends a CLS token to the timbre sequence.
+    std::vector<float> timbre_special_token_host;
 };
 
 struct AceStepTimeEmbeddingWeights {

--- a/model_specs/ace_step.json
+++ b/model_specs/ace_step.json
@@ -119,6 +119,28 @@
         "text_encoder_chat_template": "model:Qwen3-Embedding-0.6B/chat_template.jinja",
         "vae_config": "model:vae/config.json"
       },
+      "optional_files": {
+        "dit_xl_turbo_config": "model:acestep-v15-xl-turbo/config.json",
+        "dit_xl_sft_config": "model:acestep-v15-xl-sft/config.json"
+      },
+      "optional_tensors": {
+        "dit_xl_turbo_weights": {
+          "source": "weights:",
+          "prefix": "dit_xl_turbo_weights"
+        },
+        "dit_xl_turbo_silence_latent": {
+          "source": "weights:",
+          "prefix": "dit_xl_turbo_silence_latent"
+        },
+        "dit_xl_sft_weights": {
+          "source": "weights:",
+          "prefix": "dit_xl_sft_weights"
+        },
+        "dit_xl_sft_silence_latent": {
+          "source": "weights:",
+          "prefix": "dit_xl_sft_silence_latent"
+        }
+      },
       "tensors": {
         "dit_turbo_weights": {
           "source": "weights:",
@@ -171,6 +193,16 @@
         "text_encoder_tokenizer_json": "model:Qwen3-Embedding-0.6B/tokenizer.json",
         "text_encoder_chat_template": "model:Qwen3-Embedding-0.6B/chat_template.jinja",
         "vae_config": "model:vae/config.json"
+      },
+      "optional_files": {
+        "dit_xl_turbo_config": "model:acestep-v15-xl-turbo/config.json",
+        "dit_xl_sft_config": "model:acestep-v15-xl-sft/config.json"
+      },
+      "optional_tensors": {
+        "dit_xl_turbo_weights": "model:acestep-v15-xl-turbo/model.safetensors.index.json",
+        "dit_xl_turbo_silence_latent": "model:acestep-v15-xl-turbo/silence_latent.safetensors",
+        "dit_xl_sft_weights": "model:acestep-v15-xl-sft/model.safetensors.index.json",
+        "dit_xl_sft_silence_latent": "model:acestep-v15-xl-sft/silence_latent.safetensors"
       },
       "tensors": {
         "dit_turbo_weights": "model:acestep-v15-turbo/model.safetensors",

--- a/model_specs/ace_step.json
+++ b/model_specs/ace_step.json
@@ -93,6 +93,21 @@
         "ACE-Step1.5-GGUF/base/ace-step-1.5-base-bf16.gguf"
       ],
       "strip_prefix": "ACE-Step1.5-GGUF"
+    },
+    {
+      "id": "ace_step_xl_turbo_bf16",
+      "display_name": "ACE-Step 1.5 XL Turbo BF16 GGUF",
+      "format": "gguf",
+      "precision": "bf16",
+      "target_directory": "ACE-Step1.5-GGUF",
+      "files": [
+        "ACE-Step1.5-GGUF/xl-turbo/ace-step-1.5-xl-turbo-bf16.gguf"
+      ],
+      "strip_prefix": "ACE-Step1.5-GGUF",
+      "download": {
+        "kind": "huggingface_snapshot",
+        "repo": "CaptainArni/audio.cpp-gguf"
+      }
     }
   ],
   "sources": [

--- a/model_specs/ace_step.json
+++ b/model_specs/ace_step.json
@@ -108,6 +108,21 @@
         "kind": "huggingface_snapshot",
         "repo": "CaptainArni/audio.cpp-gguf"
       }
+    },
+    {
+      "id": "ace_step_xl_sft_bf16",
+      "display_name": "ACE-Step 1.5 XL SFT BF16 GGUF",
+      "format": "gguf",
+      "precision": "bf16",
+      "target_directory": "ACE-Step1.5-GGUF",
+      "files": [
+        "ACE-Step1.5-GGUF/xl-sft/ace-step-1.5-xl-sft-bf16.gguf"
+      ],
+      "strip_prefix": "ACE-Step1.5-GGUF",
+      "download": {
+        "kind": "huggingface_snapshot",
+        "repo": "CaptainArni/audio.cpp-gguf"
+      }
     }
   ],
   "sources": [

--- a/model_specs_v1/ace_step.json
+++ b/model_specs_v1/ace_step.json
@@ -305,10 +305,12 @@
       {
         "name": "dit_variant",
         "type": "enum",
-        "description": "DiT variant inside the model package; default acestep-v15-turbo.",
+        "description": "DiT variant inside the model package; default acestep-v15-turbo. The XL variants are optional package resources and are only selectable when installed.",
         "values": [
           "acestep-v15-turbo",
-          "acestep-v15-base"
+          "acestep-v15-base",
+          "acestep-v15-xl-turbo",
+          "acestep-v15-xl-sft"
         ],
         "required": false,
         "default": "acestep-v15-turbo"
@@ -343,6 +345,28 @@
         "text_encoder_tokenizer_json": "model:Qwen3-Embedding-0.6B/tokenizer.json",
         "text_encoder_chat_template": "model:Qwen3-Embedding-0.6B/chat_template.jinja",
         "vae_config": "model:vae/config.json"
+      },
+      "optional_files": {
+        "dit_xl_turbo_config": "model:acestep-v15-xl-turbo/config.json",
+        "dit_xl_sft_config": "model:acestep-v15-xl-sft/config.json"
+      },
+      "optional_tensors": {
+        "dit_xl_turbo_weights": {
+          "source": "weights:",
+          "prefix": "dit_xl_turbo_weights"
+        },
+        "dit_xl_turbo_silence_latent": {
+          "source": "weights:",
+          "prefix": "dit_xl_turbo_silence_latent"
+        },
+        "dit_xl_sft_weights": {
+          "source": "weights:",
+          "prefix": "dit_xl_sft_weights"
+        },
+        "dit_xl_sft_silence_latent": {
+          "source": "weights:",
+          "prefix": "dit_xl_sft_silence_latent"
+        }
       },
       "tensors": {
         "dit_turbo_weights": {
@@ -396,6 +420,16 @@
         "text_encoder_tokenizer_json": "model:Qwen3-Embedding-0.6B/tokenizer.json",
         "text_encoder_chat_template": "model:Qwen3-Embedding-0.6B/chat_template.jinja",
         "vae_config": "model:vae/config.json"
+      },
+      "optional_files": {
+        "dit_xl_turbo_config": "model:acestep-v15-xl-turbo/config.json",
+        "dit_xl_sft_config": "model:acestep-v15-xl-sft/config.json"
+      },
+      "optional_tensors": {
+        "dit_xl_turbo_weights": "model:acestep-v15-xl-turbo/model.safetensors.index.json",
+        "dit_xl_turbo_silence_latent": "model:acestep-v15-xl-turbo/silence_latent.safetensors",
+        "dit_xl_sft_weights": "model:acestep-v15-xl-sft/model.safetensors.index.json",
+        "dit_xl_sft_silence_latent": "model:acestep-v15-xl-sft/silence_latent.safetensors"
       },
       "tensors": {
         "dit_turbo_weights": "model:acestep-v15-turbo/model.safetensors",

--- a/src/framework/model_spec/package.cpp
+++ b/src/framework/model_spec/package.cpp
@@ -316,6 +316,27 @@ void add_tensor_map(assets::ResourceBundle & bundle,
     }
 }
 
+// Tensor sources a package may or may not ship. The required `tensors` map is
+// checked eagerly, which is what a package wants for the weights it cannot run
+// without; a family whose variants are separate multi-gigabyte downloads needs
+// the other answer, or installing one variant means downloading all of them.
+// A model that selects a missing variant reports it itself, where it can name
+// the variant instead of a resource id.
+void add_optional_tensor_map(assets::ResourceBundle & bundle,
+    const ResourceRoots & roots,
+    const engine::io::json::Value * map_value) {
+    if (map_value == nullptr || map_value->is_null()) {
+        return;
+    }
+    for (const auto & [id, ref] : map_value->as_object()) {
+        std::string prefix;
+        const auto path = resolve_tensor_source_ref(roots, ref, prefix);
+        if (engine::io::is_existing_file(path)) {
+            bundle.add_tensor_source(id, path, std::move(prefix));
+        }
+    }
+}
+
 void add_optional_resource_map(assets::ResourceBundle & bundle, const ResourceRoots & roots,
     const engine::io::json::Value * map_value) {
     if (map_value == nullptr || map_value->is_null()) {
@@ -354,6 +375,7 @@ assets::ResourceBundle load_source(const std::filesystem::path & model_root, con
     add_resource_map(bundle, roots, source.find("files"));
     add_optional_resource_map(bundle, roots, source.find("optional_files"));
     add_tensor_map(bundle, roots, source.find("tensors"));
+    add_optional_tensor_map(bundle, roots, source.find("optional_tensors"));
     return bundle;
 }
 
@@ -362,10 +384,9 @@ std::vector<assets::ResourceFile> discover_safetensors_source_resources(const en
     const ResourceRoots & roots) {
     auto resources = resources_from_resource_map(
         roots, source.find(kind == ResourceKind::Files ? "files" : "tensors"), true);
-    if (kind == ResourceKind::Files) {
-        auto optional = resources_from_resource_map(roots, source.find("optional_files"), false);
-        resources.insert(resources.end(), optional.begin(), optional.end());
-    }
+    auto optional = resources_from_resource_map(
+        roots, source.find(kind == ResourceKind::Files ? "optional_files" : "optional_tensors"), false);
+    resources.insert(resources.end(), optional.begin(), optional.end());
     return resources;
 }
 

--- a/src/framework/model_spec/schema.cpp
+++ b/src/framework/model_spec/schema.cpp
@@ -485,7 +485,7 @@ void validate_layout(const json::Value & value, std::string_view path) {
         }
         (void) require_spec_string(root_value, std::string(path) + ".roots." + root_id);
     }
-    for (const std::string map_name : {"files", "optional_files", "tensors"}) {
+    for (const std::string map_name : {"files", "optional_files", "tensors", "optional_tensors"}) {
         const auto * map_value = value.find(map_name);
         if (map_value == nullptr) {
             continue;

--- a/src/models/ace_step/assets.cpp
+++ b/src/models/ace_step/assets.cpp
@@ -101,8 +101,35 @@ AceStepDiffusionConfig parse_diffusion_config(const engine::io::json::Value & va
     config.use_sliding_window = json::optional_bool(value, "use_sliding_window", false);
     config.layer_types = json::optional_string_array(value, "layer_types");
     config.is_turbo = json::optional_bool(value, "is_turbo", config.is_turbo);
+    // `encoder_hidden_size` is what upstream's XL modeling class reads without a
+    // fallback, so a config that declares it is an XL-class package: the encoder
+    // stack is a different width from the DiT, and the timbre encoder is the
+    // variant that actually uses its CLS token.
+    config.has_separate_encoder = value.find("encoder_hidden_size") != nullptr;
+    config.timbre_special_token = config.has_separate_encoder;
     config.rms_norm_eps = json::optional_f32(value, "rms_norm_eps", config.rms_norm_eps);
     config.rope_theta = json::optional_f32(value, "rope_theta", config.rope_theta);
+    return config;
+}
+
+// Upstream builds the condition encoder, audio tokenizer and detokenizer from a
+// copy of the config with four values substituted (copy.deepcopy in
+// AceStepConditionGenerationModel.__init__). Doing the same here keeps every
+// encoder-side shape derived from one place instead of spreading `is this XL?`
+// across the weight loaders.
+AceStepDiffusionConfig derive_encoder_config(
+    const AceStepDiffusionConfig & diffusion,
+    const engine::io::json::Value & value) {
+    AceStepDiffusionConfig config = diffusion;
+    if (!diffusion.has_separate_encoder) {
+        return config;
+    }
+    config.hidden_size = json::require_i64(value, "encoder_hidden_size");
+    config.intermediate_size = json::optional_i64(value, "encoder_intermediate_size", diffusion.intermediate_size);
+    config.num_attention_heads =
+        json::optional_i64(value, "encoder_num_attention_heads", diffusion.num_attention_heads);
+    config.num_key_value_heads =
+        json::optional_i64(value, "encoder_num_key_value_heads", diffusion.num_key_value_heads);
     return config;
 }
 
@@ -118,14 +145,38 @@ AceStepVAEConfig parse_vae_config(const engine::io::json::Value & value) {
     return config;
 }
 
+// Directory inside the package -> prefix of the resource ids the model spec
+// registers for it. The XL variants are optional resources, so a package may
+// name a variant here that it does not ship; that is caught when the resources
+// are opened, with a message that says which directory is missing.
+constexpr std::pair<std::string_view, std::string_view> kDitVariants[] = {
+    {"acestep-v15-turbo", "dit_turbo_"},
+    {"acestep-v15-base", "dit_base_"},
+    {"acestep-v15-xl-turbo", "dit_xl_turbo_"},
+    {"acestep-v15-xl-sft", "dit_xl_sft_"},
+};
+
+std::string known_dit_variants() {
+    std::string names;
+    for (const auto & [directory, prefix] : kDitVariants) {
+        (void)prefix;
+        if (!names.empty()) {
+            names += ", ";
+        }
+        names += directory;
+    }
+    return names;
+}
+
 std::string dit_resource_id(const AceStepModelSelection & selection, std::string_view suffix) {
-    if (selection.dit_model_path == "acestep-v15-turbo") {
-        return "dit_turbo_" + std::string(suffix);
+    for (const auto & [directory, prefix] : kDitVariants) {
+        if (selection.dit_model_path == directory) {
+            return std::string(prefix) + std::string(suffix);
+        }
     }
-    if (selection.dit_model_path == "acestep-v15-base") {
-        return "dit_base_" + std::string(suffix);
-    }
-    throw std::runtime_error("ACE-Step package spec supports only acestep-v15-turbo and acestep-v15-base DiT variants");
+    throw std::runtime_error(
+        "unknown ACE-Step DiT variant '" + selection.dit_model_path + "'; the package spec knows " +
+        known_dit_variants());
 }
 
 void validate_selection(const AceStepModelSelection & selection) {
@@ -134,11 +185,27 @@ void validate_selection(const AceStepModelSelection & selection) {
 
 AceStepConfig parse_config(const assets::ResourceBundle & resources, const AceStepModelSelection & selection) {
     AceStepConfig config;
-    config.diffusion = parse_diffusion_config(resources.parse_json(dit_resource_id(selection, "config")));
+    const auto diffusion_json = resources.parse_json(dit_resource_id(selection, "config"));
+    config.diffusion = parse_diffusion_config(diffusion_json);
+    config.encoder = derive_encoder_config(config.diffusion, diffusion_json);
     config.planner = parse_planner_config(resources.parse_json("lm_config"));
     config.text_encoder = parse_text_encoder_config(resources.parse_json("text_encoder_config"));
     config.vae = parse_vae_config(resources.parse_json("vae_config"));
     return config;
+}
+
+// The XL variants are registered as optional package resources so that a
+// package holding only turbo does not have to ship 20 GB it will never load.
+// The cost is that "not installed" surfaces here rather than at spec-load time,
+// where a bare "missing asset resource: dit_xl_turbo_config" would not say why.
+void require_installed_variant(const assets::ResourceBundle & resources, const AceStepModelSelection & selection) {
+    if (resources.has_file(dit_resource_id(selection, "config"))) {
+        return;
+    }
+    throw std::runtime_error(
+        "ACE-Step DiT variant '" + selection.dit_model_path + "' is not installed in this package: " +
+        (resources.model_root() / selection.dit_model_path).string() +
+        " is missing. Download that variant, or load one of the variants the package ships.");
 }
 
 void validate_config(const AceStepConfig & config) {
@@ -167,6 +234,7 @@ std::shared_ptr<const AceStepAssets> load_ace_step_assets(
     assets->resources = engine::model_spec::load_resource_bundle(
         model_path,
         engine::model_spec::default_spec_path("ace_step"));
+    require_installed_variant(assets->resources, assets->selection);
     assets->config = parse_config(assets->resources, assets->selection);
     validate_config(assets->config);
     assets->dit_weights = assets->resources.open_tensor_source(dit_resource_id(assets->selection, "weights"));

--- a/src/models/ace_step/condition_encoder.cpp
+++ b/src/models/ace_step/condition_encoder.cpp
@@ -313,11 +313,11 @@ public:
 
         AceStepTextConditioning run(const AceStepTextConditioning & input) const {
             if (input.tokens <= 0 || input.tokens > tokens_ ||
-                input.hidden_size != assets_->config.diffusion.text_hidden_dim) {
+                input.hidden_size != assets_->config.encoder.text_hidden_dim) {
                 throw std::runtime_error("ACE-Step text projector input shape mismatch");
             }
             std::vector<float> padded(
-                static_cast<size_t>(tokens_ * assets_->config.diffusion.text_hidden_dim),
+                static_cast<size_t>(tokens_ * assets_->config.encoder.text_hidden_dim),
                 0.0F);
             std::copy(input.values.begin(), input.values.end(), padded.begin());
             core::write_tensor_f32(input_value_, padded);
@@ -328,7 +328,7 @@ public:
             }
             AceStepTextConditioning out;
             out.tokens = input.tokens;
-            out.hidden_size = assets_->config.diffusion.hidden_size;
+            out.hidden_size = assets_->config.encoder.hidden_size;
             std::vector<float> full;
             core::read_tensor_f32_into(output_, full);
             out.values.assign(
@@ -339,7 +339,7 @@ public:
 
     private:
         void build() {
-            const auto & config = assets_->config.diffusion;
+            const auto & config = assets_->config.encoder;
             ggml_init_params params{8ull * 1024ull * 1024ull, nullptr, true};
             ctx_.reset(ggml_init(params));
             if (ctx_ == nullptr) {
@@ -410,11 +410,11 @@ public:
 
         AceStepTextConditioning run(const AceStepTextConditioning & input) const {
             if (input.tokens <= 0 || input.tokens > tokens_ ||
-                input.hidden_size != assets_->config.diffusion.text_hidden_dim) {
+                input.hidden_size != assets_->config.encoder.text_hidden_dim) {
                 throw std::runtime_error("ACE-Step lyric encoder input shape mismatch");
             }
             std::vector<float> padded(
-                static_cast<size_t>(tokens_ * assets_->config.diffusion.text_hidden_dim),
+                static_cast<size_t>(tokens_ * assets_->config.encoder.text_hidden_dim),
                 0.0F);
             std::copy(input.values.begin(), input.values.end(), padded.begin());
             core::write_tensor_f32(input_value_, padded);
@@ -428,7 +428,7 @@ public:
             }
             AceStepTextConditioning out;
             out.tokens = input.tokens;
-            out.hidden_size = assets_->config.diffusion.hidden_size;
+            out.hidden_size = assets_->config.encoder.hidden_size;
             std::vector<float> full;
             core::read_tensor_f32_into(output_, full);
             out.values.assign(
@@ -439,7 +439,7 @@ public:
 
     private:
         void build() {
-            const auto & config = assets_->config.diffusion;
+            const auto & config = assets_->config.encoder;
             ggml_init_params params{128ull * 1024ull * 1024ull, nullptr, true};
             ctx_.reset(ggml_init(params));
             if (ctx_ == nullptr) {
@@ -563,7 +563,7 @@ public:
         }
 
         AceStepTextConditioning run_one(const std::vector<float> & packed_reference, int64_t frames) const {
-            const auto & config = assets_->config.diffusion;
+            const auto & config = assets_->config.encoder;
             if (frames <= 0 || frames > frames_ ||
                 static_cast<int64_t>(packed_reference.size()) != frames * config.timbre_hidden_dim) {
                 throw std::runtime_error("ACE-Step timbre encoder input shape mismatch");
@@ -575,7 +575,7 @@ public:
             core::write_tensor_f32(input_value_, padded);
             core::write_tensor_f16(
                 padding_mask_value_,
-                build_padding_attention_mask_values(frames_, frames));
+                build_padding_attention_mask_values(tokens_, frames + cls_tokens()));
             core::set_backend_threads(backend_, threads_);
             const ggml_status status = engine::core::compute_backend_graph(backend_, graph_);
             if (status != GGML_STATUS_SUCCESS) {
@@ -589,8 +589,17 @@ public:
         }
 
     private:
+        // XL prepends a CLS token to the reference frames and reads it back as the
+        // timbre embedding. Earlier variants declare the same parameter but leave
+        // it out of the sequence, so position 0 there is the first audio frame —
+        // which is why this is a config question and not a tensor lookup.
+        int64_t cls_tokens() const noexcept {
+            return assets_->config.encoder.timbre_special_token ? 1 : 0;
+        }
+
         void build() {
-            const auto & config = assets_->config.diffusion;
+            const auto & config = assets_->config.encoder;
+            tokens_ = frames_ + cls_tokens();
             ggml_init_params params{128ull * 1024ull * 1024ull, nullptr, true};
             ctx_.reset(ggml_init(params));
             if (ctx_ == nullptr) {
@@ -603,28 +612,35 @@ public:
                 GGML_TYPE_F32,
                 core::TensorShape::from_dims({1, frames_, config.timbre_hidden_dim}));
             input_value_ = input_;
-            positions_ = ggml_new_tensor_1d(ctx_.get(), GGML_TYPE_I32, frames_);
-            auto positions = core::wrap_tensor(positions_, core::TensorShape::from_dims({frames_}), GGML_TYPE_I32);
+            positions_ = ggml_new_tensor_1d(ctx_.get(), GGML_TYPE_I32, tokens_);
+            auto positions = core::wrap_tensor(positions_, core::TensorShape::from_dims({tokens_}), GGML_TYPE_I32);
             sliding_mask_value_ = core::make_tensor(
                 build_ctx,
                 GGML_TYPE_F16,
-                core::TensorShape::from_dims({1, 1, frames_, frames_}));
+                core::TensorShape::from_dims({1, 1, tokens_, tokens_}));
             padding_mask_value_ = core::make_tensor(
                 build_ctx,
                 GGML_TYPE_F16,
-                core::TensorShape::from_dims({1, 1, frames_, frames_}));
+                core::TensorShape::from_dims({1, 1, tokens_, tokens_}));
             auto hidden = modules::LinearModule({config.timbre_hidden_dim, config.hidden_size, true})
                               .build(
                                   build_ctx,
                                   input_,
                                   {weights_->timbre_embed_weight, weights_->timbre_embed_bias});
+            if (cls_tokens() > 0) {
+                special_token_value_ = core::make_tensor(
+                    build_ctx,
+                    GGML_TYPE_F32,
+                    core::TensorShape::from_dims({1, 1, config.hidden_size}));
+                hidden = modules::ConcatModule({1}).build(build_ctx, special_token_value_, hidden);
+            }
             const auto sliding_mask = core::wrap_tensor(
                 sliding_mask_value_.tensor,
-                core::TensorShape::from_dims({1, 1, frames_, frames_}),
+                core::TensorShape::from_dims({1, 1, tokens_, tokens_}),
                 GGML_TYPE_F16);
             const auto padding_mask = core::wrap_tensor(
                 padding_mask_value_.tensor,
-                core::TensorShape::from_dims({1, 1, frames_, frames_}),
+                core::TensorShape::from_dims({1, 1, tokens_, tokens_}),
                 GGML_TYPE_F16);
             for (int64_t i = 0; i < config.num_timbre_encoder_hidden_layers; ++i) {
                 const std::optional<core::TensorValue> mask =
@@ -648,14 +664,18 @@ public:
                 throw std::runtime_error("ACE-Step timbre encoder backend buffer allocation failed");
             }
 
-            std::vector<int32_t> position_values(static_cast<size_t>(frames_), 0);
-            for (int64_t i = 0; i < frames_; ++i) {
+            // Positions and both masks run over the extended sequence: upstream
+            // builds its cache_position from the embeddings *after* the CLS token
+            // is prepended, so the token sits at position 0 and everything else
+            // shifts by one.
+            std::vector<int32_t> position_values(static_cast<size_t>(tokens_), 0);
+            for (int64_t i = 0; i < tokens_; ++i) {
                 position_values[static_cast<size_t>(i)] = static_cast<int32_t>(i);
             }
             ggml_backend_tensor_set(positions_, position_values.data(), 0, position_values.size() * sizeof(int32_t));
             const std::vector<float> sliding_mask_values =
                 ace_step_bidirectional_sliding_mask_values(
-                    frames_,
+                    tokens_,
                     config.sliding_window,
                     "ACE-Step");
             std::vector<ggml_fp16_t> sliding_mask_f16(sliding_mask_values.size());
@@ -667,6 +687,17 @@ public:
                 sliding_mask_f16.data(),
                 0,
                 sliding_mask_f16.size() * sizeof(ggml_fp16_t));
+            if (cls_tokens() > 0) {
+                const auto & token = weights_->timbre_special_token_host;
+                if (static_cast<int64_t>(token.size()) != config.hidden_size) {
+                    throw std::runtime_error("ACE-Step timbre encoder CLS token shape mismatch");
+                }
+                ggml_backend_tensor_set(
+                    special_token_value_.tensor,
+                    token.data(),
+                    0,
+                    token.size() * sizeof(float));
+            }
         }
 
         ggml_backend_t backend_ = nullptr;
@@ -674,9 +705,12 @@ public:
         std::shared_ptr<const AceStepAssets> assets_;
         std::shared_ptr<const AceStepConditionEncoderWeights> weights_;
         int64_t frames_ = 0;
+        // frames_ plus the CLS token, when the variant has one.
+        int64_t tokens_ = 0;
         std::unique_ptr<ggml_context, GgmlContextDeleter> ctx_;
         core::TensorValue input_;
         core::TensorValue input_value_;
+        core::TensorValue special_token_value_;
         ggml_tensor * positions_ = nullptr;
         core::TensorValue sliding_mask_value_;
         core::TensorValue padding_mask_value_;
@@ -715,10 +749,10 @@ public:
         int64_t refer_audio_frames,
         const std::vector<int32_t> & refer_audio_order_mask) const {
         const auto total_start = Clock::now();
-        if (text_hidden_states.hidden_size != assets_->config.diffusion.text_hidden_dim) {
+        if (text_hidden_states.hidden_size != assets_->config.encoder.text_hidden_dim) {
             throw std::runtime_error("ACE-Step condition encoder text hidden size mismatch");
         }
-        if (lyric_token_embeddings.hidden_size != assets_->config.diffusion.text_hidden_dim) {
+        if (lyric_token_embeddings.hidden_size != assets_->config.encoder.text_hidden_dim) {
             throw std::runtime_error("ACE-Step condition encoder lyric hidden size mismatch");
         }
         const auto project_text_start = Clock::now();
@@ -795,7 +829,7 @@ private:
         int64_t refer_audio_count,
         int64_t refer_audio_frames,
         const std::vector<int32_t> & refer_audio_order_mask) const {
-        const auto & config = assets_->config.diffusion;
+        const auto & config = assets_->config.encoder;
         if (refer_audio_count <= 0 || refer_audio_frames <= 0) {
             throw std::runtime_error("ACE-Step timbre encoder requires positive reference count and frame count");
         }

--- a/src/models/ace_step/cover_tokenizer.cpp
+++ b/src/models/ace_step/cover_tokenizer.cpp
@@ -94,7 +94,7 @@ std::shared_ptr<const AceStepCoverTokenizerWeights> load_cover_tokenizer_weights
         backend_type,
         "ace_step.cover_tokenizer.weights",
         256ull * 1024ull * 1024ull);
-    const auto & config = assets.config.diffusion;
+    const auto & config = assets.config.encoder;
     const auto & source = *assets.dit_weights;
     auto weights = std::make_shared<AceStepCoverTokenizerWeights>();
     weights->store = store;
@@ -215,7 +215,7 @@ public:
             int64_t silence_channels,
             std::vector<float> & input_buffer) const {
             const auto total_start = Clock::now();
-            const auto & config = assets_->config.diffusion;
+            const auto & config = assets_->config.encoder;
             if (code_count <= 0 || code_count > code_capacity_) {
                 throw std::runtime_error("ACE-Step cover tokenizer chunk exceeds graph capacity");
             }
@@ -272,7 +272,7 @@ public:
 
     private:
         void build() {
-            const auto & config = assets_->config.diffusion;
+            const auto & config = assets_->config.encoder;
             const int64_t patch_tokens = config.pool_window_size + 1;
             ggml_init_params params{128ull * 1024ull * 1024ull, nullptr, true};
             ctx_.reset(ggml_init(params));
@@ -423,7 +423,7 @@ public:
           threads_(std::max(1, execution.config().threads)),
           storage_type_(storage_type),
           quantizer_(ace_step_build_fsq_quantizer_table(
-              assets_->config.diffusion,
+              assets_->config.encoder,
               "ACE-Step native cover tokenizer")) {
         if (assets_ == nullptr) {
             throw std::runtime_error("ACE-Step cover tokenizer requires assets");
@@ -439,7 +439,7 @@ public:
         int64_t silence_frames,
         int64_t silence_channels) const {
         const auto total_start = Clock::now();
-        const auto & config = assets_->config.diffusion;
+        const auto & config = assets_->config.encoder;
         if (latents.frames <= 0 || latents.channels != config.latent_channels) {
             throw std::runtime_error("ACE-Step cover tokenizer requires positive latent frames and matching channels");
         }

--- a/src/models/ace_step/detokenizer.cpp
+++ b/src/models/ace_step/detokenizer.cpp
@@ -123,7 +123,7 @@ public:
 
         AceStepLatents decode_audio_codes(const int32_t * audio_code_ids, int64_t code_count, std::vector<float> & expanded) const {
             const auto total_start = Clock::now();
-            const auto & config = assets_->config.diffusion;
+            const auto & config = assets_->config.encoder;
             if (code_count <= 0) {
                 return {};
             }
@@ -186,7 +186,7 @@ public:
 
     private:
         void build() {
-            const auto & config = assets_->config.diffusion;
+            const auto & config = assets_->config.encoder;
             ggml_init_params params{96ull * 1024ull * 1024ull, nullptr, true};
             ctx_.reset(ggml_init(params));
             if (ctx_ == nullptr) {
@@ -350,7 +350,7 @@ public:
           assets_(std::move(assets)),
           weights_(dit_weights_runtime->detokenizer_weights()),
           quantizer_(ace_step_build_fsq_quantizer_table(
-              assets_->config.diffusion,
+              assets_->config.encoder,
               "ACE-Step native detokenizer")) {
         if (backend_ == nullptr) {
             throw std::runtime_error("ACE-Step detokenizer backend initialization failed");
@@ -378,7 +378,7 @@ public:
         engine::debug::timing_log_scalar(
             "ace_step.detokenizer.graph.ensure_ms",
             engine::debug::elapsed_ms(ensure_start, Clock::now()));
-        const auto & config = assets_->config.diffusion;
+        const auto & config = assets_->config.encoder;
         AceStepLatents out;
         out.frames = code_count * config.pool_window_size;
         out.channels = config.latent_channels;

--- a/src/models/ace_step/diffusion.cpp
+++ b/src/models/ace_step/diffusion.cpp
@@ -161,11 +161,15 @@ core::TensorValue build_attention(
     v_heads = ensure_contiguous(ctx, v_heads);
     auto context = attention_from_heads(ctx, q_heads, k_heads, v_heads, dim, attention_mask, backend_type);
     context = ensure_contiguous(ctx, context);
+    // The attention width is heads x head_dim, which only equals hidden_size when
+    // head_dim was derived from it. XL states head_dim outright (32 x 128 against
+    // a hidden size of 2560), so o_proj is the one rectangular projection here.
+    const int64_t attention_size = config.num_attention_heads * dim;
     context = core::reshape_tensor(
         ctx,
         context,
-        core::TensorShape::from_dims({hidden_states.shape.dims[0], hidden_states.shape.dims[1], config.hidden_size}));
-    return modules::LinearModule({config.hidden_size, config.hidden_size, false, GGML_PREC_F32})
+        core::TensorShape::from_dims({hidden_states.shape.dims[0], hidden_states.shape.dims[1], attention_size}));
+    return modules::LinearModule({attention_size, config.hidden_size, false, GGML_PREC_F32})
         .build(ctx, context, {weights.out_weight, std::nullopt});
 }
 
@@ -977,7 +981,10 @@ public:
 
         Output run(const std::vector<float> & encoder_hidden_states) const {
             const auto & config = assets_->config.diffusion;
-            if (static_cast<int64_t>(encoder_hidden_states.size()) != encoder_tokens_ * config.hidden_size) {
+            // Still in the encoder's width here: the condition embedder inside the
+            // graph is what lifts it to the DiT's.
+            const int64_t encoder_hidden_size = assets_->config.encoder.hidden_size;
+            if (static_cast<int64_t>(encoder_hidden_states.size()) != encoder_tokens_ * encoder_hidden_size) {
                 throw std::runtime_error("ACE-Step diffusion cross-attention cache encoder hidden state shape mismatch");
             }
             core::write_tensor_f32(encoder_value_, encoder_hidden_states);
@@ -1012,12 +1019,14 @@ public:
             }
             core::ModuleBuildContext ctx{ctx_.get(), "ace_step.diffusion.cross_cache", backend_type_};
 
+            const int64_t encoder_hidden_size = assets_->config.encoder.hidden_size;
             encoder_value_ = core::make_tensor(
                 ctx,
                 GGML_TYPE_F32,
-                core::TensorShape::from_dims({1, encoder_tokens_, config.hidden_size}));
-            auto encoder_hidden_states = modules::LinearModule({config.hidden_size, config.hidden_size, true, GGML_PREC_F32})
-                                             .build(ctx, encoder_value_, weights_->condition_embedder);
+                core::TensorShape::from_dims({1, encoder_tokens_, encoder_hidden_size}));
+            auto encoder_hidden_states =
+                modules::LinearModule({encoder_hidden_size, config.hidden_size, true, GGML_PREC_F32})
+                    .build(ctx, encoder_value_, weights_->condition_embedder);
             key_outputs_.reserve(weights_->layers.size());
             value_outputs_.reserve(weights_->layers.size());
             for (const auto & layer : weights_->layers) {
@@ -1467,10 +1476,12 @@ public:
         const auto total_start = Clock::now();
         const auto & pre = conditioning.pre_dit;
         const auto & config = assets_->config.diffusion;
+        // Everything the condition encoder produced is still in its own width.
+        const int64_t encoder_hidden_size = assets_->config.encoder.hidden_size;
         if (pre.context_latents.frames <= 0 || pre.context_latents.channels != config.latent_channels * 2) {
             throw std::runtime_error("ACE-Step diffusion requires valid context latents");
         }
-        if (pre.encoder_hidden_states.tokens <= 0 || pre.encoder_hidden_states.hidden_size != config.hidden_size) {
+        if (pre.encoder_hidden_states.tokens <= 0 || pre.encoder_hidden_states.hidden_size != encoder_hidden_size) {
             throw std::runtime_error("ACE-Step diffusion requires valid encoder hidden states");
         }
         const int64_t encoder_token_capacity = std::max<int64_t>(
@@ -1512,7 +1523,7 @@ public:
             cfg_context_padded = duplicate_batch_values(context_padded, diffusion_batch_size);
         }
         const auto encoder_hidden_padded =
-            pad_encoder_hidden_values(pre.encoder_hidden_states, graph_->encoder_token_capacity(), config.hidden_size);
+            pad_encoder_hidden_values(pre.encoder_hidden_states, graph_->encoder_token_capacity(), encoder_hidden_size);
         const auto encoder_attention_mask_padded =
             pad_encoder_attention_mask(pre.encoder_hidden_states, graph_->encoder_token_capacity());
         engine::debug::timing_log_scalar("ace_step.diffusion.padding_ms", engine::debug::elapsed_ms(padding_start, Clock::now()));
@@ -1537,7 +1548,7 @@ public:
             const auto null_encoder_hidden_padded = null_encoder_hidden_values(
                 weights_->null_condition_emb_host,
                 graph_->encoder_token_capacity(),
-                config.hidden_size);
+                encoder_hidden_size);
             null_cross_attention_cache = cross_cache_graph_->run(null_encoder_hidden_padded);
             cross_attention_cache = combine_cross_attention_cache(cross_attention_cache, *null_cross_attention_cache);
         }
@@ -1563,7 +1574,7 @@ public:
             non_cover_encoder_hidden_padded = pad_encoder_hidden_values(
                 pre.encoder_hidden_states_non_cover,
                 graph_->encoder_token_capacity(),
-                config.hidden_size);
+                encoder_hidden_size);
             non_cover_encoder_attention_mask_padded = pad_encoder_attention_mask(
                 pre.encoder_hidden_states_non_cover,
                 graph_->encoder_token_capacity());

--- a/src/models/ace_step/dit_weights_runtime.cpp
+++ b/src/models/ace_step/dit_weights_runtime.cpp
@@ -64,7 +64,7 @@ std::shared_ptr<const AceStepConditionEncoderWeights> load_condition_encoder_wei
     const std::shared_ptr<core::BackendWeightStore> & store,
     const AceStepAssets & assets,
     assets::TensorStorageType storage_type) {
-    const auto & config = assets.config.diffusion;
+    const auto & config = assets.config.encoder;
     const auto & source = *assets.dit_weights;
     auto weights = std::make_shared<AceStepConditionEncoderWeights>();
     weights->store = store;
@@ -116,6 +116,14 @@ std::shared_ptr<const AceStepConditionEncoderWeights> load_condition_encoder_wei
             config));
     }
     weights->timbre_norm = store->load_f32_tensor(source, "encoder.timbre_encoder.norm.weight", {config.hidden_size});
+    // Every ACE-Step package carries this parameter; only the XL class prepends
+    // it to the reference frames, so loading it anywhere else would pin a tensor
+    // the graph never reads.
+    if (config.timbre_special_token) {
+        weights->timbre_special_token_host = source.require_f32(
+            "encoder.timbre_encoder.special_token",
+            {1, 1, config.hidden_size});
+    }
     return weights;
 }
 
@@ -123,7 +131,7 @@ std::shared_ptr<const AceStepDetokenizerWeights> load_detokenizer_weights(
     const std::shared_ptr<core::BackendWeightStore> & store,
     const AceStepAssets & assets,
     assets::TensorStorageType storage_type) {
-    const auto & config = assets.config.diffusion;
+    const auto & config = assets.config.encoder;
     const auto & source = *assets.dit_weights;
     const int64_t dim = config.head_dim;
 
@@ -230,6 +238,9 @@ std::shared_ptr<const AceStepDiffusionWeights> load_diffusion_weights(
     const AceStepAssets & assets,
     assets::TensorStorageType storage_type) {
     const auto & config = assets.config.diffusion;
+    // The two places the DiT meets the condition encoder, and the only shapes in
+    // this function that are not square in the DiT's own width.
+    const int64_t encoder_hidden_size = assets.config.encoder.hidden_size;
     const auto & source = *assets.dit_weights;
     auto weights = std::make_shared<AceStepDiffusionWeights>();
     weights->store = store;
@@ -241,11 +252,14 @@ std::shared_ptr<const AceStepDiffusionWeights> load_diffusion_weights(
     weights->time_embed = load_time_embedding_weights(*store, source, "decoder.time_embed", storage_type, config.hidden_size);
     weights->time_embed_r = load_time_embedding_weights(*store, source, "decoder.time_embed_r", storage_type, config.hidden_size);
     weights->condition_embedder = {
-        store->load_tensor(source, "decoder.condition_embedder.weight", storage_type, {config.hidden_size, config.hidden_size}),
+        store->load_tensor(source, "decoder.condition_embedder.weight", storage_type, {config.hidden_size, encoder_hidden_size}),
         store->load_tensor(source, "decoder.condition_embedder.bias", assets::TensorStorageType::F32, {config.hidden_size}),
     };
     if (!config.is_turbo) {
-        weights->null_condition_emb_host = source.require_f32("null_condition_emb", {1, 1, config.hidden_size});
+        // Stands in for the encoder output under classifier-free guidance, so it
+        // is sized in the encoder's width and the condition embedder projects it
+        // like any other conditioning.
+        weights->null_condition_emb_host = source.require_f32("null_condition_emb", {1, 1, encoder_hidden_size});
     }
     weights->layers.reserve(static_cast<size_t>(config.num_hidden_layers));
     for (int64_t i = 0; i < config.num_hidden_layers; ++i) {

--- a/src/models/ace_step/loader.cpp
+++ b/src/models/ace_step/loader.cpp
@@ -22,10 +22,11 @@ AceStepModelSelection selection_from_request(const runtime::ModelLoadRequest & r
     std::transform(model_name.begin(), model_name.end(), model_name.begin(), [](unsigned char ch) {
         return static_cast<char>(std::tolower(ch));
     });
-    if (model_name.find("base") != std::string::npos) {
-        selection.dit_model_path = "acestep-v15-base";
+    const bool xl = model_name.find("xl") != std::string::npos;
+    if (model_name.find("base") != std::string::npos || model_name.find("sft") != std::string::npos) {
+        selection.dit_model_path = xl ? "acestep-v15-xl-sft" : "acestep-v15-base";
     } else if (model_name.find("turbo") != std::string::npos) {
-        selection.dit_model_path = "acestep-v15-turbo";
+        selection.dit_model_path = xl ? "acestep-v15-xl-turbo" : "acestep-v15-turbo";
     }
     return selection;
 }
@@ -89,7 +90,9 @@ runtime::ModelCliInterface cli(const AceStepAssets &) {
         {"ace_step.mem_saver", "true|false", "Release staged runtime graphs after each request; default false."},
     };
     out.load_options = {
-        {"ace_step.dit_model_path", "acestep-v15-turbo|acestep-v15-base", "DiT variant inside the model package."},
+        {"ace_step.dit_model_path",
+         "acestep-v15-turbo|acestep-v15-base|acestep-v15-xl-turbo|acestep-v15-xl-sft",
+         "DiT variant inside the model package; the XL variants are optional and must be installed."},
     };
     return out;
 }


### PR DESCRIPTION
Adds `acestep-v15-xl-turbo` and `acestep-v15-xl-sft` as selectable DiT variants for `ace_step`.

XL is the larger transformer — 32 layers of 2560 against turbo's 24 of 2048 — and it differs from the existing variants in three ways that the graph had to learn. All three are read off upstream's own `modeling_acestep_v15_xl_turbo.py`, which is otherwise identical to `modeling_acestep_v15_turbo.py` apart from whitespace and a PyTorch autocast workaround that does not apply here.

### 1. The encoder stack keeps turbo's width

`AceStepConditionGenerationModel.__init__` hands the condition encoder, audio tokenizer and detokenizer a `copy.deepcopy` of the config with the `encoder_*` values substituted, so those submodules stay at 2048 while the DiT runs at 2560, and `decoder.condition_embedder` (2560×2048) bridges them.

That copy is now `AceStepConfig::encoder`, derived once in `assets.cpp`, and the encoder-side runtimes read it instead of `config.diffusion`. `null_condition_emb` is encoder-width for the same reason — it stands in for the encoder output under CFG, so the condition embedder projects it like any other conditioning. On a package that does not split the dimensions the two configs are identical, so nothing changes for turbo or base.

### 2. The attention width is no longer the model width

XL states `head_dim` outright: 32 heads × 128 = 4096 against a hidden size of 2560, so `o_proj` is rectangular. `build_attention` in `diffusion.cpp` reshaped the context to `config.hidden_size` and built `o_proj` square — which was correct for every variant until now, because `head_dim` had always been derived from `hidden_size`. It now uses `num_attention_heads * head_dim` on the input side. The condition encoder's own `encoder_layer` already did this correctly; this brings the DiT in line with it.

### 3. The XL timbre encoder prepends its CLS token

`AceStepTimbreEncoder.forward` concatenates `self.special_token` ahead of the reference frames and reads position 0 back as the timbre embedding. The pre-XL class declares the same parameter but has that line commented out, so it reads the first audio frame instead — and the tensor ships in both checkpoints, which is why its presence says nothing and the config has to. `TimbreEncoderGraph` now concatenates it and extends positions and both masks by one, matching upstream's `cache_position`, which is built after the prepend.

The gate for 1 and 3 is the presence of `encoder_hidden_size`, which is what the XL modeling class reads without a fallback.

## Packaging

The XL snapshots are ~19 GB each, so listing them in the spec's required `tensors` map would have forced the download on every install. Sources gain an **`optional_tensors`** map alongside the existing `optional_files`, and the XL entries live there. A package without them loads and behaves exactly as before; selecting a variant that is not installed reports which directory is missing rather than a bare resource id.

Their weights are four safetensors shards, which the spec points at through `model.safetensors.index.json` — `open_tensor_source` already follows that, so sharding needed no work.

`lyric_alignment_layers_config`, the other key new to the XL config, is not referenced anywhere in the modeling file and is ignored.

## Testing

RTX 5090, CUDA, safetensors package:

- `text2music` on `acestep-v15-xl-turbo` renders real, prompt-responsive audio — a lo-fi prompt gives a 166 Hz spectral centroid with 94% of energy below 500 Hz, a thrash-metal prompt on the same seed gives 587 Hz and a much stronger onset autocorrelation. No NaNs.
- `acestep-v15-turbo` and `acestep-v15-base` are unchanged, including base's CFG path, which exercises `null_condition_emb`.
- A package with the XL directory removed still loads and runs; selecting the missing variant produces the intended message.

All three graph changes are load-bearing rather than cosmetic: a wrong encoder width fails the `[2048, 1024]` text-projector shape check, a square `o_proj` fails against the `[2560, 4096]` weight, and a missing concat desynchronises the mask from the sequence — so a clean run is itself evidence that each path is taken.

One practical note, documented in `docs/models/ace_step.md`: the XL snapshots are stored in **float32**, not bf16, so `native` puts 19.9 GB of weights on the card. Passing `--session-option ace_step.dit_weight_type=bf16` took 20 s of audio from 87 s to 24 s here (turbo, for reference: 11 s).

`acestep-v15-xl-sft` shares the graph with `xl-turbo` — upstream's `modeling_acestep_v15_xl_base.py` differs only in its sampling loop, which audio.cpp implements itself and already keys on `is_turbo` — so it is registered too, but I have only run `xl-turbo` end to end.

I found this while adding music generation to a local Studio UI for audio.cpp, which is at https://github.com/CaptainArni/audiocpp-ui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
