### PR TITLE
docs: update prebuilt binaries section

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,8 +223,17 @@ model notes, and frontend development instructions.
 
 ## Prebuilt Binaries
 
-- **Windows (CUDA / CPU):** official packages on the [Releases page](https://github.com/0xShug0/audio.cpp/releases).
-- **Windows (HIP/ROCm, AMD GPUs):** community-maintained packages with the ROCm runtime bundled — no HIP SDK installation required. Published from [@IIIIIllllIIIIIlllll's fork Releases](https://github.com/IIIIIllllIIIIIlllll/audio.cpp/releases) in two tracks: ROCm 6.4 (full coverage incl. RX 7600 / gfx1102) and ROCm 7.1 (recommended for RDNA4). Version numbers follow the upstream releases; see [docs/build/windows-hip-distribution.md](docs/build/windows-hip-distribution.md) for details.
+Official packages for every release are attached to the [Releases page](https://github.com/0xShug0/audio.cpp/releases):
+
+| Platform | Backends |
+|---|---|
+| Windows x64 | CPU, Vulkan, CUDA (12.4 / 13.3) |
+| Ubuntu x64 | CPU, Vulkan |
+| macOS (arm64 / x64) | Metal |
+
+The Windows CUDA packages ship the CUDA runtime in a separate `cudart` archive. Extract it next to the binaries so the CUDA backend can load `ggml-cuda.dll` and the CUDA runtime DLLs (`cudart`, cuBLAS, cuFFT).
+
+- **Windows (HIP/ROCm, AMD GPUs):** community-maintained packages with the ROCm runtime bundled, so no HIP SDK installation is required. Published from [@IIIIIllllIIIIIlllll's fork Releases](https://github.com/IIIIIllllIIIIIlllll/audio.cpp/releases) in two tracks: ROCm 6.4 (full coverage incl. RX 7600 / gfx1102) and ROCm 7.1 (recommended for RDNA4). Version numbers follow the upstream releases; see [docs/build/windows-hip-distribution.md](docs/build/windows-hip-distribution.md) for details.
 
 ## Build
 


### PR DESCRIPTION
## What

Updates the README **Prebuilt Binaries** section to match the tag-driven release pipeline from #286.

- Lists the platforms and backends that now ship official packages on every release: Windows x64 (CPU, Vulkan, CUDA 12.4 / 13.3), Ubuntu x64 (CPU, Vulkan), macOS arm64/x64 (Metal).
- Explains what the separate cudart archive is for: extract it next to the binaries so the CUDA backend can load ggml-cuda.dll and the CUDA runtime DLLs (cudart, cuBLAS, cuFFT).
- Keeps the community-maintained Windows HIP/ROCm pointers unchanged (minus a stray em dash).

## Notes

Platform/backend list was verified against the assets attached to the v0.7.0 release.