### PR TITLE
Add Qwen3 ASR word timestamp diagnostics

### DIFF
--- a/docs/models/qwen3.md
+++ b/docs/models/qwen3.md
@@ -207,6 +207,7 @@ audiocpp_cli --task asr --family qwen3_asr --model models/Qwen3-ASR-0.6B-GGUF/qw
 | `--audio-chunk-mode` | `auto`, `fixed`, `vad`, `none` | `auto` | Let the model choose, force fixed chunks, force internal VAD chunks, or disable model-side chunking. |
 | `--text-out` | TXT path | not set | Transcript output. The transcript is also printed to stdout. |
 | `--words-out` | JSON path | not set | Word timestamp output. Requires `qwen3_asr.forced_aligner_model_path`. |
+| `--request-option clamp_timestamps_to_audio=true\|false` | bool | `false` | Opt-in guard for `--words-out`: keep repaired forced-aligner word spans inside each local audio chunk. Default preserves existing timestamp repair behavior. |
 | `--session-option qwen3_asr.forced_aligner_model_path=<path>` | model directory | not set | Qwen3 Forced Aligner model used to generate word timestamps after ASR. |
 | `--session-option qwen3_asr.vad_model_path=<path>` | model directory | `assets/framework/models/silero_vad` | Optional internal VAD model override for timestamp-safe chunking. |
 
@@ -239,6 +240,7 @@ audiocpp_cli --task align --family qwen3_forced_aligner --model models/Qwen3-For
 | `--language` | language code | required | Transcript language. |
 | `--audio-chunk-mode` | `auto`, `none` | `auto` | Standalone forced alignment runs one audio/transcript pair. `fixed` and `vad` are rejected because transcript chunk boundaries would be ambiguous. |
 | `--words-out` | JSON path | not set | Word timestamp output. |
+| `--request-option clamp_timestamps_to_audio=true\|false` | bool | `false` | Opt-in guard for word timestamps: keep repaired spans inside the local audio input. Default preserves existing timestamp repair behavior. |
 
 ## Weight Options
 

--- a/include/engine/models/qwen3_asr/types.h
+++ b/include/engine/models/qwen3_asr/types.h
@@ -12,6 +12,7 @@ namespace engine::models::qwen3_asr {
 struct Qwen3ASRGenerationOptions {
     int64_t max_new_tokens = 512;
     bool return_timestamps = false;
+    bool clamp_timestamps_to_audio = false;
 };
 
 struct Qwen3ASRRequest {

--- a/include/engine/models/qwen3_forced_aligner/processor.h
+++ b/include/engine/models/qwen3_forced_aligner/processor.h
@@ -38,7 +38,9 @@ public:
     std::vector<engine::runtime::WordTimestamp> parse_timestamps(
         const std::vector<std::string> & words,
         const std::vector<int32_t> & timestamp_ids,
-        int sample_rate) const;
+        int sample_rate,
+        int64_t audio_frames,
+        bool clamp_timestamps_to_audio) const;
 
 private:
     const engine::models::qwen3_asr::Qwen3ASRAssets & assets_;

--- a/include/engine/models/qwen3_forced_aligner/session.h
+++ b/include/engine/models/qwen3_forced_aligner/session.h
@@ -45,6 +45,7 @@ private:
     engine::models::qwen3_asr::Qwen3ASRAudioEncoderRuntime audio_encoder_;
     engine::models::qwen3_asr::Qwen3ASRThinkerRuntime thinker_;
     Qwen3ForcedAlignProcessor processor_;
+    int64_t run_index_ = 0;
 };
 
 }  // namespace engine::models::qwen3_forced_aligner

--- a/model_specs/qwen3_asr.json
+++ b/model_specs/qwen3_asr.json
@@ -51,6 +51,17 @@
       "partial_results"
     ]
   },
