### PR TITLE
fix: re-feed persistent prefill inputs on cached-graph recompute in QwenCausalDecodeRuntime

### DIFF
--- a/src/framework/modules/transformers/qwen_causal_decode_runtime.cpp
+++ b/src/framework/modules/transformers/qwen_causal_decode_runtime.cpp
@@ -747,18 +747,18 @@ private:
             !ggml_gallocr_alloc_graph(prefill_gallocr_, prefill_graph_)) {
             throw std::runtime_error("failed to allocate QwenCausalDecodeRuntime prefill graph");
         }
-        const auto positions_values = qwen_position_ids(steps);
+        prefill_positions_values_ = qwen_position_ids(steps);
         ggml_backend_tensor_set(
             prefill_positions_,
-            positions_values.data(),
+            prefill_positions_values_.data(),
             0,
-            positions_values.size() * sizeof(int32_t));
-        const auto mask = prefill_attention_mask_values(config_, 1, steps);
+            prefill_positions_values_.size() * sizeof(int32_t));
+        prefill_attention_mask_values_ = prefill_attention_mask_values(config_, 1, steps);
         ggml_backend_tensor_set(
             prefill_attention_mask_,
-            mask.data(),
+            prefill_attention_mask_values_.data(),
             0,
-            mask.size() * sizeof(ggml_fp16_t));
+            prefill_attention_mask_values_.size() * sizeof(ggml_fp16_t));
         if (prefill_logits_readback_token_ids_ != nullptr) {
             upload_logits_readback_token_ids(prefill_logits_readback_token_ids_, config_);
         }
@@ -771,6 +771,19 @@ private:
     }
 
     QwenCausalPrefillResult run_prefill() {
+        // The gallocr considers the persistent position/mask inputs dead after
+        // their last read inside a compute and may hand their memory to other
+        // tensors, so a cached prefill graph must be re-fed before recompute.
+        ggml_backend_tensor_set(
+            prefill_positions_,
+            prefill_positions_values_.data(),
+            0,
+            prefill_positions_values_.size() * sizeof(int32_t));
+        ggml_backend_tensor_set(
+            prefill_attention_mask_,
+            prefill_attention_mask_values_.data(),
+            0,
+            prefill_attention_mask_values_.size() * sizeof(ggml_fp16_t));
         core::set_backend_threads(backend_, threads_);
         const ggml_status status = core::compute_backend_graph(backend_, prefill_graph_);
         ggml_backend_synchronize(backend_);
@@ -922,18 +935,18 @@ private:
             !ggml_gallocr_alloc_graph(batched_prefill_gallocr_, batched_prefill_graph_)) {
             throw std::runtime_error("failed to allocate QwenCausalDecodeRuntime batched prefill graph");
         }
-        const auto positions_values = qwen_position_ids(steps);
+        batched_prefill_positions_values_ = qwen_position_ids(steps);
         ggml_backend_tensor_set(
             batched_prefill_positions_,
-            positions_values.data(),
+            batched_prefill_positions_values_.data(),
             0,
-            positions_values.size() * sizeof(int32_t));
-        const auto mask = prefill_attention_mask_values(config_, batch_size, steps);
+            batched_prefill_positions_values_.size() * sizeof(int32_t));
+        batched_prefill_attention_mask_values_ = prefill_attention_mask_values(config_, batch_size, steps);
         ggml_backend_tensor_set(
             batched_prefill_attention_mask_,
-            mask.data(),
+            batched_prefill_attention_mask_values_.data(),
             0,
-            mask.size() * sizeof(ggml_fp16_t));
+            batched_prefill_attention_mask_values_.size() * sizeof(ggml_fp16_t));
         if (batched_prefill_logits_readback_token_ids_ != nullptr) {
             upload_logits_readback_token_ids(batched_prefill_logits_readback_token_ids_, config_);
         }
@@ -946,6 +959,17 @@ private:
     }
 
     QwenCausalBatchedPrefillResult run_batched_prefill() {
+        // Re-feed persistent inputs before recompute (see run_prefill note).
+        ggml_backend_tensor_set(
+            batched_prefill_positions_,
+            batched_prefill_positions_values_.data(),
+            0,
+            batched_prefill_positions_values_.size() * sizeof(int32_t));
+        ggml_backend_tensor_set(
+            batched_prefill_attention_mask_,
+            batched_prefill_attention_mask_values_.data(),
+            0,
+            batched_prefill_attention_mask_values_.size() * sizeof(ggml_fp16_t));
         core::set_backend_threads(backend_, threads_);
         const ggml_status status = core::compute_backend_graph(backend_, batched_prefill_graph_);
         ggml_backend_synchronize(backend_);
@@ -1347,6 +1371,8 @@ private:
         prefill_keys_.clear();
         prefill_values_.clear();
         prefill_graph_ = nullptr;
+        prefill_positions_values_.clear();
+        prefill_attention_mask_values_.clear();
         prefill_steps_ = 0;
         prefill_input_kind_ = InputKind::None;
     }
