### PR TITLE
fix(supertonic): honor voice preset sent as a request option

### DIFF
--- a/src/models/supertonic/session.cpp
+++ b/src/models/supertonic/session.cpp
@@ -195,6 +195,16 @@ SupertonicGenerationOptions SupertonicSession::generation_options_from_request(c
     }
     if (request.voice.has_value() && request.voice->speaker.has_value() && request.voice->speaker->cached_voice_id.has_value()) {
         options.voice = *request.voice->speaker->cached_voice_id;
+    } else {
+        // WebUI model_params send the picked preset as a plain request option
+        // (see webui/configs/model_params.json). Accept it as a fallback so the
+        // voice picker takes effect; unknown ids are rejected downstream by the
+        // voice-style loader.
+        if (const auto preset = runtime::find_option(request.options, {"voice", "supertonic.voice"})) {
+            if (!preset->empty()) {
+                options.voice = *preset;
+            }
+        }
     }
     if (const auto value = runtime::parse_i64_option(request.options, {"num_inference_steps"})) {
         if (*value <= 0) {


### PR DESCRIPTION
## Summary

The WebUI voice picker for Supertonic 3 (defined in `webui/configs/model_params.json`) lets you choose one of 10 presets (M1–M5, F1–F5) and sends that choice as a plain request option (`options.voice`). However, `SupertonicSession::generation_options_from_request` only read the structured `request.voice.speaker.cached_voice_id` field and otherwise used the load-time default `M1`. The picker appeared to do nothing — output was always M1.

## Fix

In `src/models/supertonic/session.cpp`, read the `voice` (or `supertonic.voice`) request option as a fallback when no structured `cached_voice_id` is present. The structured field keeps precedence; unknown ids are still rejected downstream by the voice-style loader (`runtime.cpp` -> `require_file("voice_style_<id>.json")`).

## Verification workflow

WebUI → Supertonic 3 → voice = F1/M3/etc → synthesize → output now matches the selected preset. The UI already sends `options.voice` (requestOptions merges advancedValues), so no frontend change is required.