### PR TITLE
sampling: drop the quadratic RNG rewind and the per-token vocab readback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2032,6 +2032,27 @@ if (ENGINE_BUILD_TESTS)
         COMMAND audio_chunking_test
     )
 
+    add_engine_unittest(compact_logits_readback_test tests/unittests/test_compact_logits_readback.cpp)
+
+    add_test(
+        NAME compact_logits_readback_test
+        COMMAND compact_logits_readback_test
+    )
+
+    add_engine_unittest(hf_sampler_determinism_test tests/unittests/test_hf_sampler_determinism.cpp)
+
+    add_test(
+        NAME hf_sampler_determinism_test
+        COMMAND hf_sampler_determinism_test
+    )
+
+    add_engine_unittest(hf_sampler_ordering_test tests/unittests/test_hf_sampler_ordering.cpp)
+
+    add_test(
+        NAME hf_sampler_ordering_test
+        COMMAND hf_sampler_ordering_test
+    )
+
     add_engine_unittest(chinese_normalization_test tests/unittests/test_chinese_normalization.cpp)
 
     add_test(

--- a/include/engine/framework/modules/transformers/qwen_causal_decode_runtime.h
+++ b/include/engine/framework/modules/transformers/qwen_causal_decode_runtime.h
@@ -109,4 +109,20 @@ private:
     std::unique_ptr<Impl> impl_;
 };
 
+// Device-side gather of a fixed token subset out of a full-vocabulary logits row, so the
+// host readback carries only the entries a constrained sampler actually reads instead of
+// the whole vocabulary. `logits` must carry the vocabulary on its last dimension;
+// `token_ids` is a 1-D I32 tensor holding `compact_size` vocabulary indices. The result
+// has the shape of `logits` with its last dimension replaced by `compact_size`, ordered to
+// match `token_ids`, so entry `i` of a readback row is the logit of `token_ids[i]`.
+//
+// This is what `QwenCausalDecodeRuntimeConfig::logits_readback_token_ids` drives; it is
+// exposed so models with their own decode graphs (VibeVoice) can reuse one implementation.
+core::TensorValue build_compact_logits_gather(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & logits,
+    const core::TensorValue & token_ids,
+    int64_t logits_size,
+    int64_t compact_size);
+
 }  // namespace engine::modules

--- a/include/engine/models/vibevoice/decoder.h
+++ b/include/engine/models/vibevoice/decoder.h
@@ -11,6 +11,7 @@
 #include <ggml-backend.h>
 
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <vector>
@@ -50,10 +51,17 @@ private:
     bool graph_has_state_ = false;
 };
 
+// `values` is the full vocabulary row when `token_ids` is empty, indexed by token id.
+// When `token_ids` is populated the decoder gathered only those tokens on-device and
+// `values[i]` is the logit of `token_ids[i]`; `vocab_size` still reports the true
+// vocabulary size. Use vibevoice_logit_for_token() rather than indexing directly.
 struct VibeVoiceDecoderLogits {
     std::vector<float> values;
+    std::vector<int32_t> token_ids;
     int64_t vocab_size = 0;
 };
