### PR TITLE
audio/text: crossfade genuine chunk seams, and split space-free scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2032,6 +2032,20 @@ if (ENGINE_BUILD_TESTS)
         COMMAND audio_chunking_test
     )
 
+    add_engine_unittest(audio_chunk_join_test tests/unittests/test_audio_chunk_join.cpp)
+
+    add_test(
+        NAME audio_chunk_join_test
+        COMMAND audio_chunk_join_test
+    )
+
+    add_engine_unittest(text_chunking_test tests/unittests/test_text_chunking.cpp)
+
+    add_test(
+        NAME text_chunking_test
+        COMMAND text_chunking_test
+    )
+
     add_engine_unittest(chinese_normalization_test tests/unittests/test_chinese_normalization.cpp)
 
     add_test(

--- a/include/engine/framework/audio/chunking.h
+++ b/include/engine/framework/audio/chunking.h
@@ -61,6 +61,49 @@ struct QuietEnergyAudioChunkOptions {
     int64_t min_energy_window_samples = 0;
 };
 
+// How two consecutive output chunks are joined into one waveform.
+//
+// Concat      — raw splice, the historical behaviour. Bit-exact, but a step at the
+//               seam is a broadband impulse at 20*log10(step) dBFS.
+// EqualPower  — sin/cos pair. cos^2 + sin^2 == 1, so it preserves *power* through
+//               the overlap. Correct for the uncorrelated content either side of a
+//               text-chunk seam; +3.01 dB at the midpoint if the two sides happen
+//               to be identical.
+// CosSquared  — cos^2/sin^2 pair. The gains sum to exactly 1, so it preserves
+//               *amplitude* for correlated content and dips ~1.25 dB for
+//               uncorrelated content.
+// Auto        — measure the seam first and only crossfade a real discontinuity.
+//               A join that continues the waveform, or that lands in silence, is
+//               spliced and is bit-exact with Concat.
+enum class AudioChunkJoinMode {
+    Concat,
+    EqualPower,
+    CosSquared,
+    Auto,
+};
+
+struct AudioChunkJoinSpec {
+    AudioChunkJoinMode mode = AudioChunkJoinMode::Auto;
+    // 10 ms. F4.15 puts the practical knee at 5-20 ms: a crossfade drops the peak
+    // spectral energy of a seam step by roughly 20*log10(1/L), so 10 ms at 24 kHz
+    // buys about -47 dB while costing at most 10 ms of duration per seam.
+    float cross_fade_seconds = 0.010F;
+    // Auto declines to crossfade at or below this step. 0.002 is -54 dBFS, which
+    // is already quieter than a 0.1 step (-20 dBFS) crossfaded over 20 ms. A seam
+    // landing in the inter-sentence silence a text-chunk split produces is far
+    // below it, so Auto leaves such joins untouched.
+    float silent_seam_step = 0.002F;
+    // Auto also declines when the step is within reach of the ordinary
+    // sample-to-sample slew either side of the join, because that is what a join
+    // continuing the same waveform looks like — an accumulating streaming buffer,
+    // or a vocoder emitting consecutive frames. Only a step that stands out from
+    // its neighbourhood by this factor is treated as a discontinuity.
+    float seam_slew_ratio = 2.0F;
+    // Samples inspected either side of the seam to establish that slew. Never
+    // spans the seam itself.
+    int64_t seam_slew_window_frames = 64;
+};
+
 std::vector<AudioChunkSpan> plan_audio_chunks(int64_t input_samples, const AudioChunkSpec & spec);
 
 AudioChunkMode parse_audio_chunk_mode(
@@ -86,6 +129,36 @@ std::vector<runtime::TimeSpan> plan_quiet_energy_audio_chunks(
 runtime::AudioBuffer slice_audio_buffer(
     const runtime::AudioBuffer & audio,
     const runtime::TimeSpan & span);
+
+AudioChunkJoinMode parse_audio_chunk_join_mode(const std::string & value);
+
+AudioChunkJoinSpec parse_audio_chunk_join_spec(
+    const std::unordered_map<std::string, std::string> & options);
+
+float measure_chunk_seam_step(
+    const runtime::AudioBuffer & previous,
+    const runtime::AudioBuffer & next);
+
+float measure_chunk_edge_slew(
+    const runtime::AudioBuffer & previous,
+    const runtime::AudioBuffer & next,
+    int64_t window_frames);
+
+bool chunk_seam_is_discontinuous(
+    const runtime::AudioBuffer & previous,
+    const runtime::AudioBuffer & next,
+    const AudioChunkJoinSpec & spec);
+
+int64_t resolve_chunk_cross_fade_frames(
+    int64_t previous_frames,
+    int64_t next_frames,
+    int sample_rate,
+    float cross_fade_seconds);
+
+void append_audio_chunk(
+    runtime::AudioBuffer & dst,
+    const runtime::AudioBuffer & src,
+    const AudioChunkJoinSpec & spec);
 
 std::vector<float> make_triangular_overlap_window(int64_t chunk_samples);
 std::vector<float> make_linear_fade_window(int64_t chunk_samples, int64_t fade_samples);

--- a/include/engine/framework/runtime/session.h
+++ b/include/engine/framework/runtime/session.h
@@ -17,6 +17,10 @@ namespace engine::text {
 enum class TextChunkMode;
 }
 
+namespace engine::audio {
+struct AudioChunkJoinSpec;
+}
+
 namespace engine::runtime {
 
 enum class VoiceTaskKind {
@@ -285,7 +289,16 @@ std::vector<TaskRequest> chunk_text_request(
     const TaskRequest & request,
     int64_t codepoint_budget,
     engine::text::TextChunkMode mode);
+// Joins `src` onto the end of `dst`. The two-argument form takes the default join
+// strategy (engine::audio::AudioChunkJoinSpec) — an energy-aware crossfade that is
+// a bit-exact splice whenever the seam step is already inaudible, which is the
+// case for a seam landing in the inter-sentence silence a text-chunk split
+// produces. Pass an explicit spec to force Concat, EqualPower or CosSquared.
 void append_audio_buffer(AudioBuffer & dst, const AudioBuffer & src);
+void append_audio_buffer(
+    AudioBuffer & dst,
+    const AudioBuffer & src,
+    const engine::audio::AudioChunkJoinSpec & join);
 
 class IGraphCapacityAdapter {
 public:

--- a/src/framework/audio/chunking.cpp
+++ b/src/framework/audio/chunking.cpp
@@ -127,6 +127,35 @@ void validate_merge_spans(
     }
 }
 
+constexpr float kJoinHalfPi = 1.57079632679489661923F;
+
+float join_fade_position(int64_t frame, int64_t fade_frames) {
+    if (fade_frames <= 1) {
+        return 1.0F;
+    }
+    return static_cast<float>(frame) / static_cast<float>(fade_frames - 1);
+}
+
+void join_fade_gains(
+    AudioChunkJoinMode mode,
+    float position,
+    float & fade_out,
+    float & fade_in) {
+    const float out_gain = std::cos(position * kJoinHalfPi);
+    const float in_gain = std::sin(position * kJoinHalfPi);
+    if (mode == AudioChunkJoinMode::CosSquared) {
+        fade_out = out_gain * out_gain;
+        fade_in = in_gain * in_gain;
+        return;
+    }
+    fade_out = out_gain;
+    fade_in = in_gain;
+}
+
+void splice_audio_samples(runtime::AudioBuffer & dst, const runtime::AudioBuffer & src) {
+    dst.samples.insert(dst.samples.end(), src.samples.begin(), src.samples.end());
+}
+
 }  // namespace
 
 std::vector<AudioChunkSpan> plan_audio_chunks(int64_t input_samples, const AudioChunkSpec & spec) {
@@ -393,6 +422,183 @@ runtime::AudioBuffer slice_audio_buffer(
         audio.samples.begin() + static_cast<std::ptrdiff_t>(begin),
         audio.samples.begin() + static_cast<std::ptrdiff_t>(end));
     return out;
+}
+
+AudioChunkJoinMode parse_audio_chunk_join_mode(const std::string & value) {
+    if (value == "auto") {
+        return AudioChunkJoinMode::Auto;
+    }
+    if (value == "concat" || value == "none") {
+        return AudioChunkJoinMode::Concat;
+    }
+    if (value == "equal_power" || value == "equal-power" || value == "equalpower") {
+        return AudioChunkJoinMode::EqualPower;
+    }
+    if (value == "cos_squared" || value == "cos-squared" || value == "cos2") {
+        return AudioChunkJoinMode::CosSquared;
+    }
+    throw std::runtime_error("audio_chunk_join must be auto, concat, equal_power, or cos_squared");
+}
+
+AudioChunkJoinSpec parse_audio_chunk_join_spec(
+    const std::unordered_map<std::string, std::string> & options) {
+    AudioChunkJoinSpec spec;
+    const auto mode = runtime::find_option(options, {"audio_chunk_join", "chunk_join"});
+    if (mode.has_value()) {
+        spec.mode = parse_audio_chunk_join_mode(*mode);
+    }
+    const auto seconds = runtime::parse_finite_float_option(
+        options,
+        {"cross_fade_duration_sec", "audio_chunk_cross_fade_sec"});
+    if (seconds.has_value()) {
+        if (*seconds < 0.0F) {
+            throw std::runtime_error("cross_fade_duration_sec must be non-negative");
+        }
+        spec.cross_fade_seconds = *seconds;
+    }
+    return spec;
+}
+
+float measure_chunk_seam_step(
+    const runtime::AudioBuffer & previous,
+    const runtime::AudioBuffer & next) {
+    if (previous.channels <= 0 || next.channels != previous.channels) {
+        return 0.0F;
+    }
+    const auto channels = static_cast<size_t>(previous.channels);
+    if (previous.samples.size() < channels || next.samples.size() < channels) {
+        return 0.0F;
+    }
+    const size_t tail = previous.samples.size() - channels;
+    float step = 0.0F;
+    for (size_t channel = 0; channel < channels; ++channel) {
+        step = std::max(step, std::fabs(next.samples[channel] - previous.samples[tail + channel]));
+    }
+    return step;
+}
+
+float measure_chunk_edge_slew(
+    const runtime::AudioBuffer & previous,
+    const runtime::AudioBuffer & next,
+    int64_t window_frames) {
+    if (previous.channels <= 0 || next.channels != previous.channels || window_frames <= 0) {
+        return 0.0F;
+    }
+    const auto channels = static_cast<size_t>(previous.channels);
+    if (previous.samples.size() % channels != 0 || next.samples.size() % channels != 0) {
+        return 0.0F;
+    }
+    const auto previous_frames = static_cast<int64_t>(previous.samples.size() / channels);
+    const auto next_frames = static_cast<int64_t>(next.samples.size() / channels);
+    float slew = 0.0F;
+    const int64_t previous_span = std::min(window_frames, previous_frames - 1);
+    for (int64_t frame = 0; frame < previous_span; ++frame) {
+        const size_t high = previous.samples.size() - static_cast<size_t>(frame) * channels;
+        for (size_t channel = 0; channel < channels; ++channel) {
+            const float later = previous.samples[high - channels + channel];
+            const float earlier = previous.samples[high - 2 * channels + channel];
+            slew = std::max(slew, std::fabs(later - earlier));
+        }
+    }
+    const int64_t next_span = std::min(window_frames, next_frames - 1);
+    for (int64_t frame = 0; frame < next_span; ++frame) {
+        const size_t low = static_cast<size_t>(frame) * channels;
+        for (size_t channel = 0; channel < channels; ++channel) {
+            const float earlier = next.samples[low + channel];
+            const float later = next.samples[low + channels + channel];
+            slew = std::max(slew, std::fabs(later - earlier));
+        }
+    }
+    return slew;
+}
+
+bool chunk_seam_is_discontinuous(
+    const runtime::AudioBuffer & previous,
+    const runtime::AudioBuffer & next,
+    const AudioChunkJoinSpec & spec) {
+    const float step = measure_chunk_seam_step(previous, next);
+    if (step <= std::max(0.0F, spec.silent_seam_step)) {
+        return false;
+    }
+    const float slew = measure_chunk_edge_slew(previous, next, spec.seam_slew_window_frames);
+    return step > std::max(0.0F, spec.seam_slew_ratio) * slew;
+}
+
+int64_t resolve_chunk_cross_fade_frames(
+    int64_t previous_frames,
+    int64_t next_frames,
+    int sample_rate,
+    float cross_fade_seconds) {
+    if (previous_frames <= 0 || next_frames <= 0 || sample_rate <= 0 || !(cross_fade_seconds > 0.0F)) {
+        return 0;
+    }
+    const int64_t requested = static_cast<int64_t>(std::llround(
+        static_cast<double>(cross_fade_seconds) * static_cast<double>(sample_rate)));
+    return std::max<int64_t>(0, std::min(requested, std::min(previous_frames, next_frames)));
+}
+
+void append_audio_chunk(
+    runtime::AudioBuffer & dst,
+    const runtime::AudioBuffer & src,
+    const AudioChunkJoinSpec & spec) {
+    if (src.sample_rate <= 0 || src.channels <= 0) {
+        throw std::runtime_error("audio append requires valid source format");
+    }
+    if (dst.sample_rate == 0) {
+        dst.sample_rate = src.sample_rate;
+        dst.channels = src.channels;
+    } else if (dst.sample_rate != src.sample_rate || dst.channels != src.channels) {
+        throw std::runtime_error("audio append requires matching audio format");
+    }
+    if (spec.mode == AudioChunkJoinMode::Concat || dst.samples.empty() || src.samples.empty()) {
+        splice_audio_samples(dst, src);
+        return;
+    }
+
+    const auto channels = static_cast<size_t>(src.channels);
+    if (dst.samples.size() % channels != 0 || src.samples.size() % channels != 0) {
+        throw std::runtime_error("audio append requires whole frames on both chunks");
+    }
+
+    AudioChunkJoinMode mode = spec.mode;
+    if (mode == AudioChunkJoinMode::Auto) {
+        if (!chunk_seam_is_discontinuous(dst, src, spec)) {
+            splice_audio_samples(dst, src);
+            return;
+        }
+        mode = AudioChunkJoinMode::EqualPower;
+    }
+
+    const auto previous_frames = static_cast<int64_t>(dst.samples.size() / channels);
+    const auto next_frames = static_cast<int64_t>(src.samples.size() / channels);
+    const int64_t fade_frames = resolve_chunk_cross_fade_frames(
+        previous_frames,
+        next_frames,
+        src.sample_rate,
+        spec.cross_fade_seconds);
+    // A one-frame "crossfade" is a sample replacement, not a fade: it would drop a
+    // sample for no benefit. Splice instead.
+    if (fade_frames < 2) {
+        splice_audio_samples(dst, src);
+        return;
+    }
+
+    const size_t blend_base = static_cast<size_t>(previous_frames - fade_frames) * channels;
+    for (int64_t frame = 0; frame < fade_frames; ++frame) {
+        float fade_out = 0.0F;
+        float fade_in = 0.0F;
+        join_fade_gains(mode, join_fade_position(frame, fade_frames), fade_out, fade_in);
+        const size_t dst_base = blend_base + static_cast<size_t>(frame) * channels;
+        const size_t src_base = static_cast<size_t>(frame) * channels;
+        for (size_t channel = 0; channel < channels; ++channel) {
+            dst.samples[dst_base + channel] =
+                dst.samples[dst_base + channel] * fade_out + src.samples[src_base + channel] * fade_in;
+        }
+    }
+    dst.samples.insert(
+        dst.samples.end(),
+        src.samples.begin() + static_cast<std::ptrdiff_t>(static_cast<size_t>(fade_frames) * channels),
+        src.samples.end());
 }
 
 std::vector<float> make_triangular_overlap_window(int64_t chunk_samples) {

--- a/src/framework/runtime/session.cpp
+++ b/src/framework/runtime/session.cpp
@@ -1,4 +1,6 @@
 #include "engine/framework/runtime/session.h"
+
+#include "engine/framework/audio/chunking.h"
 #include "engine/framework/text/chunking.h"
 
 #include <algorithm>
@@ -237,16 +239,14 @@ std::vector<TaskRequest> chunk_text_request(
 }
 
 void append_audio_buffer(AudioBuffer & dst, const AudioBuffer & src) {
-    if (src.sample_rate <= 0 || src.channels <= 0) {
-        throw std::runtime_error("audio append requires valid source format");
-    }
-    if (dst.sample_rate == 0) {
-        dst.sample_rate = src.sample_rate;
-        dst.channels = src.channels;
-    } else if (dst.sample_rate != src.sample_rate || dst.channels != src.channels) {
-        throw std::runtime_error("audio append requires matching audio format");
-    }
-    dst.samples.insert(dst.samples.end(), src.samples.begin(), src.samples.end());
+    append_audio_buffer(dst, src, engine::audio::AudioChunkJoinSpec{});
+}
+
+void append_audio_buffer(
+    AudioBuffer & dst,
+    const AudioBuffer & src,
+    const engine::audio::AudioChunkJoinSpec & join) {
+    engine::audio::append_audio_chunk(dst, src, join);
 }
 
 std::vector<std::byte> bytes_from_string(std::string_view value) {

--- a/src/framework/text/chunking.cpp
+++ b/src/framework/text/chunking.cpp
@@ -6,6 +6,8 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstddef>
+#include <cstdint>
 #include <iterator>
 #include <optional>
 #include <stdexcept>
@@ -61,6 +63,73 @@ bool is_sentence_break(std::string_view token) {
 bool is_clause_break(std::string_view token) {
     return token == "," || token == ";" || token == ":" ||
            token == u8"，" || token == u8"、" || token == u8"；" || token == u8"：";
+}
+
+uint32_t span_codepoint(const Utf8Span & span) noexcept {
+    // split_utf8_spans has already validated width and continuation bytes.
+    const auto lead = static_cast<unsigned char>(span.text.front());
+    if (span.text.size() == 1) {
+        return lead;
+    }
+    uint32_t value = 0;
+    if (span.text.size() == 2) {
+        value = lead & 0x1FU;
+    } else if (span.text.size() == 3) {
+        value = lead & 0x0FU;
+    } else {
+        value = lead & 0x07U;
+    }
+    for (size_t i = 1; i < span.text.size(); ++i) {
+        value = (value << 6U) | (static_cast<unsigned char>(span.text[i]) & 0x3FU);
+    }
+    return value;
+}
+
+// Scripts that are written without ASCII word spaces. Text in these scripts
+// collapses to a single WordRange in split_word_ranges, which is what makes
+// split_text_chunks_default stop chunking altogether (F6.3).
+bool is_space_free_script_codepoint(uint32_t codepoint) noexcept {
+    return (codepoint >= 0x2E80U && codepoint <= 0x2EFFU) ||    // CJK radicals supplement
+           (codepoint >= 0x3000U && codepoint <= 0x303FU) ||    // CJK symbols and punctuation
+           (codepoint >= 0x3040U && codepoint <= 0x30FFU) ||    // hiragana and katakana
+           (codepoint >= 0x3100U && codepoint <= 0x312FU) ||    // bopomofo
+           (codepoint >= 0x3130U && codepoint <= 0x318FU) ||    // hangul compatibility jamo
+           (codepoint >= 0x31C0U && codepoint <= 0x31EFU) ||    // CJK strokes
+           (codepoint >= 0x31F0U && codepoint <= 0x31FFU) ||    // katakana phonetic extensions
+           (codepoint >= 0x3400U && codepoint <= 0x4DBFU) ||    // CJK unified ideographs extension A
+           (codepoint >= 0x4E00U && codepoint <= 0x9FFFU) ||    // CJK unified ideographs
+           (codepoint >= 0xAC00U && codepoint <= 0xD7AFU) ||    // hangul syllables
+           (codepoint >= 0xF900U && codepoint <= 0xFAFFU) ||    // CJK compatibility ideographs
+           (codepoint >= 0xFE30U && codepoint <= 0xFE4FU) ||    // CJK compatibility forms
+           (codepoint >= 0xFF00U && codepoint <= 0xFF60U) ||    // fullwidth forms
+           (codepoint >= 0xFFE0U && codepoint <= 0xFFE6U) ||    // fullwidth signs
+           (codepoint >= 0x20000U && codepoint <= 0x3134AU);    // CJK unified ideographs extensions B-G
+}
+
+// Codepoints that continue the preceding grapheme cluster. A chunk must never
+// start with one of these, or the cluster is torn in half.
+bool is_grapheme_extend_codepoint(uint32_t codepoint) noexcept {
+    return (codepoint >= 0x0300U && codepoint <= 0x036FU) ||    // combining diacritical marks
+           (codepoint >= 0x1AB0U && codepoint <= 0x1AFFU) ||    // combining diacritical marks extended
+           (codepoint >= 0x1DC0U && codepoint <= 0x1DFFU) ||    // combining diacritical marks supplement
+           codepoint == 0x200DU ||                              // zero width joiner
+           (codepoint >= 0x20D0U && codepoint <= 0x20FFU) ||    // combining marks for symbols
+           (codepoint >= 0x3099U && codepoint <= 0x309AU) ||    // combining kana voiced sound marks
+           (codepoint >= 0xFE00U && codepoint <= 0xFE0FU) ||    // variation selectors
+           (codepoint >= 0xFE20U && codepoint <= 0xFE2FU) ||    // combining half marks
+           (codepoint >= 0xE0100U && codepoint <= 0xE01EFU);    // variation selectors supplement
+}
+
+bool span_range_has_space_free_script(
+    const std::vector<Utf8Span> & spans,
+    size_t start,
+    size_t end) {
+    for (size_t i = start; i < end && i < spans.size(); ++i) {
+        if (is_space_free_script_codepoint(span_codepoint(spans[i]))) {
+            return true;
+        }
+    }
+    return false;
 }
 
 bool is_tag_open(std::string_view token) {
@@ -302,6 +371,65 @@ std::optional<std::pair<std::string, std::string>> split_leading_parenthetical_c
     return std::make_pair(prefix, body);
 }
 
+// Picks the end of a codepoint-budgeted chunk starting at `start`, preferring a
+// sentence break, then a clause break, then the hard budget. `limit` is one past
+// the last span the chunk may use. Never returns a boundary that would tear a
+// grapheme cluster; spans are whole codepoints by construction, so a multi-byte
+// codepoint can never be split either.
+size_t find_codepoint_chunk_end(
+    const std::vector<Utf8Span> & spans,
+    size_t start,
+    size_t limit,
+    int64_t codepoint_budget) {
+    const size_t hard_end = std::min(limit, start + static_cast<size_t>(codepoint_budget));
+    size_t end = hard_end;
+    if (hard_end < limit) {
+        for (size_t i = hard_end; i > start + 1; --i) {
+            if (is_sentence_break(spans[i - 1].text)) {
+                end = i;
+                break;
+            }
+        }
+        if (end == hard_end) {
+            for (size_t i = hard_end; i > start + 1; --i) {
+                if (is_clause_break(spans[i - 1].text)) {
+                    end = i;
+                    break;
+                }
+            }
+        }
+        while (end > start + 1 && end < limit && is_grapheme_extend_codepoint(span_codepoint(spans[end]))) {
+            --end;
+        }
+    }
+    return end;
+}
+
+void append_codepoint_chunks(
+    const std::string & text,
+    const std::vector<Utf8Span> & spans,
+    size_t start,
+    size_t limit,
+    int64_t codepoint_budget,
+    std::vector<std::string> & chunks) {
+    size_t position = start;
+    while (position < limit) {
+        while (position < limit && is_ascii_space(spans[position].text)) {
+            ++position;
+        }
+        if (position >= limit) {
+            break;
+        }
+        const size_t end = find_codepoint_chunk_end(spans, position, limit, codepoint_budget);
+        auto chunk = engine::io::trim_ascii_whitespace(
+            text.substr(spans[position].start, spans[end - 1].end - spans[position].start));
+        if (!chunk.empty()) {
+            chunks.push_back(std::move(chunk));
+        }
+        position = end;
+    }
+}
+
 std::vector<std::string> split_text_chunks_default(
     std::string_view text,
     int64_t codepoint_budget) {
@@ -337,6 +465,26 @@ std::vector<std::string> split_text_chunks_default(
         }
 
         if (hard_end == word_start) {
+            // A single whitespace-delimited word already exceeds the budget. For a
+            // script written without ASCII spaces that word is the whole input, and
+            // emitting it verbatim is what stops chunking entirely (F6.3). Fall back
+            // to a codepoint split inside the word. ASCII-only over-long words (URLs,
+            // base64 blobs) keep the historical whole-word behaviour, so no existing
+            // Latin-script split moves.
+            if (span_range_has_space_free_script(
+                    spans,
+                    words[word_start].span_start,
+                    words[word_start].span_end)) {
+                append_codepoint_chunks(
+                    trimmed,
+                    spans,
+                    words[word_start].span_start,
+                    words[word_start].span_end,
+                    codepoint_budget,
+                    chunks);
+                word_start += 1;
+                continue;
+            }
             hard_end = word_start + 1;
         }
 
@@ -410,43 +558,7 @@ std::vector<std::string> split_text_chunks_japanese(
     }
 
     std::vector<std::string> chunks;
-    size_t start = 0;
-    while (start < spans.size()) {
-        while (start < spans.size() && is_ascii_space(spans[start].text)) {
-            ++start;
-        }
-        if (start >= spans.size()) {
-            break;
-        }
-
-        const size_t hard_end = std::min(
-            spans.size(),
-            start + static_cast<size_t>(codepoint_budget));
-        size_t end = hard_end;
-        if (hard_end < spans.size()) {
-            for (size_t i = hard_end; i > start + 1; --i) {
-                if (is_sentence_break(spans[i - 1].text)) {
-                    end = i;
-                    break;
-                }
-            }
-            if (end == hard_end) {
-                for (size_t i = hard_end; i > start + 1; --i) {
-                    if (is_clause_break(spans[i - 1].text)) {
-                        end = i;
-                        break;
-                    }
-                }
-            }
-        }
-
-        auto chunk = engine::io::trim_ascii_whitespace(
-            trimmed.substr(spans[start].start, spans[end - 1].end - spans[start].start));
-        if (!chunk.empty()) {
-            chunks.push_back(std::move(chunk));
-        }
-        start = end;
-    }
+    append_codepoint_chunks(trimmed, spans, 0, spans.size(), codepoint_budget, chunks);
     return chunks;
 }
 

--- a/tests/unittests/test_audio_chunk_join.cpp
+++ b/tests/unittests/test_audio_chunk_join.cpp
@@ -1,0 +1,546 @@
+#include "engine/framework/audio/chunking.h"
+
+#include "test_assert.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace {
+
+using engine::audio::AudioChunkJoinMode;
+using engine::audio::AudioChunkJoinSpec;
+using engine::runtime::AudioBuffer;
+
+constexpr int kSampleRate = 24000;
+
+AudioBuffer make_buffer(int channels, std::vector<float> samples) {
+    AudioBuffer buffer;
+    buffer.sample_rate = kSampleRate;
+    buffer.channels = channels;
+    buffer.samples = std::move(samples);
+    return buffer;
+}
+
+AudioChunkJoinSpec spec_for(AudioChunkJoinMode mode, float seconds = 0.010F) {
+    AudioChunkJoinSpec spec;
+    spec.mode = mode;
+    spec.cross_fade_seconds = seconds;
+    return spec;
+}
+
+// Peak of the first difference. A step discontinuity shows up here at its full
+// height; a crossfade of length L spreads the same edge over L samples and drops
+// the peak by roughly 20*log10(1/L).
+float peak_first_difference(const std::vector<float> & samples) {
+    float peak = 0.0F;
+    for (size_t i = 1; i < samples.size(); ++i) {
+        peak = std::max(peak, std::fabs(samples[i] - samples[i - 1]));
+    }
+    return peak;
+}
+
+float rms(const std::vector<float> & samples, size_t start, size_t end) {
+    if (end <= start) {
+        return 0.0F;
+    }
+    double sum = 0.0;
+    for (size_t i = start; i < end; ++i) {
+        sum += static_cast<double>(samples[i]) * static_cast<double>(samples[i]);
+    }
+    return static_cast<float>(std::sqrt(sum / static_cast<double>(end - start)));
+}
+
+float to_db(float ratio) {
+    return 20.0F * std::log10(ratio);
+}
+
+std::vector<float> pseudo_random_noise(size_t count, uint32_t seed) {
+    std::vector<float> out(count);
+    uint32_t state = seed;
+    for (auto & value : out) {
+        state = state * 1664525U + 1013904223U;
+        value = static_cast<float>(static_cast<double>(state >> 8U) / 8388608.0 - 1.0);
+    }
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// F4.15 / F6.4 — the shared join point.
+// ---------------------------------------------------------------------------
+
+// The common case for the ~28 models that chunk text: the seam lands in the
+// inter-sentence silence the text splitter produces. The default (Auto) join must
+// leave that alone entirely — same length, same samples, no attenuation.
+void test_silent_seam_join_is_a_bit_exact_splice() {
+    std::vector<float> previous(4800, 0.0F);
+    std::vector<float> next(4800, 0.0F);
+    for (size_t i = 0; i < 2000; ++i) {
+        previous[i] = std::sin(static_cast<float>(i) * 0.01F);
+        next[next.size() - 1 - i] = std::sin(static_cast<float>(i) * 0.013F);
+    }
+
+    const AudioBuffer source = make_buffer(1, next);
+    AudioBuffer joined = make_buffer(1, previous);
+    engine::audio::append_audio_chunk(joined, source, AudioChunkJoinSpec{});
+
+    engine::test::require_close(
+        engine::audio::measure_chunk_seam_step(make_buffer(1, previous), source),
+        0.0F,
+        1e-9F,
+        "silent seam step");
+    engine::test::require_eq(
+        joined.samples.size(),
+        previous.size() + next.size(),
+        "silent seam join keeps full length");
+    for (size_t i = 0; i < previous.size(); ++i) {
+        engine::test::require(
+            joined.samples[i] == previous[i],
+            "silent seam join left the first chunk untouched at sample " + std::to_string(i));
+    }
+    for (size_t i = 0; i < next.size(); ++i) {
+        engine::test::require(
+            joined.samples[previous.size() + i] == next[i],
+            "silent seam join left the second chunk untouched at sample " + std::to_string(i));
+    }
+}
+
+// A seam that is quiet but not digitally silent must also be left alone: 0.001 is
+// -60 dBFS, below the -54 dBFS gate.
+void test_near_silent_seam_is_still_spliced() {
+    AudioBuffer joined = make_buffer(1, std::vector<float>(4800, 0.0005F));
+    const AudioBuffer source = make_buffer(1, std::vector<float>(4800, -0.0005F));
+    engine::audio::append_audio_chunk(joined, source, AudioChunkJoinSpec{});
+    engine::test::require_eq(
+        joined.samples.size(), static_cast<size_t>(9600), "near-silent seam join keeps full length");
+    engine::test::require_close(joined.samples[4799], 0.0005F, 1e-9F, "near-silent tail untouched");
+    engine::test::require_close(joined.samples[4800], -0.0005F, 1e-9F, "near-silent head untouched");
+}
+
+// Four ASR sessions use this same helper to accumulate contiguous streaming
+// input (sense_asr, qwen3_asr, voxtral_realtime, nemotron_asr), and several
+// vocoders append consecutive frames with it. There the seam step is just the
+// signal's own slew — at 24 kHz a full-scale 1 kHz tone steps 0.26 per sample,
+// far above the -54 dBFS silence gate — and crossfading it would both attenuate
+// real audio and shorten the buffer, shifting every downstream timestamp. Auto
+// must recognise a continuing waveform and splice it untouched.
+void test_continuous_waveform_join_is_a_bit_exact_splice() {
+    std::vector<float> tone(9600);
+    for (size_t i = 0; i < tone.size(); ++i) {
+        tone[i] = 0.9F * std::sin(6.2831853F * 1000.0F * static_cast<float>(i) /
+            static_cast<float>(kSampleRate));
+    }
+    const std::vector<float> previous(tone.begin(), tone.begin() + 4800);
+    const std::vector<float> next(tone.begin() + 4800, tone.end());
+
+    const float step = engine::audio::measure_chunk_seam_step(
+        make_buffer(1, previous), make_buffer(1, next));
+    engine::test::require(
+        step > 0.2F,
+        "a continuous 1 kHz tone still steps well above the silence gate, measured " +
+            std::to_string(step));
+    engine::test::require(
+        !engine::audio::chunk_seam_is_discontinuous(
+            make_buffer(1, previous), make_buffer(1, next), AudioChunkJoinSpec{}),
+        "a continuing waveform is not a discontinuity");
+
+    AudioBuffer joined = make_buffer(1, previous);
+    engine::audio::append_audio_chunk(joined, make_buffer(1, next), AudioChunkJoinSpec{});
+    engine::test::require_eq(joined.samples.size(), tone.size(), "continuous join keeps full length");
+    for (size_t i = 0; i < tone.size(); ++i) {
+        engine::test::require(
+            joined.samples[i] == tone[i],
+            "continuous join left sample " + std::to_string(i) + " untouched");
+    }
+}
+
+void test_edge_slew_measurement() {
+    // A ramp of 0.01 per sample either side, with a 0.5 step at the join.
+    std::vector<float> previous(128);
+    std::vector<float> next(128);
+    for (size_t i = 0; i < previous.size(); ++i) {
+        previous[i] = 0.01F * static_cast<float>(i);
+        next[i] = 0.5F + 0.01F * static_cast<float>(i);
+    }
+    const AudioBuffer previous_buffer = make_buffer(1, previous);
+    const AudioBuffer next_buffer = make_buffer(1, next);
+    engine::test::require_close(
+        engine::audio::measure_chunk_edge_slew(previous_buffer, next_buffer, 64),
+        0.01F,
+        1e-5F,
+        "edge slew excludes the seam itself");
+    // Previous ends at 0.01 * 127 = 1.27, next starts at 0.5.
+    engine::test::require_close(
+        engine::audio::measure_chunk_seam_step(previous_buffer, next_buffer),
+        0.77F,
+        1e-4F,
+        "ramp seam step");
+    engine::test::require(
+        engine::audio::chunk_seam_is_discontinuous(previous_buffer, next_buffer, AudioChunkJoinSpec{}),
+        "a step 50x the local slew is a discontinuity");
+    engine::test::require_close(
+        engine::audio::measure_chunk_edge_slew(make_buffer(1, {0.5F}), make_buffer(1, {0.5F}), 64),
+        0.0F,
+        1e-9F,
+        "single-frame chunks have no measurable slew");
+}
+
+// The pathological case F4.15 is about: a full-scale step at the seam. The
+// crossfade must measurably reduce it, and the measurement is asserted as a
+// number in dB, not as "smaller".
+void test_discontinuous_seam_impulse_is_reduced_by_a_measured_amount() {
+    const std::vector<float> previous(4800, 0.5F);
+    const std::vector<float> next(4800, -0.5F);
+    const AudioBuffer source = make_buffer(1, next);
+
+    engine::test::require_close(
+        engine::audio::measure_chunk_seam_step(make_buffer(1, previous), source),
+        1.0F,
+        1e-6F,
+        "discontinuous seam step");
+
+    AudioBuffer spliced = make_buffer(1, previous);
+    engine::audio::append_audio_chunk(spliced, source, spec_for(AudioChunkJoinMode::Concat));
+    const float spliced_peak = peak_first_difference(spliced.samples);
+    engine::test::require_close(spliced_peak, 1.0F, 1e-6F, "raw splice keeps the full step");
+    engine::test::require_eq(
+        spliced.samples.size(), static_cast<size_t>(9600), "raw splice length");
+
+    // Auto sees a 1.0 step, so it engages, and it engages with equal power.
+    AudioBuffer faded = make_buffer(1, previous);
+    engine::audio::append_audio_chunk(faded, source, AudioChunkJoinSpec{});
+    const int64_t fade_frames = engine::audio::resolve_chunk_cross_fade_frames(
+        4800, 4800, kSampleRate, AudioChunkJoinSpec{}.cross_fade_seconds);
+    engine::test::require_eq(fade_frames, static_cast<int64_t>(240), "10 ms at 24 kHz is 240 frames");
+    engine::test::require_eq(
+        faded.samples.size(),
+        static_cast<size_t>(9600 - 240),
+        "equal-power join overlaps by the fade length");
+
+    const float reduction_db = to_db(peak_first_difference(faded.samples) / spliced_peak);
+    engine::test::require(
+        reduction_db < -46.0F && reduction_db > -47.5F,
+        "10 ms equal-power crossfade reduces the seam impulse by 46-47.5 dB, measured " +
+            std::to_string(reduction_db));
+
+    AudioBuffer cos_squared = make_buffer(1, previous);
+    engine::audio::append_audio_chunk(cos_squared, source, spec_for(AudioChunkJoinMode::CosSquared));
+    const float cos_squared_db = to_db(peak_first_difference(cos_squared.samples) / spliced_peak);
+    engine::test::require(
+        cos_squared_db < -43.0F && cos_squared_db > -44.5F,
+        "10 ms cos-squared crossfade reduces the seam impulse by 43-44.5 dB, measured " +
+            std::to_string(cos_squared_db));
+
+    // The crossfade must not leave a residual step of its own where the blended
+    // region meets the rest of the second chunk.
+    engine::test::require_close(
+        faded.samples[faded.samples.size() - 4561], -0.5F, 1e-5F, "blend ends on the second chunk");
+}
+
+// cos^2 + sin^2 == 1, so the two gains sum to exactly one and identical content
+// passes through the overlap at unity.
+void test_cos_squared_preserves_amplitude_for_correlated_input() {
+    AudioBuffer joined = make_buffer(1, std::vector<float>(2400, 1.0F));
+    const AudioBuffer source = make_buffer(1, std::vector<float>(2400, 1.0F));
+    engine::audio::append_audio_chunk(joined, source, spec_for(AudioChunkJoinMode::CosSquared));
+    engine::test::require_eq(
+        joined.samples.size(), static_cast<size_t>(4560), "cos-squared join length");
+    for (size_t i = 0; i < joined.samples.size(); ++i) {
+        engine::test::require_close(
+            joined.samples[i], 1.0F, 1e-5F, "cos-squared unity gain at sample " + std::to_string(i));
+    }
+}
+
+// The equal-power pair is a constant-*power* fade, so identical content sums to
+// sqrt(2) at the midpoint. That +3.0103 dB is the defining property of the shape,
+// not a defect: it is the price of preserving RMS for the uncorrelated content a
+// real chunk seam carries. Asserted so it cannot be "fixed" by accident.
+void test_equal_power_correlated_midpoint_is_three_db() {
+    AudioBuffer joined = make_buffer(1, std::vector<float>(2400, 1.0F));
+    const AudioBuffer source = make_buffer(1, std::vector<float>(2400, 1.0F));
+    engine::audio::append_audio_chunk(joined, source, spec_for(AudioChunkJoinMode::EqualPower));
+    float peak = 0.0F;
+    float trough = 2.0F;
+    for (const float value : joined.samples) {
+        peak = std::max(peak, value);
+        trough = std::min(trough, value);
+    }
+    engine::test::require_close(peak, 1.41421356F, 1e-3F, "equal-power correlated peak is sqrt(2)");
+    engine::test::require_close(to_db(peak), 3.0103F, 0.01F, "equal-power correlated peak in dB");
+    engine::test::require_close(trough, 1.0F, 1e-5F, "equal-power never attenuates correlated input");
+}
+
+// The property that matters at a real seam: the two chunks are independent, and
+// the fade must hold the level through the overlap.
+void test_equal_power_preserves_level_for_uncorrelated_input() {
+    const auto previous = pseudo_random_noise(48000, 12345U);
+    const auto next = pseudo_random_noise(48000, 987654321U);
+    const AudioBuffer source = make_buffer(1, next);
+
+    AudioBuffer joined = make_buffer(1, previous);
+    engine::audio::append_audio_chunk(joined, source, spec_for(AudioChunkJoinMode::EqualPower, 0.5F));
+    const size_t fade = 12000;
+    const size_t blend_start = previous.size() - fade;
+    const float outside = rms(joined.samples, 0, blend_start);
+    const float inside = rms(joined.samples, blend_start, blend_start + fade);
+    const float level_db = to_db(inside / outside);
+    engine::test::require(
+        std::fabs(level_db) < 0.35F,
+        "equal-power holds level through the overlap for uncorrelated input, measured " +
+            std::to_string(level_db) + " dB");
+
+    // The complementary result: cos-squared is amplitude-complementary, so it dips
+    // for uncorrelated content. This is why Auto resolves to equal power.
+    AudioBuffer cos_squared = make_buffer(1, previous);
+    engine::audio::append_audio_chunk(
+        cos_squared, source, spec_for(AudioChunkJoinMode::CosSquared, 0.5F));
+    const float cos_squared_db =
+        to_db(rms(cos_squared.samples, blend_start, blend_start + fade) / outside);
+    engine::test::require(
+        cos_squared_db < -0.7F && cos_squared_db > -1.7F,
+        "cos-squared dips about 1.2 dB for uncorrelated input, measured " +
+            std::to_string(cos_squared_db) + " dB");
+}
+
+void test_concat_mode_reproduces_the_historical_join() {
+    const std::vector<float> previous = {0.1F, 0.2F, 0.3F};
+    const std::vector<float> next = {-0.9F, 0.4F};
+    AudioBuffer joined = make_buffer(1, previous);
+    engine::audio::append_audio_chunk(joined, make_buffer(1, next), spec_for(AudioChunkJoinMode::Concat));
+    engine::test::require_eq(joined.samples.size(), static_cast<size_t>(5), "concat length");
+    const std::vector<float> expected = {0.1F, 0.2F, 0.3F, -0.9F, 0.4F};
+    for (size_t i = 0; i < expected.size(); ++i) {
+        engine::test::require(
+            joined.samples[i] == expected[i], "concat sample " + std::to_string(i));
+    }
+}
+
+void test_join_crossfades_each_channel_of_interleaved_audio() {
+    // Stereo: left steps 0.6 -> -0.6, right holds 0.0. 4 frames per chunk, fade 2.
+    AudioBuffer joined = make_buffer(2, {0.6F, 0.0F, 0.6F, 0.0F, 0.6F, 0.0F, 0.6F, 0.0F});
+    const AudioBuffer source = make_buffer(2, {-0.6F, 0.0F, -0.6F, 0.0F, -0.6F, 0.0F, -0.6F, 0.0F});
+    const float two_frames_seconds = 2.0F / static_cast<float>(kSampleRate);
+    engine::audio::append_audio_chunk(
+        joined, source, spec_for(AudioChunkJoinMode::EqualPower, two_frames_seconds));
+
+    engine::test::require_eq(joined.samples.size(), static_cast<size_t>(12), "stereo join sample count");
+    engine::test::require_eq(
+        joined.samples.size() / 2, static_cast<size_t>(6), "stereo join frame count is 4 + 4 - 2");
+    // Frame 2 is the first blend frame: fade_out 1, fade_in 0.
+    engine::test::require_close(joined.samples[4], 0.6F, 1e-5F, "stereo blend starts on chunk one");
+    // Frame 3 is the last blend frame: fade_out 0, fade_in 1.
+    engine::test::require_close(joined.samples[6], -0.6F, 1e-5F, "stereo blend ends on chunk two");
+    for (size_t frame = 0; frame < 6; ++frame) {
+        engine::test::require_close(
+            joined.samples[frame * 2 + 1], 0.0F, 1e-6F,
+            "stereo right channel stays silent at frame " + std::to_string(frame));
+    }
+}
+
+void test_fade_length_is_clamped_to_the_shorter_chunk() {
+    engine::test::require_eq(
+        engine::audio::resolve_chunk_cross_fade_frames(4800, 4800, kSampleRate, 0.010F),
+        static_cast<int64_t>(240),
+        "10 ms fade at 24 kHz");
+    engine::test::require_eq(
+        engine::audio::resolve_chunk_cross_fade_frames(100, 4800, kSampleRate, 0.010F),
+        static_cast<int64_t>(100),
+        "fade clamped to the shorter previous chunk");
+    engine::test::require_eq(
+        engine::audio::resolve_chunk_cross_fade_frames(4800, 40, kSampleRate, 0.010F),
+        static_cast<int64_t>(40),
+        "fade clamped to the shorter next chunk");
+    engine::test::require_eq(
+        engine::audio::resolve_chunk_cross_fade_frames(4800, 4800, kSampleRate, 0.0F),
+        static_cast<int64_t>(0),
+        "zero duration disables the fade");
+
+    // A 20-sample chunk joined with a 10 ms request must not be consumed.
+    AudioBuffer joined = make_buffer(1, std::vector<float>(20, 0.5F));
+    engine::audio::append_audio_chunk(
+        joined, make_buffer(1, std::vector<float>(4800, -0.5F)), AudioChunkJoinSpec{});
+    engine::test::require_eq(
+        joined.samples.size(), static_cast<size_t>(4800), "short chunk join length is 20 + 4800 - 20");
+}
+
+void test_single_frame_chunks_are_never_shortened() {
+    AudioBuffer joined = make_buffer(1, {0.9F});
+    engine::audio::append_audio_chunk(joined, make_buffer(1, {-0.9F}), AudioChunkJoinSpec{});
+    engine::test::require_eq(
+        joined.samples.size(), static_cast<size_t>(2), "a one-frame chunk is spliced, not consumed");
+    engine::test::require(joined.samples[0] == 0.9F, "one-frame splice keeps the tail sample");
+    engine::test::require(joined.samples[1] == -0.9F, "one-frame splice keeps the head sample");
+}
+
+void test_zero_duration_falls_back_to_a_splice() {
+    AudioBuffer joined = make_buffer(1, std::vector<float>(480, 0.5F));
+    engine::audio::append_audio_chunk(
+        joined,
+        make_buffer(1, std::vector<float>(480, -0.5F)),
+        spec_for(AudioChunkJoinMode::EqualPower, 0.0F));
+    engine::test::require_eq(
+        joined.samples.size(), static_cast<size_t>(960), "zero-duration crossfade splices");
+}
+
+void test_join_adopts_and_validates_format() {
+    AudioBuffer joined;
+    engine::audio::append_audio_chunk(joined, make_buffer(2, {0.1F, 0.2F}), AudioChunkJoinSpec{});
+    engine::test::require_eq(joined.sample_rate, kSampleRate, "empty destination adopts sample rate");
+    engine::test::require_eq(joined.channels, 2, "empty destination adopts channel count");
+
+    bool threw = false;
+    try {
+        AudioBuffer mismatched = make_buffer(1, {0.1F});
+        AudioBuffer other = make_buffer(1, {0.2F});
+        other.sample_rate = 48000;
+        engine::audio::append_audio_chunk(mismatched, other, AudioChunkJoinSpec{});
+    } catch (const std::exception &) {
+        threw = true;
+    }
+    engine::test::require(threw, "sample-rate mismatch rejected");
+
+    threw = false;
+    try {
+        AudioBuffer mismatched = make_buffer(1, {0.1F});
+        engine::audio::append_audio_chunk(mismatched, make_buffer(2, {0.2F, 0.3F}), AudioChunkJoinSpec{});
+    } catch (const std::exception &) {
+        threw = true;
+    }
+    engine::test::require(threw, "channel-count mismatch rejected");
+
+    threw = false;
+    try {
+        AudioBuffer mismatched = make_buffer(1, {0.1F});
+        AudioBuffer invalid = make_buffer(1, {0.2F});
+        invalid.sample_rate = 0;
+        engine::audio::append_audio_chunk(mismatched, invalid, AudioChunkJoinSpec{});
+    } catch (const std::exception &) {
+        threw = true;
+    }
+    engine::test::require(threw, "invalid source format rejected");
+}
+
+void test_seam_step_measurement() {
+    engine::test::require_close(
+        engine::audio::measure_chunk_seam_step(make_buffer(1, {0.0F, 0.25F}), make_buffer(1, {-0.25F})),
+        0.5F,
+        1e-6F,
+        "mono seam step");
+    engine::test::require_close(
+        engine::audio::measure_chunk_seam_step(
+            make_buffer(2, {0.0F, 0.0F, 0.1F, 0.4F}), make_buffer(2, {0.1F, -0.4F})),
+        0.8F,
+        1e-6F,
+        "stereo seam step takes the worst channel");
+    engine::test::require_close(
+        engine::audio::measure_chunk_seam_step(make_buffer(1, {}), make_buffer(1, {0.5F})),
+        0.0F,
+        1e-9F,
+        "empty previous chunk has no seam");
+}
+
+// runtime::append_audio_buffer is the shared entry point all ~28 chunked models
+// call. The two-argument form must take the Auto default, and the three-argument
+// form must let a caller pin the historical splice.
+void test_runtime_append_audio_buffer_routes_through_the_join() {
+    AudioBuffer silent_seam = make_buffer(1, std::vector<float>(4800, 0.0F));
+    engine::runtime::append_audio_buffer(silent_seam, make_buffer(1, std::vector<float>(4800, 0.0F)));
+    engine::test::require_eq(
+        silent_seam.samples.size(),
+        static_cast<size_t>(9600),
+        "two-argument append splices a silent seam");
+
+    AudioBuffer discontinuous = make_buffer(1, std::vector<float>(4800, 0.5F));
+    engine::runtime::append_audio_buffer(discontinuous, make_buffer(1, std::vector<float>(4800, -0.5F)));
+    engine::test::require_eq(
+        discontinuous.samples.size(),
+        static_cast<size_t>(9360),
+        "two-argument append crossfades a discontinuous seam");
+
+    AudioBuffer pinned = make_buffer(1, std::vector<float>(4800, 0.5F));
+    engine::runtime::append_audio_buffer(
+        pinned, make_buffer(1, std::vector<float>(4800, -0.5F)), spec_for(AudioChunkJoinMode::Concat));
+    engine::test::require_eq(
+        pinned.samples.size(),
+        static_cast<size_t>(9600),
+        "three-argument append can pin the historical splice");
+    engine::test::require(pinned.samples[4799] == 0.5F, "pinned splice keeps the tail sample");
+    engine::test::require(pinned.samples[4800] == -0.5F, "pinned splice keeps the head sample");
+}
+
+void test_join_option_parsing() {
+    engine::test::require(
+        engine::audio::parse_audio_chunk_join_mode("auto") == AudioChunkJoinMode::Auto,
+        "auto mode parsed");
+    engine::test::require(
+        engine::audio::parse_audio_chunk_join_mode("concat") == AudioChunkJoinMode::Concat,
+        "concat mode parsed");
+    engine::test::require(
+        engine::audio::parse_audio_chunk_join_mode("none") == AudioChunkJoinMode::Concat,
+        "none is an alias for concat");
+    engine::test::require(
+        engine::audio::parse_audio_chunk_join_mode("equal_power") == AudioChunkJoinMode::EqualPower,
+        "equal_power mode parsed");
+    engine::test::require(
+        engine::audio::parse_audio_chunk_join_mode("cos-squared") == AudioChunkJoinMode::CosSquared,
+        "cos-squared mode parsed");
+
+    bool threw = false;
+    try {
+        (void)engine::audio::parse_audio_chunk_join_mode("triangle");
+    } catch (const std::exception &) {
+        threw = true;
+    }
+    engine::test::require(threw, "unknown join mode rejected");
+
+    const AudioChunkJoinSpec defaults = engine::audio::parse_audio_chunk_join_spec({});
+    engine::test::require(defaults.mode == AudioChunkJoinMode::Auto, "default join mode is auto");
+    engine::test::require_close(defaults.cross_fade_seconds, 0.010F, 1e-9F, "default fade is 10 ms");
+    engine::test::require_close(defaults.silent_seam_step, 0.002F, 1e-9F, "default silent seam gate");
+    engine::test::require_close(defaults.seam_slew_ratio, 2.0F, 1e-9F, "default seam slew ratio");
+    engine::test::require_eq(
+        defaults.seam_slew_window_frames, static_cast<int64_t>(64), "default seam slew window");
+
+    const std::unordered_map<std::string, std::string> options = {
+        {"audio_chunk_join", "cos_squared"},
+        {"cross_fade_duration_sec", "0.05"},
+    };
+    const AudioChunkJoinSpec parsed = engine::audio::parse_audio_chunk_join_spec(options);
+    engine::test::require(parsed.mode == AudioChunkJoinMode::CosSquared, "join mode option honoured");
+    engine::test::require_close(parsed.cross_fade_seconds, 0.05F, 1e-6F, "fade duration option honoured");
+}
+
+}  // namespace
+
+int main() {
+    try {
+        test_silent_seam_join_is_a_bit_exact_splice();
+        test_near_silent_seam_is_still_spliced();
+        test_continuous_waveform_join_is_a_bit_exact_splice();
+        test_edge_slew_measurement();
+        test_discontinuous_seam_impulse_is_reduced_by_a_measured_amount();
+        test_cos_squared_preserves_amplitude_for_correlated_input();
+        test_equal_power_correlated_midpoint_is_three_db();
+        test_equal_power_preserves_level_for_uncorrelated_input();
+        test_concat_mode_reproduces_the_historical_join();
+        test_join_crossfades_each_channel_of_interleaved_audio();
+        test_fade_length_is_clamped_to_the_shorter_chunk();
+        test_single_frame_chunks_are_never_shortened();
+        test_zero_duration_falls_back_to_a_splice();
+        test_join_adopts_and_validates_format();
+        test_seam_step_measurement();
+        test_runtime_append_audio_buffer_routes_through_the_join();
+        test_join_option_parsing();
+        std::cout << "audio_chunk_join_test passed\n";
+    } catch (const std::exception & ex) {
+        std::cerr << "audio_chunk_join_test failed: " << ex.what() << "\n";
+        return 1;
+    }
+    return 0;
+}

--- a/tests/unittests/test_text_chunking.cpp
+++ b/tests/unittests/test_text_chunking.cpp
@@ -1,0 +1,470 @@
+#include "engine/framework/text/chunking.h"
+
+#include "engine/framework/text/utf8.h"
+
+#include "test_assert.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+using engine::text::TextChunkMode;
+
+void require_chunks(
+    const std::vector<std::string> & actual,
+    const std::vector<std::string> & expected,
+    const std::string & label) {
+    engine::test::require_eq(actual.size(), expected.size(), label + " chunk count");
+    for (size_t i = 0; i < expected.size(); ++i) {
+        engine::test::require_eq(actual[i], expected[i], label + " chunk " + std::to_string(i));
+    }
+}
+
+std::vector<uint32_t> to_codepoints(const std::string & text, const std::string & label) {
+    std::vector<uint32_t> out;
+    for (size_t pos = 0; pos < text.size();) {
+        const auto lead = static_cast<unsigned char>(text[pos]);
+        size_t width = 0;
+        uint32_t value = 0;
+        if (lead <= 0x7FU) {
+            width = 1;
+            value = lead;
+        } else if ((lead & 0xE0U) == 0xC0U) {
+            width = 2;
+            value = lead & 0x1FU;
+        } else if ((lead & 0xF0U) == 0xE0U) {
+            width = 3;
+            value = lead & 0x0FU;
+        } else if ((lead & 0xF8U) == 0xF0U) {
+            width = 4;
+            value = lead & 0x07U;
+        } else {
+            throw std::runtime_error(label + " starts a codepoint on a continuation byte");
+        }
+        if (pos + width > text.size()) {
+            throw std::runtime_error(label + " ends inside a multi-byte codepoint");
+        }
+        for (size_t i = 1; i < width; ++i) {
+            const auto continuation = static_cast<unsigned char>(text[pos + i]);
+            if (!engine::text::is_utf8_continuation(continuation)) {
+                throw std::runtime_error(label + " has a torn multi-byte codepoint");
+            }
+            value = (value << 6U) | (continuation & 0x3FU);
+        }
+        out.push_back(value);
+        pos += width;
+    }
+    return out;
+}
+
+// Every chunk must be standalone-valid UTF-8, and concatenating the chunks must
+// reproduce the original codepoint sequence minus the ASCII whitespace the
+// splitter is allowed to drop between chunks.
+void require_lossless_codepoint_split(
+    const std::string & source,
+    const std::vector<std::string> & chunks,
+    const std::string & label) {
+    std::vector<uint32_t> rejoined;
+    for (size_t i = 0; i < chunks.size(); ++i) {
+        const auto chunk = to_codepoints(chunks[i], label + " chunk " + std::to_string(i));
+        engine::test::require(!chunk.empty(), label + " produced an empty chunk");
+        rejoined.insert(rejoined.end(), chunk.begin(), chunk.end());
+    }
+    std::vector<uint32_t> expected;
+    for (const uint32_t codepoint : to_codepoints(source, label + " source")) {
+        if (codepoint == 0x20U || codepoint == 0x09U || codepoint == 0x0AU ||
+            codepoint == 0x0DU || codepoint == 0x0BU || codepoint == 0x0CU) {
+            continue;
+        }
+        expected.push_back(codepoint);
+    }
+    std::vector<uint32_t> observed;
+    for (const uint32_t codepoint : rejoined) {
+        if (codepoint == 0x20U || codepoint == 0x09U || codepoint == 0x0AU ||
+            codepoint == 0x0DU || codepoint == 0x0BU || codepoint == 0x0CU) {
+            continue;
+        }
+        observed.push_back(codepoint);
+    }
+    engine::test::require_eq(observed.size(), expected.size(), label + " codepoint count round-trip");
+    for (size_t i = 0; i < expected.size(); ++i) {
+        engine::test::require_eq(observed[i], expected[i], label + " codepoint " + std::to_string(i));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// F6.3 regression guard.
+//
+// Every expectation below was captured from the splitter as it behaved before
+// CJK-aware splitting was added, so any change to where Latin-script text splits
+// fails here. ~28 models join their chunk audio at these boundaries; moving one
+// changes their output.
+// ---------------------------------------------------------------------------
+
+void test_ascii_default_splits_are_unchanged() {
+    require_chunks(
+        engine::text::split_text_chunks("Hello world.", 100),
+        {"Hello world."},
+        "short ascii");
+
+    require_chunks(
+        engine::text::split_text_chunks(
+            "The quick brown fox jumps over the lazy dog. Pack my box with five dozen liquor jugs.", 50),
+        {"The quick brown fox jumps over the lazy dog.", "Pack my box with five dozen liquor jugs."},
+        "ascii sentence break");
+
+    require_chunks(
+        engine::text::split_text_chunks(
+            "One two three, four five six, seven eight nine, ten eleven twelve", 20),
+        {"One two three,", "four five six,", "seven eight nine,", "ten eleven twelve"},
+        "ascii clause break");
+
+    require_chunks(
+        engine::text::split_text_chunks(
+            "alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo lima mike", 20),
+        {"alpha bravo charlie", "delta echo foxtrot", "golf hotel india", "juliet kilo lima", "mike"},
+        "ascii unpunctuated");
+
+    // An over-long ASCII word keeps the historical whole-word escape hatch: it is
+    // emitted verbatim rather than cut at the budget.
+    require_chunks(
+        engine::text::split_text_chunks(
+            "supercalifragilisticexpialidociousandthensomeextraletters tail", 10),
+        {"supercalifragilisticexpialidociousandthensomeextraletters", "tail"},
+        "ascii over-long word");
+
+    require_chunks(
+        engine::text::split_text_chunks(
+            "See https://example.com/a/very/long/path/that/never/ends/at/all now", 16),
+        {"See", "https://example.com/a/very/long/path/that/never/ends/at/all", "now"},
+        "ascii url");
+
+    require_chunks(
+        engine::text::split_text_chunks("a b c d e", 1),
+        {"a", "b", "c", "d", "e"},
+        "ascii budget one");
+
+    require_chunks(
+        engine::text::split_text_chunks("abc def ghi jkl", 3),
+        {"abc", "def", "ghi", "jkl"},
+        "ascii budget three");
+
+    require_chunks(
+        engine::text::split_text_chunks("Line one.\nLine two.\nLine three is a bit longer here.", 18),
+        {"Line one.", "Line two.", "Line three is a", "bit longer here."},
+        "ascii newlines");
+
+    require_chunks(
+        engine::text::split_text_chunks("one\ttwo\tthree\tfour\tfive\tsix", 9),
+        {"one\ttwo", "three", "four\tfive", "six"},
+        "ascii tabs");
+
+    require_chunks(
+        engine::text::split_text_chunks("one   two    three     four", 9),
+        {"one   two", "three", "four"},
+        "ascii runs of spaces");
+
+    require_chunks(
+        engine::text::split_text_chunks("   padded text with spaces around   ", 12),
+        {"padded text", "with spaces", "around"},
+        "ascii outer whitespace");
+
+    require_chunks(
+        engine::text::split_text_chunks("abcdefghij", 10),
+        {"abcdefghij"},
+        "ascii exactly at budget");
+
+    require_chunks(
+        engine::text::split_text_chunks("abcdefghijk", 10),
+        {"abcdefghijk"},
+        "ascii one over budget");
+
+    require_chunks(
+        engine::text::split_text_chunks("\"Hello,\" she said. \"How are you today?\" He shrugged.", 20),
+        {"\"Hello,\" she said.", "\"How are you today?\"", "He shrugged."},
+        "ascii dialogue");
+
+    require_chunks(
+        engine::text::split_text_chunks("first part; second part; third part; fourth part", 15),
+        {"first part;", "second part;", "third part;", "fourth part"},
+        "ascii semicolons");
+
+    require_chunks(
+        engine::text::split_text_chunks("1 22 333 4444 55555 666666 7777777 88888888", 12),
+        {"1 22 333", "4444 55555", "666666", "7777777", "88888888"},
+        "ascii numbers");
+
+    require_chunks(
+        engine::text::split_text_chunks("Wait... really? Yes! Absolutely, without a doubt.", 18),
+        {"Wait... really?", "Yes! Absolutely,", "without a doubt."},
+        "ascii mixed punctuation");
+
+    require_chunks(engine::text::split_text_chunks("hello", 5), {"hello"}, "ascii single word");
+    require_chunks(engine::text::split_text_chunks("", 10), {}, "ascii empty");
+    require_chunks(engine::text::split_text_chunks("     ", 10), {}, "ascii whitespace only");
+
+    // Latin-1 supplement and Cyrillic are multi-byte but space-delimited, so the
+    // word splitter still applies and nothing about them changed either.
+    require_chunks(
+        engine::text::split_text_chunks("caf\xC3\xA9 na\xC3\xAF" "ve r\xC3\xA9sum\xC3\xA9 jalape\xC3\xB1o", 8),
+        {"caf\xC3\xA9", "na\xC3\xAF" "ve", "r\xC3\xA9sum\xC3\xA9", "jalape\xC3\xB1o"},
+        "latin accents");
+
+    require_chunks(
+        engine::text::split_text_chunks(
+            "\xD0\x9F\xD1\x80\xD0\xB8\xD0\xB2\xD0\xB5\xD1\x82 \xD0\xBC\xD0\xB8\xD1\x80 "
+            "\xD0\xBA\xD0\xB0\xD0\xBA \xD0\xB4\xD0\xB5\xD0\xBB\xD0\xB0 "
+            "\xD1\x81\xD0\xB5\xD0\xB3\xD0\xBE\xD0\xB4\xD0\xBD\xD1\x8F",
+            8),
+        {"\xD0\x9F\xD1\x80\xD0\xB8\xD0\xB2\xD0\xB5\xD1\x82",
+         "\xD0\xBC\xD0\xB8\xD1\x80 \xD0\xBA\xD0\xB0\xD0\xBA",
+         "\xD0\xB4\xD0\xB5\xD0\xBB\xD0\xB0",
+         "\xD1\x81\xD0\xB5\xD0\xB3\xD0\xBE\xD0\xB4\xD0\xBD\xD1\x8F"},
+        "cyrillic");
+}
+
+void test_ascii_two_argument_and_default_mode_agree() {
+    const char * text = "One two three, four five six, seven eight nine, ten eleven twelve";
+    const auto implicit = engine::text::split_text_chunks(text, 20);
+    const auto explicit_default = engine::text::split_text_chunks(text, 20, TextChunkMode::Default);
+    require_chunks(explicit_default, implicit, "default mode overload agreement");
+}
+
+void test_tag_aware_and_endline_modes_are_unchanged() {
+    require_chunks(
+        engine::text::split_text_chunks(
+            "[laugh] hello there my friend how are you [sigh] doing today",
+            15,
+            TextChunkMode::TagAware),
+        {"[laugh] hello", "there my friend", "how are you", "[sigh] doing", "today"},
+        "tag aware");
+
+    require_chunks(
+        engine::text::split_text_chunks(
+            "First line.\nSecond line here.\nThird line is longer than the rest.",
+            20,
+            TextChunkMode::Endline),
+        {"First line.", "Second line here.", "Third line is longer", "than the rest."},
+        "endline");
+}
+
+// ---------------------------------------------------------------------------
+// F6.3 fix.
+// ---------------------------------------------------------------------------
+
+void test_chinese_text_splits_at_sentence_punctuation() {
+    // 这是第一句话。这是第二句话。这是第三句话。 — 21 codepoints, no ASCII space.
+    const std::string text =
+        "\xE8\xBF\x99\xE6\x98\xAF\xE7\xAC\xAC\xE4\xB8\x80\xE5\x8F\xA5\xE8\xAF\x9D\xE3\x80\x82"
+        "\xE8\xBF\x99\xE6\x98\xAF\xE7\xAC\xAC\xE4\xBA\x8C\xE5\x8F\xA5\xE8\xAF\x9D\xE3\x80\x82"
+        "\xE8\xBF\x99\xE6\x98\xAF\xE7\xAC\xAC\xE4\xB8\x89\xE5\x8F\xA5\xE8\xAF\x9D\xE3\x80\x82";
+    const auto chunks = engine::text::split_text_chunks(text, 10);
+    engine::test::require(chunks.size() > 1, "Chinese text must not collapse to one chunk");
+    require_chunks(
+        chunks,
+        {"\xE8\xBF\x99\xE6\x98\xAF\xE7\xAC\xAC\xE4\xB8\x80\xE5\x8F\xA5\xE8\xAF\x9D\xE3\x80\x82",
+         "\xE8\xBF\x99\xE6\x98\xAF\xE7\xAC\xAC\xE4\xBA\x8C\xE5\x8F\xA5\xE8\xAF\x9D\xE3\x80\x82",
+         "\xE8\xBF\x99\xE6\x98\xAF\xE7\xAC\xAC\xE4\xB8\x89\xE5\x8F\xA5\xE8\xAF\x9D\xE3\x80\x82"},
+        "chinese sentence split");
+    require_lossless_codepoint_split(text, chunks, "chinese sentence split");
+    for (const auto & chunk : chunks) {
+        engine::test::require_eq(
+            engine::text::utf8_codepoint_count(chunk, "chinese chunk"),
+            static_cast<size_t>(7),
+            "chinese chunk is one sentence");
+    }
+}
+
+void test_chinese_text_falls_back_to_clause_punctuation() {
+    // 一二三，四五六，七八九，十 — 13 codepoints, only clause breaks.
+    const std::string text =
+        "\xE4\xB8\x80\xE4\xBA\x8C\xE4\xB8\x89\xEF\xBC\x8C"
+        "\xE5\x9B\x9B\xE4\xBA\x94\xE5\x85\xAD\xEF\xBC\x8C"
+        "\xE4\xB8\x83\xE5\x85\xAB\xE4\xB9\x9D\xEF\xBC\x8C\xE5\x8D\x81";
+    const auto chunks = engine::text::split_text_chunks(text, 6);
+    require_chunks(
+        chunks,
+        {"\xE4\xB8\x80\xE4\xBA\x8C\xE4\xB8\x89\xEF\xBC\x8C",
+         "\xE5\x9B\x9B\xE4\xBA\x94\xE5\x85\xAD\xEF\xBC\x8C",
+         "\xE4\xB8\x83\xE5\x85\xAB\xE4\xB9\x9D\xEF\xBC\x8C\xE5\x8D\x81"},
+        "chinese clause split");
+    require_lossless_codepoint_split(text, chunks, "chinese clause split");
+}
+
+void test_unpunctuated_cjk_splits_at_the_budget() {
+    // 一二三四五六七八九十一二三四五 — 15 codepoints, no punctuation at all.
+    const std::string text =
+        "\xE4\xB8\x80\xE4\xBA\x8C\xE4\xB8\x89\xE5\x9B\x9B\xE4\xBA\x94"
+        "\xE5\x85\xAD\xE4\xB8\x83\xE5\x85\xAB\xE4\xB9\x9D\xE5\x8D\x81"
+        "\xE4\xB8\x80\xE4\xBA\x8C\xE4\xB8\x89\xE5\x9B\x9B\xE4\xBA\x94";
+    const auto chunks = engine::text::split_text_chunks(text, 6);
+    engine::test::require_eq(chunks.size(), static_cast<size_t>(3), "unpunctuated CJK chunk count");
+    engine::test::require_eq(
+        engine::text::utf8_codepoint_count(chunks[0], "cjk chunk"),
+        static_cast<size_t>(6),
+        "first unpunctuated CJK chunk fills the budget");
+    engine::test::require_eq(
+        engine::text::utf8_codepoint_count(chunks[1], "cjk chunk"),
+        static_cast<size_t>(6),
+        "second unpunctuated CJK chunk fills the budget");
+    engine::test::require_eq(
+        engine::text::utf8_codepoint_count(chunks[2], "cjk chunk"),
+        static_cast<size_t>(3),
+        "final unpunctuated CJK chunk holds the remainder");
+    require_lossless_codepoint_split(text, chunks, "unpunctuated CJK");
+}
+
+void test_mixed_ascii_and_cjk_only_splits_the_cjk_run() {
+    // "Hello 世界世界世界世界世界 world" — the CJK run is the only over-long word.
+    const std::string text =
+        "Hello \xE4\xB8\x96\xE7\x95\x8C\xE4\xB8\x96\xE7\x95\x8C\xE4\xB8\x96\xE7\x95\x8C"
+        "\xE4\xB8\x96\xE7\x95\x8C\xE4\xB8\x96\xE7\x95\x8C world";
+    const auto chunks = engine::text::split_text_chunks(text, 6);
+    require_chunks(
+        chunks,
+        {"Hello",
+         "\xE4\xB8\x96\xE7\x95\x8C\xE4\xB8\x96\xE7\x95\x8C\xE4\xB8\x96\xE7\x95\x8C",
+         "\xE4\xB8\x96\xE7\x95\x8C\xE4\xB8\x96\xE7\x95\x8C",
+         "world"},
+        "mixed ascii and cjk");
+    require_lossless_codepoint_split(text, chunks, "mixed ascii and cjk");
+}
+
+void test_hangul_and_fullwidth_are_treated_as_space_free() {
+    // 한국어문장입니다한국어문장입니다 — 16 Hangul syllables.
+    const std::string hangul =
+        "\xED\x95\x9C\xEA\xB5\xAD\xEC\x96\xB4\xEB\xAC\xB8\xEC\x9E\xA5"
+        "\xEC\x9E\x85\xEB\x8B\x88\xEB\x8B\xA4"
+        "\xED\x95\x9C\xEA\xB5\xAD\xEC\x96\xB4\xEB\xAC\xB8\xEC\x9E\xA5"
+        "\xEC\x9E\x85\xEB\x8B\x88\xEB\x8B\xA4";
+    const auto hangul_chunks = engine::text::split_text_chunks(hangul, 5);
+    engine::test::require_eq(hangul_chunks.size(), static_cast<size_t>(4), "hangul chunk count");
+    require_lossless_codepoint_split(hangul, hangul_chunks, "hangul");
+
+    // Ｈｅｌｌｏ！Ｗｏｒｌｄ！ — fullwidth forms, including fullwidth '!'.
+    const std::string fullwidth =
+        "\xEF\xBC\xA8\xEF\xBD\x85\xEF\xBD\x8C\xEF\xBD\x8C\xEF\xBD\x8F\xEF\xBC\x81"
+        "\xEF\xBC\xB7\xEF\xBD\x8F\xEF\xBD\x92\xEF\xBD\x8C\xEF\xBD\x84\xEF\xBC\x81";
+    const auto fullwidth_chunks = engine::text::split_text_chunks(fullwidth, 5);
+    engine::test::require_eq(fullwidth_chunks.size(), static_cast<size_t>(3), "fullwidth chunk count");
+    require_lossless_codepoint_split(fullwidth, fullwidth_chunks, "fullwidth");
+}
+
+void test_four_byte_codepoints_are_never_split() {
+    // U+20000..U+20007, CJK extension B — eight 4-byte codepoints, no punctuation.
+    std::string text;
+    for (unsigned char last = 0x80U; last < 0x88U; ++last) {
+        text.push_back(static_cast<char>(0xF0));
+        text.push_back(static_cast<char>(0xA0));
+        text.push_back(static_cast<char>(0x80));
+        text.push_back(static_cast<char>(last));
+    }
+    const auto chunks = engine::text::split_text_chunks(text, 3);
+    engine::test::require_eq(chunks.size(), static_cast<size_t>(3), "extension B chunk count");
+    engine::test::require_eq(chunks[0].size(), static_cast<size_t>(12), "extension B chunk 0 byte length");
+    engine::test::require_eq(chunks[1].size(), static_cast<size_t>(12), "extension B chunk 1 byte length");
+    engine::test::require_eq(chunks[2].size(), static_cast<size_t>(8), "extension B chunk 2 byte length");
+    require_lossless_codepoint_split(text, chunks, "extension B");
+}
+
+void test_combining_kana_marks_stay_with_their_base() {
+    // か+U+3099 き+U+3099 く+U+3099 け+U+3099 こ+U+3099 か+U+3099 き+U+3099
+    // 14 codepoints, 7 grapheme clusters. A budget of 3 lands the raw boundary on
+    // the combining mark, which must never start a chunk.
+    const std::string text =
+        "\xE3\x81\x8B\xE3\x82\x99\xE3\x81\x8D\xE3\x82\x99\xE3\x81\x8F\xE3\x82\x99"
+        "\xE3\x81\x91\xE3\x82\x99\xE3\x81\x93\xE3\x82\x99\xE3\x81\x8B\xE3\x82\x99"
+        "\xE3\x81\x8D\xE3\x82\x99";
+    const std::vector<std::string> expected = {
+        "\xE3\x81\x8B\xE3\x82\x99",
+        "\xE3\x81\x8D\xE3\x82\x99",
+        "\xE3\x81\x8F\xE3\x82\x99",
+        "\xE3\x81\x91\xE3\x82\x99",
+        "\xE3\x81\x93\xE3\x82\x99",
+        "\xE3\x81\x8B\xE3\x82\x99",
+        "\xE3\x81\x8D\xE3\x82\x99",
+    };
+    require_chunks(engine::text::split_text_chunks(text, 3), expected, "default mode kana clusters");
+    require_chunks(
+        engine::text::split_text_chunks(text, 3, TextChunkMode::Japanese),
+        expected,
+        "japanese mode kana clusters");
+    for (const auto & chunk : expected) {
+        engine::test::require(
+            static_cast<unsigned char>(chunk[0]) != 0xE3U ||
+                static_cast<unsigned char>(chunk[1]) != 0x82U ||
+                static_cast<unsigned char>(chunk[2]) != 0x99U,
+            "no chunk starts with a combining kana mark");
+    }
+}
+
+void test_japanese_mode_output_is_unchanged() {
+    // これはテストです。ありがとうございます。 — 20 codepoints.
+    const std::string text =
+        "\xE3\x81\x93\xE3\x82\x8C\xE3\x81\xAF\xE3\x83\x86\xE3\x82\xB9\xE3\x83\x88"
+        "\xE3\x81\xA7\xE3\x81\x99\xE3\x80\x82"
+        "\xE3\x81\x82\xE3\x82\x8A\xE3\x81\x8C\xE3\x81\xA8\xE3\x81\x86\xE3\x81\x94"
+        "\xE3\x81\x96\xE3\x81\x84\xE3\x81\xBE\xE3\x81\x99\xE3\x80\x82";
+    require_chunks(
+        engine::text::split_text_chunks(text, 8, TextChunkMode::Japanese),
+        {"\xE3\x81\x93\xE3\x82\x8C\xE3\x81\xAF\xE3\x83\x86\xE3\x82\xB9\xE3\x83\x88"
+         "\xE3\x81\xA7\xE3\x81\x99",
+         "\xE3\x80\x82\xE3\x81\x82\xE3\x82\x8A\xE3\x81\x8C\xE3\x81\xA8\xE3\x81\x86"
+         "\xE3\x81\x94\xE3\x81\x96",
+         "\xE3\x81\x84\xE3\x81\xBE\xE3\x81\x99\xE3\x80\x82"},
+        "japanese mode");
+}
+
+void test_short_cjk_text_is_still_returned_whole() {
+    const std::string text =
+        "\xE4\xB8\x80\xE4\xBA\x8C\xE4\xB8\x89\xE5\x9B\x9B\xE4\xBA\x94";
+    require_chunks(engine::text::split_text_chunks(text, 10), {text}, "short CJK text");
+}
+
+void test_budget_validation() {
+    bool threw = false;
+    try {
+        (void)engine::text::split_text_chunks("some text", 0);
+    } catch (const std::exception &) {
+        threw = true;
+    }
+    engine::test::require(threw, "zero budget rejected");
+
+    threw = false;
+    try {
+        (void)engine::text::split_text_chunks("some text", -4);
+    } catch (const std::exception &) {
+        threw = true;
+    }
+    engine::test::require(threw, "negative budget rejected");
+}
+
+}  // namespace
+
+int main() {
+    try {
+        test_ascii_default_splits_are_unchanged();
+        test_ascii_two_argument_and_default_mode_agree();
+        test_tag_aware_and_endline_modes_are_unchanged();
+        test_chinese_text_splits_at_sentence_punctuation();
+        test_chinese_text_falls_back_to_clause_punctuation();
+        test_unpunctuated_cjk_splits_at_the_budget();
+        test_mixed_ascii_and_cjk_only_splits_the_cjk_run();
+        test_hangul_and_fullwidth_are_treated_as_space_free();
+        test_four_byte_codepoints_are_never_split();
+        test_combining_kana_marks_stay_with_their_base();
+        test_japanese_mode_output_is_unchanged();
+        test_short_cjk_text_is_still_returned_whole();
+        test_budget_validation();
+        std::cout << "text_chunking_test passed\n";
+    } catch (const std::exception & ex) {
+        std::cerr << "text_chunking_test failed: " << ex.what() << "\n";
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
## What this changes

Two chunking defects with wide reach.

### 1. Chunk joins were a raw `insert` in ~28 models

`runtime::append_audio_buffer` is the shared join point — 39 call sites. A seam step of 0.1 is a broadband impulse at −20 dBFS. Correct crossfades already exist in DramaBox (50 ms equal-power), Seed-VC (cos²), Confucius4 and Inflect v2, so the framework's own join was the odd one out.

**The naive fix is wrong, and this is the important part.** `append_audio_buffer` is not only a TTS chunk join: `sense_asr:436`, `qwen3_asr:425`, `voxtral_realtime:308` and `nemotron_asr:433` use it to accumulate *contiguous streaming input*, as do several vocoders. A full-scale 1 kHz tone at 24 kHz steps 0.235 per sample — far above any silence threshold — so a step-only gate would have crossfaded continuous audio, attenuating real signal and **shifting every ASR word timestamp**.

The new `Auto` default therefore measures the seam before touching it:

| Condition | Action |
|---|---|
| step ≤ −54 dBFS | raw splice, byte-identical |
| step within 2× the sample-to-sample slew of the 64 samples either side | raw splice |
| otherwise | 10 ms equal-power crossfade |

Measured seam-impulse reduction on a genuine discontinuity: **−46.66 dB**. A split sine rejoins bit-exactly, which the test asserts.

Equal power rather than cos² for `Auto` because the two sides of a text-chunk seam are uncorrelated: equal-power holds RMS to **+0.056 dB** through the overlap where cos² dips **−1.17 dB**. Both remain selectable, and `AudioChunkJoinMode::Concat` reproduces the previous join sample for sample.

### 2. `split_word_ranges` stops chunking entirely for CJK

It keys on ASCII whitespace only, so space-free text degenerates to a single whole-text chunk. A long Chinese or Japanese input is handed to the model entire and then truncated at the token cap with no error. Affects Qwen3-TTS, Fish Audio and Vevo2.

Adds CJK-aware splitting: on CJK punctuation first, then on codepoint count at grapheme-safe boundaries.

Limited deliberately to CJK/kana/Hangul/fullwidth. Thai, Lao, Khmer and Myanmar have the same failure, but widening the predicate would move output for languages nobody here can test.

## Validation

**Build**
```
cmake -S . -B build -DENGINE_BUILD_TESTS=ON
cmake --build build
```

**Test**
```
ctest -R "audio_chunk_join_test|text_chunking_test"
```

`test_audio_chunk_join.cpp` (17 cases) and `test_text_chunking.cpp` (13 cases).

The ASCII regression guard is **22 exact expectations** covering sentence, clause, no-punctuation, over-long-word, URL, budget-boundary, whitespace and tag-aware cases. It was verified to pass against the pre-change implementation *before* the change landed, so it encodes the old behaviour rather than rationalising the new one. Every CJK chunk is asserted to be standalone-valid UTF-8 and to rejoin to the source codepoint sequence.

**Backend tested:** CPU (host code). Full suite **40/40** on macOS/Metal, Apple M4 Max.

## Affects

Roughly 28 models share the join, so this is the widest-reach change in the set. The slew gate is what keeps `Auto` inert for the four ASR streaming accumulators — that is the case worth a second reviewer's eye, and a long streaming ASR run confirming word timestamps and total sample count are unchanged would be the right acceptance test.

`split_text_chunks_japanese` changes for one case: a boundary landing immediately before a combining mark now backs off one codepoint. Nothing in `src/` or `app/` selects that mode.

## Known limitations

- `Auto`'s thresholds (−54 dBFS, 2× slew) are reasoned from measurements, not perceptually validated. There is no perceptual metric in the repo; if one lands, these two constants are what to re-tune.
- Self-append (`append_audio_buffer(x, x)`) is still UB, exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ATa5YkLUPMDPRL7w1gCo9p