### PR TITLE
Fix Music3 contract spec validation

### DIFF
--- a/include/engine/framework/model_spec/package.h
+++ b/include/engine/framework/model_spec/package.h
@@ -34,6 +34,7 @@ private:
 [[nodiscard]] std::filesystem::path default_contract_spec_path(std::string_view family);
 
 [[nodiscard]] engine::io::json::Value load_spec(const std::filesystem::path & spec_path);
+[[nodiscard]] engine::io::json::Value load_contract_spec(const std::filesystem::path & spec_path);
 
 [[nodiscard]] assets::ResourceBundle load_resource_bundle(const std::filesystem::path & model_path,
     const std::filesystem::path & spec_path);

--- a/model_specs/minimax_music3.json
+++ b/model_specs/minimax_music3.json
@@ -175,8 +175,7 @@
         "condition_encoder.gguf",
         "transformer_q4_0.gguf",
         "vocoder.gguf"
-      ],
-      "strip_prefix": ""
+      ]
     },
     {
       "id": "minimax_music3_q8_0",
@@ -198,8 +197,7 @@
         "condition_encoder.gguf",
         "transformer_q8_0.gguf",
         "vocoder.gguf"
-      ],
-      "strip_prefix": ""
+      ]
     },
     {
       "id": "minimax_music3_bf16",
@@ -221,8 +219,7 @@
         "condition_encoder.gguf",
         "transformer_bf16.gguf",
         "vocoder.gguf"
-      ],
-      "strip_prefix": ""
+      ]
     }
   ],
   "dependencies": [],

--- a/src/framework/model_spec/metadata.cpp
+++ b/src/framework/model_spec/metadata.cpp
@@ -2,6 +2,7 @@
 
 #include "engine/framework/model_spec/options.h"
 #include "engine/framework/model_spec/package.h"
+#include "engine/framework/model_spec/schema.h"
 #include "engine/framework/io/json.h"
 
 #include <algorithm>
