### PR TITLE
fix(audio): drop chunk word timestamps outside the chunk span instead of throwing

### DIFF
--- a/src/framework/audio/chunking.cpp
+++ b/src/framework/audio/chunking.cpp
@@ -556,7 +556,9 @@ void append_chunk_word_timestamps(
         const int64_t local_start = std::max<int64_t>(word.span.start_sample, 0);
         const int64_t local_end = std::min<int64_t>(word.span.end_sample, source_samples);
         if (local_start >= local_end) {
-            throw std::runtime_error("Audio chunker word merge received a timestamp outside the chunk span");
+            // Skip words that fall entirely outside the chunk span (e.g. aligner
+            // hallucinations at silent tails) instead of failing the whole request.
+            continue;
         }
         const int64_t global_start = source_span.start_sample + local_start;
         if (global_start < keep_span.start_sample || global_start >= keep_span.end_sample) {

--- a/tests/unittests/test_audio_chunking.cpp
+++ b/tests/unittests/test_audio_chunking.cpp
@@ -765,6 +765,26 @@ void test_chunk_word_timestamp_merge_keeps_non_overlapping_source_span() {
     require_span(merged[1].span, 1160, 1220, "inside word source span");
 }
 
+void test_chunk_word_timestamp_merge_skips_out_of_span_words() {
+    // Words that lie entirely outside the chunk span (e.g. forced-aligner
+    // hallucinations over zero-padded tail samples) are dropped instead of
+    // failing the whole transcription request.
+    std::vector<engine::runtime::WordTimestamp> merged;
+    engine::audio::append_chunk_word_timestamps(
+        merged,
+        {
+            word("kept", 10, 40),
+            word("past_end", 150, 180),
+            word("before_start", -50, -10),
+            word("starts_at_chunk_end", 100, 160),
+        },
+        engine::runtime::TimeSpan{1000, 1100});
+
+    engine::test::require_eq(merged.size(), static_cast<size_t>(1), "out-of-span merged word count");
+    engine::test::require_eq(merged[0].word, std::string("kept"), "in-span word kept");
+    require_span(merged[0].span, 1010, 1040, "in-span word span");
+}
+
 void test_chunk_word_timestamp_merge_rejects_invalid_spans() {
     require_throws(
         []() {
@@ -785,16 +805,6 @@ void test_chunk_word_timestamp_merge_rejects_invalid_spans() {
                 engine::runtime::TimeSpan{100, 90});
         },
         "inverted chunk span");
-
-    require_throws(
-        []() {
-            std::vector<engine::runtime::WordTimestamp> merged;
-            engine::audio::append_chunk_word_timestamps(
-                merged,
-                {word("outside", 120, 140)},
-                engine::runtime::TimeSpan{1000, 1100});
-        },
-        "word outside chunk");
 
     require_throws(
         []() {
@@ -837,6 +847,7 @@ int main() {
         test_chunk_word_timestamp_merge_offsets_and_clips();
         test_chunk_word_timestamp_merge_appends_multiple_chunks();
         test_chunk_word_timestamp_merge_keeps_non_overlapping_source_span();
+        test_chunk_word_timestamp_merge_skips_out_of_span_words();
         test_chunk_word_timestamp_merge_rejects_invalid_spans();
         std::cout << "audio_chunking_test passed\n";
     } catch (const std::exception & ex) {


### PR DESCRIPTION
## Summary

`append_chunk_word_timestamps()` currently throws
`Audio chunker word merge received a timestamp outside the chunk span` when a
word's clamped span becomes empty, which aborts the whole transcription
request. Forced aligners really do emit such words in practice — typically a
hallucinated token that lands entirely inside the zero-padded tail of the
final chunk — and one bad word then destroys an otherwise successful chunk
(ASR text, all other word timestamps, everything).

This PR extends the existing clamping behavior: words that only partially
stick out of the chunk span were already clipped to the span, so words with
**no overlap at all** are now simply dropped instead of failing the request.
Invalid inputs (inverted word spans, inverted chunk span, keep span outside
source span) keep raising as before.

## Changes

- `src/framework/audio/chunking.cpp`: skip words whose clamped span is empty
  instead of throwing (partial overlaps keep being clipped; degenerate words
  are dropped)
- `tests/unittests/test_audio_chunking.cpp`:
  - new `test_chunk_word_timestamp_merge_skips_out_of_span_words` covering a
    word past the chunk end, a word entirely before the span, and a word that
    starts exactly at `source_samples` — all dropped, in-span words kept
  - `test_chunk_word_timestamp_merge_rejects_invalid_spans` no longer asserts
    a throw for the fully-outside case (that assertion encoded the crash we
    are fixing); the genuinely invalid cases are unchanged

## Validation

- Backend: CUDA, RTX 4070 (sm_89), Windows, Release build (Ninja + MSVC 14.41
  + CUDA 13.3)
- Model family / route: `qwen3_asr` + `qwen3_forced_aligner` via
  `POST /v1/tasks/run` with request option `return_timestamps=true` and
  `audio_chunk_mode=fixed`, `audio_chunk_seconds=15`
- Real-world evidence: a 124-file batch (~4.3 hours of classroom recordings,
  16 kHz mono) previously failed 19 files with
  `Audio chunker word merge received a timestamp outside the chunk span`;
  with this patch the same batch completes 124/124 with word timestamps
- `audio_chunking_test` passes (`audio_chunking_test passed`), including the
  updated assertions
- Rebuilt `audiocpp_server` incrementally with the patch; no API or output
  shape changes, behavior only differs for requests that previously aborted
  with a 500

## Notes

- Behavior change is limited to requests that previously failed outright, so
  no existing successful path produces different output
- Happy to adjust if maintainers would prefer this to stay configurable
  (e.g. keep throwing under a debug flag) — the batch evidence above suggests
  silently dropping is the behavior users need, though
