### PR TITLE
Add native model manager build script flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,12 @@ For deployment builds with compiled package specs:
 scripts/build_linux.sh --backend cuda --deployment-build --target audiocpp_cli --target audiocpp_server
 ```
 
+For native WebUI model downloads, enable the native model manager:
+
+```bash
+scripts/build_linux.sh --backend cuda --native-model-manager --target audiocpp_server
+```
+
 For direct CMake commands, see [docs/build/linux.md](docs/build/linux.md).
 
 ### Windows Build
@@ -322,6 +328,12 @@ For deployment builds with compiled package specs:
 
 ```powershell
 .\scripts\build_windows.ps1 -DeploymentBuild -Target audiocpp_cli
+```
+
+For native WebUI model downloads, enable the native model manager:
+
+```powershell
+.\scripts\build_windows.ps1 -NativeModelManager -Target audiocpp_server
 ```
 
 For requirements, CPU profiles, CUDA packaging, and release zips, see [docs/build/windows.md](docs/build/windows.md).
@@ -426,6 +438,7 @@ Run with `--backend hip` (`rocm` is accepted as an alias). For GPU target select
 | `AUDIOCPP_BUILD_NATIVE_MODEL_MANAGER` | Build the standalone native model manager and enable server-side WebUI downloads/install management. This opt-in feature builds the HTTP/TLS dependency. | `OFF` |
 | `AUDIOCPP_USE_SYSTEM_OPENSSL` | Use system OpenSSL instead of bundled BoringSSL when native model management is enabled. | `OFF` |
 | `AUDIOCPP_DEPLOYMENT_BUILD` | Compile package specs into CLI/server binaries for standalone GGUF and package-spec fallback loading. Script builds expose this as `--deployment-build` on Linux/macOS and `-DeploymentBuild` on Windows. | `OFF` |
+| Native model manager script flag | Build scripts expose `AUDIOCPP_BUILD_NATIVE_MODEL_MANAGER` as `--native-model-manager` on Linux/macOS and `-NativeModelManager` on Windows. `--system-openssl` / `-SystemOpenSsl` and `--boringssl-archive` / `-BoringSslArchive` configure its TLS backend. | disabled |
 | `AUDIOCPP_MODEL_SET` | Model composite to build: `full`, `core`, or `custom`. Script builds expose this as `--model-set` on Linux/macOS and `-ModelSet` on Windows. | `full` |
 | `AUDIOCPP_MODELS` | Comma or semicolon separated model target names when `AUDIOCPP_MODEL_SET=custom`, such as `qwen3_tts,pocket_tts,qwen3_asr`. Script builds expose this as `--models` on Linux/macOS and `-Models` on Windows. | empty |
 

--- a/docs/model_manager.md
+++ b/docs/model_manager.md
@@ -28,6 +28,16 @@ cmake -S . -B build -DAUDIOCPP_BUILD_NATIVE_MODEL_MANAGER=ON
 cmake --build build --target audiocpp_model_manager audiocpp_server
 ```
 
+With build helper scripts, use the native-manager flag:
+
+```bash
+./scripts/build_linux.sh --backend cuda --native-model-manager --target audiocpp_server
+```
+
+```powershell
+.\scripts\build_windows.ps1 -NativeModelManager -Target audiocpp_server
+```
+
 Run the managed WebUI with:
 
 ```bash
@@ -45,6 +55,9 @@ Offline and sandboxed builds may provide the same verified source archive with
 this through a fixed-output derivation, so its CMake phase never accesses the
 network.
 
+With build helper scripts, use `--boringssl-archive <path>` on Linux/macOS or
+`-BoringSslArchive <path>` on Windows.
+
 Packagers that prefer their distribution's OpenSSL can select it explicitly:
 
 ```bash
