### PR TITLE
cuda: zero the MMQ stream-k fixup staging buffer

### DIFF
--- a/external/ggml/src/ggml-cuda/mmq.cuh
+++ b/external/ggml/src/ggml-cuda/mmq.cuh
@@ -4008,6 +4008,10 @@ static void launch_mul_mat_q(ggml_backend_cuda_context & ctx, const mmq_args & a
     ggml_cuda_pool_alloc<float> tmp_fixup(pool);
     if (fixup_needed) {
         tmp_fixup.alloc(block_nums_stream_k.x * mmq_x*mmq_y);
+        // Pool memory is recycled uninitialized; zero the partial-sum staging
+        // so any fixup cell the merge pass visits before/without a producer
+        // contributes exactly nothing instead of stale pool bytes.
+        CUDA_CHECK(cudaMemsetAsync(tmp_fixup.ptr, 0, block_nums_stream_k.x * mmq_x*mmq_y * sizeof(float), stream));
     }
 
     const dim3 block_nums_fixup(block_nums_stream_k.x, mmq_y/warp_size, 1);


### PR DESCRIPTION
## What

`launch_mul_mat_q` allocates the stream-k fixup staging buffer from the pool and uses it without initialization. Pool memory is recycled, so whatever the previous op left there is what the fixup merge pass reads for any cell it visits before/without a producer. This zeroes the staging buffer first.

## Why we found it

We were bisecting a bitwise-reproducible corruption in the first ~4 invocations of a freshly allocated MiniMax Music 3 flow graph at batch 1. This buffer turned out not to be the culprit (that was a view-aliasing hazard, see the MM3 perf-pack PR), but the uninitialized staging is real and cheap to close: one async memset on the same stream, only when fixup is actually needed.

## Validation

- Built and ran the full MiniMax Music 3 CUDA path (A40, driver 580.159.04) before/after: outputs byte-identical, no measurable wall change (memset is ~µs against multi-ms GEMM waves).
- `minimax_music3_*` path tests pass.

Backend tested: CUDA. Other backends untouched.
