### PR TITLE
Fix IndexTTS2 HIP decode: F16 KV cache, F16 conv weight default on HIP

### DIFF
--- a/src/models/index_tts2/gpt.cpp
+++ b/src/models/index_tts2/gpt.cpp
@@ -64,7 +64,10 @@ int64_t gpt_text_vocab_size(const IndexTTS2Config & config) {
 }
 
 ggml_type decode_cache_type(core::BackendType backend_type) {
-    return backend_type == core::BackendType::Cuda ? GGML_TYPE_F16 : GGML_TYPE_F32;
+    // F32 KV on HIP forces ggml's flash-attention kernels to convert the whole K/V
+    // cache to F16 on every decode step (convert_unary dominates the kernel profile).
+    // Keeping the cache F16 avoids that entirely, as it already does on CUDA.
+    return backend_type == core::BackendType::Cuda || backend_type == core::BackendType::Hip ? GGML_TYPE_F16 : GGML_TYPE_F32;
 }
 
 struct GgmlContextDeleter {

--- a/src/models/index_tts2/session.cpp
+++ b/src/models/index_tts2/session.cpp
@@ -235,6 +235,13 @@ IndexTTS2Session::IndexTTS2Session(
         conv_weight_storage_type_ = engine::assets::parse_tensor_storage_type(it->second);
         validate_conv_weight_storage(conv_weight_storage_type_, "index_tts2.conv_weight_type");
     }
+    // Derived conv weights (weight-norm recomputed at load) with Native storage are kept
+    // as F32, doubling conv weight bandwidth; on HIP the conv/im2col paths support F16
+    // and measure significantly faster with it, so make F16 the default there.
+    if (conv_weight_storage_type_ == engine::assets::TensorStorageType::Native &&
+        execution_context().backend_type() == engine::core::BackendType::Hip) {
+        conv_weight_storage_type_ = engine::assets::TensorStorageType::F16;
+    }
     mem_saver_ = mem_saver_from_options(options);
     for (const auto & [key, _] : options.options) {
         if (key.rfind("index_tts2.", 0) == 0 &&


### PR DESCRIPTION
IndexTTS2 on the HIP backend was ~40% slower than Vulkan on Strix Halo
(gfx1151, ROCm 7.14). #247 fixed the F32-forced derived GPT/vocoder weights;
per-stage timings plus a rocprofv3 kernel trace show two remaining
HIP-specific overheads, both fixed here (HIP-only, no behavior change on
other backends):

- `decode_cache_type` only used an F16 KV cache on CUDA. HIP shares the
  ggml-cuda flash-attention kernels, which require F16 K/V (unlike the
  Vulkan shaders, which accept F32 K/V natively), so with an F32 cache
  the whole K/V cache was converted f32->f16 twice per decode step
  (`convert_unary<float,__half>` ~= 1.95 s per in the kernel trace,
  growing quadratically with the number of decode steps). CUDA already
  returns F16 here, so its behavior is unchanged.
- The CFM/emotion derived conv weights are still stored as F32 with Native
  storage even after #247; on HIP the conv/im2col paths measure faster on
  F16, so `index_tts2.conv_weight_type` now defaults to F16 on HIP
  (overridable via the session option).

Measured Strix Halo (Ryzen AI MAX+ 395, gfx1151), same text / seed 1245 /
bf16 GGUF, ms:

| Config | wall | gpt.decode | cfm | vocoder |
| --- | ---: | ---: | ---: | ---: |
| HIP, pre-#247 baseline | 13017 | 5622 | 4045 | 2077 |
| HIP, #247 + this PR | 8533-8591 | 2762 | 3543-3582 | 975 |
| Vulkan (reference) | 9107 | 3368 | 3714 | 1037 |

With #247 and this PR, HIP goes from 39 slower than Vulkan to ~6% faster
(~1.12x realtime). Outputs validated with ASR (qwen3_asr): transcripts
identical before/after and correct. CUDA regression-checked on an
RTX 2080 Ti: unchanged6184 ms vs 6183 ms baseline).

AI usage: Kimi k3

