### PR TITLE
Add DotTTS edit inference

### DIFF
--- a/include/engine/models/dots_tts/audio_features.h
+++ b/include/engine/models/dots_tts/audio_features.h
@@ -26,6 +26,11 @@ DotsPreparedReferenceAudio prepare_dots_reference_audio(
     int64_t samples_per_patch,
     std::optional<float> max_duration_seconds = std::nullopt);
 
+std::vector<float> prepare_dots_edit_source_audio(
+    const runtime::AudioBuffer & audio,
+    int vocoder_sample_rate,
+    int64_t samples_per_patch);
+
 DotsFbankOutput compute_dots_speaker_fbank_16k(const std::vector<float> & waveform_16k);
 
 }  // namespace engine::models::dots_tts

--- a/include/engine/models/dots_tts/session.h
+++ b/include/engine/models/dots_tts/session.h
@@ -76,7 +76,11 @@ private:
         const std::string & text,
         PromptConditioning & conditioning,
         const std::function<void(const DotsLatentMatrix &, int64_t)> & on_payload_patch = {});
+    std::vector<DotsLatentMatrix> generate_edit_latent_patches(
+        const DotsRequest & request,
+        const std::function<void(const DotsLatentMatrix &, int64_t)> & on_payload_patch = {});
     runtime::AudioBuffer synthesize_segment(const DotsRequest & request, const std::string & text);
+    runtime::AudioBuffer synthesize_edit(const DotsRequest & request);
     runtime::AudioBuffer synthesize_streaming_segment(
         const DotsRequest & request,
         const std::string & text,

--- a/include/engine/models/dots_tts/tokenizer.h
+++ b/include/engine/models/dots_tts/tokenizer.h
@@ -19,8 +19,15 @@ public:
         const std::string & text,
         DotsTemplateName template_name,
         int64_t max_audio_tokens) const;
+    DotsGenerationSchedule build_edit_generation_schedule(
+        const std::string & source_text,
+        const std::string & instruction,
+        const std::string & target_text,
+        int64_t source_audio_tokens,
+        int64_t target_audio_tokens) const;
     int32_t audio_gen_span_id() const noexcept;
     int32_t audio_gen_start_id() const noexcept;
+    int32_t audio_gen_end_id() const noexcept;
     int32_t text_cond_end_id() const noexcept;
 
 private:

--- a/include/engine/models/dots_tts/types.h
+++ b/include/engine/models/dots_tts/types.h
@@ -87,12 +87,19 @@ enum class DotsTemplateName {
     InstructionTts,
     TextToAudio,
     TtsInterleave,
+    Edit,
 };
 
 enum class DotsOdeMethod {
     Euler,
     Midpoint,
     Rk4,
+};
+
+enum class DotsEditXVectorMode {
+    Auto,
+    On,
+    Off,
 };
 
 struct DotsGenerationOptions {
@@ -115,10 +122,19 @@ struct DotsPromptReference {
     std::optional<float> duration_seconds;
 };
 
+struct DotsEditOptions {
+    std::optional<runtime::AudioBuffer> source_audio;
+    std::string instruction;
+    std::string source_text;
+    std::string target_text;
+    DotsEditXVectorMode use_xvector = DotsEditXVectorMode::Auto;
+};
+
 struct DotsRequest {
     std::string text;
     DotsPromptReference reference;
     DotsGenerationOptions generation;
+    DotsEditOptions edit;
 };
 
 struct DotsGenerationSchedule {

--- a/model_specs/dots_tts.json
+++ b/model_specs/dots_tts.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "family": "dots_tts",
   "display_name": "DotTTS",
-  "description": "DotTTS is a multilingual zero-shot TTS and voice-cloning model family packaged for audio.cpp with SOAR and MeanFlow generation, prompt-audio plus prompt-text prefill, speaker-reference conditioning, language tags, multiple synthesis templates, long-form text chunking, and true streaming audio output.",
+  "description": "DotTTS is a multilingual zero-shot TTS, voice-cloning, and speech-editing model family packaged for audio.cpp with SOAR and MeanFlow generation, prompt-audio plus prompt-text prefill, speaker-reference conditioning, language tags, multiple synthesis templates, long-form text chunking, and true streaming audio output.",
   "category": "tts",
   "status": "supported",
   "tasks": [
@@ -52,15 +52,58 @@
       {
         "name": "template_name",
         "type": "enum",
-        "description": "DotTTS synthesis template. tts is normal text-to-speech; instruction_tts adds instruction conditioning; text_to_audio uses a sound-description template; tts_interleave uses the streaming interleave schedule.",
+        "description": "DotTTS synthesis template. tts is normal text-to-speech; instruction_tts adds instruction conditioning; text_to_audio uses a sound-description template; tts_interleave uses the streaming interleave schedule; edit uses the DotTTS Edit source-audio editing schedule.",
         "values": [
           "tts",
           "instruction_tts",
           "text_to_audio",
-          "tts_interleave"
+          "tts_interleave",
+          "edit"
         ],
         "required": false,
         "default": "tts"
+      },
+      {
+        "name": "source_audio",
+        "type": "audio_path",
+        "description": "Source WAV path for DotTTS Edit. Required when template_name=edit unless audio_input is supplied by the caller.",
+        "required": false
+      },
+      {
+        "name": "instruction",
+        "type": "string",
+        "description": "Structured DotTTS Edit instruction. If omitted with template_name=edit, the request text is used as the instruction.",
+        "required": false
+      },
+      {
+        "name": "instruct",
+        "type": "string",
+        "description": "Alias for instruction for CLI compatibility.",
+        "required": false
+      },
+      {
+        "name": "source_text",
+        "type": "string",
+        "description": "Optional source transcript override for DotTTS Edit. If omitted, it is rendered from instruction tags.",
+        "required": false
+      },
+      {
+        "name": "target_text",
+        "type": "string",
+        "description": "Optional target transcript override for DotTTS Edit. If omitted, it is rendered from instruction tags.",
+        "required": false
+      },
+      {
+        "name": "use_xvector",
+        "type": "enum",
+        "description": "DotTTS Edit speaker conditioning mode. auto follows the upstream tag-based behavior; on/off force or disable source-audio speaker conditioning.",
+        "values": [
+          "auto",
+          "on",
+          "off"
+        ],
+        "required": false,
+        "default": "auto"
       },
       {
         "name": "language",
@@ -277,6 +320,30 @@
         "DotTTS-MF-GGUF/dots-tts-mf-bf16.gguf"
       ],
       "strip_prefix": "DotTTS-MF-GGUF"
+    },
+    {
+      "id": "dots_tts_edit_q8_0",
+      "display_name": "DotTTS Edit Q8_0 GGUF",
+      "default": false,
+      "format": "gguf",
+      "precision": "q8_0",
+      "target_directory": "DotTTS-Edit-GGUF",
+      "files": [
+        "DotTTS-Edit-GGUF/dots-tts-edit-q8_0.gguf"
+      ],
+      "strip_prefix": "DotTTS-Edit-GGUF"
+    },
+    {
+      "id": "dots_tts_edit_bf16",
+      "display_name": "DotTTS Edit BF16 GGUF",
+      "default": false,
+      "format": "gguf",
+      "precision": "bf16",
+      "target_directory": "DotTTS-Edit-GGUF",
+      "files": [
+        "DotTTS-Edit-GGUF/dots-tts-edit-bf16.gguf"
+      ],
+      "strip_prefix": "DotTTS-Edit-GGUF"
     }
   ],
   "dependencies": [],

--- a/src/models/dots_tts/audio_features.cpp
+++ b/src/models/dots_tts/audio_features.cpp
@@ -11,9 +11,13 @@
 #include <cmath>
 #include <limits>
 #include <stdexcept>
+#include <string>
 
 namespace engine::models::dots_tts {
 namespace {
+
+constexpr float kEditEdgeSilenceMs = 250.0F;
+constexpr float kEditEdgeSilenceTopDb = 30.0F;
 
 std::vector<float> make_dots_speaker_mel_filterbank(
     int64_t sample_rate,
@@ -44,6 +48,81 @@ std::vector<float> make_dots_speaker_mel_filterbank(
         }
     }
     return filterbank;
+}
+
+std::vector<float> validated_mono_samples(const runtime::AudioBuffer & audio, const char * role) {
+    if (audio.channels <= 0) {
+        throw std::runtime_error(std::string("DotTTS ") + role + " audio channel count must be positive");
+    }
+    if (audio.sample_rate <= 0) {
+        throw std::runtime_error(std::string("DotTTS ") + role + " audio sample rate must be positive");
+    }
+    if (audio.samples.empty()) {
+        throw std::runtime_error(std::string("DotTTS ") + role + " audio must not be empty");
+    }
+    if (audio.samples.size() % static_cast<size_t>(audio.channels) != 0) {
+        throw std::runtime_error(std::string("DotTTS ") + role + " audio sample count must be divisible by channel count");
+    }
+    return audio.channels == 1
+        ? audio.samples
+        : engine::audio::mixdown_interleaved_to_mono_average(audio.samples, audio.channels);
+}
+
+void normalize_edit_edge_silence(std::vector<float> & waveform, int sample_rate) {
+    if (waveform.empty()) {
+        return;
+    }
+    const size_t target_samples = static_cast<size_t>(std::llround(
+        static_cast<double>(sample_rate) * static_cast<double>(kEditEdgeSilenceMs) / 1000.0));
+    if (target_samples == 0) {
+        return;
+    }
+    float peak = 0.0F;
+    for (const float sample : waveform) {
+        peak = std::max(peak, std::fabs(sample));
+    }
+    if (peak <= 0.0F) {
+        waveform.assign(target_samples, 0.0F);
+        return;
+    }
+    const float threshold = peak * std::pow(10.0F, -kEditEdgeSilenceTopDb / 20.0F);
+    size_t first = 0;
+    while (first < waveform.size() && std::fabs(waveform[first]) <= threshold) {
+        ++first;
+    }
+    if (first == waveform.size()) {
+        waveform.assign(target_samples, 0.0F);
+        return;
+    }
+    size_t last = waveform.size() - 1;
+    while (last > first && std::fabs(waveform[last]) <= threshold) {
+        --last;
+    }
+    const size_t leading = first;
+    const size_t trailing = waveform.size() - last - 1;
+    if (leading < target_samples) {
+        waveform.insert(waveform.begin(), target_samples - leading, 0.0F);
+    } else if (leading > target_samples) {
+        waveform.erase(waveform.begin(), waveform.begin() + static_cast<std::ptrdiff_t>(leading - target_samples));
+    }
+    const size_t current_trailing = std::min(trailing, waveform.size());
+    if (current_trailing < target_samples) {
+        waveform.insert(waveform.end(), target_samples - current_trailing, 0.0F);
+    } else if (current_trailing > target_samples) {
+        waveform.resize(waveform.size() - (current_trailing - target_samples));
+    }
+}
+
+void pad_to_multiple(std::vector<float> & waveform, int64_t multiple) {
+    if (multiple <= 0) {
+        throw std::runtime_error("DotTTS audio padding multiple must be positive");
+    }
+    const int64_t samples = static_cast<int64_t>(waveform.size());
+    const int64_t remainder = samples % multiple;
+    if (remainder == 0) {
+        return;
+    }
+    waveform.resize(static_cast<size_t>(samples + multiple - remainder), 0.0F);
 }
 
 }  // namespace
@@ -203,6 +282,32 @@ DotsPreparedReferenceAudio prepare_dots_reference_audio(
     output.waveform_vocoder_rate.resize(static_cast<size_t>(padded_samples), 0.0F);
     engine::debug::trace_log_scalar("dots_tts.reference.padded_samples", padded_samples);
     return output;
+}
+
+std::vector<float> prepare_dots_edit_source_audio(
+    const runtime::AudioBuffer & audio,
+    int vocoder_sample_rate,
+    int64_t samples_per_patch) {
+    if (audio.sample_rate <= 0 || vocoder_sample_rate <= 0) {
+        throw std::runtime_error("DotTTS edit source resampling requires positive sample rates");
+    }
+    auto mono = validated_mono_samples(audio, "edit source");
+    engine::audio::TorchaudioSincHannResampleOptions options;
+    options.lowpass_filter_width = 128;
+    options.rolloff = 0.95;
+    options.kernel_mode = engine::audio::TorchaudioSincHannKernelMode::Float32ComputationStoredAsFloat32;
+    options.accumulation = engine::audio::TorchaudioSincHannAccumulation::Float32;
+    if (audio.sample_rate != vocoder_sample_rate) {
+        mono = engine::audio::resample_mono_torchaudio_sinc_hann(
+            mono,
+            audio.sample_rate,
+            vocoder_sample_rate,
+            options);
+    }
+    normalize_edit_edge_silence(mono, vocoder_sample_rate);
+    pad_to_multiple(mono, samples_per_patch);
+    engine::debug::trace_log_scalar("dots_tts.edit.source_samples", static_cast<int64_t>(mono.size()));
+    return mono;
 }
 
 }  // namespace engine::models::dots_tts

--- a/src/models/dots_tts/request.cpp
+++ b/src/models/dots_tts/request.cpp
@@ -1,9 +1,11 @@
 #include "engine/models/dots_tts/request.h"
 
+#include "engine/framework/audio/wav_reader.h"
 #include "engine/framework/runtime/options.h"
 #include "engine/framework/text/chunking.h"
 
 #include <cmath>
+#include <filesystem>
 #include <stdexcept>
 #include <string>
 
