### PR TITLE
fixes issue #345

### DIFF
--- a/external/ggml/src/ggml-cuda/vendors/hip.h
+++ b/external/ggml/src/ggml-cuda/vendors/hip.h
@@ -121,6 +121,9 @@
 #define cudaStreamPerThread hipStreamPerThread
 #define cudaStreamSynchronize hipStreamSynchronize
 #define cudaStreamWaitEvent hipStreamWaitEvent
+#define cudaStreamCreateWithPriority hipStreamCreateWithPriority
+#define cudaStreamGetPriority hipStreamGetPriority
+#define cudaDeviceGetStreamPriorityRange hipDeviceGetStreamPriorityRange
 #define cudaGraphExec_t hipGraphExec_t
 #define cudaGraphNode_t hipGraphNode_t
 #define cudaKernelNodeParams hipKernelNodeParams


### PR DESCRIPTION
Fixes issue #345 

Building audio.cpp with the HIP backend fails to compile the ggml CUDA sources.
`common.cuh` calls `cudaStreamCreateWithPriority`, but that symbol has no
CUDA→HIP alias in `external/ggml/src/ggml-cuda/vendors/hip.h`, so every `.cu`
file that includes `common.cuh` fails with `use of undeclared identifier`
(the compiler itself suggests the correct HIP equivalent).

This fix adds the following to `src/ggml-cuda/vendors/hip.h` alongside the other
cudaStream* defines:

```c
#define cudaStreamCreateWithPriority     hipStreamCreateWithPriority
#define cudaStreamGetPriority            hipStreamGetPriority
#define cudaDeviceGetStreamPriorityRange hipDeviceGetStreamPriorityRange
```