### PR TITLE
Fix Qwen3-ASR language option propagation

### DIFF
--- a/src/models/qwen3_asr/session.cpp
+++ b/src/models/qwen3_asr/session.cpp
@@ -609,6 +609,9 @@ Qwen3ASRRequest Qwen3ASRSession::make_request(const runtime::TaskRequest & reque
         out.context = request.text_input->text;
         out.language = request.text_input->language;
     }
+    if (const auto value = runtime::find_option(request.options, {"language"})) {
+        out.language = *value == "Auto" ? "" : *value;
+    }
     if (const auto value = runtime::parse_int_option(request.options, {"max_tokens"})) {
         out.generation.max_new_tokens = *value;
         if (out.generation.max_new_tokens <= 0) {

--- a/tests/unittests/test_cli_request_options.cpp
+++ b/tests/unittests/test_cli_request_options.cpp
@@ -69,12 +69,21 @@ void test_unsafe_integer_numbers_are_not_silently_rounded() {
     require_seed_rejected(rounded);
 }
 
+void test_audio_only_language_is_request_option() {
+    const char * argv[] = {"audiocpp_cli", "--task", "asr", "--family", "qwen3_asr", "--language", "en"};
+    const auto request = minitts::cli::build_request_from_cli(7, const_cast<char **>(argv));
+
+    engine::test::require(!request.text_input.has_value(), "audio-only language does not synthesize text input");
+    engine::test::require_eq(request.options.at("language"), std::string("en"), "audio-only language request option");
+}
+
 }  // namespace
 
 int main() {
     test_large_safe_integer_numbers_stay_decimal();
     test_float_numbers_keep_json_formatting();
     test_unsafe_integer_numbers_are_not_silently_rounded();
+    test_audio_only_language_is_request_option();
     std::cout << "cli_request_options_test passed\n";
     return 0;
 }


### PR DESCRIPTION
## Summary
- Propagate request option `language` into Qwen3-ASR audio-only requests.
- Preserve `Auto` as language auto-detection mode.
- Add a CLI request-options regression test for audio-only `--language`.

Fixes #250

## Validation
- `cmake --build build/debug --target cli_request_options_test audiocpp_cli -j$(nproc)`
- `build/debug/bin/cli_request_options_test`
- CUDA Qwen3-ASR prompt-token check:
  - no language: `qwen3_asr.prompt_tokens 61`
  - `--language en`: `qwen3_asr.prompt_tokens 64`
  - `--language Auto`: `qwen3_asr.prompt_tokens 61`
  - `--language zh`: `qwen3_asr.prompt_tokens 64`
  - `--language ja`: `qwen3_asr.prompt_tokens 64`
- CUDA `--words-out` with Qwen3 forced aligner completed and produced word timestamps.
- `git diff --check`