### PR TITLE
Fix CUDA stream lookup with dynamic ggml backends

### DIFF
--- a/external/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/external/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -5897,6 +5897,9 @@ static void * ggml_backend_cuda_reg_get_proc_address(ggml_backend_reg_t reg, con
     if (strcmp(name, "ggml_backend_cuda_set_stream_priority") == 0) {
         return (void *)ggml_backend_cuda_set_stream_priority;
     }
+    if (strcmp(name, "ggml_backend_cuda_get_stream") == 0) {
+        return (void *)ggml_backend_cuda_get_stream;
+    }
     return nullptr;
 }
 

--- a/include/engine/framework/core/backend.h
+++ b/include/engine/framework/core/backend.h
@@ -59,6 +59,7 @@ void trim_backend_pools(ggml_backend_t backend);
 // higher priority, 0 = default). No-op on non-CUDA backends and on builds
 // whose CUDA backend does not export the hook.
 void set_backend_stream_priority(ggml_backend_t backend, int priority);
+void * backend_cuda_stream(ggml_backend_t backend);
 // evict_cuda_graph_cache=false (the default) is the historical no-op;
 // true drops the backend's cached compiled-graph state (CUDA/HIP graph
 // cache) for this cgraph at destruction — opt in per family.

--- a/src/framework/core/backend.cpp
+++ b/src/framework/core/backend.cpp
@@ -346,6 +346,23 @@ void set_backend_stream_priority(ggml_backend_t backend, int priority) {
     if (fn != nullptr) fn(backend, priority);
 }
 
+void * backend_cuda_stream(ggml_backend_t backend) {
+    if (backend == nullptr) return nullptr;
+    if (!is_cuda_backend_handle(backend) && !is_hip_backend_handle(backend)) return nullptr;
+    ggml_backend_dev_t device = ggml_backend_get_device(backend);
+    if (device == nullptr) {
+        throw std::runtime_error("CUDA backend stream lookup failed: backend has no device");
+    }
+    auto fn = (void * (*)(ggml_backend_t))
+        ggml_backend_reg_get_proc_address(
+            ggml_backend_dev_backend_reg(device),
+            "ggml_backend_cuda_get_stream");
+    if (fn == nullptr) {
+        throw std::runtime_error("CUDA backend stream lookup failed: backend does not export ggml_backend_cuda_get_stream");
+    }
+    return fn(backend);
+}
+
 // evict_cuda_graph_cache defaults to false, preserving historical behavior
 // for existing call sites: before the CUDA backend exported
 // ggml_backend_cuda_clear_graph the lookup resolved nothing, and families

--- a/src/framework/sampling/torch_random.cpp
+++ b/src/framework/sampling/torch_random.cpp
@@ -1,14 +1,10 @@
 #include "engine/framework/sampling/torch_random.h"
 
+#include "engine/framework/core/backend.h"
 #include "engine/framework/debug/trace.h"
 #include "engine/framework/io/dynamic_library.h"
 #ifdef ENGINE_HAS_CUDA_TORCH_RANDOM
 #include "torch_random_cuda_runtime.h"
-
-#ifdef ENGINE_HAS_CUDA_TORCH_RANDOM
-#include "ggml-backend.h"
-#include "ggml-cuda.h"
-#endif
 #endif
 
 #include <algorithm>
@@ -488,7 +484,7 @@ void torch_cuda_sample_topk_exponential_pairs(
 
 void * torch_cuda_backend_stream(void * ggml_backend) {
 #ifdef ENGINE_HAS_CUDA_TORCH_RANDOM
-    return ggml_backend_cuda_get_stream(static_cast<ggml_backend_t>(ggml_backend));
+    return core::backend_cuda_stream(static_cast<ggml_backend_t>(ggml_backend));
 #else
     (void) ggml_backend;
     return nullptr;


### PR DESCRIPTION
## Summary

Fixes the non-CPU Docker workflow failure introduced by PR #321. That PR added `ggml_backend_cuda_get_stream()` and used it from `torch_random.cpp` through a direct link-time reference. CUDA Docker builds enable `ENGINE_ENABLE_CPU_ALL_VARIANTS=ON`, which forces `GGML_BACKEND_DL=ON`, so `ggml-cuda` is a dynamic backend module and the direct symbol reference is unresolved when linking `audiocpp_cli`.

This PR keeps the Music3 call site unchanged and routes CUDA stream lookup through the backend proc-address table, matching the existing CUDA hooks for stream priority, graph clearing, and pool trimming.

## Validation

- `cmake -S . -B build/debug -DCMAKE_BUILD_TYPE=Debug -DAUDIOCPP_MODEL_SET=full -DENGINE_ENABLE_CPU_ALL_VARIANTS=ON -DENGINE_ENABLE_CUDA=ON -DENGINE_ENABLE_CUDA_GRAPHS=ON -DENGINE_ENABLE_VULKAN=OFF -DENGINE_ENABLE_OPENMP=ON -DAUDIOCPP_BUILD_NATIVE_MODEL_MANAGER=ON -DENGINE_BUILD_EXAMPLES=OFF -DENGINE_BUILD_TESTS=OFF -DENGINE_BUILD_MODEL_TESTS=OFF -DENGINE_BUILD_WARMBENCH=OFF`
- `cmake --build build/debug --parallel $(nproc) --target audiocpp_cli`
- `cmake --build build/debug --parallel $(nproc) --target audiocpp_server --target audiocpp_model_manager --target model_perf`