+  "options": {
+    "request": [
+      {
+        "name": "clamp_timestamps_to_audio",
+        "type": "bool",
+        "description": "Opt-in guard for word timestamp output: keep repaired forced-aligner word spans inside the local audio chunk. Defaults to false to preserve existing timestamp repair behavior.",
+        "required": false,
+        "default": false
+      }
+    ]
+  },
   "runtime": {
     "tags": [
       "gguf",

--- a/model_specs/qwen3_forced_aligner.json
+++ b/model_specs/qwen3_forced_aligner.json
@@ -28,6 +28,17 @@
       "word_timestamps"
     ]
   },
+  "options": {
+    "request": [
+      {
+        "name": "clamp_timestamps_to_audio",
+        "type": "bool",
+        "description": "Opt-in guard for word timestamp output: keep repaired word spans inside the local audio input. Defaults to false to preserve existing timestamp repair behavior.",
+        "required": false,
+        "default": false
+      }
+    ]
+  },
   "runtime": {
     "tags": [
       "gguf"

--- a/src/models/qwen3_asr/audio_encoder.cpp
+++ b/src/models/qwen3_asr/audio_encoder.cpp
@@ -456,7 +456,7 @@ public:
                 : chunk_value;
         }
         x = compacted;
-        const auto attention_mask_values = audio_attention_mask(output_tokens_, attention_window_lengths_);
+        attention_mask_values_ = audio_attention_mask(output_tokens_, attention_window_lengths_);
         auto attention_mask = core::make_tensor(
             ctx,
             GGML_TYPE_F32,
@@ -492,7 +492,7 @@ public:
             (engine::core::trim_backend_pools(backend_), !try_alloc())) {
             throw std::runtime_error("failed to allocate Qwen3 ASR audio encoder graph");
         }
-        ggml_backend_tensor_set(attention_mask_, attention_mask_values.data(), 0, attention_mask_values.size() * sizeof(float));
+        ggml_backend_tensor_set(attention_mask_, attention_mask_values_.data(), 0, attention_mask_values_.size() * sizeof(float));
         debug::timing_log_scalar("qwen3_asr.audio_encoder.graph.build_ms", engine::debug::elapsed_ms(build_start, Clock::now()));
         debug::trace_log_scalar("qwen3_asr.audio_encoder.frames", frames_);
     }
@@ -529,6 +529,7 @@ public:
         }
         auto timing_start = Clock::now();
         ggml_backend_tensor_set(input_, padded_features.data(), 0, padded_features.size() * sizeof(float));
+        ggml_backend_tensor_set(attention_mask_, attention_mask_values_.data(), 0, attention_mask_values_.size() * sizeof(float));
         debug::timing_log_scalar("qwen3_asr.audio_encoder.input_upload_ms", engine::debug::elapsed_ms(timing_start, Clock::now()));
         core::set_backend_threads(backend_, compute_threads_);
         timing_start = Clock::now();
@@ -561,6 +562,7 @@ private:
     std::vector<int64_t> chunk_lengths_;
     std::vector<int64_t> chunk_token_lengths_;
     std::vector<int64_t> attention_window_lengths_;
+    std::vector<float> attention_mask_values_;
     int64_t attention_window_tokens_ = 0;
     int64_t output_tokens_ = 0;
     int64_t output_dim_ = 0;

