### PR TITLE
server/cli: Add IndexTTS2 duration_factor speech-rate control

### DIFF
--- a/docs/tts.md
+++ b/docs/tts.md
@@ -570,6 +570,7 @@ audiocpp_cli --task tts --family index_tts2 --model /path/to/IndexTTS-2 --backen
 | `--request-option use_emotion_text=true\|false` | bool | `false` | Infer emotion from text. |
 | `--request-option use_random_emotion=true\|false` | bool | `false` | Use random emotion weights in the emotion mixer. |
 | `--request-option interval_silence_ms=<n>` | milliseconds | `200` | Silence inserted between generated text chunks. |
+| `--request-option duration_factor=<float>` | positive float | `1.0` | Output duration multiplier for speech-rate control; `>1` slower, `<1` faster. Matches the official IndexTTS2.5 `duration_factor`; also accepted for the v2 variant. |
 | `--text-chunk-size` | characters | not set | Optional framework outer text chunk size. When omitted, IndexTTS2 keeps its internal tokenizer segmentation. |
 | `--text-chunk-mode` | `default`, `tag_aware`, `japanese`, `endline` | `default` | Framework chunking mode used only when `--text-chunk-size` is set. |
 | `--max-tokens` | integer | model default | Maximum generated GPT mel tokens. |
@@ -636,6 +637,7 @@ License: IndexTTS-2.5 weights are distributed under the bilibili Model Use Licen
 | `--request-option use_emotion_text=true|false` | bool | `false` | Infer emotion from text. |
 | `--request-option use_random_emotion=true|false` | bool | `false` | Use random emotion weights in the emotion mixer. |
 | `--request-option interval_silence_ms=<n>` | milliseconds | `200` | Silence inserted between generated text chunks. |
+| `--request-option duration_factor=<float>` | positive float | `1.0` | Output duration multiplier for speech-rate control; `>1` slower, `<1` faster. Matches the official IndexTTS2.5 `duration_factor`. |
 | `--text-chunk-size` | characters | not set | Optional framework outer text chunk size. When omitted, IndexTTS2.5 keeps its internal tokenizer segmentation. |
 | `--text-chunk-mode` | `default`, `tag_aware`, `japanese`, `endline` | `default` | Framework chunking mode used only when `--text-chunk-size` is set. |
 | `--max-tokens` | integer | `1500` | Maximum generated GPT mel tokens. |

--- a/include/engine/models/index_tts2/types.h
+++ b/include/engine/models/index_tts2/types.h
@@ -144,6 +144,9 @@ struct IndexTTS2GenerationOptions {
     float repetition_penalty = 10.0F;
     int max_mel_tokens = 1500;
     uint32_t seed = 0;
+    // Output duration multiplier applied to the S2Mel length-regulator target
+    // (matches official IndexTTS2.5 duration_factor): >1 slower, <1 faster.
+    float duration_factor = 1.0F;
 };
 
 struct IndexTTS2Request {

--- a/src/framework/model_spec/options.cpp
+++ b/src/framework/model_spec/options.cpp
@@ -34,6 +34,7 @@ const std::unordered_map<std::string, std::unordered_set<std::string>> & shared_
         {"do_sample", {"bool"}},
         {"duration_sec", {"float", "float_list"}},
         {"duration_seconds", {"float", "float_list"}},
+        {"duration_factor", {"float"}},
         {"duration_scale", {"float"}},
         {"edge_fade_duration_sec", {"float"}},
         {"edge_pad_duration_sec", {"float"}},

--- a/src/models/index_tts2/loader.cpp
+++ b/src/models/index_tts2/loader.cpp
@@ -47,6 +47,7 @@ runtime::ModelCliInterface cli(const IndexTTS2Assets & assets) {
         {"text_chunk_mode", "default|tag_aware|japanese|endline", "Framework text chunking mode used when text_chunk_size is set."},
         {"length_penalty", "float", "GPT beam-search length penalty."},
         {"num_beams", "n", "GPT beam count."},
+        {"duration_factor", "float", "Output duration multiplier for speech-rate control; >1 slower, <1 faster. Matches official IndexTTS2.5 duration_factor."},
     };
     if (index_tts2_variant_from_version(assets.config.version) == IndexTTS2Variant::kV2_5) {
         out.request_options.push_back(

--- a/src/models/index_tts2/request.cpp
+++ b/src/models/index_tts2/request.cpp
@@ -168,6 +168,9 @@ IndexTTS2Request parse_index_tts2_request(const runtime::TaskRequest & request) 
         }
         out.generation.max_mel_tokens = *value;
     }
+    if (const auto value = runtime::parse_finite_float_option(request.options, {"duration_factor"})) {
+        out.generation.duration_factor = *value;
+    }
     if (const auto value = runtime::parse_u32_option(request.options, {"seed"})) {
         out.generation.seed = *value;
     } else {
@@ -185,6 +188,9 @@ IndexTTS2Request parse_index_tts2_request(const runtime::TaskRequest & request) 
     }
     if (out.generation.num_beams <= 0) {
         throw std::runtime_error("IndexTTS2 num_beams must be positive");
+    }
+    if (!(out.generation.duration_factor > 0.0F)) {
+        throw std::runtime_error("IndexTTS2 duration_factor must be positive");
     }
     return out;
 }

