### PR TITLE
merge for: Fix core dump issue for binary built for old GPUs (cm<89)- #231

### DIFF
--- a/docs/build/linux.md
+++ b/docs/build/linux.md
@@ -58,6 +58,24 @@ Leave `CMAKE_CUDA_ARCHITECTURES` unset to build for the GPUs present at build ti
 (`native`). Note that CMake caches the CUDA compiler: switching toolkits in an
 existing build directory requires deleting `CMakeCache.txt` and `CMakeFiles/`.
 
+
+Old CUDA GPUs (cm<89):
+
+If you build for old CUDA GPUs with CUDA architecture < 8.9, e.g. Pascal compute-capability
+6.1, use build_linux.sh with  `--cuda-arch`. Or cmake with `-DCMAKE_CUDA_ARCHITECTURES=<archi-id>` 
+(and un-defines the sticky cache value so a previous configure does not win):
+
+```bash
+./scripts/build_linux.sh --backend cuda --cuda-arch 61 --target audiocpp_cli --target audiocpp_server
+```
+or
+```bash
+cmake -S . -B build -DENGINE_ENABLE_CUDA=ON \
+  -DCUDAToolkit_ROOT=/usr/local/cuda-12.9 \
+  -DCMAKE_CUDA_COMPILER=/usr/local/cuda-12.9/bin/nvcc \
+  -DCMAKE_CUDA_ARCHITECTURES=61      # 61 = GTX 1080Ti
+```
+
 On WSL2, install the toolkit only — `cuda-toolkit-<version>` from the `wsl-ubuntu`
 repo. The `cuda` and `cuda-drivers` metapackages pull a Linux display driver that
 breaks the GPU passthrough provided by the Windows host driver.

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -6,6 +6,7 @@ CONDA_ENV=""
 BUILD_DIR=""
 BUILD_TYPE="RelWithDebInfo"
 CUDA_MODE="auto"
+CUDA_ARCH=""
 VULKAN_MODE="off"
 HIP_MODE="off"
 GPU_TARGETS=""
@@ -72,6 +73,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --gpu-targets)
             GPU_TARGETS="$2"
+            shift 2
+            ;;
+        --cuda-arch)
+            CUDA_ARCH="$2"
             shift 2
             ;;
         --with-tests)
@@ -318,6 +323,9 @@ fi
 echo "Using generator: $GENERATOR"
 echo "Using build dir: $BUILD_DIR"
 echo "Including CUDA backend: $ENGINE_ENABLE_CUDA"
+if [[ "$ENGINE_ENABLE_CUDA" == "ON" ]]; then
+    echo "CUDA architectures: ${CUDA_ARCH:-<auto: machine-native at configure time>}"
+fi
 echo "Including Vulkan backend: $ENGINE_ENABLE_VULKAN"
 echo "Including HIP backend: $ENGINE_ENABLE_HIP"
 if [[ "$ENGINE_ENABLE_HIP" == "ON" ]]; then
@@ -363,6 +371,16 @@ if [[ "$ENGINE_ENABLE_HIP" == "ON" ]]; then
         -UGPU_BUILD_TARGETS
         -UAMDGPU_TARGETS
         -DGPU_TARGETS="$GPU_TARGETS"
+    )
+fi
+
+if [[ "$ENGINE_ENABLE_CUDA" == "ON" && -n "$CUDA_ARCH" ]]; then
+    CMAKE_ARGS+=(
+        # CMAKE_CUDA_ARCHITECTURES is a sticky cache entry; -U it so a previous
+        # configure's arch list does not win over a new --cuda-arch value
+        # (mirrors the HIP --gpu-targets handling above).
+        -UCMAKE_CUDA_ARCHITECTURES
+        -DCMAKE_CUDA_ARCHITECTURES="$CUDA_ARCH"
     )
 fi
 


### PR DESCRIPTION
This is a new PR to rebased https://github.com/0xShug0/audio.cpp/pull/231 to current main. 
As the following files are already merged:
1. external/ggml/src/ggml-cuda/sage-attn2.cuh
2. external/ggml/src/ggml-cuda/CMakeLists.txt
So this PR only update build_linuix.sh to support `--cuda-arch <archi id>` and add some guidance.