@@ -23,7 +25,10 @@ DotsTemplateName parse_template_name(const std::string & value) {
     if (value == "tts_interleave") {
         return DotsTemplateName::TtsInterleave;
     }
-    throw std::runtime_error("DotTTS template_name must be tts, instruction_tts, text_to_audio, or tts_interleave");
+    if (value == "edit") {
+        return DotsTemplateName::Edit;
+    }
+    throw std::runtime_error("DotTTS template_name must be tts, instruction_tts, text_to_audio, tts_interleave, or edit");
 }
 
 DotsOdeMethod parse_sampler_mode(const std::string & value) {
@@ -37,6 +42,24 @@ DotsOdeMethod parse_sampler_mode(const std::string & value) {
         return DotsOdeMethod::Rk4;
     }
     throw std::runtime_error("DotTTS sampler_mode must be euler, midpoint, or rk4");
+}
+
+DotsEditXVectorMode parse_edit_xvector_mode(const std::string & value) {
+    if (value == "auto") {
+        return DotsEditXVectorMode::Auto;
+    }
+    if (value == "on" || value == "true" || value == "1") {
+        return DotsEditXVectorMode::On;
+    }
+    if (value == "off" || value == "false" || value == "0") {
+        return DotsEditXVectorMode::Off;
+    }
+    throw std::runtime_error("DotTTS use_xvector must be auto, on, or off");
+}
+
+runtime::AudioBuffer read_audio_buffer(const std::filesystem::path & path) {
+    const auto wav = engine::audio::read_wav_f32(path);
+    return runtime::AudioBuffer{wav.sample_rate, wav.channels, wav.samples};
 }
 
 DotsGenerationOptions generation_options(
@@ -76,6 +99,30 @@ DotsGenerationOptions generation_options(
         throw std::runtime_error("DotTTS speaker_scale must be finite and non-negative");
     }
     return defaults;
+}
+
+void apply_edit_options(DotsRequest & out, const runtime::TaskRequest & request) {
+    out.edit.instruction = runtime::find_option(request.options, {"instruction", "instruct"}).value_or(std::string{});
+    out.edit.source_text = runtime::find_option(request.options, {"source_text"}).value_or(std::string{});
+    out.edit.target_text = runtime::find_option(request.options, {"target_text"}).value_or(std::string{});
+    if (const auto value = runtime::find_option(request.options, {"use_xvector"})) {
+        out.edit.use_xvector = parse_edit_xvector_mode(*value);
+    }
+    if (const auto source_path = runtime::find_option(request.options, {"source_audio"})) {
+        out.edit.source_audio = read_audio_buffer(*source_path);
+    } else if (request.audio_input.has_value()) {
+        out.edit.source_audio = request.audio_input;
+    }
+    if (out.generation.template_name != DotsTemplateName::Edit) {
+        return;
+    }
+    const bool has_instruction_option = !out.edit.instruction.empty();
+    if (!has_instruction_option) {
+        out.edit.instruction = out.text;
+    }
+    if (out.edit.target_text.empty() && has_instruction_option) {
+        out.edit.target_text = out.text;
+    }
 }
 
 std::optional<DotsPromptReference> voice_reference(const std::optional<runtime::VoiceCondition> & voice) {
@@ -142,12 +189,20 @@ DotsRequest make_dots_request(
         }
     }
     out.generation = generation_options(assets.config, request.options, out.generation);
+    apply_edit_options(out, request);
     if (auto reference = voice_reference(request.voice)) {
         out.reference = std::move(*reference);
     }
     apply_reference_text(out.reference, request.options);
     apply_reference_duration(out.reference, request.options);