@@ -52,6 +65,9 @@ cmake -S . -B build \
   -DAUDIOCPP_BUILD_NATIVE_MODEL_MANAGER=ON \
   -DAUDIOCPP_USE_SYSTEM_OPENSSL=ON
 ```
+
+With build helper scripts, use `--system-openssl` on Linux/macOS or
+`-SystemOpenSsl` on Windows.
 
 When using system OpenSSL on machines with multiple OpenSSL installations, make
 sure CMake resolves the distribution OpenSSL that will also be available where

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -15,6 +15,9 @@ WITH_EXAMPLES="OFF"
 WITH_WARMBENCH="OFF"
 AUDIOCPP_DEPLOYMENT_BUILD="OFF"
 DEPLOYMENT_BUILD_SET="OFF"
+AUDIOCPP_BUILD_NATIVE_MODEL_MANAGER="OFF"
+AUDIOCPP_USE_SYSTEM_OPENSSL="OFF"
+AUDIOCPP_BORINGSSL_ARCHIVE=""
 AUDIOCPP_MODEL_SET="full"
 AUDIOCPP_MODELS=""
 NATIVE_CPU="ON"
@@ -101,6 +104,18 @@ while [[ $# -gt 0 ]]; do
             DEPLOYMENT_BUILD_SET="ON"
             shift
             ;;
+        --native-model-manager)
+            AUDIOCPP_BUILD_NATIVE_MODEL_MANAGER="ON"
+            shift
+            ;;
+        --system-openssl)
+            AUDIOCPP_USE_SYSTEM_OPENSSL="ON"
+            shift
+            ;;
+        --boringssl-archive)
+            AUDIOCPP_BORINGSSL_ARCHIVE="$2"
+            shift 2
+            ;;
         --model-set)
             case "$2" in
                 full|core|custom)
@@ -161,6 +176,17 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+if [[ "$AUDIOCPP_BUILD_NATIVE_MODEL_MANAGER" != "ON" ]]; then
+    if [[ "$AUDIOCPP_USE_SYSTEM_OPENSSL" == "ON" ]]; then
+        echo "--system-openssl requires --native-model-manager" >&2
+        exit 1
+    fi
+    if [[ -n "$AUDIOCPP_BORINGSSL_ARCHIVE" ]]; then
+        echo "--boringssl-archive requires --native-model-manager" >&2
+        exit 1
+    fi
+fi
 
 GENERATOR="Unix Makefiles"
 if command -v ninja >/dev/null 2>&1; then
@@ -338,6 +364,11 @@ echo "Building examples: $WITH_EXAMPLES"
 echo "Building tests: $WITH_TESTS"
 echo "Building warmbench: $WITH_WARMBENCH"
 echo "Deployment build: $AUDIOCPP_DEPLOYMENT_BUILD"
+echo "Native model manager: $AUDIOCPP_BUILD_NATIVE_MODEL_MANAGER"
+if [[ "$AUDIOCPP_BUILD_NATIVE_MODEL_MANAGER" == "ON" ]]; then
+    echo "System OpenSSL: $AUDIOCPP_USE_SYSTEM_OPENSSL"
+    echo "BoringSSL archive: ${AUDIOCPP_BORINGSSL_ARCHIVE:-<download at configure time>}"
+fi
 echo "Model composite: $AUDIOCPP_MODEL_SET"
 if [[ -n "$AUDIOCPP_MODELS" ]]; then
     echo "Selected models: $AUDIOCPP_MODELS"
@@ -357,9 +388,15 @@ CMAKE_ARGS=(
     -DENGINE_BUILD_TESTS="$WITH_TESTS"
     -DENGINE_BUILD_WARMBENCH="$WITH_WARMBENCH"
     -DAUDIOCPP_DEPLOYMENT_BUILD="$AUDIOCPP_DEPLOYMENT_BUILD"
+    -DAUDIOCPP_BUILD_NATIVE_MODEL_MANAGER="$AUDIOCPP_BUILD_NATIVE_MODEL_MANAGER"
+    -DAUDIOCPP_USE_SYSTEM_OPENSSL="$AUDIOCPP_USE_SYSTEM_OPENSSL"
+    -UAUDIOCPP_BORINGSSL_ARCHIVE
     -DAUDIOCPP_MODEL_SET="$AUDIOCPP_MODEL_SET"
     -DAUDIOCPP_MODELS="$AUDIOCPP_MODELS"
 )
+if [[ -n "$AUDIOCPP_BORINGSSL_ARCHIVE" ]]; then
+    CMAKE_ARGS+=(-DAUDIOCPP_BORINGSSL_ARCHIVE="$AUDIOCPP_BORINGSSL_ARCHIVE")
+fi
 
 if [[ "$ENGINE_ENABLE_HIP" == "ON" ]]; then
     CMAKE_ARGS+=(

--- a/scripts/build_metal.sh
+++ b/scripts/build_metal.sh
@@ -11,6 +11,9 @@ WITH_TESTS="OFF"
 WITH_EXAMPLES="OFF"
 WITH_WARMBENCH="OFF"
 AUDIOCPP_DEPLOYMENT_BUILD="OFF"
+AUDIOCPP_BUILD_NATIVE_MODEL_MANAGER="OFF"
+AUDIOCPP_USE_SYSTEM_OPENSSL="OFF"
+AUDIOCPP_BORINGSSL_ARCHIVE=""
 AUDIOCPP_MODEL_SET="full"
 AUDIOCPP_MODELS=""
 OPENMP_MODE="off"
@@ -48,6 +51,10 @@ Options:
   --with-examples          Build example binaries.
   --with-warmbench         Build warmbench helper binaries.
   --deployment-build       Embed package specs for standalone GGUF/model loading.
+  --native-model-manager   Build native model manager and managed WebUI downloads.
+  --system-openssl         Use system OpenSSL for native model management.
+  --boringssl-archive <p>  Use a local BoringSSL source archive for native model
+                           management instead of downloading at configure time.
   --model-set full|core|custom
                            Model composite to build.
                            Default: full
@@ -131,6 +138,18 @@ while [[ $# -gt 0 ]]; do
             AUDIOCPP_DEPLOYMENT_BUILD="ON"
             shift
             ;;
+        --native-model-manager)
+            AUDIOCPP_BUILD_NATIVE_MODEL_MANAGER="ON"
+            shift
+            ;;
+        --system-openssl)
+            AUDIOCPP_USE_SYSTEM_OPENSSL="ON"
+            shift
+            ;;
+        --boringssl-archive)
+            AUDIOCPP_BORINGSSL_ARCHIVE="$2"
+            shift 2
+            ;;
         --model-set)
             case "$2" in
                 full|core|custom)
@@ -166,6 +185,17 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+if [[ "$AUDIOCPP_BUILD_NATIVE_MODEL_MANAGER" != "ON" ]]; then
+    if [[ "$AUDIOCPP_USE_SYSTEM_OPENSSL" == "ON" ]]; then
+        echo "--system-openssl requires --native-model-manager" >&2
+        exit 1
+    fi
+    if [[ -n "$AUDIOCPP_BORINGSSL_ARCHIVE" ]]; then
+        echo "--boringssl-archive requires --native-model-manager" >&2
+        exit 1
+    fi
+fi
 
 if [[ "$(uname -s)" != "Darwin" ]]; then
     echo "audio.cpp Metal builds require macOS." >&2
@@ -237,9 +267,15 @@ CMAKE_CMD=(
     -DENGINE_BUILD_EXAMPLES="$WITH_EXAMPLES"
     -DENGINE_BUILD_WARMBENCH="$WITH_WARMBENCH"
     -DAUDIOCPP_DEPLOYMENT_BUILD="$AUDIOCPP_DEPLOYMENT_BUILD"
+    -DAUDIOCPP_BUILD_NATIVE_MODEL_MANAGER="$AUDIOCPP_BUILD_NATIVE_MODEL_MANAGER"
+    -DAUDIOCPP_USE_SYSTEM_OPENSSL="$AUDIOCPP_USE_SYSTEM_OPENSSL"
+    -UAUDIOCPP_BORINGSSL_ARCHIVE
     -DAUDIOCPP_MODEL_SET="$AUDIOCPP_MODEL_SET"
     -DAUDIOCPP_MODELS="$AUDIOCPP_MODELS"
 )
+if [[ -n "$AUDIOCPP_BORINGSSL_ARCHIVE" ]]; then
+    CMAKE_CMD+=(-DAUDIOCPP_BORINGSSL_ARCHIVE="$AUDIOCPP_BORINGSSL_ARCHIVE")
+fi
 
 if [[ -n "$GENERATOR" ]]; then
     CMAKE_CMD+=(-G "$GENERATOR")
@@ -270,6 +306,11 @@ echo "Building examples: $WITH_EXAMPLES"
 echo "Building tests: $WITH_TESTS"
 echo "Building warmbench: $WITH_WARMBENCH"
 echo "Deployment build: $AUDIOCPP_DEPLOYMENT_BUILD"
+echo "Native model manager: $AUDIOCPP_BUILD_NATIVE_MODEL_MANAGER"
+if [[ "$AUDIOCPP_BUILD_NATIVE_MODEL_MANAGER" == "ON" ]]; then
+    echo "System OpenSSL: $AUDIOCPP_USE_SYSTEM_OPENSSL"
+    echo "BoringSSL archive: ${AUDIOCPP_BORINGSSL_ARCHIVE:-<download at configure time>}"
+fi
 echo "Model composite: $AUDIOCPP_MODEL_SET"
 if [[ -n "$AUDIOCPP_MODELS" ]]; then
     echo "Selected models: $AUDIOCPP_MODELS"

--- a/scripts/build_windows.ps1
+++ b/scripts/build_windows.ps1
@@ -13,6 +13,9 @@ param(
     [ValidateSet("ON", "OFF")]
     [string]$Llamafile = $null,
     [switch]$DeploymentBuild,
+    [switch]$NativeModelManager,
+    [switch]$SystemOpenSsl,
+    [string]$BoringSslArchive = "",
     [ValidateSet("full", "core", "custom")]
     [string]$ModelSet = "full",
     [string]$Models = "",
@@ -21,6 +24,13 @@ param(
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Continue"  # let native command stderr (e.g. cmake warnings) flow without aborting the script
+
+if (-not $NativeModelManager -and $SystemOpenSsl) {
+    throw "-SystemOpenSsl requires -NativeModelManager"
+}
+if (-not $NativeModelManager -and $BoringSslArchive -ne "") {
+    throw "-BoringSslArchive requires -NativeModelManager"
+}
 
 function Invoke-Checked {
     param(
@@ -525,7 +535,18 @@ Write-Host "CPU architecture profile: $($cpuArchSettings.Label)"
 Write-Host "Native CPU optimization: $($settings.Native)"
 Write-Host "llamafile SGEMM: $($settings.Llamafile)"
 $deploymentBuildValue = if ($DeploymentBuild) { "ON" } else { "OFF" }
+$nativeModelManagerValue = if ($NativeModelManager) { "ON" } else { "OFF" }
+$systemOpenSslValue = if ($SystemOpenSsl) { "ON" } else { "OFF" }
 Write-Host "Deployment build: $deploymentBuildValue"
+Write-Host "Native model manager: $nativeModelManagerValue"
+if ($NativeModelManager) {
+    Write-Host "System OpenSSL: $systemOpenSslValue"
+    if ($BoringSslArchive -ne "") {
+        Write-Host "BoringSSL archive: $BoringSslArchive"
+    } else {
+        Write-Host "BoringSSL archive: <download at configure time>"
+    }
+}
 Write-Host "Model composite: $ModelSet"
 if ($Models -ne "") {
     Write-Host "Selected models: $Models"
@@ -564,9 +585,16 @@ $configureArgs = @(
     "-DENGINE_ENABLE_LLAMAFILE=$($settings.Llamafile)",
     "-DENGINE_BUILD_TESTS=$($settings.BuildTests)",
     "-DAUDIOCPP_DEPLOYMENT_BUILD=$deploymentBuildValue",
+    "-DAUDIOCPP_BUILD_NATIVE_MODEL_MANAGER=$nativeModelManagerValue",
+    "-DAUDIOCPP_USE_SYSTEM_OPENSSL=$systemOpenSslValue",
+    "-U", "AUDIOCPP_BORINGSSL_ARCHIVE",
     "-DAUDIOCPP_MODEL_SET=$ModelSet",
     "-DAUDIOCPP_MODELS=$Models"
 )
+$boringSslArchivePath = if ($BoringSslArchive -ne "") { Convert-ToCMakePath $BoringSslArchive } else { "" }
+if ($boringSslArchivePath -ne "") {
+    $configureArgs += "-DAUDIOCPP_BORINGSSL_ARCHIVE=$boringSslArchivePath"
+}
 $configureArgs += $cpuArchSettings.CMakeArgs
 if ($settings.CFlagsDebug -ne "") {
     $configureArgs += "-DCMAKE_C_FLAGS_DEBUG=$($settings.CFlagsDebug)"

--- a/scripts/build_windows_hip.ps1
+++ b/scripts/build_windows_hip.ps1
@@ -14,11 +14,21 @@ param(
     [switch]$WithVmm,        # explicitly re-enable VMM
     [switch]$NoNativeCpu,    # build ggml CPU kernels without native host ISA flags (required for distribution)
     [switch]$DeploymentBuild, # compile model_specs into the binary (self-contained deployment, no model_specs/ dir needed)
+    [switch]$NativeModelManager,
+    [switch]$SystemOpenSsl,
+    [string]$BoringSslArchive = "",
     [switch]$Graphs          # enable CUDA graphs (memory-hungry on iGPUs: each cached graph reserves its own VRAM)
 )
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
+
+if (-not $NativeModelManager -and $SystemOpenSsl) {
+    throw "-SystemOpenSsl requires -NativeModelManager"
+}
+if (-not $NativeModelManager -and $BoringSslArchive -ne "") {
+    throw "-BoringSslArchive requires -NativeModelManager"
+}
 
 function Invoke-Checked {
     param(
@@ -129,6 +139,8 @@ $forceMmqValue  = if ($ForceMmq) { "ON" } else { "OFF" }
 $noVmmValue     = if ($WithVmm) { "OFF" } elseif ($NoVmm) { "ON" } else { "OFF" }
 $nativeCpuValue = if ($NoNativeCpu) { "OFF" } else { "ON" }
 $deploymentValue = if ($DeploymentBuild) { "ON" } else { "OFF" }
+$nativeModelManagerValue = if ($NativeModelManager) { "ON" } else { "OFF" }
+$systemOpenSslValue = if ($SystemOpenSsl) { "ON" } else { "OFF" }
 $graphsValue    = if ($Graphs) { "ON" } else { "OFF" }
 
 Write-Host "ROCm:        $RocmPath"
@@ -137,6 +149,15 @@ Write-Host "CMake:       $cmake"
 Write-Host "Ninja:       $ninja"
 Write-Host "Build dir:   $buildDir"
 Write-Host "hipBLASLt GEMM: $hipblasLtValue, FORCE_MMQ: $forceMmqValue, NO_VMM: $noVmmValue, CUDA graphs: $graphsValue, native CPU ISA: $nativeCpuValue, deployment build: $deploymentValue"
+Write-Host "Native model manager: $nativeModelManagerValue"
+if ($NativeModelManager) {
+    Write-Host "System OpenSSL: $systemOpenSslValue"
+    if ($BoringSslArchive -ne "") {
+        Write-Host "BoringSSL archive: $BoringSslArchive"
+    } else {
+        Write-Host "BoringSSL archive: <download at configure time>"
+    }
+}
 
 if ($Clean) {
     Invoke-Checked $cmake @("--build", $buildDir, "--target", "clean")
@@ -172,8 +193,15 @@ $configureArgs = @(
     "-DGGML_HIP_NO_VMM=$noVmmValue",
     "-DENGINE_ENABLE_NATIVE_CPU=$nativeCpuValue",
     "-DAUDIOCPP_DEPLOYMENT_BUILD=$deploymentValue",
+    "-DAUDIOCPP_BUILD_NATIVE_MODEL_MANAGER=$nativeModelManagerValue",
+    "-DAUDIOCPP_USE_SYSTEM_OPENSSL=$systemOpenSslValue",
+    "-U", "AUDIOCPP_BORINGSSL_ARCHIVE",
     "-DENGINE_ENABLE_CUDA_GRAPHS=$graphsValue"
 )
+$boringSslArchivePath = if ($BoringSslArchive -ne "") { Convert-ToCMakePath $BoringSslArchive } else { "" }
+if ($boringSslArchivePath -ne "") {
+    $configureArgs += "-DAUDIOCPP_BORINGSSL_ARCHIVE=$boringSslArchivePath"
+}
 
 Invoke-Checked $cmake $configureArgs
 

--- a/scripts/build_xcframework.sh
+++ b/scripts/build_xcframework.sh
@@ -15,6 +15,9 @@ CLEAN="OFF"
 LLAMAFILE="ON"
 NATIVE_CPU="ON"
 AUDIOCPP_DEPLOYMENT_BUILD="OFF"
+AUDIOCPP_BUILD_NATIVE_MODEL_MANAGER="OFF"
+AUDIOCPP_USE_SYSTEM_OPENSSL="OFF"
+AUDIOCPP_BORINGSSL_ARCHIVE=""
 AUDIOCPP_MODEL_SET="full"
 AUDIOCPP_MODELS=""
 
@@ -43,6 +46,12 @@ Options:
   --native-cpu ON|OFF   Build ggml CPU kernels with native host ISA flags.
                         Default: ON
   --deployment-build    Embed package specs for standalone GGUF/model loading.
+  --native-model-manager
+                        Build native model manager and managed WebUI downloads.
+  --system-openssl      Use system OpenSSL for native model management.
+  --boringssl-archive <path>
+                        Use a local BoringSSL source archive for native model
+                        management instead of downloading at configure time.
   --model-set full|core|custom
                         Model composite to build.
                         Default: full
@@ -100,6 +109,18 @@ while [[ $# -gt 0 ]]; do
             AUDIOCPP_DEPLOYMENT_BUILD="ON"
             shift
             ;;
+        --native-model-manager)
+            AUDIOCPP_BUILD_NATIVE_MODEL_MANAGER="ON"
+            shift
+            ;;
+        --system-openssl)
+            AUDIOCPP_USE_SYSTEM_OPENSSL="ON"
+            shift
+            ;;
+        --boringssl-archive)
+            AUDIOCPP_BORINGSSL_ARCHIVE="$2"
+            shift 2
+            ;;
         --model-set)
             case "$2" in
                 full|core|custom)
@@ -131,6 +152,17 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+if [[ "$AUDIOCPP_BUILD_NATIVE_MODEL_MANAGER" != "ON" ]]; then
+    if [[ "$AUDIOCPP_USE_SYSTEM_OPENSSL" == "ON" ]]; then
+        echo "--system-openssl requires --native-model-manager" >&2
+        exit 1
+    fi
+    if [[ -n "$AUDIOCPP_BORINGSSL_ARCHIVE" ]]; then
+        echo "--boringssl-archive requires --native-model-manager" >&2
+        exit 1
+    fi
+fi
 
 if [[ "$(uname -s)" != "Darwin" ]]; then
     echo "audio.cpp XCFramework builds require macOS." >&2
@@ -216,9 +248,15 @@ archive_for_arch() {
         -DENGINE_BUILD_TESTS=OFF \
         -DENGINE_BUILD_EXAMPLES=OFF \
         -DAUDIOCPP_DEPLOYMENT_BUILD="$AUDIOCPP_DEPLOYMENT_BUILD" \
+        -DAUDIOCPP_BUILD_NATIVE_MODEL_MANAGER="$AUDIOCPP_BUILD_NATIVE_MODEL_MANAGER" \
+        -DAUDIOCPP_USE_SYSTEM_OPENSSL="$AUDIOCPP_USE_SYSTEM_OPENSSL" \
+        -UAUDIOCPP_BORINGSSL_ARCHIVE \
         -DAUDIOCPP_MODEL_SET="$AUDIOCPP_MODEL_SET" \
         -DAUDIOCPP_MODELS="$AUDIOCPP_MODELS"
     )
+    if [[ -n "$AUDIOCPP_BORINGSSL_ARCHIVE" ]]; then
+        cmake_cmd+=(-DAUDIOCPP_BORINGSSL_ARCHIVE="$AUDIOCPP_BORINGSSL_ARCHIVE")
+    fi
     if [[ -n "$GENERATOR" ]]; then
         cmake_cmd+=(-G "$GENERATOR")
     fi

--- a/scripts/package_windows_prebuilt.ps1
+++ b/scripts/package_windows_prebuilt.ps1
@@ -8,6 +8,7 @@ param(
     [string]$OutputDir = "",
     [string]$CudaArchitectures = "default",
     [string]$VsInstall = "",
+    [string]$BoringSslArchive = "",
     [switch]$SkipCudaRuntimeDlls
 )
 
@@ -159,7 +160,7 @@ Server:
 Native WebUI (no Python required):
 
 ```powershell
