### PR TITLE
Drop out-of-span chunk speech metadata instead of aborting the run

### DIFF
--- a/src/framework/audio/chunking.cpp
+++ b/src/framework/audio/chunking.cpp
@@ -648,8 +648,19 @@ void append_chunk_speech_metadata(
         const int64_t local_start = std::max<int64_t>(local_span.start_sample, 0);
         const int64_t local_end = std::min<int64_t>(local_span.end_sample, source_samples);
         if (local_start >= local_end) {
-            throw std::runtime_error(std::string("Audio chunker speech metadata merge received a ") +
-                label + " outside the chunk span");
+            std::ostringstream warning;
+            warning << "dropping " << label << " outside chunk span"
+                    << " local_start=" << local_span.start_sample
+                    << " local_end=" << local_span.end_sample
+                    << " source_samples=" << source_samples
+                    << " source_start=" << source_span.start_sample
+                    << " source_end=" << source_span.end_sample
+                    << " keep_start=" << keep_span.start_sample
+                    << " keep_end=" << keep_span.end_sample
+                    << " source_sample_rate=" << source_sample_rate
+                    << " timestamp_sample_rate=" << timestamp_sample_rate;
+            debug::log_message(debug::LogLevel::Warning, "audio.chunking", warning.str());
+            return std::optional<runtime::TimeSpan>{};
         }
         runtime::TimeSpan global{
             timestamp_source_span.start_sample + local_start,

--- a/tests/unittests/test_audio_chunking.cpp
+++ b/tests/unittests/test_audio_chunking.cpp
@@ -879,6 +879,41 @@ void test_chunk_word_timestamp_merge_drops_outside_words() {
     require_span(merged[1].span, 1050, 1080, "second valid word span");
 }
 
+void test_chunk_speech_metadata_merge_drops_outside_spans() {
+    engine::runtime::TaskResult chunk;
+    auto kept_segment = speech(20, 40);
+    kept_segment.text = "kept segment";
+    chunk.speech_segments.push_back(kept_segment);
+    auto outside_segment = speech(120, 140);
+    outside_segment.text = "outside segment";
+    chunk.speech_segments.push_back(outside_segment);
+
+    engine::runtime::SpeakerTurn kept_turn;
+    kept_turn.span = engine::runtime::TimeSpan{50, 80};
+    kept_turn.speaker_id = "SPEAKER_00";
+    chunk.speaker_turns.push_back(kept_turn);
+    engine::runtime::SpeakerTurn outside_turn;
+    outside_turn.span = engine::runtime::TimeSpan{120, 140};
+    outside_turn.speaker_id = "SPEAKER_01";
+    chunk.speaker_turns.push_back(outside_turn);
+
+    engine::runtime::TaskResult merged;
+    engine::audio::append_chunk_speech_metadata(
+        merged,
+        chunk,
+        engine::runtime::TimeSpan{1000, 1100},
+        engine::runtime::TimeSpan{1000, 1100},
+        16000,
+        16000);
+
+    engine::test::require_eq(merged.speech_segments.size(), static_cast<size_t>(1), "outside speech segment dropped");
+    engine::test::require_eq(merged.speech_segments[0].text, std::string("kept segment"), "valid speech segment kept");
+    require_span(merged.speech_segments[0].span, 1020, 1040, "valid speech segment span");
+    engine::test::require_eq(merged.speaker_turns.size(), static_cast<size_t>(1), "outside speaker turn dropped");
+    engine::test::require_eq(merged.speaker_turns[0].speaker_id, std::string("SPEAKER_00"), "valid speaker turn kept");
+    require_span(merged.speaker_turns[0].span, 1050, 1080, "valid speaker turn span");
+}
+
 }  // namespace
 
 int main() {
@@ -912,6 +947,7 @@ int main() {
         test_chunk_speech_metadata_merge_rescales_chunk_domain();
         test_chunk_word_timestamp_merge_rejects_invalid_spans();
         test_chunk_word_timestamp_merge_drops_outside_words();
+        test_chunk_speech_metadata_merge_drops_outside_spans();
         std::cout << "audio_chunking_test passed\n";
     } catch (const std::exception & ex) {
         std::cerr << "audio_chunking_test failed: " << ex.what() << "\n";


### PR DESCRIPTION
Found while investigating #249. `src/framework/audio/chunking.cpp` has two sibling merge paths that compute the identical out-of-span guard and then disagree about what it means:

| path | function | on out-of-span | reached by |
|---|---|---|---|
| word timestamps | `append_chunk_word_timestamps` | warn + `continue` (since #252) | `qwen3_asr` forced aligner |
| speech metadata | `append_chunk_speech_metadata` → `merge_span` | **`throw`**, aborting the whole run | `vibevoice_asr` |

#252 chose warn-and-drop for the word path. This PR applies that same decision to the metadata path, which still aborts. It is not proposing a new policy — it is finishing the one already merged.

`merge_span` covers **both** `speech_segments` and `speaker_turns`, so either can abort a run.

## The change

`merge_span` already returns `std::optional<TimeSpan>`, and both call sites already `continue` on `std::nullopt`. So the throw becomes a warning plus `return std::nullopt` — the "not applicable" signal the function was already built around. No signature change, no call-site change. The warning carries the same diagnostic fields the word path emits (`local_start`, `local_end`, `source_samples`, the source/keep spans, both sample rates).

## Test

Adds `test_chunk_speech_metadata_merge_drops_outside_spans`, mirroring #252's `test_chunk_word_timestamp_merge_drops_outside_words`: one kept span and one outside span for **both** `speech_segments` and `speaker_turns`, asserting the outside ones are dropped and the valid ones survive with correct global spans.

Only `test_chunk_speech_metadata_merge_rescales_chunk_domain` existed before, so the out-of-span behaviour on this path had no coverage at all.

## Scope: which routes were checked

Shared framework code, so to be explicit about blast radius:

- **Affected:** the `vibevoice_asr` chunked path (`speech_segments` and `speaker_turns`). Behaviour change: a run that previously aborted now completes, with the out-of-span entry dropped and a warning logged.
- **Not affected:** the `qwen3_asr` word-timestamp path — untouched; it has behaved this way since #252. `append_chunk_speech_metadata` calls `append_chunk_word_timestamps` at the end, so today a vibevoice user gets the lenient behaviour for words and the fatal one for segments within the same call.
- No output, performance or memory change on any path that does not hit the guard.

## Verification

Verified on this PR's base, `main` @ `288a271`, CPU-only:

```bash
cmake -S . -B build-cpu -DENGINE_ENABLE_CUDA=OFF -DENGINE_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Release
cmake --build build-cpu --target audio_chunking_test -j8
./build-cpu/bin/audio_chunking_test
```

| state | result |
|---|---|
| new test, **stock** `chunking.cpp` | ❌ `audio_chunking_test failed: Audio chunker speech metadata merge received a speech segment outside the chunk span` (exit 1) |
| new test, **with the fix** | ✅ `audio_chunking_test passed` (exit 0) |

So it is a real regression test: it fails without the change and passes with it, on the exact commit this PR targets.

Earlier I ran the same pair at `release-0.6.1` in both configurations — CPU-only and CUDA (`-DENGINE_ENABLE_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=120`, sm_120 / RTX 5090) — with identical results. I did not repeat the CUDA build on `main`; `src/framework/audio/chunking.cpp` is byte-identical between `release-0.6.1` and `288a271` (unchanged since #252), and this path has no backend-dependent code.

## Known limitation, stated plainly

**Reachability of the metadata case is unproven.** I have not observed an out-of-span *segment or turn* in the wild — my own trigger (#249) is on the *word* path. The argument for this change is the inconsistency itself: the same guard on the same arithmetic in the same file should not abort in one place and drop in the other.

The supporting evidence that it is not theoretical:

- The aligner demonstrably emits spans outside the chunk — that is exactly #249 (`local_start=272640` vs `source_samples=272000`, 40 ms past the end of the chunk's audio).
- The `vibevoice_asr` chunked-timestamp handling already has a third-party report against it: #167.

If you would rather see a reproduction on the metadata path before changing behaviour there, that is a fair ask and I am happy to keep digging instead.
