### PR TITLE
Add `--voice-dir` to server CLI arguments

### DIFF
--- a/app/server/README.md
+++ b/app/server/README.md
@@ -219,7 +219,9 @@ demo_01_man|okay,I'm Cemo and what you just heard wasn't a human voice.
 demo_02_woman|以前我对这句话一知半解，现在好像有点懂了。因为你我开始留意很多以前不曾关心的事，开始对这个世界有了更多的好奇和善意。
 ```
 
-Relative `voice_dir` paths resolve against the config file's directory. When a request sends `"voice"` that is not a configured model preset, the server checks `<voice_dir>/<name>.wav`; if the file exists it is loaded as the cloning reference, and the `<name>` transcript from `prompt_text` is injected as `reference_text` unless the request already provides one.
+Relative `voice_dir` paths resolve against the config file's directory. The command-line option `--voice-dir <directory>` overrides the configured value, which is useful when a process manager launches multiple single-model server configurations against one shared voice library. Relative command-line paths resolve against the process working directory.
+
+When a request sends `"voice"` that is not a configured model preset, the server checks `<voice_dir>/<name>.wav`; if the file exists it is loaded as the cloning reference, and the `<name>` transcript from `prompt_text` is injected as `reference_text` unless the request already provides one.
 
 Resolution precedence for a TTS request's voice fields:
 
@@ -236,10 +238,11 @@ Resolution precedence for a TTS request's voice fields:
 build/bin/audiocpp_server --config server.json
 ```
 
-You can override the configured backend at startup:
+You can override configured server settings at startup, including the backend and shared voice library:
 
 ```bash
 build/bin/audiocpp_server --config server.json --backend vulkan
+build/bin/audiocpp_server --config server.json --voice-dir /absolute/path/to/voice
 ```
 
 ## Endpoints

--- a/app/server/main.cpp
+++ b/app/server/main.cpp
@@ -61,7 +61,7 @@ void print_help() {
     std::cout
         << "audiocpp_server [--config <server.json>] [--ui] [--host <ip>] [--port <port>] [--backend <backend>]\n"
         << "                [--device <id>] [--threads <n>] [--busy-timeout-ms <ms>]\n"
-        << "                [--model-spec-override <json-or-directory>]\n"
+        << "                [--model-spec-override <json-or-directory>] [--voice-dir <directory>]\n"
         << "                [--log] [--log-file <path>]\n"
         << "                [--cors-origins <origins>]\n"
         << "  --ui                             serve the embedded WebUI; without --config, start\n"
@@ -71,6 +71,7 @@ void print_help() {
         << "  --backend cpu|cuda|hip|rocm|vulkan|metal  default cuda (rocm is an alias for hip)\n"
         << "  --busy-timeout-ms <ms>           fail a request with 503 when the model has been\n"
         << "                                   busy this long; default 300000, 0 disables\n"
+        << "  --voice-dir <directory>          override the shared reference voice library directory\n"
         << "  --cors-origins \"*\"              experimental; disabled by default. Allows browser\n"
         << "                                   requests from any origin for trusted local demos only\n"
         << "\n"
@@ -167,6 +168,9 @@ int main(int argc, char ** argv) {
         }
         if (const auto model_spec = arg_value(argc, argv, "--model-spec-override")) {
             config.model_spec_override = std::filesystem::path(*model_spec);
+        }
+        if (const auto voice_dir = arg_value(argc, argv, "--voice-dir")) {
+            config.voice_dir = std::filesystem::path(*voice_dir);
         }
         if (!(config.cors_origins == "*" || config.cors_origins == "")) {
             throw std::runtime_error("--cors-origins must be '*' (allow all origins) or '' (disabled)");


### PR DESCRIPTION
## Why this PR?

I am using `llama-swap` to manage multiple `audiocpp_server` instances. To allow `llama-swap` to start, switch, and unload models on demand, each TTS model uses a separate single-model server configuration.

These TTS models need to share the same custom reference audio library. Currently, `voice_dir` can only be specified in the Server JSON configuration, so each single-model configuration must redundantly declare the same directory:

```json
{
  "voice_dir": "somewhere"
}
```

This leads to the following issues:

- The same deployment-level configuration must be redundantly maintained across multiple model configurations;
- When changing the voice library location, all TTS configurations must be updated synchronously;
- Configuration drift is likely to occur, with some models still pointing to outdated directories;
- It is inconvenient to uniformly inject deployment environment-related paths via `llama-swap`, `systemd`, or startup scripts.

## Why choose this way?

The `audiocpp_server` already allows overriding server configurations such as host, port, backend, and model-spec-override via the command line. Similarly, `voice_dir` is a server-level setting related to the deployment environment and is therefore also suitable for being overridden via the command line.

For example, in `llama-swap`, you can use a macro to have all TTS models share a single directory:

 ```yaml
 macros:
   voice_dir: /path/to/shared/voices

 models:
   qwen3-tts:
     cmd: >-
       audiocpp_server
       --config /path/to/qwen3-tts.json
       --voice-dir "${voice_dir}"
       --port ${PORT}
 ```

In this way, the model configuration is solely responsible for describing the model itself, while the location of the voice library is managed uniformly at the deployment layer.

## What I changed?

- Add a `--voice-dir <directory>` argument to `audiocpp_server`;
- When the argument is provided, it overrides the `voice_dir` in the JSON configuration;
- Include this argument in the `--help` output;
- Update the Server documentation and explain the path resolution behavior.