-.\audiocpp_server.exe --ui --backend cuda
+.\audiocpp_server.exe --ui --ui-management --backend cuda
 ```
 
 Then open `http://127.0.0.1:8080`.
@@ -213,7 +214,7 @@ Server:
 Native WebUI (no Python required):
 
 ```powershell
-.\audiocpp_server.exe --ui --backend cpu
+.\audiocpp_server.exe --ui --ui-management --backend cpu
 ```
 
 Then open `http://127.0.0.1:8080`.
@@ -269,6 +270,11 @@ function New-PrebuiltPackage {
         [Parameter(Mandatory = $true)][ValidateSet("cpu", "cuda")][string]$Kind
     )
 
+    $nativeManagerArgs = @("-NativeModelManager")
+    if ($BoringSslArchive -ne "") {
+        $nativeManagerArgs += @("-BoringSslArchive", $BoringSslArchive)
+    }
+
     $buildArgs = @(
         "-Preset", $Preset,
         "-Target", "audiocpp_cli",
@@ -283,6 +289,7 @@ function New-PrebuiltPackage {
     if ($VsInstall -ne "") {
         $buildArgs += @("-VsInstall", $VsInstall)
     }
+    $buildArgs += $nativeManagerArgs
     Invoke-Checked "powershell.exe" (@("-NoProfile", "-ExecutionPolicy", "Bypass", "-File", $buildScript) + $buildArgs)
 
     $buildArgs = @(
@@ -299,6 +306,7 @@ function New-PrebuiltPackage {
     if ($VsInstall -ne "") {
         $buildArgs += @("-VsInstall", $VsInstall)
     }
+    $buildArgs += $nativeManagerArgs
     Invoke-Checked "powershell.exe" (@("-NoProfile", "-ExecutionPolicy", "Bypass", "-File", $buildScript) + $buildArgs)
 
     $buildArgs = @(
@@ -315,6 +323,7 @@ function New-PrebuiltPackage {
     if ($VsInstall -ne "") {
         $buildArgs += @("-VsInstall", $VsInstall)
     }
+    $buildArgs += $nativeManagerArgs
     Invoke-Checked "powershell.exe" (@("-NoProfile", "-ExecutionPolicy", "Bypass", "-File", $buildScript) + $buildArgs)
 
     $sourceBin = Join-Path (Join-Path $repoRoot "build") "$Preset\bin"

--- a/src/framework/package_manager/manager.cpp
+++ b/src/framework/package_manager/manager.cpp
@@ -530,8 +530,9 @@ std::string PackageManager::install(
         for (const auto & [remote, output] : downloads) {
             if (cancelled && cancelled->load()) throw Cancelled();
             const auto destination = staging / output.lexically_relative(final_root);
-            download_file(package, remote, destination, cancelled, [&](uint64_t file_bytes) {
-                if (progress) progress({completed + file_bytes, total, "Downloading " + remote});
+            const auto progress_message = "Downloading " + remote;
+            download_file(package, remote, destination, cancelled, [&, progress_message](uint64_t file_bytes) {
+                if (progress) progress({completed + file_bytes, total, progress_message});
             });
             const auto file_size = std::filesystem::file_size(destination);
             const auto expected = remote_files.at(remote).size;


### PR DESCRIPTION
## Summary
- add first-class native model manager flags to Linux, macOS, and Windows build scripts
- make Windows prebuilt packaging opt into native model manager builds so the packaged manager binary is produced reliably
- document the script flags for native WebUI model downloads and TLS backend selection

## Validation
- `git diff --check`
- `bash -n scripts/build_linux.sh scripts/build_metal.sh scripts/build_xcframework.sh`
- `./scripts/build_linux.sh --backend cpu --build-dir build/debug --build-type Debug --native-model-manager --target audiocpp_server --target audiocpp_model_manager --jobs $(nproc)`
- verified `AUDIOCPP_BUILD_NATIVE_MODEL_MANAGER=ON` and `AUDIOCPP_USE_SYSTEM_OPENSSL=OFF` in CMake cache
- verified produced server and model-manager binaries run with `--help`
- verified no dynamic ssl/crypto/curl dependency in the produced Linux binaries

Note: PowerShell syntax validation was not run because PowerShell is not installed in this environment.