### PR TITLE
feat(build): add Vulkan backend support for Windows builds

### DIFF
--- a/Makefile.windows
+++ b/Makefile.windows
@@ -9,7 +9,7 @@ JOBS ?=
 VS_INSTALL ?=
 NATIVE_CPU ?=
 
-.PHONY: all build configure cpu cpu-release cuda cuda-debug cuda-release clean presets help
+.PHONY: all build configure cpu cpu-release cuda cuda-debug cuda-release vulkan vulkan-debug vulkan-release clean presets help
 
 all: cuda
 
@@ -34,6 +34,15 @@ cuda-debug:
 cuda-release:
 	$(MAKE) -f "$(THIS_MAKEFILE)" build PRESET=windows-cuda-release
 
+vulkan:
+	$(MAKE) -f "$(THIS_MAKEFILE)" build PRESET=windows-vulkan-release
+
+vulkan-debug:
+	$(MAKE) -f "$(THIS_MAKEFILE)" build PRESET=windows-vulkan-debug
+
+vulkan-release:
+	$(MAKE) -f "$(THIS_MAKEFILE)" build PRESET=windows-vulkan-release
+
 clean:
 	$(POWERSHELL) -NoProfile -ExecutionPolicy Bypass -File "$(BUILD_SCRIPT)" -Preset "$(PRESET)" -Clean $(if $(VS_INSTALL),-VsInstall "$(VS_INSTALL)",)
 
@@ -46,6 +55,8 @@ help:
 	@echo   make -f Makefile.windows cpu              CPU Release build of audiocpp_cli
 	@echo   make -f Makefile.windows cuda             CUDA Release build of audiocpp_cli
 	@echo   make -f Makefile.windows cuda-debug       CUDA Debug build with /O2 /Zi
+	@echo   make -f Makefile.windows vulkan           Vulkan Release build of audiocpp_cli
+	@echo   make -f Makefile.windows vulkan-debug     Vulkan Debug build with /O2 /Zi
 	@echo   make -f Makefile.windows build TARGET=name  Build one target from the selected Windows preset
 	@echo   make -f Makefile.windows presets          List available CMake presets
 	@echo   $(BUILD_CMD)            Same build from cmd.exe without make
@@ -53,6 +64,7 @@ help:
 	@echo Examples:
 	@echo   make -f Makefile.windows cpu JOBS=8
 	@echo   make -f Makefile.windows cuda JOBS=8