-    if (out.text.empty()) {
+    if (out.generation.template_name == DotsTemplateName::Edit) {
+        if (!out.edit.source_audio.has_value()) {
+            throw std::runtime_error("DotTTS edit requires source_audio or audio_input");
+        }
+        if (out.edit.instruction.empty()) {
+            throw std::runtime_error("DotTTS edit requires instruction or request text");
+        }
+    } else if (out.text.empty()) {
         throw std::runtime_error("DotTTS request text must not be empty");
     }
     if (!out.reference.reference_text.empty() && !out.reference.audio.has_value()) {

--- a/src/models/dots_tts/session.cpp
+++ b/src/models/dots_tts/session.cpp
@@ -1,6 +1,7 @@
 #include "engine/models/dots_tts/session.h"
 
 #include "engine/framework/debug/trace.h"
+#include "engine/framework/audio/resampling.h"
 #include "engine/framework/runtime/options.h"
 #include "engine/framework/runtime/spec_backed_model.h"
 #include "engine/framework/sampling/torch_random.h"
@@ -17,7 +18,9 @@
 #include <cstring>
 #include <functional>
 #include <limits>
+#include <regex>
 #include <stdexcept>
+#include <string_view>
 #include <utility>
 
 namespace engine::models::dots_tts {
@@ -161,6 +164,207 @@ void append_projected(std::vector<float> & dst, const DotsProjectedSequence & pr
     auto values = projected.values;
     engine::core::round_f32_to_bf16_in_place(values);
     dst.insert(dst.end(), values.begin(), values.end());
+}
+
+std::string lowercase_ascii(std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char ch) {
+        return static_cast<char>(std::tolower(ch));
+    });
+    return value;
+}
+
+std::string trim_ascii(std::string_view value) {
+    return engine::io::trim_ascii_whitespace(std::string(value));
+}
+
+std::string html_unescape(std::string value) {
+    const std::pair<const char *, const char *> replacements[] = {
+        {"&quot;", "\""},
+        {"&#39;", "'"},
+        {"&apos;", "'"},
+        {"&lt;", "<"},
+        {"&gt;", ">"},
+        {"&amp;", "&"},
+    };
+    for (const auto & replacement : replacements) {
+        size_t pos = 0;
+        while ((pos = value.find(replacement.first, pos)) != std::string::npos) {
+            value.replace(pos, std::strlen(replacement.first), replacement.second);
+            pos += std::strlen(replacement.second);
+        }
+    }
+    return value;
+}
+
+std::string tag_name(std::string_view tag) {
+    size_t pos = 1;
+    while (pos < tag.size() && std::isspace(static_cast<unsigned char>(tag[pos]))) {
+        ++pos;
+    }
+    if (pos < tag.size() && tag[pos] == '/') {
+        ++pos;
+    }
+    while (pos < tag.size() && std::isspace(static_cast<unsigned char>(tag[pos]))) {
+        ++pos;
+    }
+    const size_t start = pos;
+    while (pos < tag.size()) {
+        const unsigned char ch = static_cast<unsigned char>(tag[pos]);
+        if (!std::isalnum(ch) && tag[pos] != '_' && tag[pos] != '-') {
+            break;
+        }
+        ++pos;
+    }
+    return lowercase_ascii(std::string(tag.substr(start, pos - start)));
+}
+
+bool closing_tag(std::string_view tag) {
+    size_t pos = 1;
+    while (pos < tag.size() && std::isspace(static_cast<unsigned char>(tag[pos]))) {
+        ++pos;
+    }
+    return pos < tag.size() && tag[pos] == '/';
+}
+
+bool self_closing_tag(std::string_view tag) {
+    size_t pos = tag.size();
+    while (pos > 0 && std::isspace(static_cast<unsigned char>(tag[pos - 1]))) {
+        --pos;
+    }
+    return pos >= 2 && tag[pos - 2] == '/';
+}
+
+std::optional<std::string> sub_target(std::string_view tag) {
+    static const std::regex target_re(R"(\btarg\s*=\s*([\"'])(.*?)\1)", std::regex::icase);
+    std::cmatch match;
+    const std::string text(tag);
+    if (!std::regex_search(text.c_str(), match, target_re)) {
+        return std::nullopt;
+    }
+    return html_unescape(match[2].str());
+}
+
+bool known_edit_container_tag(const std::string & tag) {
+    return tag == "del" || tag == "ins" || tag == "sub" || tag == "emo" ||
+        tag == "pitch" || tag == "rate" || tag == "enhance" || tag == "bg";
+}
+
+bool known_edit_empty_tag(const std::string & tag) {
+    return tag == "pause" || tag == "spk_transfer";
+}
+
+bool xvector_auto_disable_tag(const std::string & tag) {
+    return tag == "emo" || tag == "bg" || tag == "enhance";
+}
+
+struct RenderedEditInstruction {
+    std::string source_text;
+    std::string target_text;
+    bool auto_uses_xvector = true;
+};
+
+RenderedEditInstruction render_edit_instruction(const std::string & instruction) {
+    struct Frame {
+        std::string tag;
+        bool source_visible = true;
+        bool target_visible = true;
+    };
+    std::vector<Frame> stack;
+    bool source_visible = true;
+    bool target_visible = true;
+    bool has_operation_tag = false;
+    bool has_non_xvector_disable_tag = false;
+    RenderedEditInstruction out;
+    static const std::regex tag_re(R"(<[^>]*>)");
+    std::sregex_iterator it(instruction.begin(), instruction.end(), tag_re);
+    std::sregex_iterator end;
+    size_t cursor = 0;
+    auto append_text = [&](std::string_view text) {
+        const auto unescaped = html_unescape(std::string(text));
+        if (source_visible) {
+            out.source_text += unescaped;
+        }
+        if (target_visible) {
+            out.target_text += unescaped;
+        }
+    };
+    for (; it != end; ++it) {
+        const auto & match = *it;
+        if (static_cast<size_t>(match.position()) > cursor) {
+            append_text(std::string_view(instruction).substr(cursor, static_cast<size_t>(match.position()) - cursor));
+        }
+        const std::string raw_tag = match.str();
+        const std::string tag = tag_name(raw_tag);
+        if (tag.empty()) {
+            throw std::runtime_error("DotTTS edit instruction contains malformed tag");
+        }
+        if (closing_tag(raw_tag)) {
+            if (stack.empty() || stack.back().tag != tag) {
+                throw std::runtime_error("DotTTS edit instruction contains mismatched closing tag: " + raw_tag);
+            }
+            stack.pop_back();
+            source_visible = stack.empty() ? true : stack.back().source_visible;
+            target_visible = stack.empty() ? true : stack.back().target_visible;
+            cursor = static_cast<size_t>(match.position() + match.length());
+            continue;
+        }
+        if (known_edit_empty_tag(tag)) {
+            has_operation_tag = true;
+            has_non_xvector_disable_tag = true;
+            if (!self_closing_tag(raw_tag)) {
+                throw std::runtime_error("DotTTS edit empty tag must be self-closing: " + raw_tag);
+            }
+            cursor = static_cast<size_t>(match.position() + match.length());
+            continue;
+        }
+        if (!known_edit_container_tag(tag)) {
+            throw std::runtime_error("DotTTS edit instruction contains unsupported tag: " + raw_tag);
+        }
+        has_operation_tag = true;
+        has_non_xvector_disable_tag = has_non_xvector_disable_tag || !xvector_auto_disable_tag(tag);
+        bool next_source_visible = source_visible;
+        bool next_target_visible = target_visible;
+        if (tag == "del") {
+            next_target_visible = false;
+        } else if (tag == "ins") {
+            next_source_visible = false;
+        } else if (tag == "sub") {
+            const auto target = sub_target(raw_tag);
+            if (!target.has_value()) {
+                throw std::runtime_error("DotTTS edit <sub> tag requires a quoted targ attribute");
+            }
+            if (target_visible) {
+                out.target_text += *target;
+            }
+            next_target_visible = false;
+        }
+        stack.push_back(Frame{tag, next_source_visible, next_target_visible});
+        source_visible = next_source_visible;
+        target_visible = next_target_visible;
+        cursor = static_cast<size_t>(match.position() + match.length());
+    }
+    if (cursor < instruction.size()) {
+        append_text(std::string_view(instruction).substr(cursor));
+    }
+    if (!stack.empty()) {
+        throw std::runtime_error("DotTTS edit instruction contains an unclosed tag: <" + stack.back().tag + ">");
+    }
+    out.source_text = trim_ascii(out.source_text);
+    out.target_text = trim_ascii(out.target_text);
+    out.auto_uses_xvector = !has_operation_tag || has_non_xvector_disable_tag;
+    return out;
+}
+
+bool resolve_edit_use_xvector(DotsEditXVectorMode mode, bool auto_uses_xvector) {
+    switch (mode) {
+        case DotsEditXVectorMode::Auto:
+            return auto_uses_xvector;
+        case DotsEditXVectorMode::On:
+            return true;
+        case DotsEditXVectorMode::Off:
+            return false;
+    }
+    throw std::runtime_error("DotTTS edit use_xvector has invalid value");
 }
 
 }  // namespace
@@ -638,6 +842,310 @@ std::vector<DotsLatentMatrix> DotsSession::generate_latent_patches(
     return payload;
 }
 
