### PR TITLE
transformers: stop copying the whole KV cache on every decode step

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2032,6 +2032,20 @@ if (ENGINE_BUILD_TESTS)
         COMMAND audio_chunking_test
     )
 
+    add_engine_unittest(qwen_attention_modes_test tests/unittests/test_qwen_attention_modes.cpp)
+
+    add_test(
+        NAME qwen_attention_modes_test
+        COMMAND qwen_attention_modes_test
+    )
+
+    add_engine_unittest(graph_optimizer_identity_fold_test tests/unittests/test_graph_optimizer_identity_fold.cpp)
+
+    add_test(
+        NAME graph_optimizer_identity_fold_test
+        COMMAND graph_optimizer_identity_fold_test
+    )
+
     add_engine_unittest(chinese_normalization_test tests/unittests/test_chinese_normalization.cpp)
 
     add_test(

--- a/include/engine/framework/modules/transformers/qwen_decoder.h
+++ b/include/engine/framework/modules/transformers/qwen_decoder.h
@@ -12,6 +12,21 @@ struct ggml_cgraph;
 
 namespace engine::modules {
 
+// Attention lowerings for the Qwen decoder block.
+//
+//   ManualRepeat                 explicit QK^T -> scale/mask -> softmax -> V, with the
+//                                grouped-query K/V heads materialised at full query width.
+//                                Quadratic working set in sequence length; the numerical
+//                                reference path, and the only one that does not require the
+//                                backend to implement GGML_OP_FLASH_ATTN_EXT for this head size.
+//   FlashGrouped                 ggml_flash_attn_ext, with the permuted K/V cache views
+//                                copied into packed tensors (ggml_cont) beforehand.
+//   FlashGroupedViewKV           the same ggml_flash_attn_ext call on the K/V views directly.
+//                                The flash kernels address K/V through nb[1..3] on both the CPU
+//                                and Metal backends, so this is the same arithmetic in the same
+//                                order on the same values as FlashGrouped -- only the copy is
+//                                gone. See tests/unittests/test_qwen_attention_modes.cpp.
+//   ManualRepeatThenGroupedQuery per-head slice/matmul/softmax loop. No model selects it.
 enum class QwenDecoderAttentionMode {
     ManualRepeat,
     FlashGrouped,
@@ -69,8 +84,20 @@ struct QwenDecoderActivationCastPolicy {
 };
 
 struct QwenDecoderAttentionPolicy {
+    // prefill_mode stays on ManualRepeat deliberately. Switching prefill to flash is not a
+    // pure copy elision the way static_mode is: it replaces a materialised softmax with a
+    // fused one (different floating-point reassociation) *and* it introduces a hard backend
+    // requirement -- ggml_flash_attn_ext supports only a fixed whitelist of head sizes on
+    // Metal, and the decode/prefill graphs run on a single backend with no CPU fallback, so an
+    // unsupported head_dim becomes a hard failure rather than a slowdown. Models whose head
+    // size is known-good opt in; minimax_music3's depth decoder already restricts flash prefill
+    // to CUDA/HIP for exactly this reason (src/community_models/minimax_music3/depth_decoder.cpp).
     QwenDecoderAttentionMode prefill_mode = QwenDecoderAttentionMode::ManualRepeat;
-    QwenDecoderAttentionMode static_mode = QwenDecoderAttentionMode::FlashGrouped;
+    // static_mode defaults to the zero-copy flash lowering. FlashGrouped issues the identical
+    // ggml_flash_attn_ext call but copies the whole K/V cache per layer per token first
+    // (~100 MB/token at 24 layers / 2048 steps / f32). Set ENGINE_QWEN_ATTENTION_CONT_KV=1 to
+    // restore the copy at runtime without a rebuild, or select FlashGrouped explicitly.
+    QwenDecoderAttentionMode static_mode = QwenDecoderAttentionMode::FlashGroupedViewKV;
     QwenDecoderPrefixAttentionMode prefix_mode = QwenDecoderPrefixAttentionMode::Exact;
     int64_t grouped_query_min_steps = 0;
 };

--- a/include/engine/framework/runtime/kv_cache.h
+++ b/include/engine/framework/runtime/kv_cache.h
@@ -66,6 +66,14 @@ private:
     int64_t step_elems_ = 0;
     int64_t valid_steps_ = 0;
     int64_t current_end_ = 0;
+    // High-water mark, in steps, of everything this cache has ever written to its device
+    // tensors. import_state only has to refresh [0, valid) and clear [valid, dirty_steps_),
+    // instead of zero-filling and uploading the whole capacity every time. -1 means the
+    // device buffers are still in their as-allocated state and must be cleared in full once.
+    int64_t dirty_steps_ = -1;
+    // Monotonically grown block of zeros, shared by every layer, used to clear the stale
+    // tail. Nothing ever writes a non-zero value into it.
+    std::vector<float> zero_scratch_;
     TransformerKVCacheOptions options_;
     std::vector<LayerCache> layers_;
 };

--- a/src/framework/modules/transformers/qwen_decoder.cpp
+++ b/src/framework/modules/transformers/qwen_decoder.cpp
@@ -7,14 +7,38 @@
 #include "engine/framework/modules/structural_modules.h"
 #include "../module_internal.h"
 
+#include <algorithm>
+#include <cctype>
 #include <cmath>
+#include <cstdlib>
 #include <stdexcept>
+#include <string>
 
 namespace engine::modules {
 namespace {
 
 using engine::modules::internal::concat_all;
 using engine::modules::internal::validate_sequence_input;
+
+// Escape hatch for the FlashGroupedViewKV static-cache default. Setting
+// ENGINE_QWEN_ATTENTION_CONT_KV to a truthy value restores the historical behaviour of
+// copying the whole permuted K/V cache with ggml_cont before every flash-attention call,
+// so a suspected numerical regression can be bisected without a rebuild. The two lowerings
+// are expected to agree bit for bit; see tests/unittests/test_qwen_attention_modes.cpp.
+bool static_attention_forces_contiguous_kv() {
+    static const bool forced = [] {
+        const char * value = std::getenv("ENGINE_QWEN_ATTENTION_CONT_KV");
+        if (value == nullptr || value[0] == '\0') {
+            return false;
+        }
+        std::string normalized(value);
+        std::transform(normalized.begin(), normalized.end(), normalized.begin(), [](unsigned char ch) {
+            return static_cast<char>(std::tolower(ch));
+        });
+        return normalized != "0" && normalized != "false" && normalized != "off" && normalized != "no";
+    }();
+    return forced;
+}
 
 inline const core::ModulePortSpec kQwenDecoderInputs[] = {
     {"input", core::PortKind::Activation, false},
@@ -750,7 +774,8 @@ QwenDecoderLayerOutputs QwenDecoderLayerModule::build_with_static_cache_tail(
         k_heads = repeat_kv_heads(ctx, k_heads, kv_repeats);
         v_heads = repeat_kv_heads(ctx, v_heads, kv_repeats);
         context = attention_from_heads(ctx, q_heads, k_heads, v_heads, dim, attention_mask);
-    } else if (config_.runtime.attention.static_mode == QwenDecoderAttentionMode::FlashGroupedViewKV) {
+    } else if (config_.runtime.attention.static_mode == QwenDecoderAttentionMode::FlashGroupedViewKV &&
+               !static_attention_forces_contiguous_kv()) {
         context = flash_attention_from_grouped_heads_view_kv(
             ctx,
             q_heads,
@@ -910,7 +935,8 @@ QwenDecoderLayerOutputs QwenDecoderLayerModule::build_with_static_cache_tail_bat
         k_heads = repeat_kv_heads(ctx, k_heads, kv_repeats);
         v_heads = repeat_kv_heads(ctx, v_heads, kv_repeats);
         context = attention_from_heads(ctx, q_heads, k_heads, v_heads, dim, attention_mask);
-    } else if (config_.runtime.attention.static_mode == QwenDecoderAttentionMode::FlashGroupedViewKV) {
+    } else if (config_.runtime.attention.static_mode == QwenDecoderAttentionMode::FlashGroupedViewKV &&
+               !static_attention_forces_contiguous_kv()) {
         context = flash_attention_from_grouped_heads_view_kv(
             ctx,
             q_heads,

--- a/src/framework/runtime/kv_cache.cpp
+++ b/src/framework/runtime/kv_cache.cpp
@@ -4,8 +4,10 @@
 #include "engine/framework/debug/trace.h"
 
 #include <algorithm>
+#include <cstddef>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 namespace engine::runtime {
 
@@ -47,6 +49,45 @@ void write_cache_tensor(
     throw std::runtime_error("TransformerKVCache requires f32 cache tensors");
 }
 
+// Uploads `count` f32 elements starting at element 0 and then clears `clear_count` elements
+// immediately after them. Only valid for contiguous f32 cache tensors; the f16/bf16 storage
+// modes have no sliced writer and keep the full-capacity staging path.
+void write_cache_prefix_and_clear_tail(
+    const core::TensorValue & tensor,
+    const float * values,
+    size_t count,
+    size_t clear_count,
+    size_t scratch_slot_offset,
+    bool clear_scratch_slot,
+    size_t scratch_slot_elems,
+    std::vector<float> & zero_scratch) {
+    if (count > 0) {
+        core::write_tensor_f32_slice(tensor, 0, values, count);
+    }
+    const size_t zero_needed = std::max(clear_count, clear_scratch_slot ? scratch_slot_elems : size_t{0});
+    if (zero_needed == 0) {
+        return;
+    }
+    if (zero_scratch.size() < zero_needed) {
+        zero_scratch.resize(zero_needed, 0.0F);
+    }
+    if (clear_count > 0) {
+        core::write_tensor_f32_slice(tensor, count, zero_scratch.data(), clear_count);
+    }
+    if (clear_scratch_slot) {
+        core::write_tensor_f32_slice(tensor, scratch_slot_offset, zero_scratch.data(), scratch_slot_elems);
+    }
+}
+
+// Reads back the first `count` elements only. `read_cache_tensor` pulls the whole capacity
+// and then slices, which on a 4096-step cache is an order of magnitude more traffic than the
+// valid prefix a caller actually asked for.
+void read_cache_prefix(
+    const core::TensorValue & tensor,
+    std::vector<float> & out,
+    size_t count,
+    const TransformerKVCacheOptions & options);
+
 std::vector<float> read_cache_tensor(const core::TensorValue & tensor, const TransformerKVCacheOptions & options) {
     validate_cache_tensor(tensor, options);
     if (tensor.type == GGML_TYPE_F32) {
@@ -59,6 +100,26 @@ std::vector<float> read_cache_tensor(const core::TensorValue & tensor, const Tra
         return core::read_tensor_bf16(tensor.tensor);
     }
     throw std::runtime_error("TransformerKVCache requires f32 cache tensors");
+}
+
+void read_cache_prefix(
+    const core::TensorValue & tensor,
+    std::vector<float> & out,
+    size_t count,
+    const TransformerKVCacheOptions & options) {
+    validate_cache_tensor(tensor, options);
+    if (count > static_cast<size_t>(tensor.shape.num_elements())) {
+        throw std::runtime_error("TransformerKVCache prefix read exceeds cache tensor shape");
+    }
+    if (tensor.type == GGML_TYPE_F32) {
+        out.resize(count);
+        if (count > 0) {
+            ggml_backend_tensor_get(tensor.tensor, out.data(), 0, count * sizeof(float));
+        }
+        return;
+    }
+    const auto values = read_cache_tensor(tensor, options);
+    out.assign(values.begin(), values.begin() + static_cast<std::ptrdiff_t>(count));
 }
 
 }  // namespace
@@ -85,16 +146,18 @@ TransformerKVCache::TransformerKVCache(
     if (keys.size() != values.size()) {
         throw std::runtime_error("TransformerKVCache key/value layer counts must match");
     }
-    const size_t cache_elems = static_cast<size_t>(cache_steps_ * step_elems_);
     layers_.reserve(keys.size());
     for (size_t layer = 0; layer < keys.size(); ++layer) {
         validate_cache_tensor(keys[layer], options_);
         validate_cache_tensor(values[layer], options_);
+        // The staging buffers are only needed by the f16/bf16 storage modes, which have no
+        // sliced writer; import_state allocates them on first use. An f32 cache never pays
+        // for them (2 * cache_steps * step_elems floats per layer of host memory).
         layers_.push_back(LayerCache{
             std::move(keys[layer]),
             std::move(values[layer]),
-            std::vector<float>(cache_elems, 0.0F),
-            std::vector<float>(cache_elems, 0.0F),
+            std::vector<float>(),
+            std::vector<float>(),
         });
     }
 }
@@ -113,6 +176,27 @@ void TransformerKVCache::import_state(const TransformerKVState & state) {
         throw std::runtime_error("TransformerKVCache state valid_steps exceeds cache capacity");
     }
     valid_steps_ = state_steps;
+    // Only the prefix being replaced and the stale tail between the new prefix and this
+    // cache's high-water mark are touched, instead of zero-filling and uploading the whole
+    // capacity on every start_decode_* call.
+    //
+    // The correctness argument does not depend on knowing every slot a decode graph writes.
+    // The first import (dirty_steps_ < 0) still clears the full capacity, so no slot can
+    // afterwards hold as-allocated garbage: every slot is either zero or finite K/V from an
+    // earlier generation. Both attention lowerings give a slot outside the attention mask a
+    // weight of exactly zero -- flash attention skips fully masked blocks and
+    // ggml_soft_max_ext turns the -inf mask entry into exp(-inf) = 0 -- so finite leftovers
+    // in masked slots cannot reach the output.
+    const int64_t stale_end = dirty_steps_ < 0 ? cache_steps_ : dirty_steps_;
+    const int64_t clear_steps = std::max<int64_t>(0, stale_end - state_steps);
+    // QwenDecoderStaticCacheUpdateMode::ScratchTail writes the current token's K/V into the
+    // last slot of the cache on every decode step, so that one slot can hold data from a
+    // previous generation even when it lies past the high-water mark. Clear it as well
+    // unless the main clear region already covers it. It is a single step.
+    const bool clear_scratch_slot = cache_steps_ > 0 && state_steps + clear_steps < cache_steps_;
+    const size_t scratch_slot_offset =
+        cache_steps_ > 0 ? static_cast<size_t>((cache_steps_ - 1) * step_elems_) : 0;
+    const size_t scratch_slot_elems = static_cast<size_t>(step_elems_);
     for (size_t layer = 0; layer < layers_.size(); ++layer) {
         auto & cache = layers_[layer];
         const auto & source = state.layers[layer];
@@ -126,17 +210,49 @@ void TransformerKVCache::import_state(const TransformerKVState & state) {
         if (source.key.size() != keep_elems) {
             throw std::runtime_error("TransformerKVCache source tensors do not match valid_steps * step_elems");
         }
-        if (cache_steps_ > 0) {
-            std::fill(cache.import_key_scratch.begin(), cache.import_key_scratch.end(), 0.0F);
-            std::fill(cache.import_value_scratch.begin(), cache.import_value_scratch.end(), 0.0F);
-            if (keep_elems > 0) {
-                std::copy(source.key.begin(), source.key.end(), cache.import_key_scratch.begin());
-                std::copy(source.value.begin(), source.value.end(), cache.import_value_scratch.begin());
-            }
-            write_cache_tensor(cache.key_tensor, cache.import_key_scratch, options_);
-            write_cache_tensor(cache.value_tensor, cache.import_value_scratch, options_);
+        if (cache_steps_ <= 0) {
+            continue;
         }
+        if (cache.key_tensor.type == GGML_TYPE_F32 && cache.value_tensor.type == GGML_TYPE_F32) {
+            const size_t clear_elems = static_cast<size_t>(clear_steps * step_elems_);
+            write_cache_prefix_and_clear_tail(
+                cache.key_tensor,
+                source.key.data(),
+                keep_elems,
+                clear_elems,
+                scratch_slot_offset,
+                clear_scratch_slot,
+                scratch_slot_elems,
+                zero_scratch_);
+            write_cache_prefix_and_clear_tail(
+                cache.value_tensor,
+                source.value.data(),
+                keep_elems,
+                clear_elems,
+                scratch_slot_offset,
+                clear_scratch_slot,
+                scratch_slot_elems,
+                zero_scratch_);
+            continue;
+        }
+        // f16/bf16 storage has no sliced writer; stage the full capacity as before.
+        const size_t cache_elems = static_cast<size_t>(cache_steps_ * step_elems_);
+        if (cache.import_key_scratch.size() != cache_elems) {
+            cache.import_key_scratch.assign(cache_elems, 0.0F);
+            cache.import_value_scratch.assign(cache_elems, 0.0F);
+        }
+        std::fill(cache.import_key_scratch.begin(), cache.import_key_scratch.end(), 0.0F);
+        std::fill(cache.import_value_scratch.begin(), cache.import_value_scratch.end(), 0.0F);
+        if (keep_elems > 0) {
+            std::copy(source.key.begin(), source.key.end(), cache.import_key_scratch.begin());
+            std::copy(source.value.begin(), source.value.end(), cache.import_value_scratch.begin());
+        }
+        write_cache_tensor(cache.key_tensor, cache.import_key_scratch, options_);
+        write_cache_tensor(cache.value_tensor, cache.import_value_scratch, options_);
     }
+    // Everything from state_steps up is zero again, so the next import only has to clear
+    // what this generation writes past it.
+    dirty_steps_ = state_steps;
 }
 
 TransformerKVState TransformerKVCache::export_state() const {
@@ -150,10 +266,8 @@ TransformerKVState TransformerKVCache::export_state() const {
         if (keep_elems == 0) {
             continue;
         }
-        const auto key_values = read_cache_tensor(layers_[layer].key_tensor, options_);
-        const auto value_values = read_cache_tensor(layers_[layer].value_tensor, options_);
-        out.key.assign(key_values.begin(), key_values.begin() + static_cast<ptrdiff_t>(keep_elems));
-        out.value.assign(value_values.begin(), value_values.begin() + static_cast<ptrdiff_t>(keep_elems));
+        read_cache_prefix(layers_[layer].key_tensor, out.key, keep_elems, options_);
+        read_cache_prefix(layers_[layer].value_tensor, out.value, keep_elems, options_);
     }
     return state;
 }
@@ -167,6 +281,7 @@ void TransformerKVCache::advance_after_direct_append(int64_t steps) {
     }
     valid_steps_ += steps;
     current_end_ += steps;
+    dirty_steps_ = std::max(dirty_steps_, valid_steps_);
 }
 
 void TransformerKVCache::retain_prefix(int64_t prefix_steps) {

--- a/tests/unittests/test_graph_optimizer_identity_fold.cpp
+++ b/tests/unittests/test_graph_optimizer_identity_fold.cpp
@@ -1,0 +1,182 @@
+// engine::runtime::optimize_graph identity-materialization folding.
+//
+// F2.11 of docs/reviews/02-kv-cache-attention-performance.md notes that the graph optimizer
+// defaults on and has exactly one caller. This test pins two things a caller needs to know
+// before wiring it into the decode/prefill graphs:
+//
+//   identity_cont_is_folded        a ggml_cont whose result has the same type, shape and
+//                                  strides as its source is removed and its consumer is
+//                                  rewired to the source, producing bit-identical values.
+//   permuted_cont_is_not_folded    a ggml_cont over a permuted view is NOT folded, because
+//                                  its strides genuinely differ from the source's. That is
+//                                  the exact shape of the redundant copy in F2.1, so running
+//                                  optimize_graph over a decode graph does not remove it --
+//                                  only changing the attention lowering does.
+
+#include "engine/framework/core/backend.h"
+#include "engine/framework/runtime/graph_optimizer.h"
+
+#include <ggml-backend.h>
+#include <ggml.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr size_t kGraphBytes = 16 * 1024 * 1024;
+constexpr size_t kGraphNodes = 512;
+
+void require(bool condition, const std::string & message) {
+    if (!condition) {
+        throw std::runtime_error(message);
+    }
+}
+
+std::vector<float> patterned(size_t count) {
+    std::vector<float> values(count, 0.0F);
+    for (size_t i = 0; i < count; ++i) {
+        values[i] = std::sin(0.37F + 0.019F * static_cast<float>(i));
+    }
+    return values;
+}
+
+std::vector<float> read_all(const ggml_tensor * tensor) {
+    std::vector<float> values(static_cast<size_t>(ggml_nelements(tensor)), 0.0F);
+    ggml_backend_tensor_get(tensor, values.data(), 0, values.size() * sizeof(float));
+    return values;
+}
+
+void compute_or_throw(ggml_backend_t backend, ggml_cgraph * graph, const char * label) {
+    const ggml_status status = ggml_backend_graph_compute(backend, graph);
+    ggml_backend_synchronize(backend);
+    if (status != GGML_STATUS_SUCCESS) {
+        std::ostringstream oss;
+        oss << label << " graph compute failed with status " << static_cast<int>(status);
+        throw std::runtime_error(oss.str());
+    }
+}
+
+void run() {
+    ggml_backend_t backend = engine::core::init_backend({engine::core::BackendType::Cpu, 0, 1});
+    ggml_init_params params{kGraphBytes, nullptr, true};
+    ggml_context * ggml = ggml_init(params);
+    if (ggml == nullptr) {
+        ggml_backend_free(backend);
+        throw std::runtime_error("failed to initialize graph optimizer test context");
+    }
+    ggml_backend_buffer_t buffer = nullptr;
+
+    try {
+        // Case 1: ggml_cont over an already-packed tensor. Identity, must fold.
+        ggml_tensor * source = ggml_new_tensor_2d(ggml, GGML_TYPE_F32, 16, 5);
+        ggml_tensor * identity_cont = ggml_cont(ggml, source);
+        ggml_tensor * folded_consumer = ggml_scale(ggml, identity_cont, 2.0F);
+        ggml_tensor * reference = ggml_scale(ggml, source, 2.0F);
+
+        // Case 2: ggml_cont over a permuted view. Real copy, must not fold.
+        ggml_tensor * base = ggml_new_tensor_3d(ggml, GGML_TYPE_F32, 8, 3, 4);
+        ggml_tensor * permuted = ggml_permute(ggml, base, 0, 2, 1, 3);
+        ggml_tensor * permuted_cont = ggml_cont(ggml, permuted);
+        ggml_tensor * permuted_consumer = ggml_scale(ggml, permuted_cont, 3.0F);
+
+        ggml_cgraph * identity_graph = ggml_new_graph_custom(ggml, kGraphNodes, false);
+        ggml_build_forward_expand(identity_graph, folded_consumer);
+
+        ggml_cgraph * reference_graph = ggml_new_graph_custom(ggml, kGraphNodes, false);
+        ggml_build_forward_expand(reference_graph, reference);
+
+        ggml_cgraph * permuted_graph = ggml_new_graph_custom(ggml, kGraphNodes, false);
+        ggml_build_forward_expand(permuted_graph, permuted_consumer);
+
+        buffer = ggml_backend_alloc_ctx_tensors(ggml, backend);
+        if (buffer == nullptr) {
+            throw std::runtime_error("failed to allocate graph optimizer test tensors");
+        }
+
+        const auto source_values = patterned(static_cast<size_t>(ggml_nelements(source)));
+        ggml_backend_tensor_set(source, source_values.data(), 0, source_values.size() * sizeof(float));
+        const auto base_values = patterned(static_cast<size_t>(ggml_nelements(base)));
+        ggml_backend_tensor_set(base, base_values.data(), 0, base_values.size() * sizeof(float));
+
+        // Reference result first, while the identity graph is still unoptimized.
+        compute_or_throw(backend, reference_graph, "graph optimizer reference");
+        const auto expected = read_all(reference);
+
+        require(
+            ggml_graph_n_nodes(identity_graph) == 2,
+            "identity graph should start as [cont, scale]");
+
+        const auto report = engine::runtime::optimize_graph(
+            *identity_graph, engine::runtime::GraphOptimizationBackend::Gpu, true);
+
+        std::cout << "graph_optimizer identity_cont nodes_before=" << report.nodes_before
+                  << " nodes_after=" << report.nodes_after
+                  << " identity_materializations_elided=" << report.identity_materializations_elided
+                  << "\n";
+
+        require(report.nodes_before == 2, "identity fold nodes_before should be 2");
+        require(report.nodes_after == 1, "identity fold should leave exactly the scale node");
+        require(
+            report.identity_materializations_elided == 1,
+            "identity fold should report exactly one elided materialization");
+        require(
+            folded_consumer->src[0] == source,
+            "the scale consumer should be rewired straight to the cont's source");
+
+        compute_or_throw(backend, identity_graph, "graph optimizer folded");
+        const auto actual = read_all(folded_consumer);
+        require(actual.size() == expected.size(), "folded output size mismatch");
+        float max_abs = 0.0F;
+        for (size_t i = 0; i < actual.size(); ++i) {
+            max_abs = std::max(max_abs, std::abs(actual[i] - expected[i]));
+        }
+        std::cout << "graph_optimizer identity_cont folded_vs_reference max_abs=" << max_abs << "\n";
+        require(max_abs == 0.0F, "folding an identity cont changed the result");
+
+        // A cont over a permuted view has different strides from its source, so
+        // same_type_shape_and_layout rejects it and the copy survives. This is why running
+        // optimize_graph over a decode graph does not remove the F2.1 K/V copy.
+        const int permuted_nodes_before = ggml_graph_n_nodes(permuted_graph);
+        const auto permuted_report = engine::runtime::optimize_graph(
+            *permuted_graph, engine::runtime::GraphOptimizationBackend::Gpu, true);
+        std::cout << "graph_optimizer permuted_cont nodes_before=" << permuted_report.nodes_before
+                  << " nodes_after=" << permuted_report.nodes_after
+                  << " identity_materializations_elided="
+                  << permuted_report.identity_materializations_elided << "\n";
+        require(
+            permuted_report.identity_materializations_elided == 0,
+            "a cont over a permuted view must not be folded");
+        require(
+            permuted_report.nodes_after == permuted_nodes_before,
+            "the permuted graph should be left untouched by the GPU optimizer profile");
+    } catch (...) {
+        if (buffer != nullptr) {
+            ggml_backend_buffer_free(buffer);
+        }
+        ggml_free(ggml);
+        ggml_backend_free(backend);
+        throw;
+    }
+
+    ggml_backend_buffer_free(buffer);
+    ggml_free(ggml);
+    ggml_backend_free(backend);
+}
+
+}  // namespace
+
+int main() try {
+    run();
+    std::cout << "graph_optimizer_identity_fold passed\n";
+    return 0;
+} catch (const std::exception & error) {
+    std::cerr << "graph_optimizer_identity_fold_test failed: " << error.what() << "\n";
+    return 1;
+}

--- a/tests/unittests/test_qwen_attention_modes.cpp
+++ b/tests/unittests/test_qwen_attention_modes.cpp
@@ -1,0 +1,468 @@
+// Pins the numerical relationship between the QwenDecoderAttentionMode lowerings.
+//
+// The point of this test is F2.1 / F2.2 of docs/reviews/02-kv-cache-attention-performance.md:
+// `static_mode` used to default to FlashGrouped, which copies the whole permuted K/V cache
+// with ggml_cont before calling ggml_flash_attn_ext, while FlashGroupedViewKV makes the same
+// call on the views. If those two really are the same arithmetic on the same values, the copy
+// is pure waste and the default can move. If they are not, the default must stay.
+//
+// Everything runs on the CPU backend with synthetic weights. No Metal, no model files.
+//
+//   static_cache_flash_grouped_vs_view_kv   asserts BIT-EXACT equality (max_abs == 0).
+//   static_cache_manual_repeat_vs_flash     asserts a stated tolerance, and prints the number.
+//   prefill_manual_repeat_vs_flash          asserts a stated tolerance, and prints the number.
+
+#include "engine/framework/core/backend.h"
+#include "engine/framework/core/module.h"
+#include "engine/framework/modules/transformers/qwen_decoder.h"
+
+#include <ggml-backend.h>
+#include <ggml.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <limits>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+using engine::core::BackendType;
+using engine::core::ModuleBuildContext;
+using engine::core::TensorShape;
+using engine::core::TensorValue;
+using engine::modules::QwenDecoderAttentionMode;
+using engine::modules::QwenDecoderLayerConfig;
+using engine::modules::QwenDecoderLayerModule;
+using engine::modules::QwenDecoderLayerWeights;
+
+constexpr size_t kGraphBytes = 64 * 1024 * 1024;
+constexpr size_t kGraphNodes = 8192;
+constexpr int kRounds = 3;
+
+// Tolerances for the two lowerings that are only mathematically equivalent, not
+// bit-identical: an explicit materialised softmax versus a fused online one. These are the
+// same thresholds tests/unittests/test_scaled_dot_product_attention.cpp already applies to
+// the same class of comparison (explicit SDPA versus ggml_flash_attn_ext) on CUDA. The CPU
+// flash kernel accumulates in f32, so the real numbers here should land far below them; the
+// test prints what it measured so a regression shows up as a moved number, not just a pass.
+constexpr float kFlashMaxAbs = 7.5e-3F;
+constexpr double kFlashMeanAbs = 6.0e-4;
+constexpr double kFlashMinCosine = 0.99999;
+
+struct LayerDims {
+    int64_t hidden_size;
+    int64_t heads;
+    int64_t kv_heads;
+    int64_t head_dim;
+    int64_t intermediate_size;
+};
+
+struct DiffStats {
+    float max_abs = 0.0F;
+    double mean_abs = 0.0;
+    double cosine = 1.0;
+};
+
+std::vector<float> make_patterned_f32(size_t count, float phase, float scale) {
+    std::vector<float> values(count, 0.0F);
+    for (size_t i = 0; i < count; ++i) {
+        const float x = static_cast<float>(i);
+        values[i] = scale * (
+            std::sin(phase + 0.013F * x) +
+            0.5F * std::cos(0.7F * phase + 0.017F * x) +
+            0.25F * std::sin(0.11F * phase + 0.031F * x));
+    }
+    return values;
+}
+
+DiffStats diff_stats(const std::vector<float> & lhs, const std::vector<float> & rhs) {
+    if (lhs.size() != rhs.size()) {
+        throw std::runtime_error("diff_stats size mismatch");
+    }
+    DiffStats stats;
+    double abs_sum = 0.0;
+    double dot = 0.0;
+    double lhs_norm = 0.0;
+    double rhs_norm = 0.0;
+    for (size_t i = 0; i < lhs.size(); ++i) {
+        const float diff = std::abs(lhs[i] - rhs[i]);
+        stats.max_abs = std::max(stats.max_abs, diff);
+        abs_sum += static_cast<double>(diff);
+        dot += static_cast<double>(lhs[i]) * static_cast<double>(rhs[i]);
+        lhs_norm += static_cast<double>(lhs[i]) * static_cast<double>(lhs[i]);
+        rhs_norm += static_cast<double>(rhs[i]) * static_cast<double>(rhs[i]);
+    }
+    stats.mean_abs = abs_sum / static_cast<double>(std::max<size_t>(size_t{1}, lhs.size()));
+    stats.cosine = dot / std::sqrt(std::max(1.0e-30, lhs_norm * rhs_norm));
+    return stats;
+}
+
+QwenDecoderLayerConfig make_layer_config(const LayerDims & dims) {
+    QwenDecoderLayerConfig config;
+    config.hidden_size = dims.hidden_size;
+    config.num_attention_heads = dims.heads;
+    config.num_key_value_heads = dims.kv_heads;
+    config.head_dim = dims.head_dim;
+    config.intermediate_size = dims.intermediate_size;
+    config.rms_norm_eps = 1e-5F;
+    config.rope_theta = 10000.0F;
+    config.attention_precision = GGML_PREC_F32;
+    config.use_qk_norm = true;
+    return config;
+}
+
+// Every leaf tensor the layer needs, kept alongside its fill parameters so a single pass can
+// upload deterministic values for all of them.
+struct WeightTensors {
+    QwenDecoderLayerWeights layer;
+    std::vector<TensorValue> leaves;
+    std::vector<float> phases;
+    std::vector<float> scales;
+    std::vector<float> offsets;
+
+    void add(const TensorValue & tensor, float phase, float scale, float offset) {
+        leaves.push_back(tensor);
+        phases.push_back(phase);
+        scales.push_back(scale);
+        offsets.push_back(offset);
+    }
+
+    void upload() const {
+        for (size_t i = 0; i < leaves.size(); ++i) {
+            auto values = make_patterned_f32(
+                static_cast<size_t>(leaves[i].shape.num_elements()),
+                phases[i],
+                scales[i]);
+            if (offsets[i] != 0.0F) {
+                for (auto & value : values) {
+                    value += offsets[i];
+                }
+            }
+            engine::core::write_tensor_f32(leaves[i], values);
+        }
+    }
+};
+
+// Norm gains sit near 1.0 so the block behaves like a trained layer rather than a
+// near-degenerate one; projections stay small so activations do not saturate.
+WeightTensors make_layer_weights(ModuleBuildContext & ctx, const LayerDims & dims) {
+    WeightTensors out;
+    const int64_t q_out = dims.heads * dims.head_dim;
+    const int64_t kv_out = dims.kv_heads * dims.head_dim;
+
+    auto norm = [&](float phase) {
+        auto tensor = engine::core::make_tensor(
+            ctx, GGML_TYPE_F32, TensorShape::from_dims({dims.hidden_size}));
+        out.add(tensor, phase, 0.05F, 1.0F);
+        return tensor;
+    };
+    auto head_norm = [&](float phase) {
+        auto tensor = engine::core::make_tensor(
+            ctx, GGML_TYPE_F32, TensorShape::from_dims({dims.head_dim}));
+        out.add(tensor, phase, 0.05F, 1.0F);
+        return tensor;
+    };
+    auto matrix = [&](int64_t rows, int64_t cols, float phase) {
+        auto tensor = engine::core::make_tensor(
+            ctx, GGML_TYPE_F32, TensorShape::from_dims({rows, cols}));
+        out.add(tensor, phase, 0.09F, 0.0F);
+        return tensor;
+    };
+
+    out.layer.input_norm.weight = norm(0.11F);
+    out.layer.post_norm.weight = norm(0.23F);
+    out.layer.q_norm.weight = head_norm(0.37F);
+    out.layer.k_norm.weight = head_norm(0.41F);
+    out.layer.self_attention.q_weight = matrix(q_out, dims.hidden_size, 0.53F);
+    out.layer.self_attention.k_weight = matrix(kv_out, dims.hidden_size, 0.67F);
+    out.layer.self_attention.v_weight = matrix(kv_out, dims.hidden_size, 0.79F);
+    out.layer.self_attention.out_weight = matrix(dims.hidden_size, q_out, 0.83F);
+    out.layer.mlp.gate_proj.weight = matrix(dims.intermediate_size, dims.hidden_size, 0.97F);
+    out.layer.mlp.up_proj.weight = matrix(dims.intermediate_size, dims.hidden_size, 1.09F);
+    out.layer.mlp.down_proj.weight = matrix(dims.hidden_size, dims.intermediate_size, 1.13F);
+    return out;
+}
+
+void compute_or_throw(ggml_backend_t backend, ggml_cgraph * graph, const char * label) {
+    const ggml_status status = ggml_backend_graph_compute(backend, graph);
+    ggml_backend_synchronize(backend);
+    if (status != GGML_STATUS_SUCCESS) {
+        std::ostringstream oss;
+        oss << label << " graph compute failed with status " << static_cast<int>(status);
+        throw std::runtime_error(oss.str());
+    }
+}
+
+void check(const char * label, const DiffStats & stats, bool require_bit_exact) {
+    std::cout << "cpu " << label
+              << " max_abs=" << stats.max_abs
+              << " mean_abs=" << stats.mean_abs
+              << " cosine=" << stats.cosine << "\n";
+    const bool ok = require_bit_exact
+        ? (stats.max_abs == 0.0F && stats.mean_abs == 0.0)
+        : (stats.max_abs <= kFlashMaxAbs && stats.mean_abs <= kFlashMeanAbs &&
+           stats.cosine >= kFlashMinCosine);
+    if (ok) {
+        return;
+    }
+    std::ostringstream oss;
+    oss << label << " mismatch: max_abs=" << stats.max_abs
+        << " mean_abs=" << stats.mean_abs << " cosine=" << stats.cosine;
+    if (require_bit_exact) {
+        oss << " -- FlashGrouped and FlashGroupedViewKV are NOT bit-identical on this build."
+            << " Revert QwenDecoderAttentionPolicy::static_mode to FlashGrouped in"
+            << " include/engine/framework/modules/transformers/qwen_decoder.h";
+    }
+    throw std::runtime_error(oss.str());
+}
+
+// One decoder block, driven through the single-token static-cache path once per attention
+// mode. Each mode gets its own K/V cache tensors, filled with identical data, so the modes
+// cannot interfere through the ScratchTail write.
+void run_static_cache_parity() {
+    const LayerDims dims{128, 4, 2, 32, 256};
+    const int64_t cache_steps = 48;
+    const int64_t visible_steps = 33;
+    const int64_t scratch_slot = cache_steps - 1;
+    const int64_t step_elems = dims.kv_heads * dims.head_dim;
+
+    ggml_backend_t backend = engine::core::init_backend({BackendType::Cpu, 0, 4});
+    ggml_init_params params{kGraphBytes, nullptr, true};
+    ggml_context * ggml = ggml_init(params);
+    if (ggml == nullptr) {
+        ggml_backend_free(backend);
+        throw std::runtime_error("failed to initialize qwen attention mode test context");
+    }
+    ggml_backend_buffer_t buffer = nullptr;
+
+    try {
+        ModuleBuildContext ctx{ggml, "qwen.attention_modes.decode", BackendType::Cpu};
+
+        auto weights = make_layer_weights(ctx, dims);
+        auto input = engine::core::make_tensor(
+            ctx, GGML_TYPE_F32, TensorShape::from_dims({1, 1, dims.hidden_size}));
+        auto positions = engine::core::wrap_tensor(
+            ggml_new_tensor_1d(ggml, GGML_TYPE_I32, 1), TensorShape::from_dims({1}), GGML_TYPE_I32);
+        auto mask = engine::core::wrap_tensor(
+            ggml_new_tensor_4d(ggml, GGML_TYPE_F16, cache_steps, 1, 1, 1),
+            TensorShape::from_dims({1, 1, 1, cache_steps}),
+            GGML_TYPE_F16);
+
+        const std::vector<QwenDecoderAttentionMode> modes = {
+            QwenDecoderAttentionMode::FlashGrouped,
+            QwenDecoderAttentionMode::FlashGroupedViewKV,
+            QwenDecoderAttentionMode::ManualRepeat,
+        };
+
+        auto * graph = ggml_new_graph_custom(ggml, kGraphNodes, false);
+        std::vector<TensorValue> cache_keys;
+        std::vector<TensorValue> cache_values;
+        std::vector<TensorValue> outputs;
+        for (const auto mode : modes) {
+            auto cache_key = engine::core::make_tensor(
+                ctx,
+                GGML_TYPE_F32,
+                TensorShape::from_dims({1, cache_steps, dims.kv_heads, dims.head_dim}));
+            auto cache_value = engine::core::make_tensor(
+                ctx,
+                GGML_TYPE_F32,
+                TensorShape::from_dims({1, cache_steps, dims.kv_heads, dims.head_dim}));
+            auto config = make_layer_config(dims);
+            config.runtime.attention.static_mode = mode;
+            auto layer_out = QwenDecoderLayerModule(config).build_with_static_cache_tail(
+                ctx,
+                graph,
+                input,
+                positions,
+                weights.layer,
+                cache_key,
+                cache_value,
+                std::nullopt,
+                mask);
+            // Expand each variant before building the next one so the ScratchTail copy for
+            // this cache is ordered ahead of the attention that reads it.
+            ggml_build_forward_expand(graph, layer_out.output.tensor);
+            cache_keys.push_back(cache_key);
+            cache_values.push_back(cache_value);
+            outputs.push_back(layer_out.output);
+        }
+
+        buffer = ggml_backend_alloc_ctx_tensors(ggml, backend);
+        if (buffer == nullptr) {
+            throw std::runtime_error("failed to allocate qwen attention mode test tensors");
+        }
+
+        weights.upload();
+
+        // Visible for the prefix and for the scratch slot the current token is written into;
+        // -inf everywhere else, which is what the shared decode runtime uploads.
+        std::vector<float> mask_values(
+            static_cast<size_t>(cache_steps), -std::numeric_limits<float>::infinity());
+        for (int64_t step = 0; step < visible_steps; ++step) {
+            mask_values[static_cast<size_t>(step)] = 0.0F;
+        }
+        mask_values[static_cast<size_t>(scratch_slot)] = 0.0F;
+        engine::core::write_tensor_f16(mask, mask_values);
+
+        const std::vector<int32_t> position_values{static_cast<int32_t>(visible_steps)};
+        engine::core::write_tensor_i32(positions, position_values);
+
+        for (int round = 0; round < kRounds; ++round) {
+            const auto input_values = make_patterned_f32(
+                static_cast<size_t>(dims.hidden_size), 0.31F + static_cast<float>(round), 0.4F);
+            engine::core::write_tensor_f32(input, input_values);
+
+            const auto key_values = make_patterned_f32(
+                static_cast<size_t>(cache_steps * step_elems),
+                1.7F + static_cast<float>(round) * 0.37F,
+                0.3F);
+            const auto value_values = make_patterned_f32(
+                static_cast<size_t>(cache_steps * step_elems),
+                2.9F + static_cast<float>(round) * 0.19F,
+                0.25F);
+            for (size_t variant = 0; variant < cache_keys.size(); ++variant) {
+                engine::core::write_tensor_f32(cache_keys[variant], key_values);
+                engine::core::write_tensor_f32(cache_values[variant], value_values);
+            }
+
+            compute_or_throw(backend, graph, "qwen static-cache attention mode");
+
+            std::vector<std::vector<float>> results(outputs.size());
+            for (size_t variant = 0; variant < outputs.size(); ++variant) {
+                engine::core::read_tensor_f32_into(outputs[variant].tensor, results[variant]);
+            }
+            check("static_cache_flash_grouped_vs_view_kv", diff_stats(results[0], results[1]), true);
+            check("static_cache_manual_repeat_vs_flash", diff_stats(results[2], results[1]), false);
+        }
+    } catch (...) {
+        if (buffer != nullptr) {
+            ggml_backend_buffer_free(buffer);
+        }
+        ggml_free(ggml);
+        ggml_backend_free(backend);
+        throw;
+    }
+
+    ggml_backend_buffer_free(buffer);
+    ggml_free(ggml);
+    ggml_backend_free(backend);
+}
+
+// The prefill path: ManualRepeat (the default) versus the flash lowering that F2.2 proposes
+// promoting. These are NOT the same computation -- one materialises [heads, T, T] scores and
+// runs ggml_soft_max_ext over them, the other fuses the softmax into ggml_flash_attn_ext --
+// so the test states a tolerance rather than asserting equality.
+void run_prefill_parity() {
+    const LayerDims dims{128, 4, 2, 32, 256};
+    const int64_t steps = 24;
+
+    ggml_backend_t backend = engine::core::init_backend({BackendType::Cpu, 0, 4});
+    ggml_init_params params{kGraphBytes, nullptr, true};
+    ggml_context * ggml = ggml_init(params);
+    if (ggml == nullptr) {
+        ggml_backend_free(backend);
+        throw std::runtime_error("failed to initialize qwen prefill mode test context");
+    }
+    ggml_backend_buffer_t buffer = nullptr;
+
+    try {
+        ModuleBuildContext ctx{ggml, "qwen.attention_modes.prefill", BackendType::Cpu};
+
+        auto weights = make_layer_weights(ctx, dims);
+        auto input = engine::core::make_tensor(
+            ctx, GGML_TYPE_F32, TensorShape::from_dims({1, steps, dims.hidden_size}));
+        auto positions = engine::core::wrap_tensor(
+            ggml_new_tensor_1d(ggml, GGML_TYPE_I32, steps),
+            TensorShape::from_dims({steps}),
+            GGML_TYPE_I32);
+        auto mask = engine::core::wrap_tensor(
+            ggml_new_tensor_4d(ggml, GGML_TYPE_F16, steps, steps, 1, 1),
+            TensorShape::from_dims({1, 1, steps, steps}),
+            GGML_TYPE_F16);
+
+        auto * graph = ggml_new_graph_custom(ggml, kGraphNodes, false);
+        std::vector<TensorValue> outputs;
+        for (const auto mode : {QwenDecoderAttentionMode::ManualRepeat,
+                                QwenDecoderAttentionMode::FlashGroupedViewKV}) {
+            auto config = make_layer_config(dims);
+            config.runtime.attention.prefill_mode = mode;
+            auto layer_out = QwenDecoderLayerModule(config).build(
+                ctx,
+                input,
+                positions,
+                weights.layer,
+                std::nullopt,
+                std::nullopt,
+                std::optional<TensorValue>(mask));
+            ggml_build_forward_expand(graph, layer_out.output.tensor);
+            outputs.push_back(layer_out.output);
+        }
+
+        buffer = ggml_backend_alloc_ctx_tensors(ggml, backend);
+        if (buffer == nullptr) {
+            throw std::runtime_error("failed to allocate qwen prefill mode test tensors");
+        }
+
+        weights.upload();
+
+        std::vector<float> mask_values(
+            static_cast<size_t>(steps * steps), -std::numeric_limits<float>::infinity());
+        for (int64_t query = 0; query < steps; ++query) {
+            for (int64_t key = 0; key <= query; ++key) {
+                mask_values[static_cast<size_t>(query * steps + key)] = 0.0F;
+            }
+        }
+        engine::core::write_tensor_f16(mask, mask_values);
+
+        std::vector<int32_t> position_values(static_cast<size_t>(steps), 0);
+        for (int64_t step = 0; step < steps; ++step) {
+            position_values[static_cast<size_t>(step)] = static_cast<int32_t>(step);
+        }
+        engine::core::write_tensor_i32(positions, position_values);
+
+        for (int round = 0; round < kRounds; ++round) {
+            const auto input_values = make_patterned_f32(
+                static_cast<size_t>(steps * dims.hidden_size),
+                0.47F + static_cast<float>(round),
+                0.4F);
+            engine::core::write_tensor_f32(input, input_values);
+
+            compute_or_throw(backend, graph, "qwen prefill attention mode");
+
+            std::vector<float> manual_repeat;
+            std::vector<float> flash;
+            engine::core::read_tensor_f32_into(outputs[0].tensor, manual_repeat);
+            engine::core::read_tensor_f32_into(outputs[1].tensor, flash);
+            check("prefill_manual_repeat_vs_flash", diff_stats(manual_repeat, flash), false);
+        }
+    } catch (...) {
+        if (buffer != nullptr) {
+            ggml_backend_buffer_free(buffer);
+        }
+        ggml_free(ggml);
+        ggml_backend_free(backend);
+        throw;
+    }
+
+    ggml_backend_buffer_free(buffer);
+    ggml_free(ggml);
+    ggml_backend_free(backend);
+}
+
+}  // namespace
+
+int main() try {
+    run_static_cache_parity();
+    run_prefill_parity();
+    std::cout << "qwen_attention_modes passed\n";
+    return 0;
+} catch (const std::exception & error) {
+    std::cerr << "qwen_attention_modes_test failed: " << error.what() << "\n";
+    return 1;
+}


### PR DESCRIPTION
## What this changes

`QwenDecoderAttentionPolicy::static_mode` defaulted to `FlashGrouped`, which wraps the K/V cache views in `ggml_cont` before the flash call. The `FlashGroupedViewKV` branch **ten lines above** makes the identical call with zero copies — roughly **100 MB of dead copy traffic per token** at 24 layers and 2048 context.

## Why the default moves rather than the fast path being opt-in

CONTRIBUTING's framework-module rule says not to change shared behaviour models depend on. The justification here is that the two branches are **bit-identical**, not merely equivalent in principle:

- Both call `ggml_flash_attn_ext(q, k, v, mask, 1/sqrt(dim), 0, 0)` with the same `ggml_flash_attn_ext_set_prec`, the same mask, scale, softcap and GQA head grouping. The only difference is whether K/V are copied to a packed layout first.
- Both kernels address K/V purely through **strides**. The CPU path asserts only `nb?0 == type_size` (rows contiguous), never full contiguity, and reads `k->data + ic*nbk1 + ik2*nbk2`; the Metal FA kernel reads `k + ic*args.nb11` and `v + ic*args.nb21`.
- **Kernel selection never inspects strides**: CPU `use_split_kv_path`/`use_tiled` depend only on `ne` and types, Metal's vec path only on `ne00`/`ne01`. Both branches therefore take the identical code path with identical values in identical reduction order.
- `device_supports_op` for `GGML_OP_FLASH_ATTN_EXT` tests head size, K/V type and device caps, **never strides**, so the flip cannot make a graph invalid. That matters because these graphs run on a single backend with no scheduler fallback.

`test_qwen_attention_modes` builds a real `QwenDecoderLayerModule` on the CPU backend and asserts **`max_abs == 0`** between the two modes. On failure the exception names the one line to revert. `ENGINE_QWEN_ATTENTION_CONT_KV=1` restores the copying path at runtime without a rebuild.

**Blast radius is 5 models, not more:** `vietneu_tts`, `fun_asr_nano`, `higgs_audio_stt`, `qwen3_asr`, `index_tts2`. Fourteen configs already ship on `FlashGroupedViewKV`, and the two Moss models keep `FlashGrouped` explicitly.

## What was deliberately *not* changed

`prefill_mode` stays on `ManualRepeat`. Flash prefill is not equivalent — it fuses an online softmax where `ManualRepeat` materialises `[heads,T,T]` and calls `soft_max_ext` — and more importantly it imposes a **hard backend requirement**: Metal supports `FLASH_ATTN_EXT` only for a whitelist of head sizes and requires `ne00 % 4 == 0`, `head_dim` comes from a runtime JSON config, and with no scheduler fallback an unsupported size is a graph *failure*, not a slowdown. `minimax_music3/depth_decoder.cpp:61-63` already gates flash prefill to CUDA/HIP for exactly this reason.

## Also in this change

`TransformerKVCache::import_state` now uploads only the valid prefix and clears only the stale tail, tracked by a high-water mark, instead of zero-filling and uploading the whole capacity on every `start_decode_*`. `export_state` reads back only the valid prefix. Per-layer staging buffers are allocated lazily.

`test_graph_optimizer_identity_fold` records as a **negative control** that `optimize_graph` cannot fix the above: `is_identity_materialization` requires `same_type_shape_and_layout`, which compares `nb[]` exactly, and `ggml_cont(permute(cache))` has genuinely different strides. It only elides `ggml_cont` calls that were already no-ops.

## Validation

**Build**
```
cmake -S . -B build -DENGINE_BUILD_TESTS=ON
cmake --build build
```

**Test**
```
ctest -R "qwen_attention_modes_test|graph_optimizer_identity_fold_test"
```

**Backend tested:** Metal, Apple M4 Max. A FireRedTTS3 multi-chunk clone and a VibeVoice render are **byte-identical** before and after (SHA-256 `60441bc8…` and `d38f9ebd…`). The FireRedTTS3 case also exercises the KV prefix import across repeated `start_decode_*` calls in one process, which is where a mistake in that part would show — on the *second* generation, not the first. Full suite **40/40**.

## Affects

Performance and memory traffic on the five models above; no output change, asserted bit-exact. **No throughput number is claimed** — the renders used for validation are dominated by model load and are byte-identical, which proves correctness rather than speed. Measuring the gain properly needs a long single-utterance decode with a token-rate counter.

## Known limitations

`TransformerBatchedKVCache::import_state` has the same full-capacity pathology and is left alone here; it serves far fewer models and deserves its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ATa5YkLUPMDPRL7w1gCo9p