### PR TITLE
Fix: IndexTTS-2 F16 weight storage

### DIFF
--- a/src/framework/modules/vocoders/bigvgan_vocoder.cpp
+++ b/src/framework/modules/vocoders/bigvgan_vocoder.cpp
@@ -138,7 +138,6 @@ Conv1dWeights load_weight_norm_conv1d(
     int64_t dilation,
     bool use_bias,
     assets::TensorStorageType storage_type) {
-    (void) storage_type;
     const auto weight_v = source.require_f32(prefix + ".weight_v", {out_channels, in_channels, kernel});
     const auto weight_g = source.require_f32(prefix + ".weight_g", {out_channels, 1, 1});
     Conv1dWeights out;
@@ -151,7 +150,7 @@ Conv1dWeights load_weight_norm_conv1d(
     out.use_bias = use_bias;
     out.weight = store.make_from_f32(
         core::TensorShape::from_dims({out_channels, in_channels, kernel}),
-        assets::TensorStorageType::F32,
+        storage_type,
         fold_weight_norm(weight_v, weight_g, out_channels, in_channels, kernel));
     if (use_bias) {
         out.bias = store.make_from_f32(
@@ -199,7 +198,6 @@ ConvTranspose1dWeights load_weight_norm_conv_transpose1d(
     int64_t stride,
     int64_t padding,
     assets::TensorStorageType storage_type) {
-    (void) storage_type;
     const auto weight_v = source.require_f32(prefix + ".weight_v", {in_channels, out_channels, kernel});
     const auto weight_g = source.require_f32(prefix + ".weight_g", {in_channels, 1, 1});
     ConvTranspose1dWeights out;
@@ -211,7 +209,7 @@ ConvTranspose1dWeights load_weight_norm_conv_transpose1d(
     out.use_bias = true;
     out.conv1d_weight = store.make_from_f32(
         core::TensorShape::from_dims({out_channels, in_channels, kernel}),
-        assets::TensorStorageType::F32,
+        storage_type,
         transpose_conv1d_to_conv1d_weight(
             fold_weight_norm(weight_v, weight_g, in_channels, out_channels, kernel),
             in_channels,
@@ -234,7 +232,6 @@ ConvTranspose1dWeights load_weight_norm_conv_transpose1d_source(
     int64_t stride,
     int64_t padding,
     assets::TensorStorageType storage_type) {
-    (void) storage_type;
     const auto weight_v = source.require_f32(prefix + ".weight_v", {in_channels, out_channels, kernel});
     const auto weight_g = source.require_f32(prefix + ".weight_g", {in_channels, 1, 1});
     ConvTranspose1dWeights out;
@@ -247,11 +244,11 @@ ConvTranspose1dWeights load_weight_norm_conv_transpose1d_source(
     auto folded = fold_weight_norm(weight_v, weight_g, in_channels, out_channels, kernel);
     out.transpose_weight = store.make_from_f32(
         core::TensorShape::from_dims({in_channels, out_channels, kernel}),
-        assets::TensorStorageType::F32,
+        storage_type,
         folded);
     out.conv1d_weight = store.make_from_f32(
         core::TensorShape::from_dims({out_channels, in_channels, kernel}),
-        assets::TensorStorageType::F32,
+        storage_type,
         transpose_conv1d_to_conv1d_weight(folded, in_channels, out_channels, kernel));
     out.bias = store.make_from_f32(
         core::TensorShape::from_dims({out_channels}),
@@ -342,7 +339,6 @@ ResBlockWeights load_resblock(
     int64_t channels,
     int64_t kernel,
     assets::TensorStorageType storage_type) {
-    (void) storage_type;
     ResBlockWeights out;
     out.convs1.reserve(3);
     out.convs2.reserve(3);

--- a/src/models/index_tts2/gpt.cpp
+++ b/src/models/index_tts2/gpt.cpp
@@ -1,5 +1,6 @@
 #include "engine/models/index_tts2/gpt.h"
 
+#include "engine/framework/assets/tensor_source.h"
 #include "engine/framework/core/backend.h"
 #include "engine/framework/debug/profiler.h"
 #include "engine/framework/modules/activation_modules.h"
@@ -353,9 +354,20 @@ engine::modules::LinearWeights load_hf_conv1d_linear(
                 source_weight[static_cast<size_t>(in * out_features + out)];
         }
     }
+    // Transposed HF conv1d weights are derived host-side values, so "native"
+    // cannot resolve through load_tensor; follow the checkpoint dtype instead
+    // so an F16 GGUF keeps F16 decoder weights in the compute graph.
+    auto effective_storage_type = storage_type;
+    if (effective_storage_type == engine::assets::TensorStorageType::Native) {
+        try {
+            effective_storage_type = engine::assets::tensor_storage_type_for_dtype(
+                source.require_metadata(prefix + ".weight").dtype);
+        } catch (...) {
+        }
+    }
     weights.weight = store.make_from_f32(
         engine::core::TensorShape::from_dims({out_features, in_features}),
-        storage_type,
+        effective_storage_type,
         std::move(transposed));
     if (use_bias) {
         weights.bias = store.load_f32_tensor(source, prefix + ".bias", {out_features});

--- a/src/models/index_tts2/s2mel.cpp
+++ b/src/models/index_tts2/s2mel.cpp
@@ -168,12 +168,20 @@ core::TensorValue adaptive_rms_norm(
     return modules::AddModule{}.build(ctx, modules::MulModule{}.build(ctx, normed, weight), bias);
 }
 
+// CUDA matmul kernels handle reduced-precision weights correctly, so the s2mel
+// CFM estimator follows the module default precision there. Other backends stay
+// pinned to F32: the ggml CPU kernels produced audible noise in the CFM wavenet
+// with reduced precision.
+ggml_prec cfm_linear_precision(core::BackendType backend_type) {
+    return backend_type == core::BackendType::Cuda ? GGML_PREC_DEFAULT : GGML_PREC_F32;
+}
+
 core::TensorValue cfm_attention(
     core::ModuleBuildContext & ctx,
     const core::TensorValue & input,
     const core::TensorValue & positions,
     const IndexTTS2DitLayerWeights & weights) {
-    auto qkv = modules::LinearModule({kHidden, 3 * kHidden, false, GGML_PREC_F32}).build(ctx, input, weights.qkv);
+    auto qkv = modules::LinearModule({kHidden, 3 * kHidden, false, cfm_linear_precision(ctx.backend_type)}).build(ctx, input, weights.qkv);
     auto q = slice_last(ctx, qkv, 0, kHidden);
     auto k = slice_last(ctx, qkv, kHidden, kHidden);
     auto v = slice_last(ctx, qkv, 2 * kHidden, kHidden);
@@ -198,18 +206,18 @@ core::TensorValue cfm_attention(
         core::TensorShape::from_dims({input.shape.dims[0], input.shape.dims[1], kDitHeads, kDitHeadDim}),
         GGML_TYPE_F32);
     context = core::reshape_tensor(ctx, core::ensure_backend_addressable_layout(ctx, context), input.shape);
-    return modules::LinearModule({kHidden, kHidden, false, GGML_PREC_F32}).build(ctx, context, weights.attention_out);
+    return modules::LinearModule({kHidden, kHidden, false, cfm_linear_precision(ctx.backend_type)}).build(ctx, context, weights.attention_out);
 }
 
 core::TensorValue cfm_ffn(
     core::ModuleBuildContext & ctx,
     const core::TensorValue & input,
     const IndexTTS2DitLayerWeights & weights) {
-    auto gate = modules::LinearModule({kHidden, kDitFfnDim, false, GGML_PREC_F32}).build(ctx, input, weights.ffn_w1);
+    auto gate = modules::LinearModule({kHidden, kDitFfnDim, false, cfm_linear_precision(ctx.backend_type)}).build(ctx, input, weights.ffn_w1);
     gate = modules::SiluModule{}.build(ctx, gate);
-    auto up = modules::LinearModule({kHidden, kDitFfnDim, false, GGML_PREC_F32}).build(ctx, input, weights.ffn_w3);
+    auto up = modules::LinearModule({kHidden, kDitFfnDim, false, cfm_linear_precision(ctx.backend_type)}).build(ctx, input, weights.ffn_w3);
     auto hidden = modules::MulModule{}.build(ctx, gate, up);
-    return modules::LinearModule({kDitFfnDim, kHidden, false, GGML_PREC_F32}).build(ctx, hidden, weights.ffn_w2);
+    return modules::LinearModule({kDitFfnDim, kHidden, false, cfm_linear_precision(ctx.backend_type)}).build(ctx, hidden, weights.ffn_w2);
 }
 
 core::TensorValue cfm_transformer_layer(
@@ -221,7 +229,7 @@ core::TensorValue cfm_transformer_layer(
     const core::TensorValue * skip) {
     auto x = input;
     if (skip != nullptr) {
-        x = modules::LinearModule({2 * kHidden, kHidden, true, GGML_PREC_F32})
+        x = modules::LinearModule({2 * kHidden, kHidden, true, cfm_linear_precision(ctx.backend_type)})
                 .build(ctx, modules::ConcatModule({2}).build(ctx, x, *skip), weights.skip_in);
     }
     auto attn = cfm_attention(ctx, adaptive_rms_norm(ctx, x, timestep, weights.attention_norm), positions, weights);
@@ -284,7 +292,7 @@ core::TensorValue cfm_final_layer(
     auto scale_v = broadcast_batch_time(ctx, slice_last(ctx, mod, kHidden, kHidden), input.shape.dims[0], input.shape.dims[1], kHidden);
     auto normed = modules::LayerNormModule({kHidden, kLayerNormEps, false, false}).build(ctx, input, {std::nullopt, std::nullopt});
     normed = modules::AddModule{}.build(ctx, modules::MulModule{}.build(ctx, normed, add_one(ctx, scale_v)), shift);
-    return modules::LinearModule({kHidden, kHidden, true, GGML_PREC_F32}).build(ctx, normed, weights.final_linear);
+    return modules::LinearModule({kHidden, kHidden, true, cfm_linear_precision(ctx.backend_type)}).build(ctx, normed, weights.final_linear);
 }
 
 core::TensorValue build_cfm_estimator(
@@ -299,14 +307,14 @@ core::TensorValue build_cfm_estimator(
     const int64_t batch = x_bct.shape.dims[0];
     const int64_t frames = x_bct.shape.dims[2];
     auto t1 = timestep_embedding(ctx, timestep_b, weights.time_freqs, weights.time_mlp0, weights.time_mlp2);
-    auto cond = modules::LinearModule({kHidden, kHidden, true, GGML_PREC_F32}).build(ctx, cond_btc, weights.cond_projection);
+    auto cond = modules::LinearModule({kHidden, kHidden, true, cfm_linear_precision(ctx.backend_type)}).build(ctx, cond_btc, weights.cond_projection);
     auto x = modules::TransposeModule({{0, 2, 1, 3}, 3}).build(ctx, x_bct);
     auto prompt = modules::TransposeModule({{0, 2, 1, 3}, 3}).build(ctx, prompt_bct);
     auto style = broadcast_batch_time(ctx, style_bc, batch, frames, kStyleDim);
     auto hidden = modules::ConcatModule({2}).build(ctx, x, prompt);
     hidden = modules::ConcatModule({2}).build(ctx, hidden, cond);
     hidden = modules::ConcatModule({2}).build(ctx, hidden, style);
-    hidden = modules::LinearModule({kHidden + 2 * kMelChannels + kStyleDim, kHidden, true, GGML_PREC_F32})
+    hidden = modules::LinearModule({kHidden + 2 * kMelChannels + kStyleDim, kHidden, true, cfm_linear_precision(ctx.backend_type)})
                  .build(ctx, hidden, weights.cond_x_merge);
 
     std::vector<core::TensorValue> skips;
@@ -324,13 +332,13 @@ core::TensorValue build_cfm_estimator(
         }
     }
     hidden = adaptive_rms_norm(ctx, hidden, t1, weights.dit_norm);
-    hidden = modules::LinearModule({kHidden + kMelChannels, kHidden, true, GGML_PREC_F32})
+    hidden = modules::LinearModule({kHidden + kMelChannels, kHidden, true, cfm_linear_precision(ctx.backend_type)})
                  .build(ctx, modules::ConcatModule({2}).build(ctx, hidden, x), weights.skip_linear);
-    auto wavenet_x = modules::LinearModule({kHidden, kHidden, true, GGML_PREC_F32}).build(ctx, hidden, weights.conv1);
+    auto wavenet_x = modules::LinearModule({kHidden, kHidden, true, cfm_linear_precision(ctx.backend_type)}).build(ctx, hidden, weights.conv1);
     wavenet_x = modules::TransposeModule({{0, 2, 1, 3}, 3}).build(ctx, wavenet_x);
     auto t2 = timestep_embedding(ctx, timestep_b, weights.time2_freqs, weights.time2_mlp0, weights.time2_mlp2);
     wavenet_x = modules::TransposeModule({{0, 2, 1, 3}, 3}).build(ctx, cfm_wavenet(ctx, wavenet_x, t2, weights));
-    auto projected = modules::LinearModule({kHidden, kHidden, true, GGML_PREC_F32}).build(ctx, hidden, weights.res_projection);
+    auto projected = modules::LinearModule({kHidden, kHidden, true, cfm_linear_precision(ctx.backend_type)}).build(ctx, hidden, weights.res_projection);
     hidden = modules::AddModule{}.build(ctx, wavenet_x, projected);
     hidden = cfm_final_layer(ctx, hidden, t1, weights);
     hidden = modules::TransposeModule({{0, 2, 1, 3}, 3}).build(ctx, hidden);

--- a/src/models/index_tts2/vocoder.cpp
+++ b/src/models/index_tts2/vocoder.cpp
@@ -1,5 +1,6 @@
 #include "engine/models/index_tts2/vocoder.h"
 
+#include "engine/framework/assets/tensor_source.h"
 #include "engine/framework/io/json.h"
 
 #include <stdexcept>
@@ -46,6 +47,22 @@ IndexTTS2BigVganVocoder::IndexTTS2BigVganVocoder(
     : assets_(std::move(assets)) {
     if (assets_ == nullptr) {
         throw std::runtime_error("IndexTTS2 BigVGAN vocoder requires assets");
+    }
+    // Folded weight-norm conv tensors are derived host-side values, so "native"
+    // cannot resolve through load_tensor; follow the checkpoint dtype so an F16
+    // GGUF keeps F16 vocoder weights in the compute graph.
+    if (weight_storage_type == engine::assets::TensorStorageType::Native) {
+        for (const auto & tensor : assets_->bigvgan_weights->tensors()) {
+            if (tensor.name.find(".weight_v") != std::string::npos ||
+                tensor.name.find(".weight") != std::string::npos) {
+                try {
+                    weight_storage_type =
+                        engine::assets::tensor_storage_type_for_dtype(tensor.dtype);
+                } catch (...) {
+                }
+                break;
+            }
+        }
     }
     component_ = engine::modules::BigVganVocoderComponent::load_from_tensor_source(
         assets_->bigvgan_weights,


### PR DESCRIPTION
While running IndexTTS on the 2080 Ti, I noticed that the performance of the F16‑quantized GGUF and the F32‑quantized GGUF was almost identical, so I made a fix to address the performance difference.

Here is the comparison before and after the fix:

| Stage | Before fix (f16) | After fix (f16) | Improvement |
|-------|------------------|-----------------|-------------|
| GPT decoding | 3126 ms | 2555 ms | –18.3% |
| CFM | 2617 ms | 1930 ms | –26.3% |
| BigVGAN | 982 ms | 742 ms | –24.4% |
| Total | 6889 ms | 5393 ms | –21.7% |

Need your input: should we go ahead with this change?