### PR TITLE
Accept a recognition prompt on multipart transcriptions

### DIFF
--- a/app/server/main.cpp
+++ b/app/server/main.cpp
@@ -94,6 +94,7 @@ void print_help() {
         << "  GET  /v1/audio/voices?model=<id>\n"
         << "  POST /v1/audio/speech\n"
         << "  POST /v1/audio/transcriptions\n"
+        << "       fields: file, model, language, prompt, stream\n"
         << "       OpenAI-style streaming: speech stream_format=sse|audio, transcription stream=true\n"
         << "  POST /v1/audio/transcriptions/live?model=<id>\n"
         << "       raw PCM in a chunked body, transcript deltas as SSE on the same connection\n"

--- a/app/server/runtime.cpp
+++ b/app/server/runtime.cpp
@@ -1955,6 +1955,7 @@ HttpResponse ServerState::handle_transcription_multipart(const std::string & bod
     const MultipartPart * file_part = nullptr;
     std::string model_id;
     std::string language;
+    std::string prompt;
     std::optional<int> busy_timeout_ms;
     bool stream = false;
     for (const auto & part : parts) {
@@ -1964,6 +1965,11 @@ HttpResponse ServerState::handle_transcription_multipart(const std::string & bod
             model_id = part.data;
         } else if (part.name == "language") {
             language = part.data;
+        } else if (part.name == "prompt" || part.name == "text") {
+            // Recognition-context biasing. "prompt" is the OpenAI
+            // transcription field name; "text" matches the JSON request
+            // builder, which already forwards it to request.text_input.
+            prompt = part.data;
         } else if (part.name == "busy_timeout_ms") {
             try {
                 busy_timeout_ms = std::stoi(part.data);
@@ -2000,6 +2006,9 @@ HttpResponse ServerState::handle_transcription_multipart(const std::string & bod
     fields.emplace("model", engine::io::json::Value::make_string(model_id));
     if (!language.empty()) {
         fields.emplace("language", engine::io::json::Value::make_string(language));
+    }
+    if (!prompt.empty()) {
+        fields.emplace("text", engine::io::json::Value::make_string(prompt));
     }
     const auto body = engine::io::json::Value::make_object(std::move(fields));
 


### PR DESCRIPTION
## Summary

- Accept a `prompt` (or `text`) part in `handle_transcription_multipart` and forward it as `text` to `build_openai_transcription_request`, which already routes it to `request.text_input`.
- `prompt` matches OpenAI's `/v1/audio/transcriptions` field name; `text` is accepted so the multipart and JSON paths take the same spelling.
- Document the accepted fields in the server usage line.

Fixes #261

## Validation

Built `audiocpp_server` and ran it on a spare port beside the unmodified one. CUDA, Qwen3-ASR-0.6B, H100 12GB slice. Identical audio, identical request except the field:

| spoken | without `prompt` | with `prompt` |
|---|---|---|
| Tell me about cell-free systems. | Tell me about **self-repair** systems. | Tell me about **cell-free** systems. |
| How do cell-free systems help medicine in space? | How do **self-repair** systems help medicine in space? | How do **cell-free** systems help medicine in space? |

Context used: `cell-free systems, cell-free protein synthesis, cell lysate, PURE system, plasmid, Benchling, Opentrons, ...`

Sanity check that the context genuinely reaches `build_prompt`: with `prompt="cell-free systems"` over **one second of random noise**, the server returns `{"text":"Cell-free systems."}`. Without the field, the same audio returns empty.

Behaviour is unchanged when the field is absent (left column above) and on the JSON path.

## Note — not fixed here

The context is built into the thinker prefill graph, so its size costs VRAM. On a 12GB slice a prompt over roughly 1200 characters fails the whole request:

```
ggml_backend_cuda_buffer_type_alloc_buffer: allocating 13559.65 MiB on device 0: cudaMalloc failed: out of memory
alloc_tensor_range: failed to allocate CUDA0 buffer of size 14218318336
500 {"error":{"message":"failed to allocate Qwen3 ASR thinker prefill graph","type":"server_error"}}
```

That is pre-existing and applies to the JSON path too, but a 400 with a clear message would beat a 500 — a caller currently discovers the ceiling by taking transcription down. Happy to follow up separately if that would be welcome.