@@ -95,6 +96,10 @@ std::vector<runtime::TaskCapability> parse_tasks(const json::Value & tasks_value
 
 json::Value load_spec_for_family(std::string_view family) {
     return engine::model_spec::load_spec(engine::model_spec::default_contract_spec_path(family));
+}
+
+json::Value load_contract_spec_for_family(std::string_view family) {
+    return engine::model_spec::load_contract_spec(engine::model_spec::default_contract_spec_path(family));
 }
 
 std::string ref_candidate_path(const std::string & ref) {
@@ -300,7 +305,9 @@ std::unordered_set<std::string> option_keys(const std::vector<runtime::CliOption
 
 ModelContract contract_from_spec(const json::Value & spec) {
     ModelContract out;
-    out.metadata = metadata_from_spec(spec);
+    out.metadata.family = json::require_string(spec, "family");
+    out.metadata.variant = json::require_string(spec, "display_name");
+    out.metadata.description = json::require_string(spec, "description");
     out.capabilities = capabilities_from_spec(spec);
     out.cli = cli_from_spec(spec);
     out.request_option_keys = option_keys(out.cli.request_options);
@@ -312,9 +319,14 @@ ModelContract contract_from_spec(const json::Value & spec) {
 }  // namespace
 
 std::optional<ModelContract> model_contract(std::string_view family) {
-    const auto spec = load_spec_for_family(family);
-    if (spec.find("schema_version") == nullptr) {
+    const auto spec = load_contract_spec_for_family(family);
+    const auto * version = spec.find("schema_version");
+    if (version == nullptr) {
         return std::nullopt;
+    }
+    if (!version->is_number() || version->as_i64() != kModelSpecSchemaVersion) {
+        throw std::runtime_error(
+            "model spec schema_version: expected " + std::to_string(kModelSpecSchemaVersion));
     }
     return contract_from_spec(spec);
 }

--- a/src/framework/model_spec/package.cpp
+++ b/src/framework/model_spec/package.cpp
@@ -196,7 +196,7 @@ std::optional<std::filesystem::path> discover_workspace_model_spec(std::string_v
     return std::nullopt;
 }
 
-engine::io::json::Value parse_model_spec(const std::filesystem::path & spec_path) {
+engine::io::json::Value parse_model_spec(const std::filesystem::path & spec_path, bool validate) {
     engine::io::json::Value root;
     if (spec_path.parent_path() == "@gguf") {
         const auto & spec = embedded_model_spec();
@@ -213,7 +213,9 @@ engine::io::json::Value parse_model_spec(const std::filesystem::path & spec_path
     } else {
         root = engine::io::json::parse_file(spec_path);
     }
-    validate_spec(root, model_spec_description(spec_path));
+    if (validate) {
+        validate_spec(root, model_spec_description(spec_path));
+    }
     return root;
 }
 
@@ -419,7 +421,7 @@ SelectedSource require_selected_source(const std::filesystem::path & model_path,
     const auto spec_description = model_spec_description(spec_path);
     engine::io::json::Value spec;
     try {
-        spec = parse_model_spec(spec_path);
+        spec = parse_model_spec(spec_path, true);
     } catch (const std::exception & error) {
         throw std::runtime_error("failed to parse " + spec_description + ": " + error.what());
     }
@@ -578,7 +580,11 @@ assets::ResourceBundle load_resource_bundle_for_family(
 }
 
 engine::io::json::Value load_spec(const std::filesystem::path & spec_path) {
-    return parse_model_spec(spec_path);
+    return parse_model_spec(spec_path, true);
+}
+
+engine::io::json::Value load_contract_spec(const std::filesystem::path & spec_path) {
+    return parse_model_spec(spec_path, false);
 }
 
 std::vector<assets::ResourceFile> discover_resources(

--- a/tests/unittests/test_model_spec_system.cpp
+++ b/tests/unittests/test_model_spec_system.cpp
@@ -1170,6 +1170,59 @@ void test_schema_v1_metadata_projection() {
     std::filesystem::remove_all(root);
 }
 
+void test_contract_projection_ignores_package_metadata_validation() {
+    const auto root = make_temp_root();
+    std::string spec_text = schema_v1_spec_with_options(R"JSON({
+      "request": [
+        {
+          "name": "reference_text",
+          "type": "string",
+          "required": false,
+          "description": "Reference transcript."
+        }
+      ],
+      "session": [],
+      "load": []
+    })JSON");
+    const std::string marker = "\"default\": true";
+    const auto pos = spec_text.find(marker);
+    engine::test::require(pos != std::string::npos, "test fixture package marker");
+    spec_text.replace(pos, marker.size(), "\"default\": true,\n      \"strip_prefix\": \"\"");
+    const auto spec_path = write_text(root, "toy_model.json", spec_text);
+
+    bool full_validation_rejected = false;
+    try {
+        (void) engine::model_spec::load_spec(spec_path);
+    } catch (const std::runtime_error & error) {
+        full_validation_rejected = std::string(error.what()).find("strip_prefix: expected non-empty string") !=
+            std::string::npos;
+    }
+    engine::test::require(
+        full_validation_rejected,
+        "full package/catalog validation should reject empty strip_prefix");
+
+    const engine::model_spec::ScopedSpecOverride spec_override(root);
+    const auto contract = engine::model_spec::model_contract("toy_model");
+    engine::test::require(contract.has_value(), "contract projection should ignore package metadata validation");
+    engine::test::require(contract->metadata.weight_candidates.empty(), "contract metadata should not read packages");
+    engine::test::require(
+        contract->request_option_keys.find("reference_text") != contract->request_option_keys.end(),
+        "contract should include reference_text");
+
+    std::filesystem::remove_all(root);
+}
+
+void test_legacy_spec_contract_behavior_unchanged() {
+    const auto root = make_temp_root();
+    write_text(root, "toy_model.json", legacy_spec_text("[]"));
+
+    const engine::model_spec::ScopedSpecOverride spec_override(root);
+    const auto contract = engine::model_spec::model_contract("toy_model");
+    engine::test::require(!contract.has_value(), "legacy specs should not expose schema v1 contracts");
+
+    std::filesystem::remove_all(root);
+}
+
 void test_contract_spec_prefers_workspace_over_package_local_spec() {
     const auto root = make_temp_root();
     const auto workspace = root / "workspace";
@@ -1236,6 +1289,8 @@ int main() {
         test_options_schema();
         test_option_name_mapping_from_production_spec();
         test_schema_v1_metadata_projection();
+        test_contract_projection_ignores_package_metadata_validation();
+        test_legacy_spec_contract_behavior_unchanged();
         test_contract_spec_prefers_workspace_over_package_local_spec();
         test_loading_and_resource_bundle();
     } catch (const std::exception & error) {


### PR DESCRIPTION
## Summary
- remove invalid empty `strip_prefix` fields from the MiniMax Music3 package spec
- keep full spec/package validation strict for package/resource paths
- load schema-v1 runtime contracts without validating package-only metadata, so old bad embedded package metadata cannot break server option validation
- keep legacy/non-v1 specs returning no schema-v1 contract

Fixes #349.

## Validation
- `cmake --build build/debug --parallel \24 --target model_spec_system_test audiocpp_server audiocpp_cli`
- `build/debug/bin/model_spec_system_test`
- pulled `ghcr.io/0xshug0/audio.cpp:full-cpu` and reproduced the current failure on `POST /v1/models/load` for MiniMax Music3: 500 with `packages[0].strip_prefix: expected non-empty string`
- reran the same prebuilt CPU image with only the fixed `minimax_music3.json` overlaid and the same load request returned 200 OK
- verified a legacy non-v1 OmniVoice inspect path still works