### PR TITLE
Tighten Silero VAD auto-detection

### DIFF
--- a/src/models/silero_vad/session.cpp
+++ b/src/models/silero_vad/session.cpp
@@ -94,7 +94,12 @@ public:
             return false;
         }
         try {
-            (void) resolve_silero_assets(request.model_path);
+            const auto assets = resolve_silero_assets(request.model_path);
+            if (!request.family_hint.has_value() &&
+                engine::io::is_existing_file(request.model_path) &&
+                assets.checkpoint_path.filename() != "silero_vad_16k.safetensors") {
+                return false;
+            }
             return true;
         } catch (...) {
             return false;


### PR DESCRIPTION
## Summary
- keep explicit Silero VAD loads unchanged
- prevent Silero VAD auto-detection from claiming arbitrary single-file model paths
- allow no-family GGUF auto-detection to continue to the correct model loader

Fixes #356

## Validation
- `conda run --no-capture-output -n qwen3-tts cmake --build build/debug --target audiocpp_cli -j$(nproc)`
- `conda run --no-capture-output -n qwen3-tts cmake --build build/debug --target audiocpp_server -j$(nproc)`
- no-family Qwen GGUF inspect resolves as `family=qwen3_tts`, not Silero VAD
- Silero VAD directory inspect still resolves as `family=silero_vad`
- server `/v1/models/load` for OmniVoice returns 200 and traces `runtime.model.family omnivoice`