### PR TITLE
Add Fish Audio multi-reference conditioning

### DIFF
--- a/docs/models/fish_audio.md
+++ b/docs/models/fish_audio.md
@@ -1,0 +1,140 @@
+# Fish Audio S2 Pro
+
+Fish Audio S2 Pro is wired as `--family fish_audio` for offline text to speech
+and reference voice cloning. The integration supports standalone GGUF packages,
+session-level reference caching, framework text chunking for long-form text, and
+Fish-style multi-reference conditioning.
+
+## Install
+
+```bash
+python3 tools/model_manager_v2.py install fish_audio_s2_pro_q8_0
+```
+
+The default package installs:
+
+```text
+models/Fish-Audio-S2-Pro-GGUF/fish-audio-s2-pro-q8_0.gguf
+```
+
+## Quick Start
+
+Text-to-speech:
+
+```bash
+audiocpp_cli --task tts --family fish_audio \
+  --model models/Fish-Audio-S2-Pro-GGUF/fish-audio-s2-pro-q8_0.gguf \
+  --backend cuda \
+  --text "Hello from Fish Audio." \
+  --out out.wav
+```
+
+Reference voice clone:
+
+```bash
+audiocpp_cli --task tts --family fish_audio \
+  --model models/Fish-Audio-S2-Pro-GGUF/fish-audio-s2-pro-q8_0.gguf \
+  --backend cuda \
+  --text "The final render is ready for review." \
+  --voice-ref assets/resources/b.wav \
+  --reference-text "Some call me nature. Others call me Mother Nature." \
+  --out out_ref.wav
+```
+
+## Model
+
+| Field | Value |
+|---|---|
+| Family | `fish_audio` |
+| Task | `tts` |
+| Modes | `offline` |
+| Model path | `models/Fish-Audio-S2-Pro-GGUF/fish-audio-s2-pro-q8_0.gguf` |
+| Languages | Model auto-handles language; tested paths cover English and Chinese-style prompts |
+| Voice input | Optional reference WAV through `--voice-ref`; transcript through `--reference-text` when known |
+| Built-in voices | Not exposed |
+
+## Multi-Reference Conditioning
+
+`multi_reference_cond` is a Fish Audio request option. It takes an ordered JSON
+array of reference pairs:
+
+```json
+[
+  {
+    "audio": "assets/resources/a.wav",
+    "text": "First reference transcript."
+  },
+  {
+    "audio": "assets/resources/b.wav",
+    "text": "Second reference transcript."
+  }
+]
+```
+
+Each entry must include:
+
+| Field | Meaning |
+|---|---|
+| `audio` | Reference WAV path. |
+| `text` | Transcript for that reference audio. |
+
+The option has two useful cases.
+
+### Case 1: One Generated Voice
+
+Use multiple references without speaker tags when you want them to condition one
+generated voice/style.
+
+```bash
+audiocpp_cli --task tts --family fish_audio \
+  --model models/Fish-Audio-S2-Pro-GGUF/fish-audio-s2-pro-q8_0.gguf \
+  --backend cuda \
+  --text "The review is ready, and I will check the final numbers." \
+  --request-option 'multi_reference_cond=[{"audio":"assets/resources/a.wav","text":"First reference transcript."},{"audio":"assets/resources/b.wav","text":"Second reference transcript."}]' \
+  --out out_multi_ref.wav
+```
+
+In this mode the references are packed into the prompt context. The target text
+does not assign individual lines to reference speakers.
+
+### Case 2: Speaker-Tagged Turns
+
+Use Fish speaker tags in the target text when you want the generated output to
+follow a speaker order. Reference array index `0` maps to `<|speaker:0|>`, index
+`1` maps to `<|speaker:1|>`, and so on. Speaker ids should stay within the
+provided reference indexes.
+
+```bash
+audiocpp_cli --task tts --family fish_audio \
+  --model models/Fish-Audio-S2-Pro-GGUF/fish-audio-s2-pro-q8_0.gguf \
+  --backend cuda \
+  --text "<|speaker:0|>The review is ready. <|speaker:1|>I will check the final numbers. <|speaker:0|>Please send me the final summary." \
+  --request-option 'multi_reference_cond=[{"audio":"assets/resources/a.wav","text":"First reference transcript."},{"audio":"assets/resources/b.wav","text":"Second reference transcript."}]' \
+  --request-option max_new_tokens=220 \
+  --out out_speakers.wav
+```
+
+The reference transcripts may already contain speaker tags. If they do not, the
+runtime tags them by reference order before packing the prompt.
+
+## Options
+
+| Option | Values | Default | Meaning |
+|---|---|---:|---|
+| `--voice-ref` | WAV path | not set | Reference speaker audio for voice cloning. |
+| `--reference-text` | text | empty string | Transcript for reference audio. |
+| `--max-new-tokens` | integer | `1024` | Maximum generated semantic tokens per chunk. `0` uses the default. |
+| `--text-chunk-size` | integer chars | `200` | Long-form chunk size. |
+| `--text-chunk-mode` | `default`, `tag_aware`, `japanese`, `endline` | `default` | Framework text chunking mode. |
+| `--temperature` | float | `0.8` | Sampling temperature. |
+| `--top-k` | integer | `30` | Top-k sampling limit. |
+| `--top-p` | float | `0.8` | Nucleus sampling limit. |
+| `--seed` | integer | random when omitted | Sampling seed for reproducible output. |
+| `--request-option multi_reference_cond=<json>` | JSON array | not set | Ordered Fish Audio reference conditioning pairs. Each entry requires `audio` and `text`. |
+| `--session-option fish_audio.mem_saver=true\|false` | bool | `false` | Release cached AR runtime graphs after each request. |
+| `--session-option fish_audio.reference_cache_slots=<n>` | integer | `1` | Prepared reference-audio cache slots. |
+| `--session-option fish_audio.weight_type=<type>` | `native`, `f32`, `f16`, `bf16`, `q8_0` | `native` | AR matmul weight storage type. |
+| `--session-option fish_audio.codec_weight_type=<type>` | `native`, `f32`, `f16`, `q8_0` | `native` | Codec conv/matmul weight storage type. |
+
+For GGUF packages, leave weight options at `native` unless you are deliberately
+testing conversion or storage behavior.