+
+float vibevoice_logit_for_token(const VibeVoiceDecoderLogits & logits, int32_t token);
 
 struct VibeVoiceTokenEmbeddings {
     std::vector<float> values;
@@ -126,6 +134,13 @@ public:
     ggml_type cache_type() const noexcept;
     int threads() const noexcept;
 
+    // Opt in to a device-side gather of a fixed token subset before the logits readback.
+    // Default (empty) keeps the full-vocabulary readback every existing caller expects.
+    // Changing the set invalidates the cached logits graphs, so call this before the
+    // first decode of a generation, not inside the token loop.
+    void set_logits_readback_token_ids(std::vector<int32_t> token_ids) const;
+    const std::vector<int32_t> & logits_readback_token_ids() const noexcept;
+
     VibeVoiceTokenEmbeddings embed_tokens(const std::vector<int32_t> & input_ids) const;
     VibeVoiceDecoderPrefillOutput prefill_embeddings(const std::vector<float> & embeddings, int64_t steps) const;
     std::vector<VibeVoiceDecoderPrefillOutput> prefill_embeddings_batch(
@@ -153,6 +168,7 @@ private:
     mutable std::unique_ptr<VibeVoiceDecoderEmbeddingGraph> embedding_graph_;
     mutable std::unique_ptr<VibeVoiceDecoderPrefillGraph> prefill_graph_;
     mutable std::vector<std::unique_ptr<VibeVoiceDecoderCachedBatchStepGraph>> cached_batch_graphs_;
+    mutable std::vector<int32_t> logits_readback_token_ids_;
     ggml_backend_t backend_ = nullptr;
     ggml_type cache_type_ = GGML_TYPE_F16;
     int threads_ = 1;

--- a/src/framework/modules/transformers/qwen_causal_decode_runtime.cpp
+++ b/src/framework/modules/transformers/qwen_causal_decode_runtime.cpp
@@ -17,6 +17,48 @@
 #include <utility>
 
 namespace engine::modules {
+
+core::TensorValue build_compact_logits_gather(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & logits,
+    const core::TensorValue & token_ids,
+    int64_t logits_size,
+    int64_t compact_size) {
+    if (logits.shape.last_dim() != logits_size) {
+        throw std::runtime_error("compact logits gather requires the vocabulary on the last dimension");
+    }
+    if (compact_size <= 0) {
+        throw std::runtime_error("compact logits gather requires a non-empty token subset");
+    }
+
+    const int64_t rows = logits.shape.prefix_elements();
+    const auto flat = core::reshape_tensor(
+        ctx,
+        logits,
+        core::TensorShape::from_dims({rows, logits_size}));
+    const auto transposed = core::wrap_tensor(
+        ggml_transpose(ctx.ggml, flat.tensor),
+        core::TensorShape::from_dims({logits_size, rows}),
+        flat.type);
+    const auto source = core::wrap_tensor(
+        ggml_cont(ctx.ggml, transposed.tensor),
+        transposed.shape,
+        transposed.type);
+    const auto selected = core::wrap_tensor(
+        ggml_get_rows(ctx.ggml, source.tensor, token_ids.tensor),
+        core::TensorShape::from_dims({compact_size, rows}),
+        GGML_TYPE_F32);
+    const auto selected_t = core::wrap_tensor(
+        ggml_transpose(ctx.ggml, selected.tensor),
+        core::TensorShape::from_dims({rows, compact_size}),
+        GGML_TYPE_F32);
+    const auto contiguous = core::wrap_tensor(
+        ggml_cont(ctx.ggml, selected_t.tensor),
+        selected_t.shape,
+        selected_t.type);
+    return core::reshape_tensor(ctx, contiguous, logits.shape.with_last_dim(compact_size));
+}
+
 namespace {
 
 using Clock = std::chrono::steady_clock;
@@ -252,37 +294,12 @@ core::TensorValue compact_logits_readback(
     const QwenCausalDecodeRuntimeConfig & config,
     const core::TensorValue & logits,
     const core::TensorValue & token_ids) {
-    if (logits.shape.last_dim() != config.decoder.logits_size) {
-        throw std::runtime_error("QwenCausalDecodeRuntime compact logits requires logits on the last dimension");
-    }
-
-    const int64_t rows = logits.shape.prefix_elements();
-    const int64_t compact_size = static_cast<int64_t>(config.logits_readback_token_ids.size());
-    const auto flat = core::reshape_tensor(
+    return build_compact_logits_gather(
         ctx,
         logits,
-        core::TensorShape::from_dims({rows, config.decoder.logits_size}));
-    const auto transposed = core::wrap_tensor(
-        ggml_transpose(ctx.ggml, flat.tensor),
-        core::TensorShape::from_dims({config.decoder.logits_size, rows}),
-        flat.type);
-    const auto source = core::wrap_tensor(
-        ggml_cont(ctx.ggml, transposed.tensor),
-        transposed.shape,
-        transposed.type);
-    const auto selected = core::wrap_tensor(
-        ggml_get_rows(ctx.ggml, source.tensor, token_ids.tensor),
-        core::TensorShape::from_dims({compact_size, rows}),
-        GGML_TYPE_F32);
-    const auto selected_t = core::wrap_tensor(
-        ggml_transpose(ctx.ggml, selected.tensor),
-        core::TensorShape::from_dims({rows, compact_size}),
-        GGML_TYPE_F32);
-    const auto contiguous = core::wrap_tensor(
-        ggml_cont(ctx.ggml, selected_t.tensor),
-        selected_t.shape,
-        selected_t.type);
-    return core::reshape_tensor(ctx, contiguous, logits.shape.with_last_dim(compact_size));
+        token_ids,
+        config.decoder.logits_size,
+        static_cast<int64_t>(config.logits_readback_token_ids.size()));
 }
 
 ggml_tensor * make_logits_readback_token_ids(

--- a/src/framework/sampling/hf_sampler.cpp
+++ b/src/framework/sampling/hf_sampler.cpp
@@ -2,9 +2,12 @@
 
 #include <algorithm>
 #include <array>
+#include <cctype>
 #include <cmath>
 #include <cstdint>
+#include <cstdlib>
 #include <limits>
+#include <optional>
 #include <stdexcept>
 #include <string>
 
@@ -64,10 +67,6 @@ public:
         }
     }
 
-    void discard_exponential_draws(uint64_t count) {
-        discard(count * 2ULL);
-    }
-
 private:
     static constexpr int kStateN = 624;
     static constexpr int kStateM = 397;
@@ -109,14 +108,101 @@ float torch_cpu_exponential_float(TorchCpuMt19937 & rng) {
     return static_cast<float>(-std::log1p(-uniform));
 }
 
+struct TorchCpuRngCacheEntry {
+    bool valid = false;
+    uint64_t seed = 0;
+    uint64_t draws_per_call = 0;
+    uint64_t next_call_index = 0;
+    uint64_t last_used = 0;
+    TorchCpuMt19937 rng{0};
+};
+
+// Keeps a small set of Torch-CPU MT19937 generators alive across sampling calls.
+//
+// The stream a call must observe is defined by (seed, call_index, draws_per_call): a
+// generator freshly seeded with `seed` and fast-forwarded by `call_index *
+// draws_per_call` words. Because every call consumes exactly `draws_per_call` words
+// unconditionally, a generator left in place after call `n` is already positioned
+// exactly where call `n + 1` must start. A sequential walk therefore reproduces the
+// identical stream at O(vocab) per token instead of O(call_index * vocab), and a
+// random-access call simply misses the cache and rebuilds by fast-forwarding, which is
+// what the code did unconditionally before. The sampled token is bit-identical either
+// way; this is a cost change only.
+class TorchCpuRngCache {
+public:
+    TorchCpuMt19937 & acquire(uint64_t seed, uint64_t call_index, uint64_t draws_per_call) {
+        ++clock_;
+        for (auto & entry : entries_) {
+            if (entry.valid && entry.seed == seed && entry.draws_per_call == draws_per_call &&
+                entry.next_call_index == call_index) {
+                entry.last_used = clock_;
+                active_ = &entry;
+                return entry.rng;
+            }
+        }
+        TorchCpuRngCacheEntry * victim = &entries_.front();
+        for (auto & entry : entries_) {
+            if (!entry.valid) {
+                victim = &entry;
+                break;
+            }
+            if (entry.last_used < victim->last_used) {
+                victim = &entry;
+            }
+        }
+        victim->rng = TorchCpuMt19937(seed);
+        victim->rng.discard(call_index * draws_per_call);
+        victim->valid = true;
+        victim->seed = seed;
+        victim->draws_per_call = draws_per_call;
+        victim->next_call_index = call_index;
+        victim->last_used = clock_;
+        active_ = victim;
+        return victim->rng;
+    }
+
+    void commit() noexcept {
+        if (active_ != nullptr) {
+            ++active_->next_call_index;
+            active_ = nullptr;
+        }
+    }
+
+private:
+    static constexpr size_t kEntries = 4;
+
+    std::array<TorchCpuRngCacheEntry, kEntries> entries_{};
+    TorchCpuRngCacheEntry * active_ = nullptr;
+    uint64_t clock_ = 0;
+};
+
+bool torch_cpu_rng_cache_enabled_from_env() {
+    const char * value = std::getenv("ENGINE_TORCH_CPU_RNG_CACHE");
+    if (value == nullptr || value[0] == '\0') {
+        return true;
+    }
+    std::string normalized(value);
+    std::transform(normalized.begin(), normalized.end(), normalized.begin(), [](unsigned char ch) {
+        return static_cast<char>(std::tolower(ch));
+    });
+    return normalized != "0" && normalized != "false" && normalized != "off" && normalized != "no";
+}
+
+bool torch_cpu_rng_cache_enabled() {
+    static const bool enabled = torch_cpu_rng_cache_enabled_from_env();
+    return enabled;
+}
+
+TorchCpuRngCache & torch_cpu_rng_cache() {
+    thread_local TorchCpuRngCache cache;
+    return cache;
+}
+
 int32_t sample_torch_cpu_multinomial(
     const std::vector<float> & scores,
     uint64_t seed,
     uint64_t call_index,
     std::string_view context) {
-    TorchCpuMt19937 rng(seed);
-    rng.discard_exponential_draws(call_index * static_cast<uint64_t>(scores.size()));
-
     float max_score = -std::numeric_limits<float>::infinity();
     for (const float score : scores) {
         if (std::isfinite(score)) {
@@ -126,6 +212,19 @@ int32_t sample_torch_cpu_multinomial(
     if (!std::isfinite(max_score)) {
         throw std::runtime_error(context_message(context, "sampler has no finite logits"));
     }
+
+    // Every call consumes exactly two MT19937 words per vocabulary entry, whether or not
+    // the entry is finite, so the stream position after a call is fully determined.
+    const uint64_t draws_per_call = static_cast<uint64_t>(scores.size()) * 2ULL;
+    const bool cached = torch_cpu_rng_cache_enabled();
+    TorchCpuRngCache & cache = torch_cpu_rng_cache();
+    std::optional<TorchCpuMt19937> rebuilt;
+    if (!cached) {
+        rebuilt.emplace(seed);
+        rebuilt->discard(call_index * draws_per_call);
+    }
+    TorchCpuMt19937 & rng = cached ? cache.acquire(seed, call_index, draws_per_call) : *rebuilt;
+
     double best_rank = -std::numeric_limits<double>::infinity();
     int32_t best_token = -1;
     for (size_t token = 0; token < scores.size(); ++token) {
@@ -139,6 +238,9 @@ int32_t sample_torch_cpu_multinomial(
             best_rank = rank;
             best_token = static_cast<int32_t>(token);
         }
+    }
+    if (cached) {
+        cache.commit();
     }
     if (best_token < 0) {
         throw std::runtime_error(context_message(context, "CPU Torch sampler failed to select a token"));

--- a/src/models/fish_audio/ar.cpp
+++ b/src/models/fish_audio/ar.cpp
@@ -72,11 +72,6 @@ struct SampleCandidate {
     float probability = 0.0F;
 };
 
-struct SampleDistribution {
-    size_t source_size = 0;
-    std::vector<SampleCandidate> candidates;
-};
-
 struct GgmlContextDeleter {
     void operator()(ggml_context * ctx) const noexcept {
         if (ctx != nullptr) {
@@ -266,36 +261,46 @@ void copy_tensor_row_to_f32(const assets::TensorData & table, int64_t row, int64
     }
 }
 
-std::vector<float> lookup_row(const assets::TensorData & table, int64_t row, int64_t width) {
-    std::vector<float> out(static_cast<size_t>(width), 0.0F);
-    copy_tensor_row_to_f32(table, row, width, out.data());
-    return out;
-}
-
-void add_row(const assets::TensorData & table, int64_t row, int64_t width, std::vector<float> & out) {
-    std::vector<float> tmp(static_cast<size_t>(width), 0.0F);
-    copy_tensor_row_to_f32(table, row, width, tmp.data());
+void add_row(
+    const assets::TensorData & table,
+    int64_t row,
+    int64_t width,
+    std::vector<float> & out,
+    std::vector<float> & scratch) {
+    scratch.assign(static_cast<size_t>(width), 0.0F);
+    copy_tensor_row_to_f32(table, row, width, scratch.data());
     for (int64_t i = 0; i < width; ++i) {
-        out[static_cast<size_t>(i)] += tmp[static_cast<size_t>(i)];
+        out[static_cast<size_t>(i)] += scratch[static_cast<size_t>(i)];
     }
 }
+
+// Reused across the decode loop so a frame costs no vocabulary- or hidden-sized
+// allocations at all.
+struct SlowEmbeddingScratch {
+    std::vector<float> row;
+    std::vector<float> accumulator;
+};
 
 bool is_semantic_token(const FishAudioConfig & config, int32_t token) {
     return token >= config.semantic_start_token_id && token <= config.semantic_end_token_id;
 }
 
-std::vector<float> build_slow_embeddings(
+void build_slow_embeddings_into(
     const FishAudioConfig & config,
     const FishARWeights & weights,
     const int32_t * matrix,
-    int64_t steps) {
+    int64_t steps,
+    SlowEmbeddingScratch & scratch,
+    std::vector<float> & out) {
     const int64_t rows = config.fast.num_codebooks + 1;
     const int64_t hidden = config.text.dim;
-    std::vector<float> out(static_cast<size_t>(steps * hidden), 0.0F);
+    out.assign(static_cast<size_t>(steps * hidden), 0.0F);
+    auto & row = scratch.row;
     const float semantic_scale = 1.0F / std::sqrt(static_cast<float>(rows));
     for (int64_t step = 0; step < steps; ++step) {
         const int32_t token = matrix[step];
-        auto row = lookup_row(weights.text_embedding_host, token, hidden);
+        row.assign(static_cast<size_t>(hidden), 0.0F);
+        copy_tensor_row_to_f32(weights.text_embedding_host, token, hidden, row.data());
         if (is_semantic_token(config, token)) {
             for (int64_t codebook = 0; codebook < config.fast.num_codebooks; ++codebook) {
                 const int32_t code = matrix[(codebook + 1) * steps + step];
@@ -303,7 +308,8 @@ std::vector<float> build_slow_embeddings(
                     weights.codebook_embedding_host,
                     codebook * config.fast.vocab_size + code,
                     hidden,
-                    row);
+                    row,
+                    scratch.accumulator);
             }
             for (float & value : row) {
                 value *= semantic_scale;
@@ -311,24 +317,38 @@ std::vector<float> build_slow_embeddings(
         }
         std::copy(row.begin(), row.end(), out.begin() + static_cast<std::ptrdiff_t>(step * hidden));
     }
+}
+
+std::vector<float> build_slow_embeddings(
+    const FishAudioConfig & config,
+    const FishARWeights & weights,
+    const int32_t * matrix,
+    int64_t steps) {
+    SlowEmbeddingScratch scratch;
+    std::vector<float> out;
+    build_slow_embeddings_into(config, weights, matrix, steps, scratch, out);
     return out;
 }
 
-std::vector<float> build_slow_embedding_for_frame(
+void build_slow_embedding_for_frame_into(
     const FishAudioConfig & config,
     const FishARWeights & weights,
-    const std::vector<int32_t> & frame) {
+    const std::vector<int32_t> & frame,
+    SlowEmbeddingScratch & scratch,
+    std::vector<float> & out) {
     if (static_cast<int64_t>(frame.size()) != config.fast.num_codebooks + 1) {
         throw std::runtime_error("Fish Audio frame size mismatch");
     }
-    return build_slow_embeddings(config, weights, frame.data(), 1);
+    build_slow_embeddings_into(config, weights, frame.data(), 1, scratch, out);
 }
 
-std::vector<float> build_fast_embedding(
+void build_fast_embedding_into(
     const FishAudioConfig & config,
     const FishARWeights & weights,
-    int32_t code) {
-    return lookup_row(weights.fast_embedding_host, code, config.fast.dim);
+    int32_t code,
+    std::vector<float> & out) {
+    out.assign(static_cast<size_t>(config.fast.dim), 0.0F);
+    copy_tensor_row_to_f32(weights.fast_embedding_host, code, config.fast.dim, out.data());
 }
 
 FishLayerWeights load_layer(
@@ -463,17 +483,31 @@ struct SampleState {
     uint64_t call_index = 0;
     std::mt19937 rng;
     std::vector<int32_t> previous_main;
+    // Vocabulary-sized scratch reused across the whole generation. `sample_from_logits`
+    // runs twice per frame plus once per codebook, and the slow vocabulary is 155 776
+    // entries, so allocating these per call dominated the per-frame host cost.
+    std::vector<float> biased;
+    std::vector<int32_t> order;
+    std::vector<SampleCandidate> kept;
+    std::vector<double> weights;
 };
 
-SampleDistribution logits_to_distribution(
+// Reference parity note: this deliberately evaluates the nucleus on the *raw* logits and
+// applies the temperature afterwards, matching fish-speech's `logits_to_probs` (including
+// its "keep at least one option" rule and its max(temperature, 1e-5) floor). The shared
+// engine::sampling::HfSampler orders these the other way round; do not align them without
+// re-checking Fish Audio reference output. See docs/reviews/06 F6.8.
+void logits_to_distribution(
     const std::vector<float> & logits,
     float temperature,
     float top_p,
-    int top_k) {
+    int top_k,
+    std::vector<int32_t> & order,
+    std::vector<SampleCandidate> & kept) {
     if (logits.empty()) {
         throw std::runtime_error("Fish Audio sampling requires non-empty logits");
     }
-    std::vector<int32_t> order;
+    order.clear();
     order.reserve(logits.size());
     float max_logit = -std::numeric_limits<float>::infinity();
     for (size_t i = 0; i < logits.size(); ++i) {
@@ -502,7 +536,7 @@ SampleDistribution logits_to_distribution(
         std::sort(order.begin(), order.end(), by_logit_desc);
     }
     double cumulative = 0.0;
-    std::vector<SampleCandidate> kept;
+    kept.clear();
     kept.reserve(candidate_count);
     for (size_t i = 0; i < order.size(); ++i) {
         const int32_t index = order[i];
@@ -531,7 +565,6 @@ SampleDistribution logits_to_distribution(
     for (auto & candidate : kept) {
         candidate.probability = static_cast<float>(static_cast<double>(candidate.probability) / filtered_denom);
     }
-    return {logits.size(), std::move(kept)};
 }
 
 int32_t sample_from_logits(
@@ -541,26 +574,26 @@ int32_t sample_from_logits(
     int top_k,
     SampleState & state,
     const sampling::TorchCudaSamplingPolicy & policy) {
-    const auto distribution = logits_to_distribution(logits, temperature, top_p, top_k);
+    logits_to_distribution(logits, temperature, top_p, top_k, state.order, state.kept);
     const uint64_t call_index = state.call_index++;
     if (!policy.cuda_fast_path) {
-        std::vector<double> weights;
-        weights.reserve(distribution.candidates.size());
-        for (const auto & candidate : distribution.candidates) {
-            weights.push_back(static_cast<double>(std::max(candidate.probability, 0.0F)));
+        state.weights.clear();
+        state.weights.reserve(state.kept.size());
+        for (const auto & candidate : state.kept) {
+            state.weights.push_back(static_cast<double>(std::max(candidate.probability, 0.0F)));
         }
-        std::discrete_distribution<size_t> sampler(weights.begin(), weights.end());
-        return distribution.candidates[sampler(state.rng)].index;
+        std::discrete_distribution<size_t> sampler(state.weights.begin(), state.weights.end());
+        return state.kept[sampler(state.rng)].index;
     }
     int32_t best = 0;
     double best_score = -std::numeric_limits<double>::infinity();
-    for (const auto & candidate : distribution.candidates) {
+    for (const auto & candidate : state.kept) {
         if (!(candidate.probability > 0.0F)) {
             continue;
         }
         const float exponential = sampling::torch_cuda_tensor_iterator_exponential_element(
             state.seed,
-            static_cast<uint64_t>(distribution.source_size),
+            static_cast<uint64_t>(logits.size()),
             static_cast<uint64_t>(candidate.index),
             call_index,
             policy.multiprocessor_count,
@@ -577,11 +610,12 @@ int32_t sample_from_logits(
     return best;
 }
 
-std::vector<float> apply_semantic_bias(
+void apply_semantic_bias_into(
     const FishAudioConfig & config,
     int32_t im_end_id,
-    const std::vector<float> & logits) {
-    std::vector<float> out(logits.size(), -std::numeric_limits<float>::infinity());
+    const std::vector<float> & logits,
+    std::vector<float> & out) {
+    out.assign(logits.size(), -std::numeric_limits<float>::infinity());
     const int64_t begin = std::max<int64_t>(0, config.semantic_start_token_id);
     const int64_t end = std::min<int64_t>(static_cast<int64_t>(logits.size()) - 1, config.semantic_end_token_id);
     for (int64_t i = begin; i <= end; ++i) {
@@ -590,7 +624,6 @@ std::vector<float> apply_semantic_bias(
     if (im_end_id >= 0 && static_cast<size_t>(im_end_id) < logits.size()) {
         out[static_cast<size_t>(im_end_id)] = logits[static_cast<size_t>(im_end_id)];
     }
-    return out;
 }
 
 core::TensorValue make_fish_causal_mask(
@@ -862,11 +895,20 @@ public:
         ++profile.generated_frames;
         step_graph_->finish_prefill(prompt.steps);
         bool ended_by_im_end = false;
+        // Hoisted out of the loop: every buffer below is vocabulary- or hidden-sized and
+        // was previously reallocated on every generated frame.
+        std::vector<float> step_input;
+        SlowForwardOutput step_out;
         for (int64_t step = 1; step < max_new_tokens; ++step) {
             timing_start = Clock::now();
-            const auto input = build_slow_embedding_for_frame(assets.config, weights, frame);
+            build_slow_embedding_for_frame_into(
+                assets.config,
+                weights,
+                frame,
+                slow_embedding_scratch_,
+                step_input);
             profile.slow_embedding_ms += engine::debug::elapsed_ms(timing_start, Clock::now());
-            auto step_out = step_graph_->run(input, profile);
+            step_graph_->run_into(step_input, step_out, profile);
             frame = sample_frame(step_out.logits, step_out.hidden, options, sample, true, profile);
             if (frame.front() == im_end_id()) {
                 ended_by_im_end = true;
@@ -1164,6 +1206,15 @@ private:
         }
 
         SlowForwardOutput run(const std::vector<float> & embedding, FishARProfile & profile) {
+            SlowForwardOutput out;
+            run_into(embedding, out, profile);
+            return out;
+        }
+
+        // Hot path: writes into a caller-owned buffer so the 155 776-float logits row and
+        // the hidden row are allocated once per generation instead of once per frame.
+        // Same pattern as HiggsARDecodeGraph::run_step_into.
+        void run_into(const std::vector<float> & embedding, SlowForwardOutput & out, FishARProfile & profile) {
             const auto & config = runtime_->assets().config.text;
             if (static_cast<int64_t>(embedding.size()) != config.dim) {
                 throw std::runtime_error("Fish Audio step embedding size mismatch");
@@ -1197,14 +1248,12 @@ private:
                 throw std::runtime_error("Fish Audio AR step graph compute failed");
             }
             cache_.advance_after_direct_append(1);
-            SlowForwardOutput out;
             out.logits.resize(static_cast<size_t>(config.vocab_size));
             out.hidden.resize(static_cast<size_t>(config.dim));
             timing_start = Clock::now();
             ggml_backend_tensor_get(logits_, out.logits.data(), 0, out.logits.size() * sizeof(float));
             ggml_backend_tensor_get(hidden_, out.hidden.data(), 0, out.hidden.size() * sizeof(float));
             profile.step_output_read_ms += engine::debug::elapsed_ms(timing_start, Clock::now());
-            return out;
         }
 
     private:
@@ -1338,6 +1387,16 @@ private:
         }
 
         std::vector<float> run(const std::vector<float> & input, int64_t position, FishARProfile & profile) {
+            std::vector<float> logits;
+            run_into(input, position, logits, profile);
+            return logits;
+        }
+
+        void run_into(
+            const std::vector<float> & input,
+            int64_t position,
+            std::vector<float> & logits,
+            FishARProfile & profile) {
             const auto & config = runtime_->assets().config.fast;
             if (static_cast<int64_t>(input.size()) != config.dim) {
                 throw std::runtime_error("Fish Audio fast AR input size mismatch");
@@ -1371,11 +1430,10 @@ private:
             if (status != GGML_STATUS_SUCCESS) {
                 throw std::runtime_error("Fish Audio fast AR graph compute failed");
             }
-            std::vector<float> logits(static_cast<size_t>(config.vocab_size), 0.0F);
+            logits.assign(static_cast<size_t>(config.vocab_size), 0.0F);
             timing_start = Clock::now();
             ggml_backend_tensor_get(logits_, logits.data(), 0, logits.size() * sizeof(float));
             profile.fast_output_read_ms += engine::debug::elapsed_ms(timing_start, Clock::now());
-            return logits;
         }
 
     private:
@@ -1441,7 +1499,8 @@ private:
         const auto & config = runtime_->assets().config;
         const auto & weights = runtime_->weights();
         auto timing_start = Clock::now();
-        const auto biased = apply_semantic_bias(config, im_end_id(), slow_logits);
+        apply_semantic_bias_into(config, im_end_id(), slow_logits, sample.biased);
+        const auto & biased = sample.biased;
         profile.sample_bias_ms += engine::debug::elapsed_ms(timing_start, Clock::now());
         timing_start = Clock::now();
         int32_t main_token = sample_from_logits(
@@ -1473,7 +1532,8 @@ private:
         if (!is_semantic_token(config, main_token)) {
             return frame;
         }
-        const auto fast0_logits = fast_graph_->run(slow_hidden, 0, profile);
+        // Position 0 only primes the fast decoder's KV cache; its logits are unused.
+        fast_graph_->run_into(slow_hidden, 0, fast_logits_scratch_, profile);
         int32_t code = std::clamp<int32_t>(
             main_token - static_cast<int32_t>(config.semantic_start_token_id),
             0,
@@ -1481,12 +1541,12 @@ private:
         frame[1] = code;
         for (int64_t codebook = 1; codebook < config.fast.num_codebooks; ++codebook) {
             timing_start = Clock::now();
-            const auto embedding = build_fast_embedding(config, weights, code);
+            build_fast_embedding_into(config, weights, code, fast_embedding_scratch_);
             profile.fast_embedding_ms += engine::debug::elapsed_ms(timing_start, Clock::now());
-            const auto logits = fast_graph_->run(embedding, codebook, profile);
+            fast_graph_->run_into(fast_embedding_scratch_, codebook, fast_logits_scratch_, profile);
             timing_start = Clock::now();
             code = sample_from_logits(
-                logits,
+                fast_logits_scratch_,
                 options.temperature,
                 options.top_p,
                 options.top_k,
@@ -1530,6 +1590,9 @@ private:
     std::unique_ptr<PrefillGraph> prefill_graph_;
     std::unique_ptr<StepGraph> step_graph_;
     std::unique_ptr<FastGraph> fast_graph_;
+    SlowEmbeddingScratch slow_embedding_scratch_;
+    std::vector<float> fast_embedding_scratch_;
+    std::vector<float> fast_logits_scratch_;
 };
 
 FishAudioARRuntime::FishAudioARRuntime(

--- a/src/models/vibevoice/decoder.cpp
+++ b/src/models/vibevoice/decoder.cpp
@@ -10,6 +10,7 @@
 #include "engine/framework/modules/positional_modules.h"
 #include "engine/framework/modules/primitive_modules.h"
 #include "engine/framework/modules/structural_modules.h"
+#include "engine/framework/modules/transformers/qwen_causal_decode_runtime.h"
 #include "engine/framework/modules/weight_binding.h"
 #include "engine/framework/runtime/kv_cache.h"
 
@@ -43,6 +44,42 @@ struct GgmlContextDeleter {
         }
     }
 };
+
+// Rewrites `logits` into a compact device-side gather when `token_ids` is non-empty, so
+// the host readback carries only the control tokens VibeVoice actually reads instead of
+// the whole 152 064-entry vocabulary row. The gather itself is the framework's
+// build_compact_logits_gather(), the same mechanism MiniMax Music 3 drives through
+// QwenCausalDecodeRuntimeConfig::logits_readback_token_ids. The index input tensor is
+// allocated in `ctx` and returned through `ids_tensor`.
+core::TensorValue apply_logits_readback_subset(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & logits,
+    const std::vector<int32_t> & token_ids,
+    int64_t vocab_size,
+    ggml_tensor *& ids_tensor) {
+    ids_tensor = nullptr;
+    if (token_ids.empty()) {
+        return logits;
+    }
+    const int64_t compact_size = static_cast<int64_t>(token_ids.size());
+    ids_tensor = ggml_new_tensor_1d(ctx.ggml, GGML_TYPE_I32, compact_size);
+    const auto ids = core::wrap_tensor(
+        ids_tensor,
+        core::TensorShape::from_dims({compact_size}),
+        GGML_TYPE_I32);
+    return modules::build_compact_logits_gather(ctx, logits, ids, vocab_size, compact_size);
+}
+
+void upload_logits_readback_token_ids(ggml_tensor * tensor, const std::vector<int32_t> & token_ids) {
+    if (tensor == nullptr || token_ids.empty()) {
+        return;
+    }
+    ggml_backend_tensor_set(tensor, token_ids.data(), 0, token_ids.size() * sizeof(int32_t));
+}
+
+int64_t logits_row_size(const std::vector<int32_t> & token_ids, int64_t vocab_size) {
+    return token_ids.empty() ? vocab_size : static_cast<int64_t>(token_ids.size());
+}
 
 int64_t require_head_dim(const VibeVoiceDecoderConfig & config) {
     if (config.hidden_size <= 0 || config.intermediate_size <= 0) {
@@ -433,7 +470,8 @@ public:
         : runtime_(&runtime),
           batch_size_(batch_size),
           prompt_steps_(prompt_steps),
-          layerwise_(prompt_steps >= kLayerwisePrefillMinSteps) {
+          layerwise_(prompt_steps >= kLayerwisePrefillMinSteps),
+          readback_token_ids_(runtime.logits_readback_token_ids()) {
         if (batch_size_ <= 0) {
             throw std::runtime_error("VibeVoice decoder prefill graph requires positive batch size");
         }
@@ -491,6 +529,12 @@ public:
         auto logits = modules::LinearModule(
                           binding::linear_config(config.hidden_size, config.vocab_size, false))
                           .build(ctx, x, binding::linear_data(constants, runtime_->weights().lm_head));
+        logits = apply_logits_readback_subset(
+            ctx,
+            logits,
+            readback_token_ids_,
+            config.vocab_size,
+            readback_ids_tensor_);
         logits_output_ = logits.tensor;
         ggml_set_output(logits_output_);
         graph_ = ggml_new_graph_custom(ctx_.get(), 65536, false);
@@ -501,6 +545,7 @@ public:
         if (buffer_ == nullptr) {
             throw std::runtime_error("failed to allocate VibeVoice decoder prefill graph");
         }
+        upload_logits_readback_token_ids(readback_ids_tensor_, readback_token_ids_);
 
         const auto positions = build_position_values(prompt_steps_);
         ggml_backend_tensor_set(positions_, positions.data(), 0, positions.size() * sizeof(int32_t));
@@ -516,7 +561,8 @@ public:
 
     bool matches(const VibeVoiceDecoderWeightsRuntime & runtime, int64_t batch_size, int64_t prompt_steps) const {
         return runtime_ == &runtime && batch_size_ == batch_size && prompt_steps_ == prompt_steps &&
-            layerwise_ == (prompt_steps >= kLayerwisePrefillMinSteps);
+            layerwise_ == (prompt_steps >= kLayerwisePrefillMinSteps) &&
+            readback_token_ids_ == runtime.logits_readback_token_ids();
     }
 
     VibeVoiceDecoderPrefillOutput run(const std::vector<float> & embeddings) {
@@ -557,7 +603,8 @@ public:
             throw std::runtime_error("VibeVoice decoder prefill graph compute failed");
         }
 
-        const size_t logits_per_sample = static_cast<size_t>(config.vocab_size);
+        const size_t logits_per_sample =
+            static_cast<size_t>(logits_row_size(readback_token_ids_, config.vocab_size));
         const size_t hidden_per_sample = static_cast<size_t>(config.hidden_size);
         std::vector<float> logits(static_cast<size_t>(batch_size_) * logits_per_sample, 0.0F);
         std::vector<float> hidden(static_cast<size_t>(batch_size_) * hidden_per_sample, 0.0F);
@@ -568,6 +615,7 @@ public:
         for (int64_t batch = 0; batch < batch_size_; ++batch) {
             auto & sample = out[static_cast<size_t>(batch)];
             sample.result.logits.vocab_size = config.vocab_size;
+            sample.result.logits.token_ids = readback_token_ids_;
             sample.result.logits.values.assign(
                 logits.begin() + static_cast<std::ptrdiff_t>(batch * static_cast<int64_t>(logits_per_sample)),
                 logits.begin() + static_cast<std::ptrdiff_t>((batch + 1) * static_cast<int64_t>(logits_per_sample)));
@@ -730,6 +778,7 @@ private:
             size_t graph_arena_bytes)
             : runtime_(&runtime),
               batch_size_(batch_size),
+              readback_token_ids_(runtime.logits_readback_token_ids()),
               constants_(
                   runtime.backend(),
                   runtime.threads(),
@@ -754,6 +803,12 @@ private:
             auto logits = modules::LinearModule(
                               binding::linear_config(config.hidden_size, config.vocab_size, false))
                               .build(ctx, x, binding::linear_data(constants_, runtime_->weights().lm_head));
+            logits = apply_logits_readback_subset(
+                ctx,
+                logits,
+                readback_token_ids_,
+                config.vocab_size,
+                readback_ids_tensor_);
             logits_output_ = logits.tensor;
             graph_ = ggml_new_graph_custom(ctx_.get(), 8192, false);
             ggml_set_output(logits_output_);
@@ -764,6 +819,7 @@ private:
             if (buffer_ == nullptr) {
                 throw std::runtime_error("failed to allocate VibeVoice decoder final prefill graph");
             }
+            upload_logits_readback_token_ids(readback_ids_tensor_, readback_token_ids_);
         }
 
         ~FinalGraph() {
@@ -787,7 +843,8 @@ private:
                 throw std::runtime_error("VibeVoice decoder final prefill graph compute failed");
             }
 
-            const size_t logits_per_sample = static_cast<size_t>(config.vocab_size);
+            const size_t logits_per_sample =
+                static_cast<size_t>(logits_row_size(readback_token_ids_, config.vocab_size));
             const size_t hidden_per_sample = static_cast<size_t>(config.hidden_size);
             std::vector<float> logits(static_cast<size_t>(batch_size_) * logits_per_sample, 0.0F);
             std::vector<float> hidden(static_cast<size_t>(batch_size_) * hidden_per_sample, 0.0F);
@@ -798,6 +855,7 @@ private:
             for (int64_t batch = 0; batch < batch_size_; ++batch) {
                 auto & result = results[static_cast<size_t>(batch)];
                 result.logits.vocab_size = config.vocab_size;
+                result.logits.token_ids = readback_token_ids_;
                 result.logits.values.assign(
                     logits.begin() + static_cast<std::ptrdiff_t>(batch * static_cast<int64_t>(logits_per_sample)),
                     logits.begin() + static_cast<std::ptrdiff_t>((batch + 1) * static_cast<int64_t>(logits_per_sample)));
@@ -812,11 +870,13 @@ private:
     private:
         const VibeVoiceDecoderWeightsRuntime * runtime_ = nullptr;
         int64_t batch_size_ = 0;
+        std::vector<int32_t> readback_token_ids_;
         core::ConstantTensorCache constants_;
         std::unique_ptr<ggml_context, GgmlContextDeleter> ctx_;
         ggml_tensor * input_ = nullptr;
         ggml_tensor * hidden_output_ = nullptr;
         ggml_tensor * logits_output_ = nullptr;
+        ggml_tensor * readback_ids_tensor_ = nullptr;
         ggml_cgraph * graph_ = nullptr;
         ggml_backend_buffer_t buffer_ = nullptr;
     };
@@ -882,6 +942,8 @@ private:
     int64_t batch_size_ = 0;
     int64_t prompt_steps_ = 0;
     bool layerwise_ = false;
+    std::vector<int32_t> readback_token_ids_;
+    ggml_tensor * readback_ids_tensor_ = nullptr;
     std::unique_ptr<ggml_context, GgmlContextDeleter> ctx_;
     ggml_tensor * input_ = nullptr;
     ggml_tensor * positions_ = nullptr;
@@ -913,7 +975,8 @@ public:
         int64_t cache_steps,
         size_t graph_arena_bytes)
         : runtime_(&runtime),
-          cache_steps_(cache_steps) {
+          cache_steps_(cache_steps),
+          readback_token_ids_(runtime.logits_readback_token_ids()) {
         if (cache_steps_ <= 0) {
             throw std::runtime_error("VibeVoice decoder cached step graph requires positive cache steps");
         }
@@ -1003,6 +1066,12 @@ public:
         auto logits = modules::LinearModule(
                           binding::linear_config(config.hidden_size, config.vocab_size, false))
                           .build(ctx, x, binding::linear_data(constants, runtime_->weights().lm_head));
+        logits = apply_logits_readback_subset(
+            ctx,
+            logits,
+            readback_token_ids_,
+            config.vocab_size,
+            readback_ids_tensor_);
         logits_output_ = logits.tensor;
         ggml_set_output(logits_output_);
         ggml_build_forward_expand(graph_, logits_output_);
@@ -1012,6 +1081,7 @@ public:
         if (buffer_ == nullptr) {
             throw std::runtime_error("failed to allocate VibeVoice decoder cached step graph");
         }
+        upload_logits_readback_token_ids(readback_ids_tensor_, readback_token_ids_);
         attention_mask_buffer_.assign(static_cast<size_t>(cache_tensor_steps), ggml_fp32_to_fp16(-std::numeric_limits<float>::infinity()));
     }
 
@@ -1023,7 +1093,8 @@ public:
     }
 
     bool can_decode(const VibeVoiceDecoderWeightsRuntime & runtime, int64_t required_capacity) const {
-        return runtime_ == &runtime && cache_steps_ >= required_capacity;
+        return runtime_ == &runtime && cache_steps_ >= required_capacity &&
+            readback_token_ids_ == runtime.logits_readback_token_ids();
     }
 
     int64_t current_end() const noexcept {
@@ -1079,7 +1150,8 @@ public:
 
         VibeVoiceDecoderResult out;
         out.logits.vocab_size = config.vocab_size;
-        out.logits.values.resize(static_cast<size_t>(config.vocab_size));
+        out.logits.token_ids = readback_token_ids_;
+        out.logits.values.resize(static_cast<size_t>(logits_row_size(readback_token_ids_, config.vocab_size)));
         out.last_hidden.dims = config.hidden_size;
         out.last_hidden.values.resize(static_cast<size_t>(config.hidden_size));
         ggml_backend_tensor_get(logits_output_, out.logits.values.data(), 0, out.logits.values.size() * sizeof(float));
@@ -1114,6 +1186,7 @@ private:
 
     const VibeVoiceDecoderWeightsRuntime * runtime_ = nullptr;
     int64_t cache_steps_ = 0;
+    std::vector<int32_t> readback_token_ids_;
     bool scratch_tail_ = false;
     std::unique_ptr<ggml_context, GgmlContextDeleter> ctx_;
     ggml_tensor * input_ = nullptr;
@@ -1122,6 +1195,7 @@ private:
     ggml_tensor * attention_mask_ = nullptr;
     ggml_tensor * hidden_output_ = nullptr;
     ggml_tensor * logits_output_ = nullptr;
+    ggml_tensor * readback_ids_tensor_ = nullptr;
     std::vector<ggml_fp16_t> attention_mask_buffer_;
     runtime::TransformerKVCache cache_;
     std::vector<ggml_tensor *> key_sources_;
@@ -1141,7 +1215,8 @@ public:
         size_t graph_arena_bytes)
         : runtime_(&runtime),
           batch_size_(batch_size),
-          cache_steps_(cache_steps) {
+          cache_steps_(cache_steps),
+          readback_token_ids_(runtime.logits_readback_token_ids()) {
         if (batch_size_ <= 0 || cache_steps_ <= 0) {
             throw std::runtime_error("VibeVoice decoder cached batch graph requires positive dimensions");
         }
@@ -1199,6 +1274,12 @@ public:
         auto logits = modules::LinearModule(
                           binding::linear_config(config.hidden_size, config.vocab_size, false))
                           .build(ctx, x, binding::linear_data(constants, runtime_->weights().lm_head));
+        logits = apply_logits_readback_subset(
+            ctx,
+            logits,
+            readback_token_ids_,
+            config.vocab_size,
+            readback_ids_tensor_);
         logits_output_ = logits.tensor;
         ggml_set_output(logits_output_);
         ggml_build_forward_expand(graph_, logits_output_);
@@ -1208,6 +1289,7 @@ public:
         if (buffer_ == nullptr) {
             throw std::runtime_error("failed to allocate VibeVoice decoder cached batch graph");
         }
+        upload_logits_readback_token_ids(readback_ids_tensor_, readback_token_ids_);
         attention_mask_buffer_.assign(
             static_cast<size_t>(batch_size_ * cache_steps_),
             ggml_fp32_to_fp16(-std::numeric_limits<float>::infinity()));
@@ -1225,7 +1307,8 @@ public:
         const std::vector<VibeVoiceDecoderCachedState *> & states,
         int64_t required_capacity) const {
         if (runtime_ != &runtime || cache_steps_ < required_capacity ||
-            static_cast<int64_t>(states.size()) != batch_size_ || states.size() != states_.size()) {
+            static_cast<int64_t>(states.size()) != batch_size_ || states.size() != states_.size() ||
+            readback_token_ids_ != runtime.logits_readback_token_ids()) {
             return false;
         }
         for (size_t i = 0; i < states.size(); ++i) {
@@ -1364,7 +1447,8 @@ public:
             throw std::runtime_error("VibeVoice decoder cached batch step graph compute failed");
         }
 
-        const size_t logits_per_sample = static_cast<size_t>(config.vocab_size);
+        const size_t logits_per_sample =
+            static_cast<size_t>(logits_row_size(readback_token_ids_, config.vocab_size));
         const size_t hidden_per_sample = static_cast<size_t>(config.hidden_size);
         std::vector<float> logits(static_cast<size_t>(batch_size_) * logits_per_sample, 0.0F);
         std::vector<float> hidden(static_cast<size_t>(batch_size_) * hidden_per_sample, 0.0F);
@@ -1378,6 +1462,7 @@ public:
         for (int64_t batch = 0; batch < batch_size_; ++batch) {
             auto & result = out[static_cast<size_t>(batch)];
             result.logits.vocab_size = config.vocab_size;
+            result.logits.token_ids = readback_token_ids_;
             result.logits.values.assign(
                 logits.begin() + static_cast<std::ptrdiff_t>(batch * static_cast<int64_t>(logits_per_sample)),
                 logits.begin() + static_cast<std::ptrdiff_t>((batch + 1) * static_cast<int64_t>(logits_per_sample)));
@@ -1440,6 +1525,7 @@ public:
     const VibeVoiceDecoderWeightsRuntime * runtime_ = nullptr;
     int64_t batch_size_ = 0;
     int64_t cache_steps_ = 0;
+    std::vector<int32_t> readback_token_ids_;
     int64_t step_elems_ = 0;
     int64_t valid_steps_ = 0;
     int64_t current_end_ = 0;
@@ -1450,6 +1536,7 @@ public:
     ggml_tensor * attention_mask_ = nullptr;
     ggml_tensor * hidden_output_ = nullptr;
     ggml_tensor * logits_output_ = nullptr;
+    ggml_tensor * readback_ids_tensor_ = nullptr;
     std::vector<ggml_fp16_t> attention_mask_buffer_;
     std::vector<core::TensorValue> cache_keys_;
     std::vector<core::TensorValue> cache_values_;
@@ -1536,6 +1623,48 @@ ggml_type VibeVoiceDecoderWeightsRuntime::cache_type() const noexcept {
 
 int VibeVoiceDecoderWeightsRuntime::threads() const noexcept {
     return threads_;
+}
+
+void VibeVoiceDecoderWeightsRuntime::set_logits_readback_token_ids(std::vector<int32_t> token_ids) const {
+    const int64_t vocab_size = assets_->config.decoder.vocab_size;
+    for (const int32_t token : token_ids) {
+        if (token < 0 || token >= vocab_size) {
+            throw std::runtime_error("VibeVoice compact logits token id is outside the decoder vocabulary");
+        }
+    }
+    if (token_ids == logits_readback_token_ids_) {
+        return;
+    }
+    logits_readback_token_ids_ = std::move(token_ids);
+    // The cached logits graphs were built against the previous subset. Drop the prompt
+    // graphs outright; the step graphs are keyed on the subset through can_decode() and
+    // matches(), so they rebuild (and export their KV state first) on next use.
+    prefill_graph_.reset();
+}
+
+const std::vector<int32_t> & VibeVoiceDecoderWeightsRuntime::logits_readback_token_ids() const noexcept {
+    return logits_readback_token_ids_;
+}
+
+float vibevoice_logit_for_token(const VibeVoiceDecoderLogits & logits, int32_t token) {
+    if (logits.vocab_size <= 0 || token < 0 || token >= logits.vocab_size) {
+        throw std::runtime_error("VibeVoice logit lookup token is outside the decoder vocabulary");
+    }
+    if (logits.token_ids.empty()) {
+        if (static_cast<int64_t>(logits.values.size()) != logits.vocab_size) {
+            throw std::runtime_error("VibeVoice logit lookup received a truncated logits row");
+        }
+        return logits.values[static_cast<size_t>(token)];
+    }
+    if (logits.token_ids.size() != logits.values.size()) {
+        throw std::runtime_error("VibeVoice compact logits row does not match its token id list");
+    }
+    for (size_t index = 0; index < logits.token_ids.size(); ++index) {
+        if (logits.token_ids[index] == token) {
+            return logits.values[index];
+        }
+    }
+    throw std::runtime_error("VibeVoice compact logits row does not contain the requested token");
 }
 
 VibeVoiceTokenEmbeddings VibeVoiceDecoderWeightsRuntime::embed_tokens(

--- a/src/models/vibevoice/generator.cpp
+++ b/src/models/vibevoice/generator.cpp
@@ -418,12 +418,29 @@ struct VibeVoiceSamplingCandidate {
     float score = 0.0F;
 };
 
+// The four control tokens are the only vocabulary entries VibeVoice ever reads out of the
+// decoder logits, so the decoder gathers exactly these on-device instead of copying the
+// whole 152 064-entry row to the host on every token.
+std::vector<int32_t> vibevoice_constrained_token_ids(const VibeVoiceTextTokenizer & text_tokenizer) {
+    return {
+        text_tokenizer.speech_start_id(),
+        text_tokenizer.speech_end_id(),
+        text_tokenizer.speech_diffusion_id(),
+        text_tokenizer.eos_id(),
+    };
+}
+
 int32_t select_vibevoice_constrained_token(
     const VibeVoiceDecoderLogits & logits,
     const VibeVoiceTextTokenizer & text_tokenizer,
     const VibeVoiceGenerationOptions & options,
     std::mt19937 & rng) {
-    if (logits.vocab_size <= 0 || static_cast<int64_t>(logits.values.size()) != logits.vocab_size) {
+    if (logits.vocab_size <= 0 || logits.values.empty()) {
+        throw std::runtime_error("VibeVoice constrained token selection received invalid logits");
+    }
+    if (logits.token_ids.empty()
+            ? static_cast<int64_t>(logits.values.size()) != logits.vocab_size
+            : logits.token_ids.size() != logits.values.size()) {
         throw std::runtime_error("VibeVoice constrained token selection received invalid logits");
     }
     const int32_t candidates[] = {
@@ -438,7 +455,7 @@ int32_t select_vibevoice_constrained_token(
         if (token < 0 || token >= logits.vocab_size) {
             throw std::runtime_error("VibeVoice constrained token candidate is outside logits vocabulary");
         }
-        const float score = logits.values[static_cast<size_t>(token)];
+        const float score = vibevoice_logit_for_token(logits, token);
         if (score > best_score) {
             best_score = score;
             best_token = token;
@@ -465,7 +482,7 @@ int32_t select_vibevoice_constrained_token(
     std::vector<VibeVoiceSamplingCandidate> scores;
     scores.reserve(sizeof(candidates) / sizeof(candidates[0]));
     for (const int32_t token : candidates) {
-        scores.push_back({token, logits.values[static_cast<size_t>(token)] / options.temperature});
+        scores.push_back({token, vibevoice_logit_for_token(logits, token) / options.temperature});
     }
     if (options.top_k > 0 && static_cast<size_t>(options.top_k) < scores.size()) {
         const auto top_end = scores.begin() + static_cast<std::ptrdiff_t>(options.top_k);
@@ -532,6 +549,7 @@ VibeVoiceResult generate_vibevoice(
     VibeVoiceDecoderCachedState & positive_cache,
     VibeVoiceDecoderCachedState & negative_cache) {
     const auto & config = decoder.assets().config.decoder;
+    decoder.set_logits_readback_token_ids(vibevoice_constrained_token_ids(text_tokenizer));
     const auto prompt_noise_values = load_noise_file(request.generation.prompt_noise_file, "prompt");
     auto prompt = prepare_vibevoice_prompt(
         request,
@@ -673,6 +691,7 @@ std::vector<VibeVoiceResult> generate_vibevoice_batch(
     }
     std::cerr << "VibeVoice multi-batch generation is experimental; requested batch size "
               << requests.size() << ".\n";
+    decoder.set_logits_readback_token_ids(vibevoice_constrained_token_ids(text_tokenizer));
 
     const auto & first_options = requests.front().generation;
     for (const auto & request : requests) {

--- a/tests/unittests/test_compact_logits_readback.cpp
+++ b/tests/unittests/test_compact_logits_readback.cpp
@@ -1,0 +1,239 @@
+#include "engine/framework/core/backend.h"
+#include "engine/framework/core/module.h"
+#include "engine/framework/modules/transformers/qwen_causal_decode_runtime.h"
+
+#include "test_assert.h"
+
+#include <ggml-backend.h>
+#include <ggml.h>
+
+#include <cstdint>
+#include <exception>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+using engine::test::require;
+using engine::test::require_eq;
+
+struct GgmlContextDeleter {
+    void operator()(ggml_context * ctx) const noexcept {
+        if (ctx != nullptr) {
+            ggml_free(ctx);
+        }
+    }
+};
+
+class CpuBackend {
+public:
+    CpuBackend() {
+        backend_ = engine::core::init_backend({engine::core::BackendType::Cpu, 0, 1});
+        if (backend_ == nullptr) {
+            throw std::runtime_error("failed to initialize the CPU backend");
+        }
+    }
+
+    ~CpuBackend() {
+        if (backend_ != nullptr) {
+            ggml_backend_free(backend_);
+        }
+    }
+
+    CpuBackend(const CpuBackend &) = delete;
+    CpuBackend & operator=(const CpuBackend &) = delete;
+
+    ggml_backend_t get() const noexcept {
+        return backend_;
+    }
+
+private:
+    ggml_backend_t backend_ = nullptr;
+};
+
+// Distinct, exactly representable float per (row, token) so an equality comparison is
+// meaningful: every value below 2^24 is an integer that float holds without rounding.
+std::vector<float> synthetic_logits(int64_t rows, int64_t vocab) {
+    std::vector<float> out(static_cast<size_t>(rows * vocab), 0.0F);
+    for (int64_t row = 0; row < rows; ++row) {
+        for (int64_t token = 0; token < vocab; ++token) {
+            out[static_cast<size_t>(row * vocab + token)] =
+                static_cast<float>(row) * 1000000.0F + static_cast<float>(token) - 500.0F;
+        }
+    }
+    return out;
+}
+
+struct CompactReadback {
+    std::vector<float> values;
+    size_t compact_bytes = 0;
+    size_t full_bytes = 0;
+};
+
+// Builds exactly the graph the decode runtimes build for a compact logits readback,
+// computes it on the CPU backend, and returns the gathered row.
+CompactReadback run_compact_gather(
+    const CpuBackend & backend,
+    int64_t rows,
+    int64_t vocab,
+    const std::vector<float> & values,
+    const std::vector<int32_t> & subset) {
+    const int64_t compact_size = static_cast<int64_t>(subset.size());
+    ggml_init_params params{16ull * 1024ull * 1024ull, nullptr, true};
+    std::unique_ptr<ggml_context, GgmlContextDeleter> holder(ggml_init(params));
+    if (holder == nullptr) {
+        throw std::runtime_error("failed to initialize the test ggml context");
+    }
+
+    engine::core::ModuleBuildContext ctx{holder.get(), "test.compact_logits_readback"};
+    auto logits = engine::core::make_tensor(
+        ctx,
+        GGML_TYPE_F32,
+        engine::core::TensorShape::from_dims({rows, 1, vocab}));
+    ggml_set_input(logits.tensor);
+    ggml_tensor * ids = ggml_new_tensor_1d(holder.get(), GGML_TYPE_I32, compact_size);
+    ggml_set_input(ids);
+    const auto ids_value = engine::core::wrap_tensor(
+        ids,
+        engine::core::TensorShape::from_dims({compact_size}),
+        GGML_TYPE_I32);
+
+    const auto compact =
+        engine::modules::build_compact_logits_gather(ctx, logits, ids_value, vocab, compact_size);
+    ggml_set_output(compact.tensor);
+    ggml_cgraph * graph = ggml_new_graph(holder.get());
+    ggml_build_forward_expand(graph, compact.tensor);
+
+    ggml_backend_buffer_t buffer = ggml_backend_alloc_ctx_tensors(holder.get(), backend.get());
+    if (buffer == nullptr) {
+        throw std::runtime_error("failed to allocate the compact logits test graph");
+    }
+
+    ggml_backend_tensor_set(logits.tensor, values.data(), 0, values.size() * sizeof(float));
+    ggml_backend_tensor_set(ids, subset.data(), 0, subset.size() * sizeof(int32_t));
+    const ggml_status status = engine::core::compute_backend_graph(backend.get(), graph);
+    ggml_backend_synchronize(backend.get());
+    if (status != GGML_STATUS_SUCCESS) {
+        ggml_backend_buffer_free(buffer);
+        throw std::runtime_error("compact logits test graph compute failed");
+    }
+
+    CompactReadback out;
+    out.values.assign(static_cast<size_t>(rows) * subset.size(), 0.0F);
+    out.compact_bytes = ggml_nbytes(compact.tensor);
+    out.full_bytes = ggml_nbytes(logits.tensor);
+    ggml_backend_tensor_get(compact.tensor, out.values.data(), 0, out.values.size() * sizeof(float));
+    engine::core::release_backend_graph_resources(backend.get(), graph);
+    ggml_backend_buffer_free(buffer);
+    return out;
+}
+
+void require_matches_full_readback(
+    int64_t rows,
+    int64_t vocab,
+    const std::vector<float> & values,
+    const std::vector<int32_t> & subset,
+    const std::vector<float> & compact,
+    const std::string & label) {
+    require_eq(compact.size(), static_cast<size_t>(rows) * subset.size(), label + " compact size");
+    for (int64_t row = 0; row < rows; ++row) {
+        for (size_t index = 0; index < subset.size(); ++index) {
+            const float actual = compact[static_cast<size_t>(row) * subset.size() + index];
+            const float expected =
+                values[static_cast<size_t>(row * vocab + static_cast<int64_t>(subset[index]))];
+            if (actual != expected) {
+                throw std::runtime_error(
+                    label + " row " + std::to_string(row) + " slot " + std::to_string(index) +
+                    " (token " + std::to_string(subset[index]) + "): expected " +
+                    std::to_string(expected) + ", got " + std::to_string(actual));
+            }
+        }
+    }
+}
+
+void test_single_row_subset_matches_full_row(const CpuBackend & backend) {
+    constexpr int64_t rows = 1;
+    constexpr int64_t vocab = 32;
+    const std::vector<int32_t> subset = {7, 0, 31, 7};
+    const auto values = synthetic_logits(rows, vocab);
+    const auto readback = run_compact_gather(backend, rows, vocab, values, subset);
+    require_matches_full_readback(rows, vocab, values, subset, readback.values, "single row");
+    require_eq(readback.compact_bytes, size_t{16}, "single row compact byte count");
+    require_eq(readback.full_bytes, size_t{128}, "single row full byte count");
+}
+
+void test_multi_row_subset_matches_full_row(const CpuBackend & backend) {
+    constexpr int64_t rows = 3;
+    constexpr int64_t vocab = 17;
+    const std::vector<int32_t> subset = {16, 1, 9};
+    const auto values = synthetic_logits(rows, vocab);
+    const auto readback = run_compact_gather(backend, rows, vocab, values, subset);
+    require_matches_full_readback(rows, vocab, values, subset, readback.values, "multi row");
+    require_eq(readback.compact_bytes, size_t{3 * 3 * 4}, "multi row compact byte count");
+}
+
+// The VibeVoice shape from docs/reviews/03 F3.12: four control tokens out of a 152 064
+// entry vocabulary. 608 256 bytes per token become 16.
+void test_vibevoice_shape_overfetch_ratio(const CpuBackend & backend) {
+    constexpr int64_t rows = 1;
+    constexpr int64_t vocab = 152064;
+    const std::vector<int32_t> subset = {151643, 151646, 151647, 151645};
+    const auto values = synthetic_logits(rows, vocab);
+    const auto readback = run_compact_gather(backend, rows, vocab, values, subset);
+    require_matches_full_readback(rows, vocab, values, subset, readback.values, "vibevoice shape");
+    require_eq(readback.full_bytes, size_t{608256}, "vibevoice full readback bytes");
+    require_eq(readback.compact_bytes, size_t{16}, "vibevoice compact readback bytes");
+    require_eq(readback.full_bytes / readback.compact_bytes, size_t{38016}, "vibevoice overfetch ratio");
+}
+
+void test_rejects_logits_without_vocab_on_last_dim() {
+    ggml_init_params params{4ull * 1024ull * 1024ull, nullptr, true};
+    std::unique_ptr<ggml_context, GgmlContextDeleter> holder(ggml_init(params));
+    require(holder != nullptr, "failed to initialize the validation ggml context");
+    engine::core::ModuleBuildContext ctx{holder.get(), "test.compact_logits_validate"};
+    auto logits = engine::core::make_tensor(
+        ctx,
+        GGML_TYPE_F32,
+        engine::core::TensorShape::from_dims({1, 1, 16}));
+    ggml_tensor * ids = ggml_new_tensor_1d(holder.get(), GGML_TYPE_I32, 2);
+    const auto ids_value = engine::core::wrap_tensor(
+        ids,
+        engine::core::TensorShape::from_dims({2}),
+        GGML_TYPE_I32);
+
+    bool threw = false;
+    try {
+        (void)engine::modules::build_compact_logits_gather(ctx, logits, ids_value, 32, 2);
+    } catch (const std::exception &) {
+        threw = true;
+    }
+    require(threw, "compact logits gather accepted a mismatched vocabulary size");
+
+    threw = false;
+    try {
+        (void)engine::modules::build_compact_logits_gather(ctx, logits, ids_value, 16, 0);
+    } catch (const std::exception &) {
+        threw = true;
+    }
+    require(threw, "compact logits gather accepted an empty token subset");
+}
+
+}  // namespace
+
+int main() {
+    try {
+        CpuBackend backend;
+        test_single_row_subset_matches_full_row(backend);
+        test_multi_row_subset_matches_full_row(backend);
+        test_vibevoice_shape_overfetch_ratio(backend);
+        test_rejects_logits_without_vocab_on_last_dim();
+        std::cout << "compact_logits_readback_test passed\n";
+    } catch (const std::exception & ex) {
+        std::cerr << "compact_logits_readback_test failed: " << ex.what() << "\n";
+        return 1;
+    }
+    return 0;
+}

--- a/tests/unittests/test_hf_sampler_determinism.cpp
+++ b/tests/unittests/test_hf_sampler_determinism.cpp
@@ -1,0 +1,343 @@
+// Pins the Torch-CPU multinomial stream of engine::sampling::HfTokenSampler.
+//
+// hf_sampler.cpp used to rebuild a Mersenne Twister and fast-forward it by
+// call_index * vocab * 2 words on every single sample, which is quadratic in the number of
+// generated tokens and is paid on Metal by FireRedTTS3, MagpieTTS, MuScriptor and
+// PersonaPlex. It now keeps a small set of generators alive across calls instead.
+//
+// The oracle below is a verbatim copy of the *old* rebuild-and-rewind algorithm. Every
+// assertion in this file compares the shipping sampler against it, so any change that
+// alters the RNG stream for a given seed fails here rather than silently changing
+// generated audio.
+
+#include "engine/framework/sampling/hf_sampler.h"
+#include "engine/framework/sampling/torch_random.h"
+
+#include "test_assert.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <exception>
+#include <iostream>
+#include <limits>
+#include <random>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+using engine::test::require;
+using engine::test::require_eq;
+
+// Verbatim copy of hf_sampler.cpp's TorchCpuMt19937 as it stood before the cache landed.
+class ReferenceMt19937 {
+public:
+    explicit ReferenceMt19937(uint64_t seed) {
+        state_[0] = static_cast<uint32_t>(seed & 0xffffffffU);
+        for (int index = 1; index < kStateN; ++index) {
+            state_[index] =
+                1812433253U * (state_[index - 1] ^ (state_[index - 1] >> 30U)) + static_cast<uint32_t>(index);
+        }
+        left_ = 1;
+        next_ = 0;
+    }
+
+    uint32_t random() {
+        if (--left_ == 0) {
+            next_state();
+        }
+        uint32_t y = state_[next_++];
+        y ^= y >> 11U;
+        y ^= (y << 7U) & 0x9d2c5680U;
+        y ^= (y << 15U) & 0xefc60000U;
+        y ^= y >> 18U;
+        return y;
+    }
+
+    uint64_t random64() {
+        const uint32_t high = random();
+        const uint32_t low = random();
+        return (static_cast<uint64_t>(high) << 32U) | static_cast<uint64_t>(low);
+    }
+
+    void discard(uint64_t count) {
+        for (uint64_t index = 0; index < count; ++index) {
+            (void)random();
+        }
+    }
+
+private:
+    static constexpr int kStateN = 624;
+    static constexpr int kStateM = 397;
+    static constexpr uint32_t kMatrixA = 0x9908b0dfU;
+    static constexpr uint32_t kUpperMask = 0x80000000U;
+    static constexpr uint32_t kLowerMask = 0x7fffffffU;
+
+    static uint32_t mix_bits(uint32_t lhs, uint32_t rhs) {
+        return (lhs & kUpperMask) | (rhs & kLowerMask);
+    }
+
+    static uint32_t twist(uint32_t lhs, uint32_t rhs) {
+        return (mix_bits(lhs, rhs) >> 1U) ^ ((rhs & 1U) != 0U ? kMatrixA : 0U);
+    }
+
+    void next_state() {
+        uint32_t * p = state_.data();
+        left_ = kStateN;
+        next_ = 0;
+
+        for (int index = kStateN - kStateM + 1; --index != 0; ++p) {
+            *p = p[kStateM] ^ twist(p[0], p[1]);
+        }
+        for (int index = kStateM; --index != 0; ++p) {
+            *p = p[kStateM - kStateN] ^ twist(p[0], p[1]);
+        }
+        *p = p[kStateM - kStateN] ^ twist(p[0], state_[0]);
+    }
+
+    int left_ = 1;
+    uint32_t next_ = 0;
+    std::array<uint32_t, kStateN> state_{};
+};
+
+float reference_exponential(ReferenceMt19937 & rng) {
+    constexpr uint64_t mask = (uint64_t{1} << std::numeric_limits<double>::digits) - 1U;
+    constexpr double divisor = 1.0 / static_cast<double>(uint64_t{1} << std::numeric_limits<double>::digits);
+    const double uniform = static_cast<double>(rng.random64() & mask) * divisor;
+    return static_cast<float>(-std::log1p(-uniform));
+}
+
+// Verbatim copy of the old sample_torch_cpu_multinomial: rebuild, fast-forward, sample.
+int32_t reference_sample(const std::vector<float> & scores, uint64_t seed, uint64_t call_index) {
+    ReferenceMt19937 rng(seed);
+    rng.discard(call_index * static_cast<uint64_t>(scores.size()) * 2ULL);
+
+    float max_score = -std::numeric_limits<float>::infinity();
+    for (const float score : scores) {
+        if (std::isfinite(score)) {
+            max_score = std::max(max_score, score);
+        }
+    }
+    if (!std::isfinite(max_score)) {
+        throw std::runtime_error("reference sampler has no finite logits");
+    }
+    double best_rank = -std::numeric_limits<double>::infinity();
+    int32_t best_token = -1;
+    for (size_t token = 0; token < scores.size(); ++token) {
+        const float exponential = reference_exponential(rng);
+        if (!std::isfinite(scores[token])) {
+            continue;
+        }
+        const double weight = std::exp(static_cast<double>(scores[token] - max_score));
+        const double rank = weight / static_cast<double>(exponential);
+        if (rank > best_rank) {
+            best_rank = rank;
+            best_token = static_cast<int32_t>(token);
+        }
+    }
+    if (best_token < 0) {
+        throw std::runtime_error("reference sampler failed to select a token");
+    }
+    return best_token;
+}
+
+int32_t engine_sample(const std::vector<float> & scores, uint64_t seed, uint64_t call_index) {
+    // cuda_fast_path stays false, which is what the policy resolves to on every non-CUDA
+    // backend, so this is exactly the path Metal takes.
+    engine::sampling::TorchCudaSamplingPolicy policy;
+    engine::sampling::HfTorchSamplingState torch_state;
+    torch_state.policy = &policy;
+    torch_state.seed = seed;
+    torch_state.call_index = call_index;
+    engine::sampling::HfSamplerScratch scratch;
+    std::mt19937 unused_fallback(0);
+    return engine::sampling::HfTokenSampler::sample_from_processed_scores(
+        scores,
+        scratch,
+        unused_fallback,
+        &torch_state,
+        "hf sampler determinism test");
+}
+
+// A logits row with enough spread that the sampled token genuinely varies with the RNG.
+std::vector<float> make_scores(size_t vocab_size, uint32_t shape_seed) {
+    std::mt19937 shaper(shape_seed);
+    std::uniform_real_distribution<float> spread(-4.0F, 4.0F);
+    std::vector<float> scores(vocab_size, 0.0F);
+    for (float & score : scores) {
+        score = spread(shaper);
+    }
+    return scores;
+}
+
+size_t distinct_count(const std::vector<int32_t> & tokens) {
+    return std::set<int32_t>(tokens.begin(), tokens.end()).size();
+}
+
+// A sequential walk is the case the cache is built for: it must consume the identical
+// stream the rebuild-and-rewind algorithm did.
+void test_sequential_walk_matches_rebuild_and_rewind() {
+    constexpr uint64_t seed = 20240301;
+    constexpr size_t vocab_size = 97;
+    constexpr uint64_t steps = 64;
+    const auto scores = make_scores(vocab_size, 11);
+
+    std::vector<int32_t> engine_tokens;
+    std::vector<int32_t> reference_tokens;
+    engine_tokens.reserve(static_cast<size_t>(steps));
+    reference_tokens.reserve(static_cast<size_t>(steps));
+    for (uint64_t call_index = 0; call_index < steps; ++call_index) {
+        engine_tokens.push_back(engine_sample(scores, seed, call_index));
+        reference_tokens.push_back(reference_sample(scores, seed, call_index));
+    }
+
+    for (size_t index = 0; index < engine_tokens.size(); ++index) {
+        require_eq(
+            engine_tokens[index],
+            reference_tokens[index],
+            "sequential walk call_index " + std::to_string(index));
+    }
+    // Guards against the test passing because every call returns the same token.
+    require(
+        distinct_count(engine_tokens) >= size_t{8},
+        "sequential walk produced only " + std::to_string(distinct_count(engine_tokens)) +
+            " distinct tokens; the fixture is not exercising the RNG");
+}
+
+// Out-of-order call_index values must miss the cache and rebuild, still reproducing the
+// exact stream position the old code would have reached.
+void test_random_access_matches_rebuild_and_rewind() {
+    constexpr uint64_t seed = 777;
+    constexpr size_t vocab_size = 41;
+    const auto scores = make_scores(vocab_size, 22);
+    const std::vector<uint64_t> call_indices = {5, 2, 9, 0, 5, 7, 1, 9, 3, 0};
+
+    for (const uint64_t call_index : call_indices) {
+        require_eq(
+            engine_sample(scores, seed, call_index),
+            reference_sample(scores, seed, call_index),
+            "random access call_index " + std::to_string(call_index));
+    }
+}
+
+// Several generations running on one thread must not contaminate one another. The first
+// group fits in the cache so every call is a hit; the second deliberately exceeds it so
+// every call is an eviction and a rebuild. Both must reproduce the reference stream.
+void test_interleaved_seeds_stay_independent() {
+    constexpr size_t vocab_size = 53;
+    const auto scores = make_scores(vocab_size, 33);
+    const std::vector<uint64_t> fitting_seeds = {1, 2, 3};
+    const std::vector<uint64_t> thrashing_seeds = {11, 12, 13, 14, 15, 16, 17};
+
+    for (uint64_t call_index = 0; call_index < 12; ++call_index) {
+        for (const uint64_t seed : fitting_seeds) {
+            require_eq(
+                engine_sample(scores, seed, call_index),
+                reference_sample(scores, seed, call_index),
+                "interleaved seed " + std::to_string(seed) + " call_index " + std::to_string(call_index));
+        }
+    }
+    for (uint64_t call_index = 0; call_index < 6; ++call_index) {
+        for (const uint64_t seed : thrashing_seeds) {
+            require_eq(
+                engine_sample(scores, seed, call_index),
+                reference_sample(scores, seed, call_index),
+                "thrashing seed " + std::to_string(seed) + " call_index " + std::to_string(call_index));
+        }
+    }
+}
+
+// Filtered-out tokens are -inf but still consume two RNG words each. If that invariant
+// ever breaks, the cached generator drifts and this fails.
+void test_filtered_scores_still_advance_the_stream() {
+    constexpr uint64_t seed = 4242;
+    constexpr size_t vocab_size = 128;
+    auto scores = make_scores(vocab_size, 44);
+    for (size_t index = 0; index < scores.size(); ++index) {
+        if (index % 3 != 0) {
+            scores[index] = -std::numeric_limits<float>::infinity();
+        }
+    }
+
+    std::vector<int32_t> tokens;
+    for (uint64_t call_index = 0; call_index < 32; ++call_index) {
+        const int32_t token = engine_sample(scores, seed, call_index);
+        require_eq(
+            token,
+            reference_sample(scores, seed, call_index),
+            "filtered scores call_index " + std::to_string(call_index));
+        require(token % 3 == 0, "sampler selected a filtered-out token");
+        tokens.push_back(token);
+    }
+    require(distinct_count(tokens) >= size_t{5}, "filtered fixture is not exercising the RNG");
+}
+
+// Two identical walks in the same process — one on a cold cache slot, one on a warm one —
+// must return the identical token sequence.
+void test_repeated_walk_is_reproducible() {
+    constexpr uint64_t seed = 99991;
+    constexpr size_t vocab_size = 71;
+    constexpr uint64_t steps = 40;
+    const auto scores = make_scores(vocab_size, 55);
+
+    std::vector<int32_t> first;
+    for (uint64_t call_index = 0; call_index < steps; ++call_index) {
+        first.push_back(engine_sample(scores, seed, call_index));
+    }
+    // Evict the warm slot with unrelated traffic before replaying.
+    const auto filler = make_scores(23, 66);
+    for (uint64_t seed_offset = 0; seed_offset < 8; ++seed_offset) {
+        (void)engine_sample(filler, 500 + seed_offset, seed_offset);
+    }
+    std::vector<int32_t> second;
+    for (uint64_t call_index = 0; call_index < steps; ++call_index) {
+        second.push_back(engine_sample(scores, seed, call_index));
+    }
+
+    require_eq(second.size(), first.size(), "repeated walk length");
+    for (size_t index = 0; index < first.size(); ++index) {
+        require_eq(second[index], first[index], "repeated walk call_index " + std::to_string(index));
+    }
+    require(distinct_count(first) >= size_t{8}, "repeated walk fixture is not exercising the RNG");
+}
+
+// Vocabulary size is part of the stream position. A generation that changes it mid-walk
+// (a different sampler head) must not reuse the previous generator.
+void test_vocab_size_change_invalidates_the_stream_position() {
+    constexpr uint64_t seed = 31337;
+    const auto small = make_scores(19, 77);
+    const auto large = make_scores(83, 88);
+
+    for (uint64_t call_index = 0; call_index < 10; ++call_index) {
+        require_eq(
+            engine_sample(small, seed, call_index),
+            reference_sample(small, seed, call_index),
+            "small vocab call_index " + std::to_string(call_index));
+        require_eq(
+            engine_sample(large, seed, call_index),
+            reference_sample(large, seed, call_index),
+            "large vocab call_index " + std::to_string(call_index));
+    }
+}
+
+}  // namespace
+
+int main() {
+    try {
+        test_sequential_walk_matches_rebuild_and_rewind();
+        test_random_access_matches_rebuild_and_rewind();
+        test_interleaved_seeds_stay_independent();
+        test_filtered_scores_still_advance_the_stream();
+        test_repeated_walk_is_reproducible();
+        test_vocab_size_change_invalidates_the_stream_position();
+        std::cout << "hf_sampler_determinism_test passed\n";
+    } catch (const std::exception & ex) {
+        std::cerr << "hf_sampler_determinism_test failed: " << ex.what() << "\n";
+        return 1;
+    }
+    return 0;
+}

--- a/tests/unittests/test_hf_sampler_ordering.cpp
+++ b/tests/unittests/test_hf_sampler_ordering.cpp
@@ -1,0 +1,155 @@
+// Pins the warper order of engine::sampling::HfSampler: repetition penalty, then
+// temperature, then top-k, then top-p — the HuggingFace order (hf_sampler.cpp:452-454).
+//
+// The order is load-bearing, not cosmetic: evaluating the nucleus before the temperature
+// divides admits a different set of tokens, and the difference grows as the temperature
+// moves away from 1.0. docs/reviews/06 F6.8 flagged Fish Audio for using the reversed
+// order; that model deliberately reproduces fish-speech's `logits_to_probs`, so the two
+// orders coexist on purpose. This test fixes the shared sampler's order so nobody
+// "harmonises" them by changing the wrong one.
+
+#include "engine/framework/sampling/hf_sampler.h"
+
+#include "test_assert.h"
+
+#include <cmath>
+#include <cstdint>
+#include <exception>
+#include <iostream>
+#include <limits>
+#include <random>
+#include <string>
+#include <vector>
+
+namespace {
+
+using engine::test::require;
+using engine::test::require_close;
+using engine::test::require_eq;
+
+// Hand-computed fixture.
+//
+//   logits      = [2, 1, 0, -1], temperature = 0.5, top_p = 0.9
+//
+// Temperature first (the HF order, and this repo's):
+//   scaled      = [4, 2, 0, -2]
+//   softmax     = [0.864665, 0.117057, 0.015842, 0.002144]
+//   apply_top_p removes from the tail while the removed mass stays <= 1 - top_p = 0.1:
+//     -1 -> 0.002144 (<= 0.1, removed), 0 -> 0.017986 (<= 0.1, removed),
+//      1 -> 0.135043 (>  0.1, kept)
+//   survivors   = {0, 1}
+//   renormalised p(token 0) = 1 / (1 + e^-2) = 0.8807971
+//
+// Top-p first at T = 1 (the reversed order):
+//   softmax     = [0.643914, 0.236883, 0.087144, 0.032058]
+//     -1 -> 0.032058 (<= 0.1, removed), 0 -> 0.119202 (> 0.1, kept)
+//   survivors   = {0, 1, 2}
+constexpr float kTemperature = 0.5F;
+constexpr float kTopP = 0.9F;
+constexpr float kExpectedTopProbability = 0.8807971F;
+
+const std::vector<float> & fixture_logits() {
+    static const std::vector<float> logits = {2.0F, 1.0F, 0.0F, -1.0F};
+    return logits;
+}
+
+bool is_removed(float score) {
+    return score == -std::numeric_limits<float>::infinity();
+}
+
+void test_temperature_before_top_p_keeps_two_tokens() {
+    std::vector<float> scores = fixture_logits();
+    engine::sampling::HfSamplerScratch scratch;
+    engine::sampling::HfLogitsProcessor::apply_temperature(scores, kTemperature);
+    engine::sampling::HfLogitsProcessor::apply_top_p(scores, kTopP, 1, scratch);
+
+    require_close(scores[0], 4.0F, 0.0F, "temperature-first scaled logit 0");
+    require_close(scores[1], 2.0F, 0.0F, "temperature-first scaled logit 1");
+    require(!is_removed(scores[0]), "temperature-first removed token 0");
+    require(!is_removed(scores[1]), "temperature-first removed token 1");
+    require(is_removed(scores[2]), "temperature-first kept token 2 inside the nucleus");
+    require(is_removed(scores[3]), "temperature-first kept token 3 inside the nucleus");
+}
+
+void test_top_p_before_temperature_keeps_three_tokens() {
+    std::vector<float> scores = fixture_logits();
+    engine::sampling::HfSamplerScratch scratch;
+    engine::sampling::HfLogitsProcessor::apply_top_p(scores, kTopP, 1, scratch);
+    engine::sampling::HfLogitsProcessor::apply_temperature(scores, kTemperature);
+
+    require(!is_removed(scores[0]), "top-p-first removed token 0");
+    require(!is_removed(scores[1]), "top-p-first removed token 1");
+    // The whole point: at T = 0.5 the reversed order admits a token the HF order rejects.
+    require(!is_removed(scores[2]), "top-p-first rejected token 2; the two orders no longer differ");
+    require(is_removed(scores[3]), "top-p-first kept token 3 inside the nucleus");
+    require_close(scores[2], 0.0F, 0.0F, "top-p-first scaled logit 2");
+}
+
+void test_sampler_end_to_end_uses_the_temperature_first_nucleus() {
+    engine::sampling::HfSampler sampler;
+    engine::sampling::HfSamplerScratch scratch;
+    engine::sampling::HfSamplingOptions options;
+    options.do_sample = true;
+    options.temperature = kTemperature;
+    options.top_p = kTopP;
+    std::mt19937 rng(1234);
+
+    constexpr int64_t draws = 20000;
+    std::vector<int64_t> counts(fixture_logits().size(), 0);
+    for (int64_t draw = 0; draw < draws; ++draw) {
+        const int32_t token = sampler.sample(
+            fixture_logits(),
+            {},
+            options,
+            scratch,
+            rng,
+            nullptr,
+            "hf sampler ordering test");
+        require(token >= 0 && token < 4, "sampler returned an out-of-range token");
+        ++counts[static_cast<size_t>(token)];
+    }
+
+    require_eq(counts[2], int64_t{0}, "token 2 was sampled from outside the nucleus");
+    require_eq(counts[3], int64_t{0}, "token 3 was sampled from outside the nucleus");
+    require(counts[1] > 0, "token 1 never sampled; the nucleus collapsed to a single token");
+
+    const float observed = static_cast<float>(counts[0]) / static_cast<float>(draws);
+    // 20 000 draws give a standard error of 0.0023, so 0.01 is a ~4.3 sigma band.
+    require_close(observed, kExpectedTopProbability, 0.01F, "post-temperature top token frequency");
+}
+
+void test_argmax_ignores_the_warpers_when_sampling_is_off() {
+    engine::sampling::HfSampler sampler;
+    engine::sampling::HfSamplerScratch scratch;
+    engine::sampling::HfSamplingOptions options;
+    options.do_sample = false;
+    options.temperature = kTemperature;
+    options.top_p = kTopP;
+    std::mt19937 rng(1);
+
+    const int32_t token = sampler.sample(
+        fixture_logits(),
+        {},
+        options,
+        scratch,
+        rng,
+        nullptr,
+        "hf sampler ordering test");
+    require_eq(token, int32_t{0}, "greedy decode did not pick the maximum logit");
+}
+
+}  // namespace
+
+int main() {
+    try {
+        test_temperature_before_top_p_keeps_two_tokens();
+        test_top_p_before_temperature_keeps_three_tokens();
+        test_sampler_end_to_end_uses_the_temperature_first_nucleus();
+        test_argmax_ignores_the_warpers_when_sampling_is_off();
+        std::cout << "hf_sampler_ordering_test passed\n";
+    } catch (const std::exception & ex) {
+        std::cerr << "hf_sampler_ordering_test failed: " << ex.what() << "\n";
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
## What this changes

Three changes. **None of them alters a sampled token.**

### 1. Quadratic RNG rewind, reachable on non-CUDA backends

`hf_sampler` rebuilt the Torch-CPU MT19937 on every call and discarded `call_index * vocab * 2` words to reach the right stream position, so a sequential walk cost O(call_index × vocab) per token. Most call sites gate this behind `cuda_fast_path`, but `fireredtts3:730`, `magpie_tts:1236`, `muscriptor:1504` and `personaplex:410` do not — MuScriptor at 1500 steps burns on the order of **1e10 wasted RNG words**.

Replaced with a 4-entry `thread_local` LRU generator cache keyed on `(seed, draws_per_call, next_call_index)`.

**The stream is identical by construction.** `torch_cpu_exponential_float` is called at the top of the loop body, *before* the `isfinite` check, so every entry draws exactly two words whether or not it is `-inf`, and there is no `break` or early return. After call *n* the generator therefore sits at exactly the offset a rebuild for call *n+1* would produce. Any key mismatch falls through to the previous construct-and-discard path verbatim.

The `max_score` finiteness throw moved above generator acquisition. That is unobservable in the stream — no words were drawn before it — and it guarantees no exception can occur between acquire and commit, so the cache can never record a position the generator did not reach.

`ENGINE_TORCH_CPU_RNG_CACHE=0` restores the old path.

**Note on existing coverage:** `tests/unittests/test_torch_random.cpp` does *not* cover this. It includes only `torch_random.h` and exercises the CUDA Philox path, never the CPU MT19937. So the new test carries a **verbatim copy of the previous algorithm as an independent oracle** and compares token by token across a 64-step sequential walk, out-of-order call indices, forced cache eviction, three and seven interleaved seeds, alternating vocab sizes, and a row that is two-thirds `-inf`. Anti-vacuity guards assert at least 8 distinct tokens so it cannot pass by returning a constant.

### 2. VibeVoice copied 152,064 floats per token to read four of them

`decoder.cpp:1085` pulled the full vocabulary row; `generator.cpp:429-441` indexes exactly four fixed control-token ids. A **38,016× overfetch** — 608,256 bytes and a 594 KiB allocation, every token.

`compact_logits_readback` already existed in the framework, gathering an arbitrary token subset on-device via `ggml_get_rows`, with exactly one user (`minimax_music3`). VibeVoice now drives the same mechanism across all four of its logits-producing graphs: **608,256 → 16 bytes per token**. The gather body was hoisted into `build_compact_logits_gather` so there is one implementation and it is unit-testable; the node sequence is unchanged, so `minimax_music3` is bit-identical.

The other six full-vocabulary readback consumers were audited and **none** can use this: four run in `Hidden` mode where no logits tensor is built at all, and two are genuinely unconstrained samplers that need the whole row.

### 3. Fish Audio allocated ~2.5 MB of heap per frame

Across six sites, including two full 155,776-float logits vectors because `sample_from_logits` runs twice. Adopts the `run_step_into` pattern that `higgs_audio_tts/generator.cpp:451-453` already uses; steady state is now zero per-frame heap traffic on those paths. Call order, RNG consumption and the weights handed to `std::discrete_distribution` are unchanged.

## Investigated and deliberately left alone

Fish Audio's top-p-before-temperature ordering. `ar.cpp:487-527` is a line-by-line port of fish-speech's `logits_to_probs` — confirmed by the `&& i != 0` keep-at-least-one guard and the `max(temperature, 1e-5)` clamp — so it is an **intentional divergence** from the shared sampler, not a defect. Changing it would break reference parity and move generated audio for every existing seed. Documented in place, with `test_hf_sampler_ordering` pinning the shared sampler's HF order (hand-computed fixture, both orders asserted to actually differ) so the two do not get harmonised by mistake.

## Validation

**Build**
```
cmake -S . -B build -DENGINE_BUILD_TESTS=ON
cmake --build build
```

**Test**
```
ctest -R "hf_sampler_determinism_test|compact_logits_readback_test|hf_sampler_ordering_test"
```

**Backend tested:** Metal, Apple M4 Max. A VibeVoice render is **byte-identical** before and after (SHA-256 `d38f9ebd…`) — that is the check that matters for the on-device gather, since a Metal `GET_ROWS` divergence would change which control token wins *without erroring*. Full suite **41/41**.

## Affects

Performance only; output asserted unchanged. If any sampled-token change is observed on FireRedTTS3 / MagpieTTS / MuScriptor / PersonaPlex, set `ENGINE_TORCH_CPU_RNG_CACHE=0` first to confirm the cache is the cause.

## Known limitations

Two genuinely unconstrained full-vocabulary readbacks remain and are out of scope here — `fireredtts3/pipeline.cpp:718` (151,936 floats per prefill step) and `qwen3_asr/thinker.cpp:710-711`. Both sit on model-owned graphs that `logits_readback_token_ids` cannot reach; they need a device-side top-k rather than a subset gather.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ATa5YkLUPMDPRL7w1gCo9p