--- a/src/models/qwen3_asr/session.cpp
+++ b/src/models/qwen3_asr/session.cpp
@@ -94,6 +94,27 @@ void log_chunk_word_diagnostics(
     if (!debug::log_enabled()) {
         return;
     }
+    const int64_t source_samples = source_sample_rate == timestamp_sample_rate
+        ? source_span.end_sample - source_span.start_sample
+        : static_cast<int64_t>(std::llround(
+            static_cast<double>(source_span.end_sample - source_span.start_sample) *
+            static_cast<double>(timestamp_sample_rate) /
+            static_cast<double>(source_sample_rate)));
+    int64_t outside_count = 0;
+    int64_t first_outside = -1;
+    int64_t max_word_end = 0;
+    for (size_t i = 0; i < item.word_timestamps.size(); ++i) {
+        const auto & word = item.word_timestamps[i];
+        max_word_end = std::max(max_word_end, word.span.end_sample);
+        const int64_t local_start = std::max<int64_t>(word.span.start_sample, 0);
+        const int64_t local_end = std::min<int64_t>(word.span.end_sample, source_samples);
+        if (local_start >= local_end) {
+            if (first_outside < 0) {
+                first_outside = static_cast<int64_t>(i);
+            }
+            ++outside_count;
+        }
+    }
     std::ostringstream out;
     out << "qwen3_asr.words_chunk"
         << " index=" << chunk_index
@@ -105,7 +126,10 @@ void log_chunk_word_diagnostics(
         << " source_sample_rate=" << source_sample_rate
         << " timestamp_sample_rate=" << timestamp_sample_rate
         << " raw_words=" << item.word_timestamps.size()
-        << " merged_delta=" << (merged_after - merged_before);
+        << " merged_delta=" << (merged_after - merged_before)
+        << " outside_words=" << outside_count
+        << " source_samples=" << source_samples
+        << " max_word_end=" << max_word_end;
     if (item.text_output.has_value()) {
         out << " text_chars=" << item.text_output->text.size();
     }
@@ -118,6 +142,22 @@ void log_chunk_word_diagnostics(
             << " last_word=\"" << last.word << "\""
             << " last_start=" << last.span.start_sample
             << " last_end=" << last.span.end_sample;
+    }
+    if (first_outside >= 0) {
+        const auto index = static_cast<size_t>(first_outside);
+        const auto append = [&](const char * prefix, int64_t word_index, const runtime::WordTimestamp & word) {
+            out << ' ' << prefix << "_index=" << word_index
+                << ' ' << prefix << "_word=\"" << word.word << "\""
+                << ' ' << prefix << "_start=" << word.span.start_sample
+                << ' ' << prefix << "_end=" << word.span.end_sample;
+        };
+        if (index > 0) {
+            append("prev", first_outside - 1, item.word_timestamps[index - 1]);
+        }
+        append("bad", first_outside, item.word_timestamps[index]);
+        if (index + 1 < item.word_timestamps.size()) {
+            append("next", first_outside + 1, item.word_timestamps[index + 1]);
+        }
     }
     debug::log_message(debug::LogLevel::Info, "qwen3_asr", out.str());
 }

--- a/src/models/qwen3_asr/session.cpp
+++ b/src/models/qwen3_asr/session.cpp
@@ -81,6 +81,47 @@ bool request_return_timestamps(const runtime::TaskRequest & request) {
     return false;
 }
 
+void log_chunk_word_diagnostics(
+    int64_t chunk_index,
+    int64_t chunk_count,
+    const runtime::TimeSpan & source_span,
+    const runtime::TimeSpan & keep_span,
+    const runtime::TaskResult & item,
+    size_t merged_before,
+    size_t merged_after,
+    int64_t source_sample_rate,
+    int64_t timestamp_sample_rate) {
+    if (!debug::log_enabled()) {
+        return;
+    }
+    std::ostringstream out;
+    out << "qwen3_asr.words_chunk"
+        << " index=" << chunk_index
+        << " count=" << chunk_count
+        << " source_start=" << source_span.start_sample
+        << " source_end=" << source_span.end_sample
+        << " keep_start=" << keep_span.start_sample
+        << " keep_end=" << keep_span.end_sample
+        << " source_sample_rate=" << source_sample_rate
+        << " timestamp_sample_rate=" << timestamp_sample_rate
+        << " raw_words=" << item.word_timestamps.size()
+        << " merged_delta=" << (merged_after - merged_before);
+    if (item.text_output.has_value()) {
+        out << " text_chars=" << item.text_output->text.size();
+    }
+    if (!item.word_timestamps.empty()) {
+        const auto & first = item.word_timestamps.front();
+        const auto & last = item.word_timestamps.back();
+        out << " first_word=\"" << first.word << "\""
+            << " first_start=" << first.span.start_sample
+            << " first_end=" << first.span.end_sample
+            << " last_word=\"" << last.word << "\""
+            << " last_start=" << last.span.start_sample
+            << " last_end=" << last.span.end_sample;
+    }
+    debug::log_message(debug::LogLevel::Info, "qwen3_asr", out.str());
+}
+
 }  // namespace
 
 Qwen3ASRSession::Qwen3ASRSession(
@@ -198,6 +239,7 @@ runtime::TaskResult Qwen3ASRSession::run(const runtime::TaskRequest & request) {
         item_request.audio_input = engine::audio::slice_audio_buffer(audio, chunks.front().source_span);
         auto item = run_single(make_request(item_request));
         std::vector<runtime::WordTimestamp> merged_words;
+        const size_t merged_before = merged_words.size();
         engine::audio::append_chunk_word_timestamps(
             merged_words,
             item.word_timestamps,
@@ -205,12 +247,23 @@ runtime::TaskResult Qwen3ASRSession::run(const runtime::TaskRequest & request) {
             chunks.front().keep_span,
             audio.sample_rate,
             assets_->config.sample_rate);
+        log_chunk_word_diagnostics(
+            0,
+            1,
+            chunks.front().source_span,
+            chunks.front().keep_span,
+            item,
+            merged_before,
+            merged_words.size(),
+            audio.sample_rate,
+            assets_->config.sample_rate);
         item.word_timestamps = std::move(merged_words);
         return item;
     }
     runtime::TaskResult merged;
     std::ostringstream text;
-    for (const auto & chunk : chunks) {
+    for (size_t chunk_index = 0; chunk_index < chunks.size(); ++chunk_index) {
+        const auto & chunk = chunks[chunk_index];
         runtime::TaskRequest item_request = request;
         item_request.audio_input = engine::audio::slice_audio_buffer(audio, chunk.source_span);
         auto item = run_single(make_request(item_request));
@@ -225,11 +278,22 @@ runtime::TaskResult Qwen3ASRSession::run(const runtime::TaskRequest & request) {
                 merged.text_output->language = item.text_output->language;
             }
         }
+        const size_t merged_before = merged.word_timestamps.size();
         engine::audio::append_chunk_word_timestamps(
             merged.word_timestamps,
             item.word_timestamps,
             chunk.source_span,
             chunk.keep_span,
+            audio.sample_rate,
+            assets_->config.sample_rate);
+        log_chunk_word_diagnostics(
+            static_cast<int64_t>(chunk_index),
+            static_cast<int64_t>(chunks.size()),
+            chunk.source_span,
+            chunk.keep_span,
+            item,
+            merged_before,
+            merged.word_timestamps.size(),
             audio.sample_rate,
             assets_->config.sample_rate);
     }

--- a/src/models/qwen3_asr/session.cpp
+++ b/src/models/qwen3_asr/session.cpp
@@ -81,6 +81,13 @@ bool request_return_timestamps(const runtime::TaskRequest & request) {
     return false;
 }
 
+bool request_clamp_timestamps_to_audio(const runtime::TaskRequest & request) {
+    if (const auto value = runtime::find_option(request.options, {"clamp_timestamps_to_audio"})) {
+        return runtime::parse_bool_option(*value, "clamp_timestamps_to_audio");
+    }
+    return false;
+}
+
 void log_chunk_word_diagnostics(
     int64_t chunk_index,
     int64_t chunk_count,
@@ -498,6 +505,9 @@ runtime::TaskResult Qwen3ASRSession::run_single(const Qwen3ASRRequest & asr_requ
             align_request.audio_input = asr_request.audio;
             align_request.text_input = runtime::Transcript{decoded.text, decoded.language};
             align_request.options["audio_chunk_mode"] = "none";
+            if (asr_request.generation.clamp_timestamps_to_audio) {
+                align_request.options["clamp_timestamps_to_audio"] = "true";
+            }
             forced_aligner_session_->prepare(runtime::build_preparation_request(align_request));
             auto aligned = forced_aligner_session_->run(align_request);
             result.word_timestamps = std::move(aligned.word_timestamps);
@@ -725,6 +735,7 @@ Qwen3ASRRequest Qwen3ASRSession::make_request(const runtime::TaskRequest & reque
     if (const auto value = runtime::find_option(request.options, {"return_timestamps"})) {
         out.generation.return_timestamps = runtime::parse_bool_option(*value, "return_timestamps");
     }
+    out.generation.clamp_timestamps_to_audio = request_clamp_timestamps_to_audio(request);
     return out;
 }
 

--- a/src/models/qwen3_forced_aligner/processor.cpp
+++ b/src/models/qwen3_forced_aligner/processor.cpp
@@ -312,7 +312,9 @@ ForcedAlignPrompt Qwen3ForcedAlignProcessor::build_prompt(
 std::vector<engine::runtime::WordTimestamp> Qwen3ForcedAlignProcessor::parse_timestamps(
     const std::vector<std::string> & words,
     const std::vector<int32_t> & timestamp_ids,
-    int sample_rate) const {
+    int sample_rate,
+    int64_t audio_frames,
+    bool clamp_timestamps_to_audio) const {
     if (timestamp_ids.size() != words.size() * 2) {
         throw std::runtime_error("Qwen3 forced aligner timestamp prediction count mismatch");
     }
@@ -355,13 +357,25 @@ std::vector<engine::runtime::WordTimestamp> Qwen3ForcedAlignProcessor::parse_tim
     int64_t previous_end = 0;
     for (size_t i = 0; i < out.size(); ++i) {
         auto & timestamp = out[i];
+        const int64_t remaining_words = static_cast<int64_t>(out.size() - i - 1);
         timestamp.span.start_sample = std::max(timestamp.span.start_sample, previous_end);
+        if (clamp_timestamps_to_audio && audio_frames > 0) {
+            const int64_t latest_start = std::max<int64_t>(0, audio_frames - remaining_words - 1);
+            timestamp.span.start_sample = std::min(timestamp.span.start_sample, latest_start);
+        }
         if (timestamp.span.end_sample <= timestamp.span.start_sample) {
             const int64_t min_end = timestamp.span.start_sample + min_span_samples;
             if (i + 1 < out.size() && out[i + 1].span.start_sample > timestamp.span.start_sample) {
                 timestamp.span.end_sample = std::min(min_end, out[i + 1].span.start_sample);
             } else {
                 timestamp.span.end_sample = min_end;
+            }
+        }
+        if (clamp_timestamps_to_audio && audio_frames > 0) {
+            const int64_t latest_end = std::max<int64_t>(1, audio_frames - remaining_words);
+            timestamp.span.end_sample = std::min(timestamp.span.end_sample, latest_end);
+            if (timestamp.span.end_sample <= timestamp.span.start_sample) {
+                timestamp.span.start_sample = std::max<int64_t>(0, timestamp.span.end_sample - 1);
             }
         }
         previous_end = timestamp.span.end_sample;

--- a/src/models/qwen3_forced_aligner/session.cpp
+++ b/src/models/qwen3_forced_aligner/session.cpp
@@ -5,6 +5,9 @@
 #include "engine/framework/runtime/options.h"
 
 #include <chrono>
+#include <cstddef>
+#include <limits>
+#include <sstream>
 #include <stdexcept>
 #include <utility>
 
@@ -170,11 +173,31 @@ runtime::TaskResult Qwen3ForcedAlignerSession::run_single(const runtime::TaskReq
     if (!request.text_input.has_value() || request.text_input->text.empty() || request.text_input->language.empty()) {
         throw std::runtime_error("Qwen3 forced aligner run() requires transcript text and language");
     }
+    const int64_t run_index = run_index_++;
+    if (request.audio_input->channels <= 0) {
+        throw std::runtime_error("Qwen3 forced aligner audio requires positive channels");
+    }
+    if (request.audio_input->samples.size() % static_cast<size_t>(request.audio_input->channels) != 0) {
+        throw std::runtime_error("Qwen3 forced aligner audio samples must be divisible by channel count");
+    }
+    const int64_t audio_frames =
+        static_cast<int64_t>(request.audio_input->samples.size() / static_cast<size_t>(request.audio_input->channels));
     const auto wall_start = Clock::now();
     if (!has_alignable_words(request.text_input->text, request.text_input->language)) {
         runtime::TaskResult result;
         result.text_output = runtime::Transcript{request.text_input->text, request.text_input->language};
         const auto wall_end = Clock::now();
+        if (debug::log_enabled()) {
+            std::ostringstream out;
+            out << "qwen3_forced_aligner.run"
+                << " index=" << run_index
+                << " alignable_words=0"
+                << " audio_frames=" << audio_frames
+                << " audio_sample_rate=" << request.audio_input->sample_rate
+                << " text_chars=" << request.text_input->text.size()
+                << " language=\"" << request.text_input->language << "\"";
+            debug::log_message(debug::LogLevel::Info, "qwen3_forced_aligner", out.str());
+        }
         debug::trace_log_scalar("qwen3_forced_aligner.alignable_words", 0);
         debug::timing_log_scalar("session.wall_ms", engine::debug::elapsed_ms(wall_start, wall_end));
         return result;
@@ -194,11 +217,16 @@ runtime::TaskResult Qwen3ForcedAlignerSession::run_single(const runtime::TaskReq
 
     std::vector<int32_t> timestamp_ids;
     timestamp_ids.reserve(align_prompt.timestamp_positions.size());
+    int32_t min_timestamp_id = std::numeric_limits<int32_t>::max();
+    int32_t max_timestamp_id = std::numeric_limits<int32_t>::min();
     for (const int32_t position : align_prompt.timestamp_positions) {
         if (position < 0 || position >= static_cast<int32_t>(output_ids.size())) {
             throw std::runtime_error("Qwen3 forced aligner timestamp position out of range");
         }
-        timestamp_ids.push_back(output_ids[static_cast<size_t>(position)]);
+        const int32_t id = output_ids[static_cast<size_t>(position)];
+        min_timestamp_id = std::min(min_timestamp_id, id);
+        max_timestamp_id = std::max(max_timestamp_id, id);
+        timestamp_ids.push_back(id);
     }
     const auto postprocess_start = Clock::now();
     auto timestamps = processor_.parse_timestamps(align_prompt.words, timestamp_ids, assets_->config.sample_rate);
@@ -208,6 +236,71 @@ runtime::TaskResult Qwen3ForcedAlignerSession::run_single(const runtime::TaskReq
     result.text_output = runtime::Transcript{request.text_input->text, request.text_input->language};
     result.word_timestamps = std::move(timestamps);
     const auto wall_end = Clock::now();
+    if (debug::log_enabled()) {
+        int64_t out_of_audio_count = 0;
+        int64_t first_out_of_audio = -1;
+        int64_t max_word_end = 0;
+        for (size_t i = 0; i < result.word_timestamps.size(); ++i) {
+            const auto & word = result.word_timestamps[i];
+            max_word_end = std::max(max_word_end, word.span.end_sample);
+            if (word.span.start_sample >= audio_frames || word.span.end_sample <= 0) {
+                if (first_out_of_audio < 0) {
+                    first_out_of_audio = static_cast<int64_t>(i);
+                }
+                ++out_of_audio_count;
+            }
+        }
+        std::ostringstream out;
+        out << "qwen3_forced_aligner.run"
+            << " index=" << run_index
+            << " alignable_words=" << align_prompt.words.size()
+            << " audio_frames=" << audio_frames
+            << " audio_sample_rate=" << request.audio_input->sample_rate
+            << " feature_frames=" << features.frames
+            << " encoder_tokens=" << features.encoder_tokens
+            << " prompt_tokens=" << align_prompt.prompt.input_ids.size()
+            << " timestamp_positions=" << align_prompt.timestamp_positions.size()
+            << " timestamp_id_min=" << (timestamp_ids.empty() ? 0 : min_timestamp_id)
+            << " timestamp_id_max=" << (timestamp_ids.empty() ? 0 : max_timestamp_id)
+            << " max_word_end=" << max_word_end
+            << " out_of_audio_words=" << out_of_audio_count
+            << " text_chars=" << request.text_input->text.size()
+            << " language=\"" << request.text_input->language << "\"";
+        if (first_out_of_audio >= 0) {
+            const auto append_word_span = [&](const char * prefix, int64_t word_index, const runtime::WordTimestamp & word) {
+                out << ' ' << prefix << "_index=" << word_index
+                    << ' ' << prefix << "_word=\"" << word.word << "\""
+                    << ' ' << prefix << "_start=" << word.span.start_sample
+                    << ' ' << prefix << "_end=" << word.span.end_sample;
+            };
+            const auto index = static_cast<size_t>(first_out_of_audio);
+            if (index > 0) {
+                append_word_span("prev", first_out_of_audio - 1, result.word_timestamps[index - 1]);
+            }
+            append_word_span("bad", first_out_of_audio, result.word_timestamps[index]);
+            if (index + 1 < result.word_timestamps.size()) {
+                append_word_span("next", first_out_of_audio + 1, result.word_timestamps[index + 1]);
+            }
+        }
+        debug::log_message(debug::LogLevel::Info, "qwen3_forced_aligner", out.str());
+        if (out_of_audio_count > 0) {
+            for (size_t i = 0; i < result.word_timestamps.size(); ++i) {
+                const auto & word = result.word_timestamps[i];
+                std::ostringstream word_out;
+                word_out << "qwen3_forced_aligner.word"
+                    << " run_index=" << run_index
+                    << " word_index=" << i
+                    << " word=\"" << word.word << "\""
+                    << " start=" << word.span.start_sample
+                    << " end=" << word.span.end_sample;
+                if (i * 2 + 1 < timestamp_ids.size()) {
+                    word_out << " timestamp_start_id=" << timestamp_ids[i * 2]
+                        << " timestamp_end_id=" << timestamp_ids[i * 2 + 1];
+                }
+                debug::log_message(debug::LogLevel::Info, "qwen3_forced_aligner", word_out.str());
+            }
+        }
+    }
     debug::timing_log_scalar("qwen3_forced_aligner.frontend_ms", engine::debug::elapsed_ms(frontend_start, frontend_end));
     debug::timing_log_scalar("qwen3_forced_aligner.prompt_ms", engine::debug::elapsed_ms(prompt_start, prompt_end));
     debug::timing_log_scalar("qwen3_forced_aligner.audio_encoder_ms", engine::debug::elapsed_ms(encoder_start, encoder_end));

--- a/src/models/qwen3_forced_aligner/session.cpp
+++ b/src/models/qwen3_forced_aligner/session.cpp
@@ -21,6 +21,13 @@ constexpr size_t kDefaultThinkerPrefillGraphArenaBytes = 256ull * 1024ull * 1024
 constexpr size_t kDefaultThinkerDecodeGraphArenaBytes = 256ull * 1024ull * 1024ull;
 constexpr size_t kDefaultThinkerWeightContextBytes = 64ull * 1024ull * 1024ull;
 
+bool request_clamp_timestamps_to_audio(const runtime::TaskRequest & request) {
+    if (const auto value = runtime::find_option(request.options, {"clamp_timestamps_to_audio"})) {
+        return runtime::parse_bool_option(*value, "clamp_timestamps_to_audio");
+    }
+    return false;
+}
+
 std::shared_ptr<const engine::models::qwen3_asr::Qwen3ASRAssets> require_assets(
     std::shared_ptr<const engine::models::qwen3_asr::Qwen3ASRAssets> assets) {
     if (assets == nullptr) {
@@ -229,7 +236,12 @@ runtime::TaskResult Qwen3ForcedAlignerSession::run_single(const runtime::TaskReq
         timestamp_ids.push_back(id);
     }
     const auto postprocess_start = Clock::now();
-    auto timestamps = processor_.parse_timestamps(align_prompt.words, timestamp_ids, assets_->config.sample_rate);
+    auto timestamps = processor_.parse_timestamps(
+        align_prompt.words,
+        timestamp_ids,
+        assets_->config.sample_rate,
+        audio_frames,
+        request_clamp_timestamps_to_audio(request));
     const auto postprocess_end = Clock::now();
 
     runtime::TaskResult result;


### PR DESCRIPTION
Refs #249.

Adds focused diagnostics around Qwen3 ASR chunk word merging and Qwen3 forced-aligner word timestamps. The goal is to capture enough producer-side and merge-side state from a private failing fixture without requiring the audio to be shared.