--- a/src/models/index_tts2/session.cpp
+++ b/src/models/index_tts2/session.cpp
@@ -692,7 +692,8 @@ runtime::AudioBuffer IndexTTS2Session::synthesize_segment(
         content = add_latent_to_semantic(semantic, projected);
         content_frames = code_frames;
     }
-    const int64_t target_frames = static_cast<int64_t>(static_cast<float>(content_frames) * 1.72F);
+    const int64_t target_frames =
+        static_cast<int64_t>(static_cast<float>(content_frames) * 1.72F * options.duration_factor);
     const int64_t total_frames = speaker.prompt_condition.frames + target_frames;
     s2mel_->prepare_length_regulator(content_frames, target_frames);
     auto generated_condition = s2mel_->regulate_length(content, content_frames, target_frames);

--- a/webui/configs/model_params.json
+++ b/webui/configs/model_params.json
@@ -190,7 +190,8 @@
     {"name": "emotion_alpha", "type": "slider", "label": "emotion_alpha（情感强度）", "label_en": "emotion_alpha", "default": 1.0, "minimum": 0.0, "maximum": 1.0, "step": 0.05},
     {"name": "use_emotion_text", "type": "bool", "label": "use_emotion_text（从朗读文本推断情感）", "label_en": "use_emotion_text (infer from text)", "default": false},
     {"name": "use_random_emotion", "type": "bool", "label": "use_random_emotion（随机情感）", "label_en": "use_random_emotion", "default": false},
-    {"name": "interval_silence_ms", "type": "number", "label": "interval_silence_ms（分段间静音）", "label_en": "interval_silence_ms", "default": 200, "minimum": 0, "step": 50, "precision": 0}
+    {"name": "interval_silence_ms", "type": "number", "label": "interval_silence_ms（分段间静音）", "label_en": "interval_silence_ms", "default": 200, "minimum": 0, "step": 50, "precision": 0},
+    {"name": "duration_factor", "type": "slider", "label": "duration_factor（语速/时长倍率，>1 更慢，<1 更快）", "label_en": "duration_factor (duration multiplier; >1 slower, <1 faster)", "default": 1.0, "minimum": 0.5, "maximum": 2.0, "step": 0.05, "info": "对齐官方 IndexTTS2.5 的 duration_factor：缩放输出时长，不改变音色/内容", "info_en": "Matches official IndexTTS2.5 duration_factor: scales output duration without changing timbre or content"}
   ],
 
   "irodori_tts": [


### PR DESCRIPTION
Have a great weekend! I forgot about a feature; let's see if we need to add it.

Matches the official IndexTTS2.5 duration_factor: scales the S2Mel length-regulator target frames (content_frames * 1.72 * duration_factor), so >1 slows speech down and <1 speeds it up without changing timbre. Accepted for both the v2 and v2.5 variants.

AI usage: Kimi k3 write code, human reivew