--- a/docs/models/index_tts.md
+++ b/docs/models/index_tts.md
@@ -1,0 +1,239 @@
+# IndexTTS
+
+IndexTTS is wired as `--family index_tts2` for offline text to speech and voice
+cloning. The same model family handles IndexTTS2 and IndexTTS2.5; the runtime
+selects the variant from the model config.
+
+## IndexTTS2
+
+IndexTTS2 is a Chinese and English TTS model with voice cloning and expressive
+emotion controls. It requires a speaker reference through the framework
+`--voice-ref` path.
+
+| Field | Value |
+|---|---|
+| Family | `index_tts2` |
+| Model directory | `models/IndexTTS-2` |
+| Task | `tts`, `clon` |
+| Modes | `offline` |
+| Languages | `zh`, `en` |
+| Voice input | Required reference WAV through `--voice-ref` |
+| Built-in voices | Not exposed |
+
+Voice clone:
+
+```bash
+audiocpp_cli --task clon --family index_tts2 \
+  --model /path/to/IndexTTS-2 \
+  --backend cuda \
+  --language en \
+  --text "Hello from IndexTTS2." \
+  --voice-ref /path/to/reference.wav \
+  --out out.wav
+```
+
+Emotion text:
+
+```bash
+audiocpp_cli --task tts --family index_tts2 \
+  --model /path/to/IndexTTS-2 \
+  --backend cuda \
+  --language zh \
+  --text "今天的演示会更有情绪。" \
+  --voice-ref /path/to/reference.wav \
+  --emotion "你吓死我了！你是鬼吗？" \
+  --request-option emotion_alpha=0.6 \
+  --out out.wav
+```
+
+### IndexTTS2 Options
+
+| Option | Values | Default | Meaning |
+|---|---|---:|---|
+| `--voice-ref` | WAV path | required | Reference speaker audio. |
+| `--language` | `zh`, `en` | empty | Text language label. |
+| `--emotion` | text | not set | Emotion-text conditioning through the framework style field. |
+| `--request-option emotion_alpha=<float>` | float in `[0, 1]` | `1.0` | Blend strength for explicit emotion conditioning. |
+| `--request-option emotion_vector=<v0,...,v7>` | 8 floats | not set | Explicit emotion vector. |
+| `--request-option use_emotion_text=true\|false` | bool | `false` | Infer emotion from text. |
+| `--request-option use_random_emotion=true\|false` | bool | `false` | Use random emotion weights in the emotion mixer. |
+| `--request-option interval_silence_ms=<n>` | milliseconds | `200` | Silence inserted between generated text chunks. |
+| `--request-option duration_factor=<float>` | positive float | `1.0` | Output duration multiplier for speech-rate control; `>1` slower, `<1` faster. Matches the official IndexTTS2.5 `duration_factor`; also accepted for the v2 variant. |
+| `--text-chunk-size` | characters | not set | Optional framework outer text chunk size. When omitted, IndexTTS2 keeps its internal tokenizer segmentation. |
+| `--text-chunk-mode` | `default`, `tag_aware`, `japanese`, `endline` | `default` | Framework chunking mode used only when `--text-chunk-size` is set. |
+| `--max-tokens` | integer | model default | Maximum generated GPT mel tokens. |
+| `--temperature` | float | model default | GPT sampling temperature. |
+| `--top-p` | float | model default | GPT nucleus sampling limit. |
+| `--top-k` | integer | model default | GPT top-k sampling limit. |
+| `--repetition-penalty` | float | model default | GPT repetition penalty. |
+| `--do-sample` | `true`, `false` | model default | Enable stochastic GPT sampling. |
+| `--session-option index_tts2.mem_saver=true\|false` | bool | `false` | Release staged reference and conditioning graphs after request phases. |
+| `--session-option index_tts2.weight_type=native\|f32\|f16\|bf16\|q8_0` | enum | `native` | Matmul weight storage type. |
+| `--session-option index_tts2.conv_weight_type=native\|f32\|f16` | enum | `native` | Convolution weight storage type. |
+| `--session-option index_tts2.speaker_cache_slots=<n>` | integer slots | `1` | Prepared speaker-reference cache slots; set `0` to disable reuse. |
+| `--session-option index_tts2.emotion_cache_slots=<n>` | integer slots | `1` | Prepared emotion-reference cache slots; set `0` to disable reuse. |
+| `--session-option index_tts2.emotion_text_cache_slots=<n>` | integer slots | `1` | Emotion-text weight cache slots; set `0` to disable reuse. |
+| `--session-option index_tts2.gpt_graph_arena_mb=<n>` | MB | model default | GPT graph arena size. |
+| `--session-option index_tts2.s2mel_graph_arena_mb=<n>` | MB | model default | S2Mel graph arena size. |
+| `--session-option index_tts2.reference_graph_arena_mb=<n>` | MB | model default | Reference encoder and codec graph arena size. |
+| `--session-option index_tts2.emotion_text_prefill_graph_arena_mb=<n>` | MB | model default | Emotion-text prefill graph arena size. |
+| `--session-option index_tts2.emotion_text_decode_graph_arena_mb=<n>` | MB | model default | Emotion-text cached-step graph arena size. |
+| `--session-option index_tts2.emotion_text_max_tokens=<n>` | tokens | `256` | Maximum generated tokens for emotion-text classification; old name `index_tts2.emotion_text_max_new_tokens` is still accepted. |
+| `--session-option index_tts2.weight_context_mb=<n>` | MB | `32` | Shared ggml weight metadata context size. |
+
+Text normalization note: audio.cpp reimplements the official IndexTTS text
+front-end (wetext-style number/date/symbol rules, pinyin-tone and name
+protection) as lightweight C++ rules instead of running the official OpenFst
+grammars. Alignment is tracked by a golden-corpus parity test
+(`index_tts_tn_corpus_test`, which replays 50+ tricky cases against outputs
+generated by the official Python normalizer), but a rule-based port cannot be
+exhaustive: for unusual inputs (letter-attached digits, rare date/unit formats,
+emails, URLs) the normalized text can still differ from the official pipeline,
+so the same prompt may be read differently. This is a text-frontend difference,
+not a model-quality problem; the GPT/codec/S2Mel stack itself matches the
+official pipeline token-for-token on the validated cases.
+
+## IndexTTS2.5
+
+IndexTTS2.5 is IndexTeam/bilibili's multilingual zero-shot TTS model (released
+2026-07): a 0.8B GPT autoregressive model + DiT CFM + BigVGAN stack that keeps
+IndexTTS2's timbre-emotion decoupling and adds Japanese, Spanish, and Arabic on
+top of Chinese and English. It requires a speaker reference through the
+framework `--voice-ref` path. Inline `<文字|发音>` pronunciation overrides
+(pinyin, CMU phonemes, or kana) are supported. Upstream weights live at
+[IndexTeam/IndexTTS-2.5](https://huggingface.co/IndexTeam/IndexTTS-2.5); the
+reference implementation is [index-tts/index-tts](https://github.com/index-tts/index-tts)
+branch `indextts-2.5`.
+
+IndexTTS2.5 is implemented as a variant of the `index_tts2` family rather than
+a separate family: both variants share the audio features, wav2vec2bert, Qwen
+emotion, style encoder, BigVGAN vocoder, S2Mel, and GPT decode/cache code. The
+tokenizer, GPT speaker conditioning, and semantic-codec decode path are selected
+per variant from the model config `version` field (`"2.5"`). All
+`index_tts2.*` session options apply to both variants.
+
+| Field | Value |
+|---|---|
+| Family | `index_tts2` |
+| Variant | `2.5`, selected from the model config `version` field |
+| Model directory | `models/IndexTTS2.5-GGUF` |
+| Default package | `index_tts2_5_q8_0` |
+| Other packages | `index_tts2_5_f16`, `index_tts2_5_orig` |
+| Task | `tts`, `clon` |
+| Modes | `offline` |
+| Languages | `zh`, `en`, `ja`, `es`, `ar` |
+| Voice input | Required reference WAV through `--voice-ref` |
+| Built-in voices | Not exposed |
+
+Voice clone:
+
+```bash
+audiocpp_cli --task clon --family index_tts2 \
+  --model /path/to/IndexTTS2.5-GGUF \
+  --backend cuda \
+  --text "Hello from IndexTTS2.5." \
+  --voice-ref /path/to/reference.wav \
+  --out out.wav
+```
+
+Emotion text:
+
+```bash
+audiocpp_cli --task tts --family index_tts2 \
+  --model /path/to/IndexTTS2.5-GGUF \
+  --backend cuda \
+  --text "今天的演示会更有情绪。" \
+  --voice-ref /path/to/reference.wav \
+  --emotion "你吓死我了！你是鬼吗？" \
+  --request-option emotion_alpha=0.6 \
+  --out out.wav
+```
+
+The `language` request option selects the text language (`auto`, `zh`, `en`,
+`ja`, `es`, `ar`, or any tokenizer language code). The default `auto` picks
+`zh` when the text contains Han characters and `en` otherwise, so mixed
+Japanese, Spanish, or Arabic text should set
+`--request-option language=ja|es|ar` explicitly.
+
+Emotion conditioning supports all three IndexTTS2 paths: an emotion reference
+WAV through `--audio`, an explicit `emotion_vector`, and Qwen-based emotion-text
+classification through `--emotion` / `use_emotion_text`. See the IndexTTS2
+text-normalization note above for the zh/en caveat. Known limitations: the
+Spanish NeMo text normalizer is not ported, so es text passes through without
+upstream-style normalization. The official ja path has no NeMo grammar, so NeMo
+TN is a no-op for Japanese upstream; the official ja wakachi/fugashi word
+segmentation is also not ported, so ja text is tokenized unsegmented. It is
+intelligible, but not token-identical to the official pipeline.
+
+License: IndexTTS-2.5 weights are distributed under the bilibili Model Use
+License, which is not OSI-approved. It requires separate commercial
+authorization when monthly active users exceed 100 million or annual revenue
+exceeds 1 billion RMB, and it forbids using model outputs to improve other AI
+models. Check the upstream repository for the full terms before redistribution
+or commercial use.
+
+### IndexTTS2.5 Options
+
+| Option | Values | Default | Meaning |
+|---|---|---:|---|
+| `--voice-ref` | WAV path | required | Reference speaker audio. |
+| `--request-option language=<code>` | `auto`, `zh`, `en`, `ja`, `es`, `ar`, ... | `auto` | Text language hint; `auto` infers `zh` when the text contains Han characters, otherwise `en`. |
+| `--emotion` | text | not set | Emotion-text conditioning through the framework style field. |
+| `--request-option emotion_alpha=<float>` | float in `[0, 1]` | `1.0` | Blend strength for explicit emotion conditioning. |
+| `--request-option emotion_vector=<v0,...,v7>` | 8 floats | not set | Explicit emotion vector. |
+| `--request-option use_emotion_text=true\|false` | bool | `false` | Infer emotion from text. |
+| `--request-option use_random_emotion=true\|false` | bool | `false` | Use random emotion weights in the emotion mixer. |
+| `--request-option interval_silence_ms=<n>` | milliseconds | `200` | Silence inserted between generated text chunks. |
+| `--request-option duration_factor=<float>` | positive float | `1.0` | Output duration multiplier for speech-rate control; `>1` slower, `<1` faster. Matches the official IndexTTS2.5 `duration_factor`. |
+| `--text-chunk-size` | characters | not set | Optional framework outer text chunk size. When omitted, IndexTTS2.5 keeps its internal tokenizer segmentation. |
+| `--text-chunk-mode` | `default`, `tag_aware`, `japanese`, `endline` | `default` | Framework chunking mode used only when `--text-chunk-size` is set. |
+| `--max-tokens` | integer | `1500` | Maximum generated GPT mel tokens. |
+| `--temperature` | float | `0.8` | GPT sampling temperature. |
+| `--top-p` | float | `0.8` | GPT nucleus sampling limit. |
+| `--top-k` | integer | `30` | GPT top-k sampling limit. |
+| `--repetition-penalty` | float | `10.0` | GPT repetition penalty. |
+| `--do-sample` | `true`, `false` | `true` | Enable stochastic GPT sampling. |
+| `--request-option length_penalty=<float>` | float | `0.0` | GPT beam-search length penalty. |
+| `--request-option num_beams=<n>` | integer | `3` | GPT beam count. |
+| `--session-option index_tts2.mem_saver=true\|false` | bool | `false` | Release staged reference and conditioning graphs after request phases. |
+| `--session-option index_tts2.weight_type=native\|f32\|f16\|bf16\|q8_0` | enum | `native` | Matmul weight storage type. |
+| `--session-option index_tts2.conv_weight_type=native\|f32\|f16` | enum | `native` | Convolution weight storage type. |
+| `--session-option index_tts2.speaker_cache_slots=<n>` | integer slots | `1` | Prepared speaker-reference cache slots; set `0` to disable reuse. |
+| `--session-option index_tts2.emotion_cache_slots=<n>` | integer slots | `1` | Prepared emotion-reference cache slots; set `0` to disable reuse. |
+| `--session-option index_tts2.emotion_text_cache_slots=<n>` | integer slots | `1` | Emotion-text weight cache slots; set `0` to disable reuse. |
+| `--session-option index_tts2.gpt_graph_arena_mb=<n>` | MB | model default | GPT graph arena size. |
+| `--session-option index_tts2.s2mel_graph_arena_mb=<n>` | MB | model default | S2Mel graph arena size. |
+| `--session-option index_tts2.reference_graph_arena_mb=<n>` | MB | model default | Reference encoder and codec graph arena size. |
+| `--session-option index_tts2.emotion_text_prefill_graph_arena_mb=<n>` | MB | model default | Emotion-text prefill graph arena size. |
+| `--session-option index_tts2.emotion_text_decode_graph_arena_mb=<n>` | MB | model default | Emotion-text cached-step graph arena size. |
+| `--session-option index_tts2.emotion_text_max_tokens=<n>` | tokens | `256` | Maximum generated tokens for emotion-text classification; old name `index_tts2.emotion_text_max_new_tokens` is still accepted. |
+| `--session-option index_tts2.weight_context_mb=<n>` | MB | `32` | Shared ggml weight metadata context size. |
+
+## Converting IndexTTS2.5 From Upstream Weights
+
+`tools/convert_index_tts2_5.py` turns an official `IndexTeam/IndexTTS-2.5`
+snapshot (the `.pth` checkpoints) into the Safetensors staging layout the
+engine expects, and prints or runs the matching `audiocpp_gguf` command. The
+w2v-bert-2.0, CAMPPlus, and BigVGAN checkpoints are auto-detected under
+`<model-dir>/hf_cache/` after running official inference once to populate it,
+and each has an explicit override flag:
+
+```bash
+python tools/convert_index_tts2_5.py \
+    --model-dir /path/to/IndexTTS-2.5 \
+    --output-dir /path/to/staging \
+    --run-converter /path/to/audiocpp_gguf --type q8_0
+```
+
+Pass `--native-dir /path/to/IndexTTS-2.5-native` to also emit a directly
+loadable native Safetensors model directory hardlinked from the staging files,
+without GGUF conversion.
+
+The script repackages the checkpoints the loader needs, unwraps the
+`s2mel.pth`/`codec.pth` container keys, prefixes CAMPPlus tensors with
+`speaker_encoder.`, strips BigVGAN's `generator.` prefix, wraps the
+`feat1/feat2.pt` matrices as a single `tensor`, and assembles the sidecar
+`root/` config/tokenizer resources that get embedded into the GGUF. The staged
+`config.yaml` has its `version` field normalized to `"2.5"` because the
+official snapshot ships `version: 2.0`; the engine uses that field to select the
+IndexTTS2 family variant.

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -18,8 +18,8 @@
 | VoxCPM2 | `voxcpm2` | `tts`, `vdes` | [VoxCPM2](#voxcpm2) |
 | Higgs Audio v3 TTS | `higgs_audio_tts` | `tts` | [Higgs Audio v3 TTS](#higgs-audio-v3-tts) |
 | Fish Audio S2 Pro | `fish_audio` | `tts` | [Fish Audio S2 Pro](#fish-audio-s2-pro) |
-| IndexTTS2 | `index_tts2` | `tts` | [IndexTTS2](#indextts2) |
-| IndexTTS2.5 | `index_tts2` (variant `2.5`) | `tts` | [IndexTTS2.5](#indextts25) |
+| IndexTTS2 | `index_tts2` | `tts` | [IndexTTS](models/index_tts.md) |
+| IndexTTS2.5 | `index_tts2` (variant `2.5`) | `tts` | [IndexTTS](models/index_tts.md) |
 | Irodori-TTS | `irodori_tts` | `tts`, `vdes` | [Irodori-TTS](#irodori-tts) |
 | GLM-TTS | `glm_tts` | `tts`, `clon` | [GLM-TTS](#glm-tts) |
 | Inflect Micro v2 | `inflect_v2` | `tts` | [Inflect v2](#inflect-v2) |
@@ -511,7 +511,9 @@ python3 tools/model_manager_v2.py install --models-root models higgs_audio_tts_4
 
 ## Fish Audio S2 Pro
 
-Fish Audio S2 Pro is a TTS and reference voice-clone model. The integration uses the framework text chunker for long-form input, caches prepared reference audio in the session, and supports GGUF loading through the package spec path.
+Fish Audio S2 Pro is a TTS and reference voice-clone model. See the dedicated
+[Fish Audio guide](models/fish_audio.md) for multi-reference conditioning,
+speaker-tagged turns, and the full option list.
 
 | Field | Value |
 |---|---|
@@ -535,31 +537,24 @@ Reference voice clone:
 audiocpp_cli --task tts --family fish_audio --model models/Fish-Audio-S2-Pro-GGUF/fish-audio-s2-pro-q8_0.gguf --backend cuda --text "The final render is ready for review." --voice-ref assets/resources/b.wav --reference-text "Some call me nature. Others call me Mother Nature. I've been here for over 4.5 billion years. 22,500 times longer than you." --out out.wav
 ```
 
+Multiple reference pairs:
+
+```bash
+audiocpp_cli --task tts --family fish_audio --model models/Fish-Audio-S2-Pro-GGUF/fish-audio-s2-pro-q8_0.gguf --backend cuda --text "The review is ready, and I will check the final numbers." --request-option 'multi_reference_cond=[{"audio":"assets/resources/a.wav","text":"First reference transcript."},{"audio":"assets/resources/b.wav","text":"Second reference transcript."}]' --out out.wav
+```
+
 The model manager installs the Q8_0 standalone GGUF package by default:
 
 ```bash
 python3 tools/model_manager_v2.py install --models-root models fish_audio_s2_pro_q8_0
 ```
 
-| Option | Values | Default | Meaning |
-|---|---|---:|---|
-| `--voice-ref` | WAV path | not set | Reference speaker audio for voice cloning. |
-| `--reference-text` | text | empty string | Transcript for reference audio. |
-| `--max-new-tokens` | integer | `1024` | Maximum generated semantic tokens per chunk. `0` uses the default. |
-| `--text-chunk-size` | integer chars | `200` | Long-form chunk size. |
-| `--text-chunk-mode` | `default`, `tag_aware`, `japanese`, `endline` | `default` | Framework text chunking mode. |
-| `--temperature` | float | `0.8` | Sampling temperature. |
-| `--top-k` | integer | `30` | Top-k sampling limit. |
-| `--top-p` | float | `0.8` | Nucleus sampling limit. |
-| `--seed` | integer | random when omitted | Sampling seed for reproducible output. |
-| `--session-option fish_audio.mem_saver=true\|false` | bool | `false` | Release cached AR runtime graphs after each request. |
-| `--session-option fish_audio.reference_cache_slots=<n>` | integer | `1` | Prepared reference-audio cache slots. |
-| `--session-option fish_audio.weight_type=<type>` | `native`, `f32`, `f16`, `bf16`, `q8_0` | `native` | AR matmul weight storage type. |
-| `--session-option fish_audio.codec_weight_type=<type>` | `native`, `f32`, `f16`, `q8_0` | `native` | Codec conv/matmul weight storage type. |
-
 ## IndexTTS2
 
-IndexTTS2 is a Chinese and English TTS model with voice cloning and expressive emotion controls. It requires a speaker reference through the framework `--voice-ref` path.
+IndexTTS2 is a Chinese and English TTS model with voice cloning and expressive
+emotion controls. See the dedicated [IndexTTS guide](models/index_tts.md) for
+IndexTTS2, IndexTTS2.5, text normalization notes, conversion, and the full
+option list.
 
 | Field | Value |
 |---|---|
@@ -571,58 +566,18 @@ IndexTTS2 is a Chinese and English TTS model with voice cloning and expressive e
 | Voice input | Required reference WAV through `--voice-ref` |
 | Built-in voices | Not exposed |
 
-Voice clone:
+Quick start:
 
 ```bash
 audiocpp_cli --task clon --family index_tts2 --model /path/to/IndexTTS-2 --backend cuda --language en --text "Hello from IndexTTS2." --voice-ref /path/to/reference.wav --out out.wav
 ```
 
-Emotion text:
-
-```bash
-audiocpp_cli --task tts --family index_tts2 --model /path/to/IndexTTS-2 --backend cuda --language zh --text "今天的演示会更有情绪。" --voice-ref /path/to/reference.wav --emotion "你吓死我了！你是鬼吗？" --request-option emotion_alpha=0.6 --out out.wav
-```
-
-| Option | Values | Default | Meaning |
-|---|---|---:|---|
-| `--voice-ref` | WAV path | required | Reference speaker audio. |
-| `--language` | `zh`, `en` | empty | Text language label. |
-| `--emotion` | text | not set | Emotion-text conditioning through the framework style field. |
-| `--request-option emotion_alpha=<float>` | float in `[0, 1]` | `1.0` | Blend strength for explicit emotion conditioning. |
-| `--request-option emotion_vector=<v0,...,v7>` | 8 floats | not set | Explicit emotion vector. |
-| `--request-option use_emotion_text=true\|false` | bool | `false` | Infer emotion from text. |
-| `--request-option use_random_emotion=true\|false` | bool | `false` | Use random emotion weights in the emotion mixer. |
-| `--request-option interval_silence_ms=<n>` | milliseconds | `200` | Silence inserted between generated text chunks. |
-| `--request-option duration_factor=<float>` | positive float | `1.0` | Output duration multiplier for speech-rate control; `>1` slower, `<1` faster. Matches the official IndexTTS2.5 `duration_factor`; also accepted for the v2 variant. |
-| `--text-chunk-size` | characters | not set | Optional framework outer text chunk size. When omitted, IndexTTS2 keeps its internal tokenizer segmentation. |
-| `--text-chunk-mode` | `default`, `tag_aware`, `japanese`, `endline` | `default` | Framework chunking mode used only when `--text-chunk-size` is set. |
-| `--max-tokens` | integer | model default | Maximum generated GPT mel tokens. |
-| `--temperature` | float | model default | GPT sampling temperature. |
-| `--top-p` | float | model default | GPT nucleus sampling limit. |
-| `--top-k` | integer | model default | GPT top-k sampling limit. |
-| `--repetition-penalty` | float | model default | GPT repetition penalty. |
-| `--do-sample` | `true`, `false` | model default | Enable stochastic GPT sampling. |
-| `--session-option index_tts2.mem_saver=true\|false` | bool | `false` | Release staged reference and conditioning graphs after request phases. |
-| `--session-option index_tts2.weight_type=native\|f32\|f16\|bf16\|q8_0` | enum | `native` | Matmul weight storage type. |
-| `--session-option index_tts2.conv_weight_type=native\|f32\|f16` | enum | `native` | Convolution weight storage type. |
-| `--session-option index_tts2.speaker_cache_slots=<n>` | integer slots | `1` | Prepared speaker-reference cache slots; set `0` to disable reuse. |
-| `--session-option index_tts2.emotion_cache_slots=<n>` | integer slots | `1` | Prepared emotion-reference cache slots; set `0` to disable reuse. |
-| `--session-option index_tts2.emotion_text_cache_slots=<n>` | integer slots | `1` | Emotion-text weight cache slots; set `0` to disable reuse. |
-| `--session-option index_tts2.gpt_graph_arena_mb=<n>` | MB | model default | GPT graph arena size. |
-| `--session-option index_tts2.s2mel_graph_arena_mb=<n>` | MB | model default | S2Mel graph arena size. |
-| `--session-option index_tts2.reference_graph_arena_mb=<n>` | MB | model default | Reference encoder and codec graph arena size. |
-| `--session-option index_tts2.emotion_text_prefill_graph_arena_mb=<n>` | MB | model default | Emotion-text prefill graph arena size. |
-| `--session-option index_tts2.emotion_text_decode_graph_arena_mb=<n>` | MB | model default | Emotion-text cached-step graph arena size. |
-| `--session-option index_tts2.emotion_text_max_tokens=<n>` | tokens | `256` | Maximum generated tokens for emotion-text classification; old name `index_tts2.emotion_text_max_new_tokens` is still accepted. |
-| `--session-option index_tts2.weight_context_mb=<n>` | MB | `32` | Shared ggml weight metadata context size. |
-
-Text normalization note: audio.cpp reimplements the official IndexTTS text front-end (wetext-style number/date/symbol rules, pinyin-tone and name protection) as lightweight C++ rules instead of running the official OpenFst grammars. Alignment is tracked by a golden-corpus parity test (`index_tts_tn_corpus_test`, which replays 50+ tricky cases against outputs generated by the official Python normalizer), but a rule-based port cannot be exhaustive: for unusual inputs (letter-attached digits, rare date/unit formats, emails, URLs) the normalized text can still differ from the official pipeline, so the same prompt may be read differently. This is a text-frontend difference, not a model-quality problem — the GPT/codec/S2Mel stack itself matches the official pipeline token-for-token on the validated cases.
-
 ## IndexTTS2.5
 
-IndexTTS2.5 is IndexTeam/bilibili's multilingual zero-shot TTS model (released 2026-07): a 0.8B GPT (autoregressive) + DiT CFM + BigVGAN stack that keeps IndexTTS2's timbre-emotion decoupling and adds Japanese, Spanish, and Arabic on top of Chinese and English. It requires a speaker reference through the framework `--voice-ref` path. Inline `<文字|发音>` pronunciation overrides (pinyin, CMU phonemes, or kana) are supported. Upstream weights live at [IndexTeam/IndexTTS-2.5](https://huggingface.co/IndexTeam/IndexTTS-2.5); the reference implementation is [index-tts/index-tts](https://github.com/index-tts/index-tts) branch `indextts-2.5`.
-
-IndexTTS2.5 is implemented as a variant of the `index_tts2` family rather than a separate family: both variants share the audio features, wav2vec2bert, Qwen emotion, style encoder, BigVGAN vocoder, S2Mel, and the GPT decode/cache code, while the tokenizer (SentencePiece vs multilingual tiktoken), GPT speaker conditioning (conditioning encoder + perceiver vs CAMPPlus `spk_emb_proj` + `lang_embedding`), and the semantic-codec decode path (v2.5 adds a 2x nearest upsample + `up` conv) are selected per variant from the model config `version` field (`"2.5"`). All IndexTTS2 session options (`index_tts2.*`) apply to both variants.
+IndexTTS2.5 is the multilingual `index_tts2` variant selected from model
+config. It adds Japanese, Spanish, and Arabic on top of Chinese and English.
+See the dedicated [IndexTTS guide](models/index_tts.md) for variant details,
+language notes, conversion, and the full option list.
 
 | Field | Value |
 |---|---|
@@ -634,73 +589,11 @@ IndexTTS2.5 is implemented as a variant of the `index_tts2` family rather than a
 | Voice input | Required reference WAV through `--voice-ref` |
 | Built-in voices | Not exposed |
 
-Voice clone:
+Quick start:
 
 ```bash
 audiocpp_cli --task clon --family index_tts2 --model /path/to/IndexTTS2.5-GGUF --backend cuda --text "Hello from IndexTTS2.5." --voice-ref /path/to/reference.wav --out out.wav
 ```
-
-Emotion text:
-
-```bash
-audiocpp_cli --task tts --family index_tts2 --model /path/to/IndexTTS2.5-GGUF --backend cuda --text "今天的演示会更有情绪。" --voice-ref /path/to/reference.wav --emotion "你吓死我了！你是鬼吗？" --request-option emotion_alpha=0.6 --out out.wav
-```
-
-The `language` request option selects the text language (`auto`, `zh`, `en`, `ja`, `es`, `ar`, or any tokenizer language code). The default `auto` picks `zh` when the text contains Han characters and `en` otherwise, so mixed Japanese/Spanish/Arabic text should set `--request-option language=ja|es|ar` explicitly.
-
-Emotion conditioning supports all three IndexTTS2 paths: an emotion reference WAV through `--audio`, an explicit `emotion_vector`, and Qwen-based emotion-text classification through `--emotion` / `use_emotion_text`. See the IndexTTS2 text-normalization note above for the zh/en caveat. Known limitations: the Spanish NeMo text normalizer is not ported, so es text passes through without upstream-style normalization (the official ja path has no NeMo grammar — NeMo TN is a no-op for Japanese upstream); the official ja wakachi/fugashi word segmentation is also not ported, so ja text is tokenized unsegmented — intelligible, but not token-identical to the official pipeline.
-
-License: IndexTTS-2.5 weights are distributed under the bilibili Model Use License, which is not OSI-approved. It requires separate commercial authorization when monthly active users exceed 100 million or annual revenue exceeds 1 billion RMB, and it forbids using model outputs to improve other AI models. Check the upstream repository for the full terms before redistribution or commercial use.
-
-| Option | Values | Default | Meaning |
-|---|---|---:|---|
-| `--voice-ref` | WAV path | required | Reference speaker audio. |
-| `--request-option language=<code>` | `auto`, `zh`, `en`, `ja`, `es`, `ar`, ... | `auto` | Text language hint; `auto` infers `zh` when the text contains Han characters, otherwise `en`. |
-| `--emotion` | text | not set | Emotion-text conditioning through the framework style field. |
-| `--request-option emotion_alpha=<float>` | float in `[0, 1]` | `1.0` | Blend strength for explicit emotion conditioning. |
-| `--request-option emotion_vector=<v0,...,v7>` | 8 floats | not set | Explicit emotion vector. |
-| `--request-option use_emotion_text=true|false` | bool | `false` | Infer emotion from text. |
-| `--request-option use_random_emotion=true|false` | bool | `false` | Use random emotion weights in the emotion mixer. |
-| `--request-option interval_silence_ms=<n>` | milliseconds | `200` | Silence inserted between generated text chunks. |
-| `--request-option duration_factor=<float>` | positive float | `1.0` | Output duration multiplier for speech-rate control; `>1` slower, `<1` faster. Matches the official IndexTTS2.5 `duration_factor`. |
-| `--text-chunk-size` | characters | not set | Optional framework outer text chunk size. When omitted, IndexTTS2.5 keeps its internal tokenizer segmentation. |
-| `--text-chunk-mode` | `default`, `tag_aware`, `japanese`, `endline` | `default` | Framework chunking mode used only when `--text-chunk-size` is set. |
-| `--max-tokens` | integer | `1500` | Maximum generated GPT mel tokens. |
-| `--temperature` | float | `0.8` | GPT sampling temperature. |
-| `--top-p` | float | `0.8` | GPT nucleus sampling limit. |
-| `--top-k` | integer | `30` | GPT top-k sampling limit. |
-| `--repetition-penalty` | float | `10.0` | GPT repetition penalty. |
-| `--do-sample` | `true`, `false` | `true` | Enable stochastic GPT sampling. |
-| `--request-option length_penalty=<float>` | float | `0.0` | GPT beam-search length penalty. |
-| `--request-option num_beams=<n>` | integer | `3` | GPT beam count. |
-| `--session-option index_tts2.mem_saver=true|false` | bool | `false` | Release staged reference and conditioning graphs after request phases. |
-| `--session-option index_tts2.weight_type=native|f32|f16|bf16|q8_0` | enum | `native` | Matmul weight storage type. |
-| `--session-option index_tts2.conv_weight_type=native|f32|f16` | enum | `native` | Convolution weight storage type. |
-| `--session-option index_tts2.speaker_cache_slots=<n>` | integer slots | `1` | Prepared speaker-reference cache slots; set `0` to disable reuse. |
-| `--session-option index_tts2.emotion_cache_slots=<n>` | integer slots | `1` | Prepared emotion-reference cache slots; set `0` to disable reuse. |
-| `--session-option index_tts2.emotion_text_cache_slots=<n>` | integer slots | `1` | Emotion-text weight cache slots; set `0` to disable reuse. |
-| `--session-option index_tts2.gpt_graph_arena_mb=<n>` | MB | model default | GPT graph arena size. |
-| `--session-option index_tts2.s2mel_graph_arena_mb=<n>` | MB | model default | S2Mel graph arena size. |
-| `--session-option index_tts2.reference_graph_arena_mb=<n>` | MB | model default | Reference encoder and codec graph arena size. |
-| `--session-option index_tts2.emotion_text_prefill_graph_arena_mb=<n>` | MB | model default | Emotion-text prefill graph arena size. |
-| `--session-option index_tts2.emotion_text_decode_graph_arena_mb=<n>` | MB | model default | Emotion-text cached-step graph arena size. |
-| `--session-option index_tts2.emotion_text_max_tokens=<n>` | tokens | `256` | Maximum generated tokens for emotion-text classification; old name `index_tts2.emotion_text_max_new_tokens` is still accepted. |
-| `--session-option index_tts2.weight_context_mb=<n>` | MB | `32` | Shared ggml weight metadata context size. |
-
-### Converting From Upstream Weights
-
-`tools/convert_index_tts2_5.py` turns an official `IndexTeam/IndexTTS-2.5` snapshot (the `.pth` checkpoints) into the Safetensors staging layout the engine expects, and prints (or runs) the matching `audiocpp_gguf` command. The w2v-bert-2.0, CAMPPlus, and BigVGAN checkpoints are auto-detected under `<model-dir>/hf_cache/` (run the official inference once to populate it) and each has an explicit override flag:
-
-```bash
-python tools/convert_index_tts2_5.py \
-    --model-dir /path/to/IndexTTS-2.5 \
-    --output-dir /path/to/staging \
-    --run-converter /path/to/audiocpp_gguf --type q8_0
-```
-
-Pass `--native-dir /path/to/IndexTTS-2.5-native` to also emit a directly loadable native Safetensors model directory (hardlinked from the staging files), no GGUF conversion required.
-
-The script repackages the checkpoints the loader needs (unwraps the `s2mel.pth`/`codec.pth` container keys, prefixes CAMPPlus tensors with `speaker_encoder.`, strips BigVGAN's `generator.` prefix, wraps the `feat1/feat2.pt` matrices as a single `tensor`) and assembles the sidecar `root/` (config, tiktoken vocabulary, auxiliary model configs) that gets embedded into the GGUF. The staged `config.yaml` has its `version` field normalized to `"2.5"` (the official snapshot ships `version: 2.0`); the engine uses that field to select the IndexTTS2 family variant.
 
 ## Irodori-TTS
 

--- a/include/engine/models/fish_audio/generator.h
+++ b/include/engine/models/fish_audio/generator.h
@@ -26,7 +26,7 @@ public:
     FishAudioCodes encode_reference(const runtime::AudioBuffer & audio);
     FishAudioGenerationResult generate(
         const FishAudioRequest & request,
-        const std::optional<FishAudioCodes> & reference_codes,
+        const std::vector<FishAudioCodes> & reference_codes,
         const std::optional<FishAudioConversationTurn> & previous_turn,
         bool mem_saver);
 

--- a/include/engine/models/fish_audio/prompt_builder.h
+++ b/include/engine/models/fish_audio/prompt_builder.h
@@ -11,7 +11,7 @@ public:
 
     FishAudioPrompt build(
         const FishAudioRequest & request,
-        const std::optional<FishAudioCodes> & reference_codes,
+        const std::vector<FishAudioCodes> & reference_codes,
         const std::optional<FishAudioConversationTurn> & previous_turn) const;
 
 private:

--- a/include/engine/models/fish_audio/types.h
+++ b/include/engine/models/fish_audio/types.h
@@ -26,7 +26,7 @@ struct FishAudioReference {
 
 struct FishAudioRequest {
     std::string text;
-    std::optional<FishAudioReference> reference = std::nullopt;
+    std::vector<FishAudioReference> references;
     FishAudioGenerationOptions generation;
 };
 

--- a/model_specs/fish_audio.json
+++ b/model_specs/fish_audio.json
@@ -24,6 +24,145 @@
       "gguf"
     ]
   },
+  "options": {
+    "request": [
+      {
+        "name": "reference_text",
+        "type": "string",
+        "description": "Reference transcript used with speaker reference audio.",
+        "required": false
+      },
+      {
+        "name": "multi_reference_cond",
+        "type": "string",
+        "description": "Fish Audio ordered JSON array of reference conditioning pairs for one generated speaker: [{\"audio\":\"ref1.wav\",\"text\":\"Transcript one.\"},{\"audio\":\"ref2.wav\",\"text\":\"Transcript two.\"}]. This is not a multi-speaker dialogue routing option.",
+        "required": false
+      },
+      {
+        "name": "max_tokens",
+        "type": "int",
+        "description": "Maximum Fish Audio semantic tokens to generate; default 1024.",
+        "required": false,
+        "min": 1,
+        "default": 1024
+      },
+      {
+        "name": "text_chunk_size",
+        "type": "int",
+        "description": "Maximum characters per generated text chunk; default 200.",
+        "required": false,
+        "min": 1,
+        "default": 200
+      },
+      {
+        "name": "text_chunk_mode",
+        "type": "enum",
+        "description": "Framework text chunking mode; default word_budget.",
+        "preset": "text_chunk_mode_full",
+        "required": false,
+        "default": "word_budget"
+      },
+      {
+        "name": "top_p",
+        "type": "float",
+        "description": "Top-p sampling value in (0, 1]; default 0.8.",
+        "required": false,
+        "min": 0.0,
+        "max": 1.0,
+        "default": 0.8
+      },
+      {
+        "name": "top_k",
+        "type": "int",
+        "description": "Top-k sampling value; default 30.",
+        "required": false,
+        "min": 1,
+        "default": 30
+      },
+      {
+        "name": "temperature",
+        "type": "float",
+        "description": "Semantic-token sampling temperature in (0, 2); default 0.8.",
+        "required": false,
+        "min": 0.0,
+        "max": 2.0,
+        "default": 0.8
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "description": "Sampling seed for reproducible output; omitted uses a random seed.",
+        "required": false,
+        "min": 0
+      }
+    ],
+    "session": [
+      {
+        "name": "mem_saver",
+        "type": "bool",
+        "description": "Release cached AR runtime graphs after each request; default false.",
+        "required": false,
+        "default": false
+      },
+      {
+        "name": "reference_cache_slots",
+        "type": "int",
+        "description": "Prepared reference-audio cache slots; default 1.",
+        "required": false,
+        "min": 0,
+        "default": 1
+      },
+      {
+        "name": "weight_type",
+        "type": "enum",
+        "description": "AR matmul weight storage type; default native.",
+        "preset": "weight_type_full",
+        "required": false,
+        "default": "native"
+      },
+      {
+        "name": "codec_weight_type",
+        "type": "enum",
+        "description": "Codec conv/matmul weight storage type; default native.",
+        "preset": "weight_type_codec_q8",
+        "required": false,
+        "default": "native"
+      },
+      {
+        "name": "ar_graph_arena_mb",
+        "type": "int",
+        "description": "AR runtime graph arena size in MiB; default 512.",
+        "required": false,
+        "min": 0,
+        "default": 512
+      },
+      {
+        "name": "ar_weight_context_mb",
+        "type": "int",
+        "description": "AR weight context size in MiB; default 512.",
+        "required": false,
+        "min": 0,
+        "default": 512
+      },
+      {
+        "name": "codec_graph_arena_mb",
+        "type": "int",
+        "description": "Codec encode/decode graph arena size in MiB; default 512.",
+        "required": false,
+        "min": 0,
+        "default": 512
+      },
+      {
+        "name": "codec_weight_context_mb",
+        "type": "int",
+        "description": "Codec weight context size in MiB; default 512.",
+        "required": false,
+        "min": 0,
+        "default": 512
+      }
+    ],
+    "load": []
+  },
   "ui": {
     "recommended_package": "fish_audio_s2_pro_q8_0",
     "tags": [

--- a/src/models/fish_audio/generator.cpp
+++ b/src/models/fish_audio/generator.cpp
@@ -37,10 +37,11 @@ FishAudioCodes FishAudioGenerator::encode_reference(const runtime::AudioBuffer &
 
 FishAudioGenerationResult FishAudioGenerator::generate(
     const FishAudioRequest & request,
-    const std::optional<FishAudioCodes> & reference_codes,
+    const std::vector<FishAudioCodes> & reference_codes,
     const std::optional<FishAudioConversationTurn> & previous_turn,
     bool mem_saver) {
-    engine::debug::trace_log_scalar("fish_audio.request.has_reference", request.reference.has_value());
+    engine::debug::trace_log_scalar("fish_audio.request.has_reference", !request.references.empty());
+    engine::debug::trace_log_scalar("fish_audio.request.reference_count", static_cast<int64_t>(request.references.size()));
     engine::debug::trace_log_scalar("fish_audio.request.text_chars", static_cast<int64_t>(request.text.size()));
     engine::debug::trace_log_scalar("fish_audio.request.has_previous_turn", previous_turn.has_value());
     engine::debug::trace_log_scalar("fish_audio.sampler.seed", request.generation.seed);

--- a/src/models/fish_audio/loader.cpp
+++ b/src/models/fish_audio/loader.cpp
@@ -34,6 +34,7 @@ runtime::ModelCliInterface cli(const FishAudioAssets &) {
     runtime::ModelCliInterface out;
     out.request_options = {
         {"reference_text", "TEXT", "Reference transcript used with speaker reference audio."},
+        {"multi_reference_cond", "JSON", "Ordered Fish Audio reference conditioning pairs: [{\"audio\":\"ref.wav\",\"text\":\"transcript\"}, ...]."},
         {"max_new_tokens", "N", "Maximum Fish Audio semantic tokens to generate; default 1024, 0 uses the default."},
         {"text_chunk_size", "N", "Long-form text chunk size; default 200."},
         {"text_chunk_mode", "default|tag_aware|japanese|endline", "Framework text chunking mode."},

--- a/src/models/fish_audio/prompt_builder.cpp
+++ b/src/models/fish_audio/prompt_builder.cpp
@@ -16,12 +16,12 @@ struct CodeSpan {
     const FishAudioCodes * codes = nullptr;
 };
 
-std::string reference_text_with_speakers(const std::string & text) {
+std::string reference_text_with_speakers(const std::string & text, int64_t speaker) {
     static const std::regex speaker_re(R"(<\|speaker:\d+\|>)");
     if (std::regex_search(text, speaker_re)) {
         return text;
     }
-    return "<|speaker:0|>" + text;
+    return "<|speaker:" + std::to_string(speaker) + "|>" + text;
 }
 
 void append_code_span(
@@ -55,7 +55,7 @@ FishAudioPromptBuilder::FishAudioPromptBuilder(
 
 FishAudioPrompt FishAudioPromptBuilder::build(
     const FishAudioRequest & request,
-    const std::optional<FishAudioCodes> & reference_codes,
+    const std::vector<FishAudioCodes> & reference_codes,
     const std::optional<FishAudioConversationTurn> & previous_turn) const {
     if (request.text.empty()) {
         throw std::runtime_error("Fish Audio request text must not be empty");
@@ -67,15 +67,26 @@ FishAudioPrompt FishAudioPromptBuilder::build(
 
     std::vector<int32_t> row0;
     std::vector<CodeSpan> code_spans;
-    if (request.reference.has_value()) {
-        if (!reference_codes.has_value()) {
-            throw std::runtime_error("Fish Audio reference request requires encoded reference codes");
+    if (!request.references.empty()) {
+        if (reference_codes.size() != request.references.size()) {
+            throw std::runtime_error("Fish Audio reference request requires one encoded code tensor per reference");
         }
         append_tokens(row0, tokenizer_.encode("<|im_start|>system\n"));
         append_tokens(row0, tokenizer_.encode("convert the provided text to speech reference to the following:\n\nText:\n"));
-        append_tokens(row0, tokenizer_.encode(reference_text_with_speakers(request.reference->text)));
+        for (size_t index = 0; index < request.references.size(); ++index) {
+            if (index != 0) {
+                append_tokens(row0, tokenizer_.encode("\n"));
+            }
+            append_tokens(
+                row0,
+                tokenizer_.encode(reference_text_with_speakers(
+                    request.references[index].text,
+                    static_cast<int64_t>(index))));
+        }
         append_tokens(row0, tokenizer_.encode("\n\nSpeech:\n"));
-        append_code_span(row0, code_spans, tokenizer_, *reference_codes, assets_->config.fast.num_codebooks);
+        for (const auto & codes : reference_codes) {
+            append_code_span(row0, code_spans, tokenizer_, codes, assets_->config.fast.num_codebooks);
+        }
         append_tokens(row0, tokenizer_.encode("<|im_end|>\n"));
     } else {
         append_tokens(row0, tokenizer_.encode("<|im_start|>system\n"));

--- a/src/models/fish_audio/session.cpp
+++ b/src/models/fish_audio/session.cpp
@@ -2,6 +2,7 @@
 
 #include "engine/framework/audio/wav_reader.h"
 #include "engine/framework/debug/profiler.h"
+#include "engine/framework/io/json.h"
 #include "engine/framework/io/filesystem.h"
 #include "engine/framework/runtime/options.h"
 #include "engine/framework/runtime/session.h"
@@ -32,6 +33,7 @@ constexpr size_t kDefaultArWeightContextBytes = 512ull * 1024ull * 1024ull;
 constexpr size_t kDefaultCodecWeightContextBytes = 512ull * 1024ull * 1024ull;
 constexpr int64_t kDefaultReferenceCacheSlots = 1;
 constexpr const char * kReferenceTextOption = "reference_text";
+constexpr const char * kMultiReferenceCondOption = "multi_reference_cond";
 
 std::shared_ptr<const FishAudioAssets> require_assets(std::shared_ptr<const FishAudioAssets> assets) {
     if (assets == nullptr) {
@@ -194,7 +196,7 @@ runtime::AudioBuffer read_saved_reference_audio(const fs::path & path) {
     return runtime::AudioBuffer{wav.sample_rate, wav.channels, std::move(wav.samples)};
 }
 
-FishAudioReference load_saved_reference(
+std::vector<FishAudioReference> load_saved_references(
     const FishAudioAssets & assets,
     const std::string & reference_id) {
     validate_reference_id(reference_id);
@@ -205,20 +207,20 @@ FishAudioReference load_saved_reference(
     if (audio_files.empty()) {
         throw std::runtime_error(
             "Fish Audio cached_voice_id '" + reference_id +
-            "' requires one WAV reference with a matching .lab file under " +
+            "' requires at least one WAV reference with a matching .lab file under " +
             reference_dir.string());
     }
-    if (audio_files.size() > 1) {
-        throw std::runtime_error(
-            "Fish Audio cached_voice_id '" + reference_id +
-            "' has multiple WAV references with .lab files; the C++ session expects exactly one reference pair");
+    std::vector<FishAudioReference> references;
+    references.reserve(audio_files.size());
+    for (const auto & audio_file : audio_files) {
+        auto lab_path = audio_file;
+        lab_path.replace_extension(".lab");
+        references.push_back(FishAudioReference{
+            read_saved_reference_audio(audio_file),
+            engine::io::read_text_file(lab_path),
+            reference_id + "\n" + audio_file.lexically_normal().string()});
     }
-    auto lab_path = audio_files.front();
-    lab_path.replace_extension(".lab");
-    return FishAudioReference{
-        read_saved_reference_audio(audio_files.front()),
-        engine::io::read_text_file(lab_path),
-        reference_id};
+    return references;
 }
 
 std::string reference_cache_id_from_voice(const std::optional<runtime::VoiceCondition> & voice) {
@@ -240,13 +242,13 @@ bool has_reference_selector(const std::optional<runtime::VoiceCondition> & voice
         (speaker.cached_voice_id.has_value() && !speaker.cached_voice_id->empty());
 }
 
-std::optional<FishAudioReference> reference_from_voice(
+std::vector<FishAudioReference> references_from_voice(
     const FishAudioAssets & assets,
     const std::optional<runtime::VoiceCondition> & voice,
     const std::unordered_map<std::string, std::string> & options,
     const char * role) {
     if (!has_reference_selector(voice)) {
-        return std::nullopt;
+        return {};
     }
     const auto & speaker = *voice->speaker;
     if (speaker.audio.has_value()) {
@@ -255,12 +257,44 @@ std::optional<FishAudioReference> reference_from_voice(
             throw std::runtime_error(
                 std::string(role) + " with inline reference audio requires reference_text option");
         }
-        return FishAudioReference{
+        return {FishAudioReference{
             speaker.audio,
             *reference_text,
-            reference_cache_id_from_voice(voice)};
+            reference_cache_id_from_voice(voice)}};
     }
-    return load_saved_reference(assets, *speaker.cached_voice_id);
+    return load_saved_references(assets, *speaker.cached_voice_id);
+}
+
+std::vector<FishAudioReference> multi_reference_cond_from_options(
+    const std::unordered_map<std::string, std::string> & options) {
+    const auto value = runtime::find_option(options, {kMultiReferenceCondOption});
+    if (!value.has_value()) {
+        return {};
+    }
+    const auto root = engine::io::json::parse(*value);
+    if (!root.is_array()) {
+        throw std::runtime_error("Fish Audio multi_reference_cond must be a JSON array");
+    }
+    std::vector<FishAudioReference> references;
+    references.reserve(root.as_array().size());
+    for (const auto & item : root.as_array()) {
+        if (!item.is_object()) {
+            throw std::runtime_error("Fish Audio multi_reference_cond entries must be objects");
+        }
+        const auto audio_path = engine::io::json::require_string(item, "audio");
+        const auto text = engine::io::json::require_string(item, "text");
+        if (audio_path.empty()) {
+            throw std::runtime_error("Fish Audio multi_reference_cond audio path must not be empty");
+        }
+        if (text.empty()) {
+            throw std::runtime_error("Fish Audio multi_reference_cond text must not be empty");
+        }
+        references.push_back(FishAudioReference{
+            read_saved_reference_audio(audio_path),
+            text,
+            {}});
+    }
+    return references;
 }
 
 }  // namespace
@@ -346,9 +380,13 @@ void FishAudioSession::prepare(const runtime::SessionPreparationRequest & reques
             defaults.generation.max_new_tokens = *value;
         }
     }
-    if (auto reference = reference_from_voice(*assets_, request.voice, request.options, "Fish Audio prepare");
-        reference.has_value()) {
-        defaults.reference = std::move(*reference);
+    if (auto references = references_from_voice(*assets_, request.voice, request.options, "Fish Audio prepare");
+        !references.empty()) {
+        defaults.references = std::move(references);
+        has_defaults = true;
+    } else if (auto references = multi_reference_cond_from_options(request.options);
+               !references.empty()) {
+        defaults.references = std::move(references);
         has_defaults = true;
     }
     if (has_defaults) {
@@ -363,11 +401,14 @@ FishAudioRequest FishAudioSession::make_request(const runtime::TaskRequest & req
         out.text = request.text_input->text;
     }
     out.generation = generation_options_from_request(request);
-    if (auto reference = reference_from_voice(*assets_, request.voice, request.options, "Fish Audio request");
-        reference.has_value()) {
-        out.reference = std::move(*reference);
+    if (auto references = references_from_voice(*assets_, request.voice, request.options, "Fish Audio request");
+        !references.empty()) {
+        out.references = std::move(references);
+    } else if (auto references = multi_reference_cond_from_options(request.options);
+               !references.empty()) {
+        out.references = std::move(references);
     } else if (request.text_input.has_value()) {
-        out.reference = std::nullopt;
+        out.references.clear();
     }
     if (out.text.empty()) {
         throw std::runtime_error("Fish Audio request text must not be empty");
@@ -436,13 +477,16 @@ runtime::TaskResult FishAudioSession::run(const runtime::TaskRequest & request) 
     engine::debug::trace_log_scalar("fish_audio.text_chunk_count", static_cast<int64_t>(chunk_requests.size()));
 
     runtime::AudioBuffer merged_audio;
-    std::optional<FishAudioCodes> reference_codes = std::nullopt;
+    std::vector<FishAudioCodes> reference_codes;
     std::optional<FishAudioConversationTurn> previous_turn = std::nullopt;
     for (size_t chunk_index = 0; chunk_index < chunk_requests.size(); ++chunk_index) {
         const auto & chunk_request = chunk_requests[chunk_index];
         auto fish_request = make_request(chunk_request);
-        if (fish_request.reference.has_value() && !reference_codes.has_value()) {
-            reference_codes = resolve_reference_codes(*fish_request.reference);
+        if (!fish_request.references.empty() && reference_codes.empty()) {
+            reference_codes.reserve(fish_request.references.size());
+            for (const auto & reference : fish_request.references) {
+                reference_codes.push_back(resolve_reference_codes(reference));
+            }
         }
         auto generated = generator_->generate(fish_request, reference_codes, previous_turn, mem_saver);
         runtime::append_audio_buffer(merged_audio, generated.audio);


### PR DESCRIPTION
## Summary
- add Fish Audio `multi_reference_cond` request option for ordered reference audio/transcript pairs
- support both combined reference conditioning and speaker-tagged target text such as `<|speaker:0|>... <|speaker:1|>...`
- add dedicated Fish Audio and IndexTTS model docs while keeping the top-level TTS quick starts concise

## Validation
- generated Fish Audio output with two references and speaker order `speaker0 -> speaker1 -> speaker0`
- confirmed request-level `multi_reference_cond` overrides model `default_request_options` through the normal server request option merge path
- `git diff --check` passed

Resolves #270