+std::vector<DotsLatentMatrix> DotsSession::generate_edit_latent_patches(
+    const DotsRequest & request,
+    const std::function<void(const DotsLatentMatrix &, int64_t)> & on_payload_patch) {
+    ensure_llm_loaded();
+    ensure_patch_encoder_loaded();
+    ensure_flow_loaded();
+    ensure_audio_vae_loaded();
+    const auto rendered = render_edit_instruction(request.edit.instruction);
+    const std::string source_text = request.edit.source_text.empty()
+        ? rendered.source_text
+        : trim_ascii(request.edit.source_text);
+    const std::string target_text = request.edit.target_text.empty()
+        ? rendered.target_text
+        : trim_ascii(request.edit.target_text);
+    if (source_text.empty()) {
+        throw std::runtime_error("DotTTS edit source_text is missing and instruction renders an empty source transcript");
+    }
+    if (target_text.empty()) {
+        throw std::runtime_error("DotTTS edit target_text is missing and instruction renders an empty target transcript");
+    }
+    if (!request.edit.source_audio.has_value()) {
+        throw std::runtime_error("DotTTS edit requires source audio");
+    }
+
+    const int64_t samples_per_patch = assets_->config.patch_size * audio_vae_.hop_size();
+    auto source_waveform = prepare_dots_edit_source_audio(
+        *request.edit.source_audio,
+        assets_->config.vocoder.sample_rate,
+        samples_per_patch);
+    const auto rng_policy = engine::sampling::resolve_torch_cuda_sampling_policy(
+        execution_context().backend_type(),
+        execution_context().config().device,
+        "dots_tts.edit.rng",
+        "DotTTS",
+        engine::sampling::TorchCudaSamplingPolicyFailureMode::StrictCuda);
+    const auto encoded = audio_vae_.extract_latents(source_waveform);
+    auto source_latents = latent_codec_.sample_from_encoder_latents(
+        encoded.values,
+        encoded.channels,
+        encoded.frames,
+        request.generation.seed,
+        0,
+        rng_policy);
+    if (source_latents.frames % assets_->config.patch_size != 0) {
+        throw std::runtime_error("DotTTS edit source latent frames must align to patch size");
+    }
+    const int64_t source_patch_count = source_latents.frames / assets_->config.patch_size;
+    if (source_patch_count <= 0) {
+        throw std::runtime_error("DotTTS edit source audio produced no latent patches");
+    }
+    if (request.generation.max_tokens <= source_patch_count) {
+        throw std::runtime_error("DotTTS edit max_tokens must exceed source audio patch count");
+    }
+    const int64_t target_audio_tokens = request.generation.max_tokens - source_patch_count;
+    const bool use_xvector = resolve_edit_use_xvector(request.edit.use_xvector, rendered.auto_uses_xvector);
+    std::vector<float> speaker_condition(static_cast<size_t>(assets_->config.dit.hidden_size), 0.0F);
+    if (use_xvector) {
+        ensure_speaker_encoder_loaded();
+        const auto resample_options = engine::audio::torchaudio_sinc_hann_float32_options();
+        auto source_16k = assets_->config.vocoder.sample_rate == 16000
+            ? source_waveform
+            : engine::audio::resample_mono_torchaudio_sinc_hann(
+                source_waveform,
+                assets_->config.vocoder.sample_rate,
+                16000,
+                resample_options);
+        const auto fbank = compute_dots_speaker_fbank_16k(source_16k);
+        auto speaker = speaker_encoder_.embed_from_features(fbank.values, fbank.frames, fbank.dims);
+        for (float & value : speaker.embedding) {
+            value *= request.generation.speaker_scale;
+        }
+        speaker_condition = flow_.project_speaker(speaker.embedding).values;
+        engine::core::round_f32_to_bf16_in_place(speaker_condition);
+    }
+
+    auto schedule = tokenizer_.build_edit_generation_schedule(
+        source_text,
+        request.edit.instruction,
+        target_text,
+        source_patch_count,
+        target_audio_tokens);
+    debug::trace_log_scalar("dots_tts.edit.schedule.length", static_cast<int64_t>(schedule.token_ids.size()));
+    if (static_cast<int64_t>(schedule.token_ids.size()) > kDefaultMaxSequenceLength) {
+        throw std::runtime_error("DotTTS edit generation schedule exceeds max_sequence_length");
+    }
+    const auto spans = audio_span_positions(schedule, tokenizer_.audio_gen_span_id());
+    debug::trace_log_scalar("dots_tts.edit.schedule.audio_spans", static_cast<int64_t>(spans.size()));
+    debug::trace_log_scalar("dots_tts.edit.source.patch_count", source_patch_count);
+    if (static_cast<int64_t>(spans.size()) <= source_patch_count) {
+        throw std::runtime_error("DotTTS edit schedule is too short for target audio generation");
+    }
+
+    SegmentState state;
+    state.llm = llm_.create_state(kDefaultMaxSequenceLength);
+    state.patch = patch_encoder_.create_state(static_cast<int64_t>(spans.size()));
+    state.rng_offset_blocks = engine::sampling::torch_cuda_tensor_iterator_offset_blocks(
+        static_cast<uint64_t>(assets_->config.latent_dim * source_latents.frames),
+        rng_policy);
+    state.null_hidden_projected = flow_.project_llm_hidden(
+        std::vector<float>(static_cast<size_t>(assets_->config.llm.hidden_size), 0.0F),
+        1).values;
+    engine::core::round_f32_to_bf16_in_place(state.null_hidden_projected);
+
+    double flow_project_ms = 0.0;
+    double flow_decode_ms = 0.0;
+    DotsFlowRuntimeStats flow_runtime_stats;
+    double patch_encoder_ms = 0.0;
+    double llm_embed_ms = 0.0;
+    double llm_prefill_ms = 0.0;
+    double llm_decode_ms = 0.0;
+    double eos_ms = 0.0;
+    int64_t llm_state_version = 0;
+
+    const auto patch_prefill_start = Clock::now();
+    auto source_embeddings = patch_encoder_.prefill(source_latents.values, source_latents.frames, state.patch);
+    engine::core::round_f32_to_bf16_in_place(source_embeddings.values);
+    patch_encoder_ms += engine::debug::elapsed_ms(patch_prefill_start, Clock::now());
+
+    const int64_t prefill_end = spans[static_cast<size_t>(source_patch_count)];
+    debug::trace_log_scalar("dots_tts.edit.prefill.end", prefill_end);
+    std::vector<int32_t> prefill_ids(
+        schedule.token_ids.begin(),
+        schedule.token_ids.begin() + static_cast<std::ptrdiff_t>(prefill_end));
+    if (!prefill_ids.empty()) {
+        const auto embed_start = Clock::now();
+        auto embeddings = llm_.embed_tokens(prefill_ids);
+        engine::core::round_f32_to_bf16_in_place(embeddings);
+        llm_embed_ms += engine::debug::elapsed_ms(embed_start, Clock::now());
+        for (int64_t source_index = 0; source_index < source_patch_count; ++source_index) {
+            const int64_t span_pos = spans[static_cast<size_t>(source_index)];
+            const int64_t hidden = assets_->config.llm.hidden_size;
+            std::copy(
+                source_embeddings.values.begin() + static_cast<std::ptrdiff_t>(source_index * hidden),
+                source_embeddings.values.begin() + static_cast<std::ptrdiff_t>((source_index + 1) * hidden),
+                embeddings.begin() + static_cast<std::ptrdiff_t>(span_pos * hidden));
+        }
+        engine::core::round_f32_to_bf16_in_place(embeddings);
+        const auto prefill_start = Clock::now();
+        state.llm_hiddens = llm_.prefill_embeddings(embeddings, prefill_end, state.llm);
+        llm_prefill_ms += engine::debug::elapsed_ms(prefill_start, Clock::now());
+        ++llm_state_version;
+    }
+
+    auto append_hidden = [&](const std::vector<float> & hidden) {
+        const auto start = Clock::now();
+        append_projected(state.fm_sequence, flow_.project_llm_hidden(hidden, 1));
+        flow_project_ms += engine::debug::elapsed_ms(start, Clock::now());
+        state.fm_cfg_sequence.insert(state.fm_cfg_sequence.end(), state.null_hidden_projected.begin(), state.null_hidden_projected.end());
+        ++state.fm_seq_len;
+    };
+    auto append_history = [&](const DotsLatentMatrix & patch) {
+        const auto start = Clock::now();
+        auto projected = flow_.project_latents(patch.values, patch.frames);
+        append_projected(state.fm_sequence, projected);
+        append_projected(state.fm_cfg_sequence, projected);
+        flow_project_ms += engine::debug::elapsed_ms(start, Clock::now());
+        state.fm_seq_len += patch.frames;
+    };
+    if (prefill_end > 0) {
+        append_hidden(slice_row(state.llm_hiddens.values, prefill_end - 1, state.llm_hiddens.hidden_size));
+    }
+
+    std::vector<DotsLatentMatrix> payload;
+    int64_t payload_count = 0;
+    float last_post_eos_probability = 0.0F;
+    int64_t decoded_audio_count = 0;
+    bool cached_eos_valid = false;
+    int64_t cached_eos_version = -1;
+    float cached_eos_probability = 0.0F;
+    int64_t position = prefill_end;
+    size_t span_cursor = static_cast<size_t>(std::lower_bound(spans.begin(), spans.end(), position) - spans.begin());
+    while (position < static_cast<int64_t>(schedule.token_ids.size())) {
+        const int32_t token_id = schedule.token_ids[static_cast<size_t>(position)];
+        if (token_id == tokenizer_.audio_gen_span_id()) {
+            float eos_probability = 0.0F;
+            if (state.llm_hiddens.hidden_size > 0) {
+                if (cached_eos_valid && cached_eos_version == llm_state_version) {
+                    eos_probability = cached_eos_probability;
+                } else {
+                    const auto eos_start = Clock::now();
+                    eos_probability = llm_.eos_probability(slice_row(
+                        state.llm_hiddens.values,
+                        state.llm_hiddens.steps - 1,
+                        state.llm_hiddens.hidden_size));
+                    eos_ms += engine::debug::elapsed_ms(eos_start, Clock::now());
+                    cached_eos_valid = true;
+                    cached_eos_version = llm_state_version;
+                    cached_eos_probability = eos_probability;
+                }
+            }
+            const bool stop_after_current = state.llm_hiddens.hidden_size > 0 && eos_probability > kEosThreshold;
+            DotsFlowDecodeRequest flow_request;
+            flow_request.sequence = &state.fm_sequence;
+            flow_request.cfg_sequence = &state.fm_cfg_sequence;
+            flow_request.speaker_condition = &speaker_condition;
+            flow_request.fm_seq_len = state.fm_seq_len;
+            flow_request.num_inference_steps = request.generation.num_inference_steps;
+            flow_request.ode_method = request.generation.ode_method;
+            flow_request.guidance_scale = request.generation.guidance_scale;
+            flow_request.seed = request.generation.seed;
+            flow_request.rng_offset_blocks = state.rng_offset_blocks;
+            flow_request.cache_capacity = static_cast<int64_t>(spans.size()) * (assets_->config.patch_size + 1);
+            flow_request.runtime_stats = &flow_runtime_stats;
+            flow_request.decode_state = &state.flow;
+            flow_request.use_cached_dit = true;
+            const auto flow_start = Clock::now();
+            auto audio_patch = assets_->config.meanflow.has_value() && assets_->config.meanflow->enabled
+                ? flow_.decode_next_meanflow(flow_request)
+                : flow_.decode_next_soar(flow_request);
+            flow_decode_ms += engine::debug::elapsed_ms(flow_start, Clock::now());
+            ++decoded_audio_count;
+            state.rng_offset_blocks += engine::sampling::torch_cuda_tensor_iterator_offset_blocks(
+                static_cast<uint64_t>(audio_patch.values.size()),
+                rng_policy);
+            append_history(audio_patch);
+            auto patch_encoder_input = latent_codec_.denormalize(audio_patch);
+            const auto patch_start = Clock::now();
+            auto llm_embedding = patch_encoder_.decode_patch(patch_encoder_input.values, state.patch);
+            patch_encoder_ms += engine::debug::elapsed_ms(patch_start, Clock::now());
+            engine::core::round_f32_to_bf16_in_place(llm_embedding.values);
+            const auto llm_start = Clock::now();
+            state.llm_hiddens = llm_.decode_embedding(llm_embedding.values, state.llm);
+            llm_decode_ms += engine::debug::elapsed_ms(llm_start, Clock::now());
+            ++llm_state_version;
+            cached_eos_valid = false;
+            float post_eos_probability = 0.0F;
+            if (state.llm_hiddens.hidden_size > 0) {
+                const auto eos_start = Clock::now();
+                post_eos_probability = llm_.eos_probability(slice_row(
+                    state.llm_hiddens.values,
+                    state.llm_hiddens.steps - 1,
+                    state.llm_hiddens.hidden_size));
+                eos_ms += engine::debug::elapsed_ms(eos_start, Clock::now());
+                last_post_eos_probability = post_eos_probability;
+                cached_eos_valid = true;
+                cached_eos_version = llm_state_version;
+                cached_eos_probability = post_eos_probability;
+            }
+            if (next_token_is_audio_span(schedule, position, tokenizer_.audio_gen_span_id())) {
+                append_hidden(slice_row(
+                    state.llm_hiddens.values,
+                    state.llm_hiddens.steps - 1,
+                    state.llm_hiddens.hidden_size));
+            }
+            ++position;
+            ++span_cursor;
+            DotsLatentMatrix payload_patch = latent_codec_.denormalize(audio_patch);
+            ++payload_count;
+            if (on_payload_patch) {
+                on_payload_patch(payload_patch, payload_count);
+            } else {
+                payload.push_back(std::move(payload_patch));
+            }
+            if (stop_after_current) {
+                break;
+            }
+            continue;
+        }
+        const int64_t next_audio_pos = span_cursor < spans.size()
+            ? spans[span_cursor]
+            : static_cast<int64_t>(schedule.token_ids.size());
+        while (position < next_audio_pos) {
+            const std::vector<int32_t> token = {schedule.token_ids[static_cast<size_t>(position)]};
+            const auto embed_start = Clock::now();
+            auto embedding = llm_.embed_tokens(token);
+            llm_embed_ms += engine::debug::elapsed_ms(embed_start, Clock::now());
+            const auto llm_start = Clock::now();
+            state.llm_hiddens = llm_.decode_embedding(embedding, state.llm);
+            llm_decode_ms += engine::debug::elapsed_ms(llm_start, Clock::now());
+            ++llm_state_version;
+            cached_eos_valid = false;
+            ++position;
+        }
+        if (position > 0) {
+            append_hidden(slice_row(
+                state.llm_hiddens.values,
+                state.llm_hiddens.steps - 1,
+                state.llm_hiddens.hidden_size));
+        }
+    }
+    if (payload_count == 0) {
+        throw std::runtime_error("DotTTS edit generation produced no decodable latents");
+    }
+    debug::trace_log_scalar("dots_tts.edit.decode.last_post_eos_probability", last_post_eos_probability);
+    debug::trace_log_scalar("dots_tts.edit.decode.payload_patches", payload_count);
+    debug::trace_log_scalar("dots_tts.edit.decode.audio_patches", decoded_audio_count);
+    debug::timing_log_scalar("dots_tts.edit.decode.flow_project_ms", flow_project_ms);
+    debug::timing_log_scalar("dots_tts.edit.decode.flow_ms", flow_decode_ms);
+    debug::trace_log_scalar("dots_tts.edit.decode.flow_velocity_calls", flow_runtime_stats.velocity_calls);
+    debug::timing_log_scalar("dots_tts.edit.decode.flow.modulation_graph_ms", flow_runtime_stats.modulation_graph_ms);
+    debug::timing_log_scalar("dots_tts.edit.decode.flow.modulation_upload_ms", flow_runtime_stats.modulation_input_upload_ms);
+    debug::timing_log_scalar("dots_tts.edit.decode.flow.modulation_compute_ms", flow_runtime_stats.modulation_compute_ms);
+    debug::timing_log_scalar("dots_tts.edit.decode.flow.velocity_graph_ms", flow_runtime_stats.velocity_graph_ms);
+    debug::timing_log_scalar("dots_tts.edit.decode.flow.velocity_upload_ms", flow_runtime_stats.velocity_input_upload_ms);
+    debug::timing_log_scalar("dots_tts.edit.decode.flow.velocity_compute_ms", flow_runtime_stats.velocity_compute_ms);
+    debug::timing_log_scalar("dots_tts.edit.decode.flow.velocity_read_ms", flow_runtime_stats.velocity_output_read_ms);
+    debug::timing_log_scalar("dots_tts.edit.decode.patch_encoder_ms", patch_encoder_ms);
+    debug::timing_log_scalar("dots_tts.edit.decode.llm_embed_ms", llm_embed_ms);
+    debug::timing_log_scalar("dots_tts.edit.decode.llm_prefill_ms", llm_prefill_ms);
+    debug::timing_log_scalar("dots_tts.edit.decode.llm_decode_ms", llm_decode_ms);
+    debug::timing_log_scalar("dots_tts.edit.decode.eos_ms", eos_ms);
+    return payload;
+}
+
 runtime::AudioBuffer DotsSession::synthesize_segment(const DotsRequest & request, const std::string & text) {
     const auto conditioning_start = Clock::now();
     auto conditioning = prepare_prompt_conditioning(request);
@@ -656,6 +1164,24 @@ runtime::AudioBuffer DotsSession::synthesize_segment(const DotsRequest & request
     ensure_audio_vae_loaded();
     auto audio = audio_vae_.decode_latents(joined.values, joined.frames);
     debug::timing_log_scalar("dots_tts.segment.vocoder_ms", engine::debug::elapsed_ms(vocoder_start, Clock::now()));
+    release_audio_phase_components();
+    return {static_cast<int>(audio.sample_rate), 1, std::move(audio.samples)};
+}
+
+runtime::AudioBuffer DotsSession::synthesize_edit(const DotsRequest & request) {
+    auto patches = generate_edit_latent_patches(request);
+    release_generation_phase_components();
+    DotsLatentMatrix joined;
+    joined.frames = 0;
+    joined.dims = assets_->config.latent_dim;
+    for (const auto & patch : patches) {
+        joined.values.insert(joined.values.end(), patch.values.begin(), patch.values.end());
+        joined.frames += patch.frames;
+    }
+    const auto vocoder_start = Clock::now();
+    ensure_audio_vae_loaded();
+    auto audio = audio_vae_.decode_latents(joined.values, joined.frames);
+    debug::timing_log_scalar("dots_tts.edit.vocoder_ms", engine::debug::elapsed_ms(vocoder_start, Clock::now()));
     release_audio_phase_components();
     return {static_cast<int>(audio.sample_rate), 1, std::move(audio.samples)};
 }
@@ -822,6 +1348,9 @@ void DotsSession::release_audio_phase_components() {
 runtime::AudioBuffer DotsSession::synthesize_chunked(
     const runtime::TaskRequest & request,
     const DotsRequest & parsed) {
+    if (parsed.generation.template_name == DotsTemplateName::Edit) {
+        return synthesize_edit(parsed);
+    }
     const auto chunk_requests = runtime::chunk_text_request(
         request,
         parsed.generation.text_chunk_size,
@@ -872,6 +1401,9 @@ void DotsSession::start_stream(const runtime::TaskRequest & request) {
     reset();
     const auto start = Clock::now();
     auto parsed = make_dots_request(*assets_, request, prepared_defaults_);
+    if (parsed.generation.template_name == DotsTemplateName::Edit) {
+        throw std::runtime_error("DotTTS edit is only supported in offline mode");
+    }
     const auto chunk_requests = runtime::chunk_text_request(
         request,
         parsed.generation.text_chunk_size,

--- a/src/models/dots_tts/tokenizer.cpp
+++ b/src/models/dots_tts/tokenizer.cpp
@@ -10,6 +10,7 @@ namespace {
 
 constexpr const char * kAudioGenStartToken = "<|audio_gen_start|>";
 constexpr const char * kAudioGenSpanToken = "<|audio_gen_span|>";
+constexpr const char * kAudioGenEndToken = "<|audio_gen_end|>";
 constexpr const char * kTextCondEndToken = "<|text_cond_end|>";
 constexpr const char * kTtsTemplatePrefix = "[文本]";
 constexpr const char * kTtsTemplateAudio = "[文本对应语音]";
@@ -17,6 +18,11 @@ constexpr const char * kInstructionTemplatePrefix = "[带指令文本]";
 constexpr const char * kTextToAudioTemplatePrefix = "[声音描述]";
 constexpr const char * kTextToAudioTemplateAudio = "[描述对应声音]";
 constexpr const char * kInterleaveTemplatePrefix = "[流式语音合成]";
+constexpr const char * kEditSourceTextPrefix = "[原文本]";
+constexpr const char * kEditSourceAudioPrefix = "[原语音]";
+constexpr const char * kEditInstructionPrefix = "[编辑指令]";
+constexpr const char * kEditTargetTextPrefix = "[编辑文本]";
+constexpr const char * kEditTargetAudioPrefix = "[编辑后语音]";
 
 int32_t require_token_id(const engine::tokenizers::LlamaBpeTokenizer & tokenizer, const std::string & token) {
     const auto id = tokenizer.find_token_id(token);
@@ -40,12 +46,14 @@ struct DotsTokenizer::Impl {
           }),
           audio_gen_start_id(require_token_id(tokenizer, kAudioGenStartToken)),
           audio_gen_span_id(require_token_id(tokenizer, kAudioGenSpanToken)),
+          audio_gen_end_id(require_token_id(tokenizer, kAudioGenEndToken)),
           text_cond_end_id(require_token_id(tokenizer, kTextCondEndToken)) {}
 
     std::shared_ptr<const DotsAssets> assets;
     engine::tokenizers::LlamaBpeTokenizer tokenizer;
     int32_t audio_gen_start_id = 0;
     int32_t audio_gen_span_id = 0;
+    int32_t audio_gen_end_id = 0;
     int32_t text_cond_end_id = 0;
 };
 
@@ -90,6 +98,8 @@ DotsGenerationSchedule DotsTokenizer::build_generation_schedule(
         case DotsTemplateName::TtsInterleave:
             prefix = kInterleaveTemplatePrefix;
             break;
+        case DotsTemplateName::Edit:
+            throw std::runtime_error("DotTTS edit template requires build_edit_generation_schedule");
     }
     DotsGenerationSchedule schedule;
     auto prefix_ids = encode(prefix);
@@ -121,12 +131,62 @@ DotsGenerationSchedule DotsTokenizer::build_generation_schedule(
     return schedule;
 }
 
+DotsGenerationSchedule DotsTokenizer::build_edit_generation_schedule(
+    const std::string & source_text,
+    const std::string & instruction,
+    const std::string & target_text,
+    int64_t source_audio_tokens,
+    int64_t target_audio_tokens) const {
+    if (source_audio_tokens <= 0 || target_audio_tokens <= 0) {
+        throw std::runtime_error("DotTTS edit source and target audio token counts must be positive");
+    }
+    DotsGenerationSchedule schedule;
+    const auto source_text_prefix_ids = encode(kEditSourceTextPrefix);
+    const auto source_text_ids = encode(source_text);
+    const auto source_audio_prefix_ids = encode(kEditSourceAudioPrefix);
+    const auto instruction_prefix_ids = encode(kEditInstructionPrefix);
+    const auto instruction_ids = encode(instruction);
+    const auto target_text_prefix_ids = encode(kEditTargetTextPrefix);
+    const auto target_text_ids = encode(target_text);
+    const auto target_audio_prefix_ids = encode(kEditTargetAudioPrefix);
+    schedule.token_ids.reserve(
+        source_text_prefix_ids.size() +
+        source_text_ids.size() +
+        source_audio_prefix_ids.size() +
+        instruction_prefix_ids.size() +
+        instruction_ids.size() +
+        target_text_prefix_ids.size() +
+        target_text_ids.size() +
+        target_audio_prefix_ids.size() +
+        static_cast<size_t>(source_audio_tokens + target_audio_tokens + 4));
+    schedule.token_ids.insert(schedule.token_ids.end(), source_text_prefix_ids.begin(), source_text_prefix_ids.end());
+    schedule.token_ids.insert(schedule.token_ids.end(), source_text_ids.begin(), source_text_ids.end());
+    schedule.token_ids.insert(schedule.token_ids.end(), source_audio_prefix_ids.begin(), source_audio_prefix_ids.end());
+    schedule.token_ids.push_back(impl_->audio_gen_start_id);
+    schedule.token_ids.insert(schedule.token_ids.end(), static_cast<size_t>(source_audio_tokens), impl_->audio_gen_span_id);
+    schedule.token_ids.push_back(impl_->audio_gen_end_id);
+    schedule.token_ids.insert(schedule.token_ids.end(), instruction_prefix_ids.begin(), instruction_prefix_ids.end());
+    schedule.token_ids.insert(schedule.token_ids.end(), instruction_ids.begin(), instruction_ids.end());
+    schedule.token_ids.insert(schedule.token_ids.end(), target_text_prefix_ids.begin(), target_text_prefix_ids.end());
+    schedule.token_ids.insert(schedule.token_ids.end(), target_text_ids.begin(), target_text_ids.end());
+    schedule.token_ids.insert(schedule.token_ids.end(), target_audio_prefix_ids.begin(), target_audio_prefix_ids.end());
+    schedule.token_ids.push_back(impl_->audio_gen_start_id);
+    schedule.token_ids.insert(schedule.token_ids.end(), static_cast<size_t>(target_audio_tokens), impl_->audio_gen_span_id);
+    schedule.token_ids.push_back(impl_->audio_gen_end_id);
+    schedule.interleave = false;
+    return schedule;
+}
+
 int32_t DotsTokenizer::audio_gen_span_id() const noexcept {
     return impl_->audio_gen_span_id;
 }
 
 int32_t DotsTokenizer::audio_gen_start_id() const noexcept {
     return impl_->audio_gen_start_id;
+}
+
+int32_t DotsTokenizer::audio_gen_end_id() const noexcept {
+    return impl_->audio_gen_end_id;
 }
 
 int32_t DotsTokenizer::text_cond_end_id() const noexcept {


### PR DESCRIPTION
## Summary

Adds DotTTS edit inference support through the existing `dots_tts` family:

- adds `template_name=edit` request handling
- parses official edit instruction tags: `<del>`, `<ins>`, `<sub targ="...">`, `<emo>`, `<pitch>`, `<rate>`, `<enhance>`, `<bg>`, `<pause/>`, and `<spk_transfer/>`
- derives source/target transcripts from tagged instructions, with explicit `source_text` / `target_text` overrides
- supports `use_xvector=auto|on|off` speaker guidance for edit mode
- adds edit source-audio preparation and edit schedule generation
- adds DotTTS edit model spec/package entries

## Validation

Build:

```bash
cmake --build build/debug --target audiocpp_cli -j$(nproc)
```

Official README-style edit example:

```text
source audio ASR: Hello brave world.
edit instruction: Hello <sub targ="small">brave</sub> world.
edited audio ASR: Hello small world.
```

Existing DotTTS path checks against clean `main`:

```text
SOAR focused cases: 4/4 match, 0 differences
MF case: 1/1 match, 0 differences
```
