### PR TITLE
asr: allocate inference graphs with ggml_gallocr, not alloc_ctx_tensors

### DIFF
--- a/src/models/citrinet_asr/runtime.cpp
+++ b/src/models/citrinet_asr/runtime.cpp
@@ -374,12 +374,13 @@ class CitrinetRuntime::Graph {
         };
         auto input = core::make_tensor(build_ctx, GGML_TYPE_F32, core::TensorShape::from_dims({1, weights_->config.n_mels, frames_}));
         input_ = input.tensor;
+        ggml_set_input(input_);
         output_ = build_citrinet_graph(build_ctx, input, *backend_weights_).tensor;
         ggml_set_output(output_);
         graph_ = ggml_new_graph_custom(ctx_.get(), 16384, false);
         ggml_build_forward_expand(graph_, output_);
-        buffer_ = ggml_backend_alloc_ctx_tensors(ctx_.get(), backend_);
-        if (buffer_ == nullptr) {
+        gallocr_ = ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend_));
+        if (gallocr_ == nullptr || !ggml_gallocr_alloc_graph(gallocr_, graph_)) {
             throw std::runtime_error("failed to allocate graph");
         }
         if (engine::core::uses_host_graph_plan(backend_)) {
@@ -399,8 +400,8 @@ class CitrinetRuntime::Graph {
         if (plan_ != nullptr) {
             engine::core::free_backend_graph_plan(backend_, plan_);
         }
-        if (buffer_ != nullptr) {
-            ggml_backend_buffer_free(buffer_);
+        if (gallocr_ != nullptr) {
+            ggml_gallocr_free(gallocr_);
         }
     }
 
@@ -466,7 +467,7 @@ class CitrinetRuntime::Graph {
     ggml_cgraph * graph_ = nullptr;
     ggml_backend_t backend_ = nullptr;
     int compute_threads_ = 1;
-    ggml_backend_buffer_t buffer_ = nullptr;
+    ggml_gallocr_t gallocr_ = nullptr;
     ggml_backend_graph_plan_t plan_ = nullptr;
     double plan_create_ms_ = 0.0;
     std::vector<float> channels_first_;

--- a/src/models/qwen3_asr/thinker.cpp
+++ b/src/models/qwen3_asr/thinker.cpp
@@ -326,15 +326,37 @@ public:
             if (!layer.key.has_value() || !layer.value.has_value()) {
                 throw std::runtime_error("Qwen3 ASR thinker prefill decoder did not return K/V state");
             }
-            keys_.push_back(layer.key->tensor);
-            values_.push_back(layer.value->tensor);
+            // The graph allocator recycles intermediates, and the decoder K/V is an
+            // intermediate that run() has to read back afterwards. Copy each one into
+            // a tensor of its own and mark it as a graph output, which is what keeps
+            // it off the reuse list. Same shape as QwenCausalDecodeRuntime prefill.
+            auto * key = ggml_cpy(
+                ctx_.get(),
+                layer.key->tensor,
+                ggml_dup_tensor(ctx_.get(), layer.key->tensor));
+            auto * value = ggml_cpy(
+                ctx_.get(),
+                layer.value->tensor,
+                ggml_dup_tensor(ctx_.get(), layer.value->tensor));
+            ggml_set_output(key);
+            ggml_set_output(value);
+            keys_.push_back(key);
+            values_.push_back(value);
         }
         logits_ = decoder_out.logits.tensor;
         ggml_set_output(logits_);
         graph_ = ggml_new_graph_custom(ctx_.get(), 65536, false);
         ggml_build_forward_expand(graph_, logits_);
-        buffer_ = ggml_backend_alloc_ctx_tensors(ctx_.get(), runtime_->backend());
-        if (buffer_ == nullptr) {
+        for (auto * key : keys_) {
+            ggml_build_forward_expand(graph_, key);
+        }
+        for (auto * value : values_) {
+            ggml_build_forward_expand(graph_, value);
+        }
+        gallocr_ = ggml_gallocr_new(ggml_backend_get_default_buffer_type(runtime_->backend()));
+        if (gallocr_ == nullptr ||
+            !ggml_gallocr_reserve(gallocr_, graph_) ||
+            !ggml_gallocr_alloc_graph(gallocr_, graph_)) {
             // Size, not a fault: the graph scales with prompt_steps_, which the
             // caller controls through the transcription prompt and the length of
             // the audio. Say which, and by how much, so the remedy is obvious.
@@ -344,16 +366,15 @@ public:
                 + std::to_string(audio_tokens_) + " are audio tokens); "
                 "shorten the transcription prompt or the audio");
         }
-        const auto pos = modules::qwen_position_ids(prompt_steps_);
-        ggml_backend_tensor_set(positions_, pos.data(), 0, pos.size() * sizeof(int32_t));
+        position_ids_ = modules::qwen_position_ids(prompt_steps_);
         debug::timing_log_scalar("qwen3_asr.thinker.prefill.graph.build_ms", engine::debug::elapsed_ms(build_start, Clock::now()));
         debug::trace_log_scalar("qwen3_asr.thinker.prefill_prompt_steps", prompt_steps_);
     }
 
     ~PrefillGraph() {
         engine::core::release_backend_graph_resources(runtime_->backend(), graph_);
-        if (buffer_ != nullptr) {
-            ggml_backend_buffer_free(buffer_);
+        if (gallocr_ != nullptr) {
+            ggml_gallocr_free(gallocr_);
         }
     }
 
@@ -376,6 +397,10 @@ public:
             throw std::runtime_error("Qwen3 ASR thinker prefill audio position count mismatch");
         }
         auto timing_start = Clock::now();
+        // Re-uploaded on every run: the graph allocator may hand this leaf out to a
+        // later node once the graph has consumed it, so it cannot be written once at
+        // build time and left alone.
+        ggml_backend_tensor_set(positions_, position_ids_.data(), 0, position_ids_.size() * sizeof(int32_t));
         ggml_backend_tensor_set(token_ids_, token_ids.data(), 0, token_ids.size() * sizeof(int32_t));
         if (audio_tokens_ > 0) {
             std::vector<int64_t> positions(audio_positions.begin(), audio_positions.end());
@@ -430,8 +455,9 @@ private:
     ggml_tensor * logits_ = nullptr;
     std::vector<ggml_tensor *> keys_;
     std::vector<ggml_tensor *> values_;
+    std::vector<int32_t> position_ids_;
     ggml_cgraph * graph_ = nullptr;
-    ggml_backend_buffer_t buffer_ = nullptr;
+    ggml_gallocr_t gallocr_ = nullptr;
 };
 
 class PromptClassificationGraph {
@@ -482,20 +508,21 @@ public:
         ggml_set_output(token_ids_);
         graph_ = ggml_new_graph_custom(ctx_.get(), 65536, false);
         ggml_build_forward_expand(graph_, token_ids_);
-        buffer_ = ggml_backend_alloc_ctx_tensors(ctx_.get(), runtime_->backend());
-        if (buffer_ == nullptr) {
+        gallocr_ = ggml_gallocr_new(ggml_backend_get_default_buffer_type(runtime_->backend()));
+        if (gallocr_ == nullptr ||
+            !ggml_gallocr_reserve(gallocr_, graph_) ||
+            !ggml_gallocr_alloc_graph(gallocr_, graph_)) {
             throw std::runtime_error("failed to allocate Qwen3 ASR thinker classification graph");
         }
-        const auto pos = modules::qwen_position_ids(prompt_steps_);
-        ggml_backend_tensor_set(positions_, pos.data(), 0, pos.size() * sizeof(int32_t));
+        position_ids_ = modules::qwen_position_ids(prompt_steps_);
         debug::timing_log_scalar("qwen3_asr.thinker.classify.graph.build_ms", engine::debug::elapsed_ms(build_start, Clock::now()));
         debug::trace_log_scalar("qwen3_asr.thinker.classify_prompt_steps", prompt_steps_);
     }
 
     ~PromptClassificationGraph() {
         engine::core::release_backend_graph_resources(runtime_->backend(), graph_);
-        if (buffer_ != nullptr) {
-            ggml_backend_buffer_free(buffer_);
+        if (gallocr_ != nullptr) {
+            ggml_gallocr_free(gallocr_);
         }
     }
 
@@ -518,6 +545,8 @@ public:
             throw std::runtime_error("Qwen3 ASR thinker classification audio position count mismatch");
         }
         auto timing_start = Clock::now();
+        // See PrefillGraph::run: leaves are not pinned by the graph allocator.
+        ggml_backend_tensor_set(positions_, position_ids_.data(), 0, position_ids_.size() * sizeof(int32_t));
         ggml_backend_tensor_set(token_ids_input_, input_ids.data(), 0, input_ids.size() * sizeof(int32_t));
         if (audio_tokens_ > 0) {
             std::vector<int64_t> positions(audio_positions.begin(), audio_positions.end());
@@ -558,8 +587,9 @@ private:
     ggml_tensor * audio_positions_ = nullptr;
     ggml_tensor * positions_ = nullptr;
     ggml_tensor * token_ids_ = nullptr;
+    std::vector<int32_t> position_ids_;
     ggml_cgraph * graph_ = nullptr;
-    ggml_backend_buffer_t buffer_ = nullptr;
+    ggml_gallocr_t gallocr_ = nullptr;
 };
 
 class DecodeGraph {


### PR DESCRIPTION
## Summary

Several ASR inference graphs are built with `no_alloc = true` and then allocated with `ggml_backend_alloc_ctx_tensors`, which allocates **every tensor in the context simultaneously**. Intermediate activations for all layers stay resident for the whole graph instead of being recycled, so peak memory scales with sequence length at roughly **50× the legitimate cost**.

This switches the affected graphs to `ggml_gallocr`, which this repository already uses elsewhere — including in `qwen3_asr/audio_encoder.cpp` and `hviske_asr/encoder.cpp`, one file away from two of the sites changed here.

Output is unchanged: **22 transcript comparisons between the two builds are byte-identical.**

## The problem

```cpp
ggml_init_params params{arena, nullptr, true};   // no_alloc
...
graph_ = ggml_new_graph_custom(ctx_.get(), N, false);
ggml_build_forward_expand(graph_, output_);
buffer_ = ggml_backend_alloc_ctx_tensors(ctx_.get(), backend);   // every tensor, no reuse
```

Measured on a 12 GB H100 slice with Qwen3-ASR 0.6B, 32 s of audio and a 3000-character recognition prompt, this asks for **a single `cudaMalloc` of 9739 MiB** for 886 prompt steps:

```
alloc_tensor_range: failed to allocate CUDA0 buffer of size 10212568704
```

That is **11.0 MiB per token**, where the KV cache for a 0.6 B model across 28 layers is about **224 KB per token**. It fails as one monolithic allocation rather than as gradual pressure, so it is not a fragmentation issue and more free VRAM does not help proportionally.

## Results

Peak GPU, sampled at ~11 ms intervals, fresh process per measurement, three repetitions per point (deterministic to the MiB).

**`citrinet_asr` — encoder, single output, no KV cache**

| audio | before | after | |
|---|---|---|---|
| 4 s | 492 MiB | 392 MiB | −20% |
| 8 s | 588 MiB | 396 MiB | −33% |
| 16 s | 780 MiB | 398 MiB | −49% |
| 32 s | 1163 MiB | 404 MiB | −65% |
| **slope** | **23.96 MiB/s** | **0.43 MiB/s** | **56× flatter** |

**`qwen3_asr` — audio length, no prompt**

| audio | 0.6B before | 0.6B after | 1.7B before | 1.7B after |
|---|---|---|---|---|
| 4 s | 2197 | 1867 | 3632 | 3158 |
| 8 s | 2617 | 1991 | 4138 | 3252 |
| 16 s | 3594 | 2263 | 5344 | 3526 |
| 32 s | 5660 | 2741 | 7813 | 4006 |
| **slope** | **123.7 MiB/s** | **31.2** | **149.3 MiB/s** | **30.3** |

**`qwen3_asr` 0.6B — recognition-prompt length, fixed 8 s clip**

| prompt | before | after |
|---|---|---|
| 0 chars | 2617 MiB | 1991 MiB |
| 898 | 3767 MiB | 2127 MiB |
| 1795 | 5218 MiB | 2271 MiB |
| 2996 | 7582 MiB | 2463 MiB |
| **slope** | **1.657 MiB/char** | **0.158 MiB/char** (10.5×) |

**Previously failing, now working**

| case | before | after |
|---|---|---|
| 0.6B, 32 s + 2996-char prompt | OOM (9739 MiB request) | 3227 MiB |
| 1.7B, 32 s + 1795-char prompt | OOM (8246 MiB request) | 4294 MiB |

## Two details that are not just swapping the allocator

**K/V readback.** `PrefillGraph` hands `run()` the decoder's K/V state, which is an intermediate the allocator would recycle. Marking those tensors as outputs is **not sufficient** — they may be views, and `GGML_TENSOR_FLAG_OUTPUT` on a view does not protect its `view_src`; `ggml_gallocr_free_node` frees `view_src` on its own flag. Each is copied into a tensor of its own with `ggml_cpy` over `ggml_dup_tensor`, and the copy is marked as an output. This matches the existing pattern in `framework/modules/transformers/qwen_causal_decode_runtime.cpp`.

**Constant leaves.** Both `qwen3_asr` graphs uploaded position ids once at build time. That is safe when every tensor is pinned, but the graph allocator may reuse a leaf once its last consumer has run, so a second `run()` on a cached graph would read stale positions. The upload moves into `run()`. **Anyone converting the remaining sites should audit for this specifically.**

## Deliberately not changed

- **`DecodeGraph`** in `qwen3_asr/thinker.cpp` keeps `alloc_ctx_tensors`. Its context holds a persistent step cache that must retain stable storage across successive decode steps, and its per-step activations are one token wide, so it does not contribute to length scaling. Converting it would mean splitting the cache into its own buffer.
- **`hviske_asr/decoder.cpp`**, for a similar reason: `PrefillGraph` builds views onto prefill K/V that separate `DecodeGraph`/`BeamDecodeGraph` contexts consume, needing stable addresses across graph boundaries. Its memory is also flat with audio length (fixed 30 s padded window), so it does not show the symptom.

## Correctness

22 comparisons of the CLI `text_output` line, baseline binary vs patched, same clip and flags — all byte-identical:

- `citrinet` at 4/8/16/32 s
- `qwen3` 0.6B and 1.7B at 4/8/16/32 s
- `qwen3` 0.6B at 8 s × prompts of 499/898/1795/2996 chars
- `hviske` at 4/32 s (unchanged code, both builds)
- CPU backend (`--backend cpu`), exercising the `uses_host_graph_plan` path
- 3-request batch runs (`--batch-audio-dir`), exercising graph-cache reuse via `matches()` — the path the `positions_` change protects

## Possibly affected elsewhere

51 `.cpp` files build graphs and also call `ggml_backend_alloc_ctx_tensors`. Many of those calls are legitimate — weight contexts and persistent caches — so this is a triage list rather than a bug list. Files that build graphs with **no** `gallocr` anywhere include `vibevoice/decoder.cpp`, `higgs_audio_tts/ar.cpp`, `qwen3_tts/talker.cpp`, `ace_step/condition_encoder.cpp`, `vevo2/ar.cpp`, `miotts/causal_lm.cpp`, and several single-site runtimes. I have not measured those and make no claim about them here.
