### PR TITLE
server: resolve the model contract once per model, not per request

### DIFF
--- a/app/server/runtime.cpp
+++ b/app/server/runtime.cpp
@@ -1180,7 +1180,29 @@ std::unique_ptr<ServerState::LoadedModel> ServerState::make_model(ServerModelCon
         engine::runtime::parse_run_mode(loaded->config.mode),
     };
     load_voice_presets(*loaded);
+    refresh_model_option_flags(*loaded);
     return loaded;
+}
+
+void ServerState::refresh_model_option_flags(LoadedModel & model) {
+    const auto effective_override = model.config.model_spec_override.has_value()
+        ? model.config.model_spec_override
+        : config_.model_spec_override;
+    try {
+        model.accepts_reference_text = model_accepts_request_option(
+            model.config.family,
+            "reference_text",
+            effective_override,
+            model.config.path);
+    } catch (const std::exception & ex) {
+        // Keep registration robust: a model whose contract cannot be resolved gets
+        // the same permissive behavior as a model with no contract; the failure is
+        // reported so the misconfiguration stays visible.
+        std::cerr << "[server] model '" << model.config.id
+                  << "': reference_text option check failed (" << ex.what()
+                  << "); assuming the option is accepted\n";
+        model.accepts_reference_text = true;
+    }
 }
 
 HttpResponse ServerState::handle_model_load(const std::string & body_text) {
@@ -1221,6 +1243,7 @@ HttpResponse ServerState::handle_model_load(const std::string & body_text) {
                 engine::runtime::parse_run_mode(existing->config.mode),
             };
             load_voice_presets(*existing);
+            refresh_model_option_flags(*existing);
         }
         ensure_model_loaded_locked(*existing);
         return json_response(
@@ -1869,15 +1892,10 @@ engine::runtime::TaskRequest ServerState::build_speech_request(const LoadedModel
 
     bool voice_field_is_preset = false;
     const auto * preset = select_voice_preset(model, body, voice_field_is_preset);
-    const auto effective_model_spec_override = model.config.model_spec_override.has_value()
-        ? model.config.model_spec_override
-        : config_.model_spec_override;
-    const bool can_inject_reference_text =
-        model_accepts_request_option(
-            model.config.family,
-            "reference_text",
-            effective_model_spec_override,
-            model.config.path);
+    // Resolved once at registration (refresh_model_option_flags): calling
+    // model_accepts_request_option per request re-reads the model file's embedded
+    // spec on the request thread, which cost ~0.9 s per request for large GGUFs.
+    const bool can_inject_reference_text = model.accepts_reference_text;
 
     engine::runtime::VoiceCondition voice;
     bool has_voice = false;

--- a/app/server/runtime.cpp
+++ b/app/server/runtime.cpp
@@ -1188,21 +1188,16 @@ void ServerState::refresh_model_option_flags(LoadedModel & model) {
     const auto effective_override = model.config.model_spec_override.has_value()
         ? model.config.model_spec_override
         : config_.model_spec_override;
-    try {
-        model.accepts_reference_text = model_accepts_request_option(
-            model.config.family,
-            "reference_text",
-            effective_override,
-            model.config.path);
-    } catch (const std::exception & ex) {
-        // Keep registration robust: a model whose contract cannot be resolved gets
-        // the same permissive behavior as a model with no contract; the failure is
-        // reported so the misconfiguration stays visible.
-        std::cerr << "[server] model '" << model.config.id
-                  << "': reference_text option check failed (" << ex.what()
-                  << "); assuming the option is accepted\n";
-        model.accepts_reference_text = true;
-    }
+    // Deliberately uncaught: model_accepts_request_option already returns true for a
+    // model with no contract, swallowing only the missing-contract errors and
+    // rethrowing the rest. Anything that propagates here is therefore a real
+    // misconfiguration (invalid spec, missing override file, family mismatch) and
+    // must fail at registration rather than be assumed away.
+    model.accepts_reference_text = model_accepts_request_option(
+        model.config.family,
+        "reference_text",
+        effective_override,
+        model.config.path);
 }
 
 HttpResponse ServerState::handle_model_load(const std::string & body_text) {

--- a/app/server/runtime.h
+++ b/app/server/runtime.h
@@ -65,6 +65,12 @@ private:
         mutable std::shared_mutex metadata_mutex;
         std::unordered_map<std::string, RuntimeVoicePreset> voice_presets;
         std::optional<RuntimeVoicePreset> default_voice_preset;
+        // Whether this model's contract accepts the `reference_text` request
+        // option, resolved once at registration (refresh_model_option_flags).
+        // Resolving it per request re-reads the model file's embedded spec on
+        // the request thread, which costs ~0.9 s per request for large GGUFs.
+        // `true` mirrors model_accepts_request_option's no-contract behavior.
+        bool accepts_reference_text = true;
         // Serializes runs on this model and bounds how long a caller waits for its
         // turn; see BusyGuard.
         BusyGuard busy;
@@ -85,6 +91,9 @@ private:
 
     void load_models();
     std::unique_ptr<LoadedModel> make_model(ServerModelConfig config);
+    // Recompute the per-model, config-derived request-option flags (currently
+    // accepts_reference_text). Called at registration and on reconfiguration.
+    void refresh_model_option_flags(LoadedModel & model);
     std::filesystem::path resolve_ui_model_path(const std::filesystem::path & path) const;
     HttpResponse handle_model_load(const std::string & body_text);
     HttpResponse handle_model_unload(const std::string & body_text);


### PR DESCRIPTION
### Problem

`ServerState::build_speech_request` calls `model_accepts_request_option()` on every
`POST /v1/audio/speech`. That resolves the model contract through
`engine::model_spec::model_contract(family)`, which reads the model's embedded spec with
`gguf_init_from_file()` on the full GGUF.

The resolution cache is `thread_local` (`src/framework/model_spec/package.cpp:22-26`), and
`serve_http` handles each request on a fresh detached thread, so the cache is cold every time. Each
request re-opens and re-parses the whole model file.

With a 298 MB GGUF this adds a fixed **~900 ms** to every request, independent of backend, text
length and audio duration. It is invisible in `X-AudioCPP-Wall-Ms` because `run_model` starts its
clock after `build_speech_request`, and it does not affect `audiocpp_cli`, which resolves the spec
once on a single thread.

### Fix

Resolve the option once per model instead of once per request:

- `LoadedModel` gains `bool accepts_reference_text` (defaults to `true`, the existing permissive
  behaviour for models with no contract).
- `refresh_model_option_flags()` sets it in `make_model`, and again in `handle_model_load` when a
  model is reconfigured, so dynamic model management stays correct.
- `build_speech_request` reads the cached flag.

A contract that fails to resolve is caught at registration, logged to `stderr`, and falls back to
the permissive default — same behaviour as before, but reported once instead of throwing per
request.

The one-off resolution cost moves to registration, where the model load already performs a
`gguf_init_from_file`.

### Measurements

`v0.7.0`, Windows x64, Vulkan backend, `supertonic-3-f16.gguf` (298 MB), same `server.json`, same
request:

| | ttfb | `X-AudioCPP-Wall-Ms` |
|---|---|---|
| before | 0.956–1.153 s | 44–176 ms |
| after | **0.045–0.049 s** | 44–50 ms |

Also reproduced before the fix on `--backend cpu` (ttfb 1.268–1.414 s against 341–362 ms reported),
confirming it is not backend-specific.

Response bytes are unchanged: the same request returns `Content-Length` 114090 with an identical
MD5 (`1514cf1fcf6bfc4e865a1cc24d5b8948`) before and after.

### Notes

- Long utterances now scale with synthesis time rather than sitting on a fixed floor.
- This caches the `reference_text` lookup, the only contract option the speech path uses today.
  Any other per-request contract lookup added later would hit the same cold `thread_local` path, so
  it may be worth resolving the contract once per model more generally.