+	@echo   make -f Makefile.windows vulkan JOBS=8
 	@echo   make -f Makefile.windows cuda NATIVE_CPU=OFF JOBS=8
 	@echo   make -f Makefile.windows cuda-debug TARGET=audiocpp_cli JOBS=8
 	@echo   make -f Makefile.windows cuda VS_INSTALL="C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools"

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Huge thanks to [@kigner](https://github.com/kigner) for the original [audio.cpp-
 | OS | Requirements |
 |---|---|
 | Linux | GCC 13 or newer, CMake, plus the backend toolchain for the build you want: NVIDIA CUDA Toolkit for CUDA, Vulkan SDK for Vulkan, ROCm for HIP |
-| Windows | Visual Studio Build Tools 2022 or newer with C++ desktop workload, MSVC x64 compiler, Windows SDK, CMake, Ninja, MSVC OpenMP components; official NVIDIA CUDA Toolkit for CUDA builds, AMD HIP SDK for HIP builds |
+| Windows | Visual Studio Build Tools 2022 or newer with C++ desktop workload, MSVC x64 compiler, Windows SDK, CMake, Ninja, MSVC OpenMP components; official NVIDIA CUDA Toolkit for CUDA builds, Vulkan SDK for Vulkan builds, AMD HIP SDK for HIP builds |
 | macOS | Xcode or Xcode Command Line Tools, plus CMake. Metal builds also require the Metal compiler available through `xcrun` |
 
 ### Homebrew Install
@@ -263,6 +263,7 @@ Common presets:
 
 ```powershell
 .\scripts\build_windows.ps1 -Preset windows-cuda-release -Target audiocpp_cli
+.\scripts\build_windows.ps1 -Preset windows-vulkan-release -Target audiocpp_cli
 .\scripts\build_windows.ps1 -Preset windows-cpu-release -Target audiocpp_cli
 .\scripts\build_windows.ps1 -Target audiocpp_server -Jobs 16
 .\scripts\build_windows.ps1 -Preset windows-cuda-release -ModelSet custom -Models "qwen3_tts,pocket_tts,qwen3_asr" -Target audiocpp_cli

--- a/docs/build/windows.md
+++ b/docs/build/windows.md
@@ -7,6 +7,7 @@ This document covers native Windows builds and release zip packaging.
 - Visual Studio Build Tools 2022 or newer with the C++ desktop workload
 - MSVC x64 compiler, Windows SDK, CMake, Ninja, and MSVC OpenMP components
 - Official NVIDIA CUDA Toolkit for CUDA builds
+- Official LunarG Vulkan SDK with `glslc` compiler for Vulkan builds
 
 The Visual Studio IDE is not required.
 
@@ -34,7 +35,14 @@ CUDA:
 .\scripts\build_windows.ps1 -Preset windows-cuda-release -Target audiocpp_server -Jobs 16
 ```
 
-The CUDA build also includes the CPU backend, so the same binary can run with `--backend cpu` or `--backend cuda`.
+Vulkan:
+
+```powershell
+.\scripts\build_windows.ps1 -Preset windows-vulkan-release -Target audiocpp_cli -Jobs 16
+.\scripts\build_windows.ps1 -Preset windows-vulkan-release -Target audiocpp_server -Jobs 16
+```
+
+The CUDA and Vulkan builds also include the CPU backend, so the same binary can run with `--backend cpu` or `--backend cuda` / `--backend vulkan`.
 
 From `cmd.exe`:
 
@@ -47,6 +55,7 @@ If GNU Make is available on Windows:
 ```bash
 make -f Makefile.windows cpu JOBS=16
 make -f Makefile.windows cuda JOBS=16
+make -f Makefile.windows vulkan JOBS=16
 make -f Makefile.windows cuda NATIVE_CPU=OFF JOBS=16
 ```
 
@@ -55,7 +64,9 @@ Useful script variants:
 ```powershell
 .\scripts\build_windows.ps1 -Target audiocpp_server -Jobs 16
 .\scripts\build_windows.ps1 -Preset windows-cpu-release -Target audiocpp_cli
+.\scripts\build_windows.ps1 -Preset windows-vulkan-release -Target audiocpp_cli
 .\scripts\build_windows.ps1 -Preset windows-cuda-debug -Target audiocpp_cli
+.\scripts\build_windows.ps1 -Preset windows-vulkan-debug -Target audiocpp_cli
 .\scripts\build_windows.ps1 -NativeCpu OFF -Target audiocpp_cli
 .\scripts\build_windows.ps1 -ConfigureOnly
 .\scripts\build_windows.ps1 -CudaArchitectures 120a-real
@@ -72,6 +83,7 @@ The built CLI is written to the selected preset directory:
 ```text
 build\windows-cpu-release\bin\audiocpp_cli.exe
 build\windows-cuda-release\bin\audiocpp_cli.exe
+build\windows-vulkan-release\bin\audiocpp_cli.exe
 ```
 
 ## CPU Architecture Profiles
@@ -144,6 +156,12 @@ CUDA package:
 - 64-bit Windows
 - NVIDIA GPU with compute capability 7.5 or newer
 - NVIDIA driver 580 or newer
+- Model files downloaded separately
+
+Vulkan package:
+
+- 64-bit Windows
+- GPU with a Vulkan 1.1 or newer driver (AMD, NVIDIA, or Intel)
 - Model files downloaded separately
 
 The package script copies MSVC/OpenMP runtime DLLs into both packages. The CUDA package also copies the CUDA DLLs used by this build, so users should not need to install the CUDA Toolkit or Visual Studio Build Tools.

--- a/scripts/build_windows.ps1
+++ b/scripts/build_windows.ps1
@@ -355,8 +355,35 @@ function Get-PresetSettings {
                 Llamafile = "ON"
                 EnableCuda = "OFF"
                 EnableCudaGraphs = "OFF"
+                EnableVulkan = "OFF"
                 CFlagsDebug = ""
                 CxxFlagsDebug = ""
+            }
+        }
+        "windows-vulkan-release" {
+            return @{
+                BuildType = "Release"
+                BuildTests = "OFF"
+                Native = "ON"
+                Llamafile = "ON"
+                EnableCuda = "OFF"
+                EnableCudaGraphs = "OFF"
+                EnableVulkan = "ON"
+                CFlagsDebug = ""
+                CxxFlagsDebug = ""
+            }
+        }
+        "windows-vulkan-debug" {
+            return @{
+                BuildType = "Debug"
+                BuildTests = "ON"
+                Native = "ON"
+                Llamafile = "ON"
+                EnableCuda = "OFF"
+                EnableCudaGraphs = "OFF"
+                EnableVulkan = "ON"
+                CFlagsDebug = "/O2 /Zi"
+                CxxFlagsDebug = "/O2 /Zi"
             }
         }
         "windows-cuda-debug" {
@@ -367,6 +394,7 @@ function Get-PresetSettings {
                 Llamafile = "ON"
                 EnableCuda = "ON"
                 EnableCudaGraphs = "ON"
+                EnableVulkan = "OFF"
                 CFlagsDebug = "/O2 /Zi"
                 CxxFlagsDebug = "/O2 /Zi"
             }
@@ -379,6 +407,7 @@ function Get-PresetSettings {
                 Llamafile = "ON"
                 EnableCuda = "ON"
                 EnableCudaGraphs = "ON"
+                EnableVulkan = "OFF"
                 CFlagsDebug = ""
                 CxxFlagsDebug = ""
             }
@@ -391,14 +420,32 @@ function Get-PresetSettings {
                 Llamafile = "ON"
                 EnableCuda = "ON"
                 EnableCudaGraphs = "ON"
+                EnableVulkan = "OFF"
                 CFlagsDebug = "/O2 /Zi"
                 CxxFlagsDebug = "/O2 /Zi"
             }
         }
         default {
-            throw "Unsupported Windows preset '$Name'. Use windows-cpu-release, windows-cuda-release, windows-cuda-debug, or windows-cuda-native-debug."
+            throw "Unsupported Windows preset '$Name'. Use windows-cpu-release, windows-vulkan-release, windows-vulkan-debug, windows-cuda-release, windows-cuda-debug, or windows-cuda-native-debug."
         }
     }
+}
+
+function Find-VulkanRoot {
+    foreach ($root in @($env:VULKAN_SDK, $env:VK_SDK_PATH)) {
+        if ($root -and (Test-Path (Join-Path $root "bin\glslc.exe"))) {
+            return (Resolve-Path $root).Path
+        }
+    }
+    $sdk = Find-FirstFile @(
+        "C:\VulkanSDK\*\bin\glslc.exe",
+        "C:\Program Files\VulkanSDK\*\bin\glslc.exe",
+        "C:\Program Files (x86)\VulkanSDK\*\bin\glslc.exe"
+    )
+    if ($sdk -ne "") {
+        return (Resolve-Path (Join-Path (Split-Path $sdk -Parent) "..")).Path
+    }
+    return ""
 }
 
 $settings = Get-PresetSettings $Preset
@@ -413,6 +460,7 @@ if (-not [string]::IsNullOrEmpty($Llamafile)) {
     $settings.Llamafile = $Llamafile
 }
 $isCudaPreset = $settings.EnableCuda -eq "ON"
+$isVulkanPreset = $settings.EnableVulkan -eq "ON"
 
 if ($isCudaPreset) {
     $cudaRoot = Find-CudaRoot
@@ -424,6 +472,17 @@ if ($isCudaPreset) {
     $env:CUDAToolkit_ROOT = $cudaRoot
 } else {
     $cudaRoot = ""
+}
+
+if ($isVulkanPreset) {
+    $vulkanRoot = Find-VulkanRoot
+    if ($vulkanRoot -eq "") {
+        throw "Vulkan SDK was not found. Install it from https://vulkan.lunarg.com/ and ensure VULKAN_SDK is set with glslc.exe available."
+    }
+    Add-PathFront (Join-Path $vulkanRoot "Bin")
+    $env:VULKAN_SDK = $vulkanRoot
+} else {
+    $vulkanRoot = ""
 }
 
 $vsInstall = Find-VsInstall $VsInstall
@@ -448,6 +507,11 @@ if ($isCudaPreset) {
     Write-Host "CUDA: $cudaRoot"
 } else {
     Write-Host "CUDA: disabled"
+}
+if ($isVulkanPreset) {
+    Write-Host "Vulkan SDK: $vulkanRoot"
+} else {
+    Write-Host "Vulkan: disabled"
 }
 Write-Host "Visual Studio Build Tools: $vsInstall"
 Write-Host "MSVC: $cl"
@@ -493,7 +557,7 @@ $configureArgs = @(
     "-DENGINE_ENABLE_CUDA=$($settings.EnableCuda)",
     "-DENGINE_ENABLE_OPENMP=ON",
     "-DENGINE_ENABLE_CUDA_GRAPHS=$($settings.EnableCudaGraphs)",
-    "-DENGINE_ENABLE_VULKAN=OFF",
+    "-DENGINE_ENABLE_VULKAN=$($settings.EnableVulkan)",
     "-DENGINE_ENABLE_METAL=OFF",
     "-DGGML_OPENMP=ON",
     "-DENGINE_ENABLE_NATIVE_CPU=$($settings.Native)",


### PR DESCRIPTION
This PR adds support for building `audio.cpp` with the Vulkan backend on Windows using MSVC and the LunarG Vulkan SDK.

Resolves #233

### Changes
- **`scripts/build_windows.ps1`**:
  - Added `windows-vulkan-release` and `windows-vulkan-debug` presets.
  - Implemented robust `Find-VulkanRoot` detection checking `%VULKAN_SDK%`, `%VK_SDK_PATH%`, and standard LunarG installation directories.
  - Forwarded `-DENGINE_ENABLE_VULKAN` to CMake configuration.
- **`Makefile.windows`**: Added `vulkan`, `vulkan-release`, and `vulkan-debug` targets.
- **`docs/build/windows.md` & `README.md`**: Documented requirements and build commands for Windows Vulkan presets.

### Verification
- Built `audiocpp_cli` and `audiocpp_server` using MSVC 2022 + Vulkan SDK.
- Tested Vulkan device detection (`--list-devices`) on AMD GPU.
- Verified TTS synthesis with Supertonic-3 GGUF model via `--backend vulkan` and WebUI server.
- Passed `tools/check_loader_catalog_sync.py`.
