### PR TITLE
Honor MiniMax Music3 component options during load

### DIFF
--- a/src/community_models/minimax_music3/assets.cpp
+++ b/src/community_models/minimax_music3/assets.cpp
@@ -138,12 +138,8 @@ std::shared_ptr<const MiniMaxMusic3Assets> load_minimax_music3_assets(
     assets->config.condition = parse_condition_config(assets->model_root);
     assets->config.flow = parse_flow_config(assets->model_root);
     assets->config.vocoder = parse_vocoder_config(assets->model_root);
-    assets->language_model_weights = open_model_root_gguf(assets->model_root, "language_model_q4_0.gguf");
-    assets->depth_decoder_weights = open_model_root_gguf(assets->model_root, "rvq_depth_decoder_q8_0.gguf");
     assets->condition_encoder_weights = open_model_root_gguf(assets->model_root, "condition_encoder.gguf");
-    assets->transformer_weights = open_model_root_gguf(assets->model_root, "transformer_q4_0.gguf");
     assets->vocoder_weights = open_model_root_gguf(assets->model_root, "vocoder.gguf");
-    validate_minimax_music3_anchors(*assets);
     return assets;
 }
 

--- a/src/community_models/minimax_music3/session.cpp
+++ b/src/community_models/minimax_music3/session.cpp
@@ -56,31 +56,27 @@ std::shared_ptr<const MiniMaxMusic3Assets> select_component_assets(
     std::shared_ptr<const MiniMaxMusic3Assets> base,
     const std::unordered_map<std::string, std::string> & options) {
     auto selected = std::make_shared<MiniMaxMusic3Assets>(*base);
-    bool changed = false;
-    if (const auto value = runtime::find_option(options, {"minimax_music3.language_model_gguf"})) {
-        selected->language_model_weights = assets::open_tensor_source(resolve_component_gguf_path(
-            *base,
-            "minimax_music3.language_model_gguf",
-            *value));
-        changed = true;
-    }
-    if (const auto value = runtime::find_option(options, {"minimax_music3.rvq_depth_decoder_gguf"})) {
-        selected->depth_decoder_weights = assets::open_tensor_source(resolve_component_gguf_path(
-            *base,
-            "minimax_music3.rvq_depth_decoder_gguf",
-            *value));
-        changed = true;
-    }
-    if (const auto value = runtime::find_option(options, {"minimax_music3.flow_transformer_gguf"})) {
-        selected->transformer_weights = assets::open_tensor_source(resolve_component_gguf_path(
-            *base,
-            "minimax_music3.flow_transformer_gguf",
-            *value));
-        changed = true;
-    }
-    if (!changed) {
-        return base;
-    }
+    const std::string language_model_gguf =
+        runtime::find_option(options, {"minimax_music3.language_model_gguf"}).value_or("language_model_q4_0.gguf");
+    selected->language_model_weights = assets::open_tensor_source(resolve_component_gguf_path(
+        *base,
+        "minimax_music3.language_model_gguf",
+        language_model_gguf));
+
+    const std::string depth_decoder_gguf =
+        runtime::find_option(options, {"minimax_music3.rvq_depth_decoder_gguf"}).value_or("rvq_depth_decoder_q8_0.gguf");
+    selected->depth_decoder_weights = assets::open_tensor_source(resolve_component_gguf_path(
+        *base,
+        "minimax_music3.rvq_depth_decoder_gguf",
+        depth_decoder_gguf));
+
+    const std::string flow_transformer_gguf =
+        runtime::find_option(options, {"minimax_music3.flow_transformer_gguf"}).value_or("transformer_q4_0.gguf");
+    selected->transformer_weights = assets::open_tensor_source(resolve_component_gguf_path(
+        *base,
+        "minimax_music3.flow_transformer_gguf",
+        flow_transformer_gguf));
+
     validate_minimax_music3_anchors(*selected);
     return selected;
 }


### PR DESCRIPTION
## Summary
- defer MiniMax Music3 selectable component GGUF loading until session options are available
- keep always-required condition encoder and vocoder loading in the asset loader
- validate anchors after the selected LM/RVQ/flow components are opened

Fixes #334

## Validation
- rebuilt debug audiocpp_cli
- reproduced the issue setup with language_model_q4_0.gguf absent from the model root
- ran the Q8-selected Music3 command successfully with:
  - minimax_music3.language_model_gguf=language_model_q8_0.gguf
  - minimax_music3.rvq_depth_decoder_gguf=rvq_depth_decoder_q8_0.gguf
  - minimax_music3.flow_transformer_gguf=transformer_q8_0.gguf

