### PR TITLE
Fix HIP classification in backend device test

### DIFF
--- a/tests/unittests/test_backend_device_resolution.cpp
+++ b/tests/unittests/test_backend_device_resolution.cpp
@@ -33,6 +33,7 @@ const char * backend_label(BackendType type) {
     switch (type) {
         case BackendType::Cpu:           return "cpu";
         case BackendType::Cuda:          return "cuda";
+        case BackendType::Hip:           return "hip";
         case BackendType::Vulkan:        return "vulkan";
         case BackendType::Metal:         return "metal";
         case BackendType::BestAvailable: return "best";
@@ -46,11 +47,12 @@ std::optional<BackendType> backend_type_for_reg_name(const char * reg_name) {
     if (reg_name == nullptr) {
         return std::nullopt;
     }
-    // CUDA's registry name follows the ggml build: "ROCm" under HIP, "MUSA" under MUSA.
-    if (std::strcmp(reg_name, "CUDA") == 0 ||
-        std::strcmp(reg_name, "ROCm") == 0 ||
-        std::strcmp(reg_name, "MUSA") == 0) {
+    // CUDA's registry name is "CUDA" or "MUSA" depending on the ggml build.
+    if (std::strcmp(reg_name, "CUDA") == 0 || std::strcmp(reg_name, "MUSA") == 0) {
         return BackendType::Cuda;
+    }
+    if (std::strcmp(reg_name, "ROCm") == 0) {
+        return BackendType::Hip;
     }
     if (std::strcmp(reg_name, "Vulkan") == 0) {
         return BackendType::Vulkan;
@@ -158,7 +160,12 @@ void test_every_enumerated_device_resolves() {
 void test_unregistered_backends_are_rejected() {
     ensure_backends_loaded();
 
-    for (const BackendType type : {BackendType::Cuda, BackendType::Vulkan, BackendType::Metal}) {
+    for (const BackendType type : {
+             BackendType::Cuda,
+             BackendType::Hip,
+             BackendType::Vulkan,
+             BackendType::Metal,
+         }) {
         bool registered = false;
         for (size_t i = 0; i < ggml_backend_reg_count(); ++i) {
             ggml_backend_reg_t reg = ggml_backend_reg_get(i);


### PR DESCRIPTION
## What changed

`backend_device_resolution_test` mirrors the backend registry mapping from `src/framework/core/backend.cpp`, but it still treated the `ROCm` registry as CUDA after HIP became its own `BackendType`.

On a HIP build, the test would discover `ROCm`, request a CUDA backend, and fail instead of validating the enumerated HIP device.

This change:

- maps `ROCm` to `BackendType::Hip` in the test contract
- adds the missing HIP label
- checks that an unregistered HIP backend is rejected, alongside CUDA, Vulkan, and Metal

## Validation

Both focused builds and test runs passed on an Apple M3 Max with AppleClang 17.0.0:

```text
macOS CPU core build
checked 0 accelerator registries
backend_device_resolution_test passed

macOS Metal core build
checked 1 accelerator registry
backend_device_resolution_test passed
```

The prior project warning about the unhandled `BackendType::Hip` enum value is gone. The remaining compile warning is in the vendored ggml CPU backend.

I did not have a usable HIP host for this change. A Windows CUDA attempt reached commit `4584379101c765a64fac1abc4d1e8f72fc42d2f4`, but the host lacked the official CUDA Toolkit, so I am not claiming Windows GPU coverage.
