### PR TITLE
Document macOS CPU-only builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Huge thanks to [@kigner](https://github.com/kigner) for the original [audio.cpp-
 |---|---|
 | Linux | GCC 13 or newer, CMake, plus the backend toolchain for the build you want: NVIDIA CUDA Toolkit for CUDA, Vulkan SDK for Vulkan, ROCm for HIP |
 | Windows | Visual Studio Build Tools 2022 or newer with C++ desktop workload, MSVC x64 compiler, Windows SDK, CMake, Ninja, MSVC OpenMP components; official NVIDIA CUDA Toolkit for CUDA builds, AMD HIP SDK for HIP builds |
-| macOS | Xcode or Xcode Command Line Tools with the Metal compiler available through `xcrun` |
+| macOS | Xcode or Xcode Command Line Tools, plus CMake. Metal builds also require the Metal compiler available through `xcrun` |
 
 ### Homebrew Install
 
@@ -280,6 +280,29 @@ For deployment builds with compiled package specs:
 ```
 
 For requirements, CPU profiles, CUDA packaging, and release zips, see [docs/build/windows.md](docs/build/windows.md).
+
+### macOS CPU Build
+
+Apple builds enable Metal by default. To build a CPU-only binary, disable Metal explicitly:
+
+```bash
+cmake -S . -B build/macos-cpu-release \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DENGINE_ENABLE_CUDA=OFF \
+  -DENGINE_ENABLE_VULKAN=OFF \
+  -DENGINE_ENABLE_METAL=OFF \
+  -DENGINE_ENABLE_OPENMP=OFF \
+  -DGGML_OPENMP=OFF
+cmake --build build/macos-cpu-release \
+  --parallel "$(sysctl -n hw.logicalcpu)" \
+  --target audiocpp_cli audiocpp_server audiocpp_gguf
+```
+
+Confirm that the resulting CLI sees the host CPU backend:
+
+```bash
+build/macos-cpu-release/bin/audiocpp_cli --list-devices
+```
 
 ### Metal Build
 


### PR DESCRIPTION
## What changed

- Add CMake to the macOS source-build prerequisites.
- Clarify that the Metal compiler is only required for Metal builds.
- Add an explicit CPU-only CMake recipe for macOS. Apple builds otherwise enable Metal by default.
- Add a device-list check so users can confirm that the resulting binary sees the CPU backend.

## Validation

Tested on an Apple M3 Max with macOS 26.3.1, Xcode 26.3, AppleClang 17.0.0, and CMake 4.4.2.

The documented configure command completed in 8.89 seconds. The documented build command completed in 55.76 seconds and produced arm64 `audiocpp_cli`, `audiocpp_server`, and `audiocpp_gguf` binaries.

`audiocpp_cli --list-devices` reported:

```text
available_devices=2
BLAS:0 "Accelerate" [ACCEL]
CPU:0 "Apple M3 Max" [CPU]
```

The loader/catalog checks also passed:

```text
active_loaders=49 commented_loaders=0 specs=47 packages=140 manager_packages=140
ok: runtime loaders, model_specs, and model_manager_v2 are in sync
```