@@ -1370,6 +1396,8 @@ private:
         batched_prefill_keys_.clear();
         batched_prefill_values_.clear();
         batched_prefill_graph_ = nullptr;
+        batched_prefill_positions_values_.clear();
+        batched_prefill_attention_mask_values_.clear();
         batched_prefill_batch_size_ = 0;
         batched_prefill_steps_ = 0;
         batched_prefill_input_kind_ = InputKind::None;
@@ -1442,6 +1470,11 @@ private:
     std::vector<ggml_tensor *> prefill_values_;
     ggml_cgraph * prefill_graph_ = nullptr;
     ggml_gallocr_t prefill_gallocr_ = nullptr;
+    // Host-side copies of the persistent graph inputs. The gallocr may reuse
+    // their memory after the last read within one compute, so they must be
+    // re-uploaded before every recompute of a cached prefill graph.
+    std::vector<int32_t> prefill_positions_values_;
+    std::vector<ggml_fp16_t> prefill_attention_mask_values_;
     int64_t prefill_steps_ = 0;
     InputKind prefill_input_kind_ = InputKind::None;
 
@@ -1456,6 +1489,9 @@ private:
     std::vector<ggml_tensor *> batched_prefill_values_;
     ggml_cgraph * batched_prefill_graph_ = nullptr;
     ggml_gallocr_t batched_prefill_gallocr_ = nullptr;
+    // Host-side copies, re-uploaded before every recompute (see prefill note).
+    std::vector<int32_t> batched_prefill_positions_values_;
+    std::vector<ggml_fp16_t> batched_prefill_attention_mask_values_;
     int64_t batched_prefill_batch_size_ = 0;
     int64_t batched_prefill_steps_ = 0;
     InputKind batched_prefill_input_kind_ = InputKind::None;


### PR DESCRIPTION
## Validation (native CPU + Vulkan; no NVIDIA GPU available)

### NeuTTS (`prefill_tokens`, token-prompt, persistent runtime - recompute reachable)

Two identical utterances in one session (batch-text-file x2):

| | pre-fix (81ef451) | post-fix (ce1b8bc) |
|---|---|---|
| first utterance | 1.84s audio | 1.84s audio |
| second utterance | **12.2s garbage** (NaN divergence) | **1.84s deterministic, healthy** |
| first-run hash parity post vs pre | identical (F7CDE40A...) | identical |
| cross-run determinism (post-fix) | first utterance byte-identical across separate runs | |

NeuTTS applies an intentional per-chunk seed offset for utterance 2, so the two
lines legitimately differ from each other; the point is the pre-fix second line
is 12.2s of garbage while post-fix it is healthy and reproducible.

### DotTTS (`prefill_embeddings`, persistent runtime)

Two identical lines, `template_name=tts`, fixed seed. Pre-fix and post-fix are
**byte-identical and healthy** in both lines (278A7D17...): the DotTTS path does
not trigger the gallocr reuse, confirming the fix is a behavioral no-op where
the corruption cannot occur.

### Soprano (surfaced the bug)

PR #323 branch (which carried this fix until the split): `--warmup 1
--iterations 3` passes on CPU and Vulkan; three identical seeded generations
are bit-identical (previously fatal `no finite logits`). Soprano is not in
upstream yet, so it was validated on the PR branch carrying the same fix code.

### Compile matrix

Custom build including all runtime consumers (neutts, dots_tts, fireredtts3,
midashenglm_gen, minimax_music3, qwen3_asr) links cleanly - the header is
unchanged, so no API breakage.

### Consumers and why the rest are low-risk

- **qwen3_asr: not a consumer** - it builds its own prefill graphs and only
  mentions QwenCausalDecodeRuntime in a comment. Removed from the affected list.
- **fireredtts3 / midashenglm_gen / minimax_music3 / redae**: each prefill call
  creates a fresh runtime (graph built once, not recomputed) - the re-feed is a
  no-op for them. miniMax-H3 needs 15GB+ for a runtime test (skipped).
- The re-feed re-uploads byte-identical position/mask values, mirroring what the
  decode step already does every token; it is backend-agnostic.

### Caveats

- The CLI batch/repeat path did not discriminate for qwen3_asr or the DotTTS
  loop pre-fix (graph branch reused); NeuTTS two-line and Soprano
  warmup/iterations are the discriminating repeat proofs.
- CUDA backends were not exercised (no NVIDIA GPU here); the fix is a generic
  `ggml_backend_tensor_set` before compute, so no backend-specific surprises
  are expected, but CUDA CI coverage would be valuable.
