### PR TITLE
tts: make the OmniVoice reference clamp reachable, and stop silent truncation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2032,6 +2032,22 @@ if (ENGINE_BUILD_TESTS)
         COMMAND audio_chunking_test
     )
 
+    add_engine_unittest(qwen3_tts_chunk_budget_test tests/unittests/test_qwen3_tts_chunk_budget.cpp)
+
+    add_test(
+        NAME qwen3_tts_chunk_budget_test
+        COMMAND qwen3_tts_chunk_budget_test
+    )
+
+    if (omnivoice IN_LIST AUDIOCPP_LINKED_MODELS)
+        add_engine_unittest(omnivoice_reference_clamp_test tests/unittests/test_omnivoice_reference_clamp.cpp)
+
+        add_test(
+            NAME omnivoice_reference_clamp_test
+            COMMAND omnivoice_reference_clamp_test
+        )
+    endif()
+
     add_engine_unittest(chinese_normalization_test tests/unittests/test_chinese_normalization.cpp)
 
     add_test(

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -95,10 +95,14 @@ audiocpp_cli --task vc --family chatterbox --model models/chatterbox --backend c
 | `--text-chunk-size` | integer chars | `128` | Long-form chunk size. |
 | `--guidance-scale` | float | `0.5` | CFG strength. |
 | `--temperature` | float | `0.8` | T3 sampling temperature. |
-| `--top-p` | float | `0.8` | T3 nucleus sampling limit. |
-| `--repetition-penalty` | float | `2.0` | T3 repetition penalty. |
-| `--max-tokens` | integer | `1000` | Maximum generated T3 tokens per chunk. |
+| `--top-p` | float | `1.0` | T3 nucleus sampling limit. `1.0` disables nucleus filtering outright; `min_p` is the truncation filter that runs by default. |
+| `--request-option min_p=<float>` | float | `0.05` | T3 minimum-probability filter, applied before top-p. |
+| `--repetition-penalty` | float | `1.2` | T3 repetition penalty. |
+| `--max-tokens` | integer | `1000` | Maximum generated T3 tokens per chunk. At the 25 Hz speech-token rate this is about 40 s of audio; a chunk that reaches it is truncated mid-utterance and a warning is printed. |
 | `--do-sample` | `true`, `false` | `true` | Enable stochastic T3 sampling. |
+| `--request-option exaggeration=<float>` | float | `0.5` | Emotion-advance conditioning strength. |
+| `--request-option s3gen_cfg_rate=<float>` | float | `0.7` | S3Gen flow-matching CFG rate. |
+| `--request-option stop_on_eos=<bool>` | `true`, `false` | `true` | Stop T3 decoding at the speech end token. Set `false` only to inspect raw decode behaviour; the cap-hit warning is suppressed. |
 
 ## Confucius4-TTS
 
@@ -389,6 +393,15 @@ Streaming voice clone:
 ```bash
 audiocpp_cli --task tts --mode streaming --family omnivoice --model models/OmniVoice --backend cuda --text "Hello from OmniVoice." --voice-ref assets/resources/b.wav --reference-text "Some call me nature. Others call me Mother Nature. I've been here for over 4.5 billion years. 22,500 times longer than you." --text-chunk-size 160 --out stream.wav --out-dir stream_chunks
 ```
+
+Reference clips are clamped to 15 seconds of speech before encoding. OmniVoice conditions on the whole reference at 75 Hz with no KV cache, so a long clip is both the worst quality and the worst latency: a 101 s reference measured at 0.30x realtime with garbled output, against 2.26x and clean output for a 12 s cut of the same voice. The shipped demo voices run 4.7-9.9 s. The clamp cuts at the *start* of a real pause, never mid-word, and re-pads both ends with exact digital silence; if no pause exists inside the limit the whole clip is kept and a warning is printed instead of a word being sliced. Both knobs are request options:
+
+| Option | Values | Default | Meaning |
+|---|---|---:|---|
+| `--request-option reference_max_seconds=<float>` | float, `0` for no limit | `15` | Longest stretch of reference speech used for conditioning. |
+| `--request-option reference_pad_ms=<int>` | integer | `150` | Exact digital silence written onto both ends of a clamped reference. |
+
+The clamp runs as part of the reference preprocessing chain, so `--request-option preprocess_prompt=false` bypasses it along with the silence trimming.
 
 OmniVoice streaming is pseudo streaming: audio.cpp emits audio chunk events from text chunks and returns a merged final WAV. Upstream Python does not expose model-native streaming. For server SSE examples, options, and tag controls, see [OmniVoice](models/omnivoice.md).
 
@@ -783,6 +796,7 @@ audiocpp_cli --task tts --family vibevoice --model models/VibeVoice-1.5B --backe
 | Option | Values | Default | Meaning |
 |---|---|---:|---|
 | `--request-option voice_samples=a.wav,b.wav` | comma-separated WAVs | not set | Speaker reference WAVs, ordered by speaker id. |
+| `--session-option vibevoice.voice_prompt_max_seconds=<int>` | integer, `0` for no cap | `30` on CUDA/HIP, `10` elsewhere | Reference voice prompt length cap. |
 | `--guidance-scale` | float | `1.3` | Classifier-free guidance scale. |
 | `--num-inference-steps` | integer | `10` | Diffusion steps per audio chunk. |
 | `--max-tokens` | integer, `0` for unlimited | `0` | Maximum generated decoder tokens. |
@@ -793,6 +807,8 @@ audiocpp_cli --task tts --family vibevoice --model models/VibeVoice-1.5B --backe
 | `--top-p` | float | `1.0` | Decoder nucleus sampling limit. |
 | `--load-option vibevoice.lora=<path>` | fine-tune adapter dir | not set | Overlay a fine-tune at load time: the language-model LoRA is delta-merged into the decoder linears, and the diffusion head and acoustic/semantic connectors (when present in the adapter dir) replace their base tensors. Dims must match the base model size. |
 | `--load-option vibevoice.lora_scale=<float>` | float | `lora_alpha / r` | Override the LoRA merge scale from `adapter_config.json`. |
+
+Reference voice prompts are truncated to `vibevoice.voice_prompt_max_seconds` before the acoustic encoder sees them, with a 10 ms fade at the cut and a message on stderr when it fires. The default differs by backend — 30 s on CUDA and HIP, 10 s on CPU, Metal and Vulkan — so the same command conditions on a third as much reference audio on Metal as it does on CUDA. That split has never been measured; it dates from the initial VibeVoice integration and reads as caution rather than a known limit. Set the option explicitly (`=30`, or `=0` for no cap) if you want the two backends to match, and check for out-of-memory before trusting the result on a large reference.
 
 The adapter follows the PEFT training layout: `adapter_model.safetensors` + `adapter_config.json` for the language-model LoRA, plus optional `diffusion_head/model.safetensors` (or `diffusion_head_full.bin`), `acoustic_connector/pytorch_model.bin`, and `semantic_connector/pytorch_model.bin` for the fully fine-tuned components. Everything is applied at load time, so it composes with the `vibevoice.*_weight_type` quantization options and adds no per-step cost; the overlay is logged with `--log`. Use a 1.5B adapter with `VibeVoice-1.5B` and a 7B adapter with `VibeVoice-7B`; a size mismatch is rejected with a descriptive error. The same option may instead be passed as `--session-option vibevoice.lora` (but not via both at once).
 

--- a/include/engine/models/chatterbox/t3_types.h
+++ b/include/engine/models/chatterbox/t3_types.h
@@ -75,11 +75,14 @@ struct T3GenerateRequest {
     std::vector<float> emotion_adv;
     std::vector<int32_t> text_tokens;
     std::vector<int32_t> initial_speech_tokens;
-    int64_t max_new_tokens = 256;
+    // Every field below is overwritten by ChatterboxTtsComponent before this
+    // request is issued; keep the values in step with ChatterboxVoiceCloneConfig
+    // so reading this header does not suggest a second, different default set.
+    int64_t max_new_tokens = 1000;
     bool stop_on_eos = true;
     bool do_sample = true;
     float temperature = 0.8f;
-    float top_p = 0.95f;
+    float top_p = 1.0f;
     float min_p = 0.05f;
     float repetition_penalty = 1.2f;
     float guidance_scale = 0.5f;
@@ -90,6 +93,9 @@ struct T3GenerateOutputs {
     std::vector<int32_t> predicted_tokens;
     int64_t token_count = 0;
     bool hit_eos = false;
+    // Budget actually used, after clamping the request against the number of
+    // rows in the checkpoint's speech position table.
+    int64_t max_new_tokens = 0;
     double prefix_cache_build_ms = 0.0;
     double decoder_cache_clone_ms = 0.0;
     double prefill_runner_ms = 0.0;

--- a/include/engine/models/chatterbox/tts.h
+++ b/include/engine/models/chatterbox/tts.h
@@ -22,9 +22,17 @@ struct ChatterboxVoiceCloneConfig {
     float temperature = 0.8f;
     float repetition_penalty = 1.2f;
     float min_p = 0.05f;
+    // top_p = 1.0 is upstream's own default and is a deliberate no-op: min_p
+    // (0.05) is the truncation filter that actually runs. Matches
+    // tests/chatterbox/chatterbox_python_warm_bench.py, the repo's parity
+    // harness, which passes top_p=1.0 and repetition_penalty=1.2.
     float top_p = 1.0f;
     float s3gen_cfg_rate = 0.7f;
-    int64_t max_new_tokens = 384;
+    // 384 was 15.4 s of audio at the 25 Hz speech-token rate -- below the
+    // 128-codepoint text chunk in the worst case, so long chunks truncated
+    // silently. 1000 is what upstream's generate() passes and what
+    // tests/chatterbox/chatterbox_warm_bench.cpp and docs/tts.md both use.
+    int64_t max_new_tokens = 1000;
     uint32_t seed = 0;
     std::string language = "en";
     bool do_sample = true;
@@ -36,6 +44,12 @@ struct ChatterboxVoiceCloneOutputs {
     std::vector<int32_t> text_tokens;
     std::vector<int32_t> generated_speech_tokens;
     std::vector<int32_t> cleaned_speech_tokens;
+    // F6.5/F6.6: false with stop_on_eos means the T3 decode loop ran out of
+    // budget rather than finishing the utterance, so the audio is clipped.
+    bool hit_eos = false;
+    // Budget actually applied, after clamping to the checkpoint's speech
+    // position table.
+    int64_t max_new_tokens = 0;
     int64_t cuda_memory_total_bytes = 0;
     double prompt_prep_ms = 0.0;
     double prompt_prep_gen_ms = 0.0;

--- a/include/engine/models/omnivoice/audio_tokenizer.h
+++ b/include/engine/models/omnivoice/audio_tokenizer.h
@@ -5,14 +5,57 @@
 #include "engine/models/omnivoice/assets.h"
 #include "engine/models/omnivoice/types.h"
 
+#include <cstdint>
 #include <memory>
+#include <vector>
 
 namespace engine::models::omnivoice {
 
 struct OmniVoiceReferenceAudioOptions {
     bool preprocess_prompt = true;
-    bool has_reference_text = false;
+    // Longest reference the model is conditioned on. Everything past the last
+    // pause inside this window is dropped. Zero disables the limit.
+    float reference_max_seconds = 15.0F;
+    // Exact digital silence written onto both ends of a clamped reference.
+    int64_t reference_pad_ms = 150;
 };
+
+struct OmniVoiceReferenceClipOptions {
+    float max_seconds = 15.0F;
+    int64_t pad_ms = 150;
+};
+
+struct OmniVoiceReferenceClipResult {
+    std::vector<float> samples;
+    // True when speech was actually dropped off the end of the reference.
+    bool clamped = false;
+    // True when the reference is over the limit but holds no pause to cut at,
+    // so the whole clip was kept rather than a word being sliced in half.
+    bool no_pause_found = false;
+    // Silence-run tier that produced the cut, in milliseconds; 0 when no cut.
+    int64_t pause_tier_ms = 0;
+    int64_t content_start_sample = 0;
+    int64_t cut_sample = 0;
+    double input_seconds = 0.0;
+    double output_seconds = 0.0;
+};
+
+// Bounds a reference clip to `options.max_seconds` of speech.
+//
+// A reference within the limit is returned byte-for-byte unchanged. A longer
+// one is cut at the *start* of the last silence run that finishes inside the
+// budget -- never at the quietest single window, which lands mid-word -- and
+// the surviving body is re-padded with exact digital silence at both ends.
+// Silence runs are searched in tiers (250 ms, then 150 ms, then 80 ms); when
+// no tier matches, the clip is kept whole and `no_pause_found` is set so the
+// caller can warn instead of slicing a word.
+//
+// This is a port of the `clip_reference` shell function in
+// `scripts/omnivoice_studio.sh`, which is the known-good implementation.
+OmniVoiceReferenceClipResult clip_reference_mono(
+    const std::vector<float> & mono,
+    int sample_rate,
+    const OmniVoiceReferenceClipOptions & options);
 
 struct OmniVoiceAudioTokenizerRuntimeStats {
     bool encoder_graph_rebuilt = false;

--- a/include/engine/models/omnivoice/session.h
+++ b/include/engine/models/omnivoice/session.h
@@ -55,7 +55,8 @@ private:
 
     struct ReferencePromptCacheEntry {
         bool preprocess_prompt = true;
-        bool reference_text_provided = false;
+        float reference_max_seconds = 15.0F;
+        int64_t reference_pad_ms = 150;
         int sample_rate = 0;
         int channels = 0;
         uint64_t sample_count = 0;
@@ -70,8 +71,7 @@ private:
     std::unordered_map<std::string, std::string> merged_request_options(const runtime::TaskRequest & request) const;
     OmniVoiceAudioTokens resolve_reference_audio_tokens(
         const runtime::AudioBuffer & audio,
-        bool preprocess_prompt,
-        bool reference_text_provided);
+        const OmniVoiceReferenceAudioOptions & reference_options);
     std::vector<std::string> plan_text_chunks(const OmniVoiceRequest & request, const OmniVoicePrompt & prompt) const;
     void initialize_streaming_request(const runtime::TaskRequest & request);
     runtime::AudioBuffer synthesize_stream_chunk(size_t chunk_index);

--- a/include/engine/models/omnivoice/types.h
+++ b/include/engine/models/omnivoice/types.h
@@ -29,6 +29,13 @@ struct OmniVoiceGenerationOptions {
     float position_temperature = 5.0F;
     float class_temperature = 0.0F;
     bool preprocess_prompt = true;
+    // Longest stretch of reference speech the model is conditioned on. Past
+    // roughly 15 s cloning quality collapses and generation slows sharply, so
+    // the reference is cut back to the last pause inside this window. Zero
+    // disables the limit.
+    float reference_max_seconds = 15.0F;
+    // Exact digital silence written onto both ends of a clamped reference.
+    int64_t reference_pad_ms = 150;
     float audio_chunk_duration_seconds = 15.0F;
     float audio_chunk_threshold_seconds = 30.0F;
     std::optional<int64_t> text_chunk_size = std::nullopt;
@@ -40,6 +47,14 @@ struct OmniVoiceAudioTokens {
     int64_t frames = 0;
     int64_t codebooks = 0;
     float reference_rms = 0.0F;
+    // Fraction of the caller's reference audio these tokens actually cover, 1.0
+    // when nothing was dropped. The length clamp cuts the audio but cannot cut
+    // the caller's transcript, and estimate_target_tokens derives the output
+    // duration from the ref_text-to-ref_frames ratio -- so a clamped reference
+    // paired with a full transcript collapses the implied speaking rate and
+    // truncates the output. prompt_builder trims the transcript by this
+    // fraction to keep the pair consistent.
+    double retained_fraction = 1.0;
 };
 
 struct OmniVoiceRequest {

--- a/include/engine/models/qwen3_tts/talker.h
+++ b/include/engine/models/qwen3_tts/talker.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace engine::models::qwen3_tts {
@@ -32,9 +33,20 @@ struct Qwen3TalkerPrefill {
     bool x_vector_only_mode = false;
 };
 
+// Why the talker decode loop stopped. F6.5/F6.6: without this the caller cannot
+// tell a clean end-of-speech from an utterance clipped at the token cap, which
+// is what made long-form truncation silent.
+enum class Qwen3TalkerStopReason {
+    Eos,
+    MaxTokens,
+};
+
+std::string_view qwen3_talker_stop_reason_name(Qwen3TalkerStopReason reason) noexcept;
+
 struct Qwen3TalkerCodes {
     Qwen3SpeechCodes generated_codes;
     Qwen3SpeechCodes decoder_input_codes;
+    Qwen3TalkerStopReason stop_reason = Qwen3TalkerStopReason::MaxTokens;
 };
 
 void validate_qwen3_talker_voice_clone_prefill(

--- a/include/engine/models/qwen3_tts/types.h
+++ b/include/engine/models/qwen3_tts/types.h
@@ -20,6 +20,47 @@ enum class Qwen3TTSPerfMode {
     FlashAttention,
 };
 
+// The speech tokenizer emits one codec frame per 1920 samples at 24 kHz
+// (src/models/qwen3_tts/tokenizer_speech_encoder.cpp:45-46), so the talker
+// produces 12.5 frames of audio per second.
+inline constexpr double kQwen3TTSCodecFrameRateHz = 24000.0 / 1920.0;
+// Codepoints of prose a speaker gets through in one second. 13 is a brisk
+// English delivery (~155 wpm); languages that pack more speech into fewer
+// characters are covered by the safety margin below.
+inline constexpr double kQwen3TTSCodepointsPerSecond = 13.0;
+// Headroom left for punctuation, prompt tokens, and slower deliveries. The
+// chunk is sized so a typical chunk finishes well before the token cap rather
+// than exactly at it.
+inline constexpr double kQwen3TTSChunkSafetyMargin = 0.75;
+inline constexpr int64_t kQwen3TTSMinTextChunkSize = 64;
+
+// Largest text chunk the talker can be expected to finish within
+// `max_new_tokens` codec frames.
+//
+// F6.2: the previous fixed default of 8192 codepoints was roughly five times
+// what a 2048-frame cap can synthesise (2048 frames is 163.8 s of audio, about
+// a fifth of what 8192 characters of prose needs), so long-form input was
+// truncated mid-sentence with no diagnostic.
+constexpr int64_t qwen3_tts_default_text_chunk_size(int64_t max_new_tokens) noexcept {
+    if (max_new_tokens <= 0) {
+        return kQwen3TTSMinTextChunkSize;
+    }
+    const double seconds = static_cast<double>(max_new_tokens) / kQwen3TTSCodecFrameRateHz;
+    const double codepoints = seconds * kQwen3TTSCodepointsPerSecond * kQwen3TTSChunkSafetyMargin;
+    const auto budget = static_cast<int64_t>(codepoints);
+    return budget < kQwen3TTSMinTextChunkSize ? kQwen3TTSMinTextChunkSize : budget;
+}
+
+// Codec frames needed to speak `codepoints` characters at the same rate. The
+// inverse of the function above, so the two can be checked against each other.
+constexpr int64_t qwen3_tts_frames_for_codepoints(int64_t codepoints) noexcept {
+    if (codepoints <= 0) {
+        return 0;
+    }
+    const double seconds = static_cast<double>(codepoints) / kQwen3TTSCodepointsPerSecond;
+    return static_cast<int64_t>(seconds * kQwen3TTSCodecFrameRateHz) + 1;
+}
+
 struct Qwen3TTSGenerationOptions {
     int64_t max_new_tokens = 2048;
     bool do_sample = true;

--- a/include/engine/models/vibevoice/session.h
+++ b/include/engine/models/vibevoice/session.h
@@ -9,6 +9,7 @@
 #include "engine/models/vibevoice/tokenizer_audio.h"
 #include "engine/models/vibevoice/tokenizer_text.h"
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
@@ -43,6 +44,10 @@ private:
 
     runtime::TaskSpec task_;
     std::shared_ptr<const VibeVoiceAssets> assets_;
+    // Reference voice prompt cap in seconds; 0 means the whole reference.
+    // Defaults to 30 on CUDA/HIP and 10 elsewhere, overridable with
+    // `vibevoice.voice_prompt_max_seconds`.
+    int64_t voice_prompt_max_seconds_ = 10;
     VibeVoiceTextTokenizer text_tokenizer_;
     VibeVoiceTokenizerWeightsRuntime audio_tokenizer_;
     VibeVoiceConnectorWeightsRuntime connector_;

--- a/src/models/chatterbox/session.cpp
+++ b/src/models/chatterbox/session.cpp
@@ -11,9 +11,11 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <cstdio>
 #include <limits>
 #include <memory>
 #include <stdexcept>
+#include <string>
 
 namespace engine::models::chatterbox {
 
@@ -60,7 +62,7 @@ ChatterboxVoiceCloneConfig make_voice_clone_config(
         .value_or(config.s3gen_cfg_rate);
     config.max_new_tokens = runtime::parse_positive_i64_option(
         options,
-        {"max_tokens"},
+        {"max_tokens", "max_new_tokens"},
         config.max_new_tokens);
     config.seed = runtime::parse_u32_option(options, {"seed"})
         .value_or(runtime::random_u32_seed());
@@ -533,12 +535,28 @@ runtime::TaskResult ChatterboxSession::run_voice_cloning(const runtime::TaskRequ
     const auto chunk_requests = runtime::chunk_text_request(request, text_chunk_size);
     engine::debug::trace_log_scalar("chatterbox.text_chunk_size", text_chunk_size);
     engine::debug::trace_log_scalar("chatterbox.text_chunk_count", static_cast<int64_t>(chunk_requests.size()));
+    size_t chunk_index = 0;
     for (const auto & chunk_request : chunk_requests) {
         auto outputs = component_->synthesize_voice_clone_with_conditionals(
             chunk_request.text_input->text,
             *cached_conditionals_,
             *voice_clone_config_);
         outputs.prompt_prep_ms = cached_prompt_prep_ms_;
+        // F6.5/F6.6: the T3 decode loop used to end on the cap with no signal at
+        // all, so a clipped utterance was indistinguishable from a complete one.
+        if (voice_clone_config_->stop_on_eos && !outputs.hit_eos) {
+            std::fprintf(
+                stderr,
+                "[chatterbox] warning: text chunk %zu of %zu hit the %lld-token cap before an end-of-speech "
+                "token; its audio is truncated mid-utterance. Lower --text-chunk-size or raise --max-tokens.\n",
+                chunk_index + 1,
+                chunk_requests.size(),
+                static_cast<long long>(outputs.max_new_tokens));
+        }
+        engine::debug::trace_log_scalar(
+            "chatterbox.chunk." + std::to_string(chunk_index) + ".hit_eos",
+            outputs.hit_eos);
+        ++chunk_index;
         runtime::append_audio_buffer(merged_audio, runtime::AudioBuffer{
             24000,
             1,

--- a/src/models/chatterbox/t3_component.cpp
+++ b/src/models/chatterbox/t3_component.cpp
@@ -589,10 +589,20 @@ T3GenerateOutputs T3InferenceComponent::generate_speech_tokens(const T3GenerateR
     outputs.prefill_runner_ms = std::chrono::duration<double, std::milli>(
         std::chrono::steady_clock::now() - step_started).count();
     last_logits = std::move(prefill_output.logits);
+    // The decode loop indexes speech_position_weight directly at `step + 1`, so
+    // the budget can never exceed the rows the checkpoint ships. Upstream tables
+    // hold ~4100 rows, which is well clear of the 1000-token default, but clamp
+    // rather than trust it.
+    const int64_t position_capacity = weights_->speech_position_vocab > 1
+        ? weights_->speech_position_vocab - 1
+        : request.max_new_tokens;
+    const int64_t max_new_tokens =
+        std::max<int64_t>(1, std::min<int64_t>(request.max_new_tokens, position_capacity));
+    outputs.max_new_tokens = max_new_tokens;
     const int64_t prefill_cache_steps = total_length + 1;
-    const int64_t max_decode_cache_steps = prefill_cache_steps + request.max_new_tokens;
+    const int64_t max_decode_cache_steps = prefill_cache_steps + max_new_tokens;
     const int64_t initial_decode_cache_steps =
-        prefill_cache_steps + std::min<int64_t>(request.max_new_tokens, kDecodeCapacityChunk);
+        prefill_cache_steps + std::min<int64_t>(max_new_tokens, kDecodeCapacityChunk);
     {
         std::lock_guard<std::mutex> lock(state_->mutex);
         runner = state_->get_runner(batch, initial_decode_cache_steps, backend_config, *weights_);
@@ -606,7 +616,7 @@ T3GenerateOutputs T3InferenceComponent::generate_speech_tokens(const T3GenerateR
     std::vector<float> sampling_probs;
     std::vector<size_t> sampling_order;
     std::vector<uint8_t> sampling_mask;
-    for (int64_t step = 0; step < request.max_new_tokens; ++step) {
+    for (int64_t step = 0; step < max_new_tokens; ++step) {
         std::copy_n(last_logits.data(), speech_vocab, logits.data());
         if (use_cfg) {
             for (int64_t i = 0; i < speech_vocab; ++i) {

--- a/src/models/chatterbox/tts.cpp
+++ b/src/models/chatterbox/tts.cpp
@@ -187,6 +187,8 @@ ChatterboxVoiceCloneOutputs ChatterboxTtsComponent::synthesize_voice_clone_impl(
     } else if (t3_memory_before.available) {
         outputs.cuda_memory_total_bytes = t3_memory_before.total_bytes;
     }
+    outputs.hit_eos = t3_outputs.hit_eos;
+    outputs.max_new_tokens = t3_outputs.max_new_tokens;
     outputs.t3_prefix_cache_build_ms = t3_outputs.prefix_cache_build_ms;
     outputs.t3_decoder_cache_clone_ms = t3_outputs.decoder_cache_clone_ms;
     outputs.t3_prefill_runner_ms = t3_outputs.prefill_runner_ms;
@@ -204,6 +206,11 @@ ChatterboxVoiceCloneOutputs ChatterboxTtsComponent::synthesize_voice_clone_impl(
     engine::debug::timing_log_scalar("chatterbox.voice_clone.t3.logits_ms", outputs.t3_logits_ms);
     engine::debug::timing_log_scalar("chatterbox.voice_clone.t3.sampling_ms", outputs.t3_sampling_ms);
     engine::debug::timing_log_scalar("chatterbox.voice_clone.t3.next_embed_ms", outputs.t3_next_embed_ms);
+    engine::debug::trace_log_scalar("chatterbox.voice_clone.t3.hit_eos", outputs.hit_eos);
+    engine::debug::trace_log_scalar("chatterbox.voice_clone.t3.max_new_tokens", outputs.max_new_tokens);
+    engine::debug::trace_log_scalar(
+        "chatterbox.voice_clone.t3.generated_tokens",
+        static_cast<int64_t>(t3_outputs.predicted_tokens.size()));
     outputs.generated_speech_tokens = t3_outputs.predicted_tokens;
     outputs.cleaned_speech_tokens = clean_generated_speech_tokens_like_python(outputs.generated_speech_tokens);
     if (mem_saver_) {

--- a/src/models/omnivoice/audio_tokenizer.cpp
+++ b/src/models/omnivoice/audio_tokenizer.cpp
@@ -23,6 +23,7 @@
 #include <chrono>
 #include <cmath>
 #include <cstdint>
+#include <cstdio>
 #include <memory>
 #include <numeric>
 #include <optional>
@@ -75,6 +76,7 @@ struct NormalizedReferenceAudio {
     std::vector<float> semantic_samples_16k_padded;
     float reference_rms = 0.0F;
     int64_t frames = 0;
+    double retained_fraction = 1.0;
 };
 
 std::vector<float> to_mono(const runtime::AudioBuffer & audio) {
@@ -371,43 +373,60 @@ std::vector<int16_t> remove_mid_silence_pcm16(
 std::vector<float> preprocess_reference_mono(
     std::vector<float> mono,
     int sample_rate,
-    const OmniVoiceReferenceAudioOptions & options) {
+    const OmniVoiceReferenceAudioOptions & options,
+    double * retained_fraction = nullptr) {
     if (!options.preprocess_prompt) {
         return mono;
     }
     auto mono_pcm16 = engine::audio::float_to_pcm16_clipped(
         mono,
         engine::audio::Pcm16QuantizeMode::TruncateTowardZero);
-    if (!options.has_reference_text) {
-        const double duration = static_cast<double>(mono_pcm16.size()) / static_cast<double>(sample_rate);
-        if (duration > 20.0) {
-            auto nonsilent = detect_nonsilent_ranges_ms(mono_pcm16, sample_rate, 100, -40.0F, 10);
-            if (!nonsilent.empty()) {
-                const int64_t max_ms = 15000;
-                const int64_t min_ms = 3000;
-                int64_t best_split_ms = 0;
-                for (const auto & range : nonsilent) {
-                    if (range.first > best_split_ms && range.first <= max_ms) {
-                        best_split_ms = range.first;
-                    }
-                    if (range.second > max_ms) {
-                        break;
-                    }
-                }
-                if (best_split_ms < min_ms) {
-                    best_split_ms = std::min<int64_t>(max_ms, samples_to_ms(mono_pcm16.size(), sample_rate));
-                }
-                mono_pcm16 = slice_pcm16_ms(mono_pcm16, sample_rate, 0, best_split_ms);
-            }
-        }
-    }
     mono_pcm16 = remove_mid_silence_pcm16(mono_pcm16, sample_rate, 200, 200, kSilenceThresholdDb);
     mono_pcm16 = trim_edges_pcm16(mono_pcm16, sample_rate, 100, 200, kSilenceThresholdDb);
     if (mono_pcm16.empty()) {
         throw std::runtime_error(
             "OmniVoice reference audio is empty after silence removal; try preprocess_prompt=false");
     }
-    return engine::audio::pcm16_to_float_unit_range(mono_pcm16);
+    auto processed = engine::audio::pcm16_to_float_unit_range(mono_pcm16);
+
+    // F6.1: the reference length clamp used to sit behind `!has_reference_text`,
+    // a condition no working voice clone can satisfy -- prompt_builder.cpp
+    // refuses to clone without reference text -- so a 101 s reference was
+    // encoded whole at 75 Hz. It now runs on every reference that reaches the
+    // preprocessing chain, and cuts only at a real pause.
+    OmniVoiceReferenceClipOptions clip_options;
+    clip_options.max_seconds = options.reference_max_seconds;
+    clip_options.pad_ms = options.reference_pad_ms;
+    auto clipped = clip_reference_mono(processed, sample_rate, clip_options);
+    if (clipped.no_pause_found) {
+        std::fprintf(
+            stderr,
+            "[omnivoice] warning: reference audio is %.2f s with no pause inside %.2f s; keeping the whole "
+            "clip rather than cutting mid-word. Cloning quality and speed will suffer -- trim the reference "
+            "by hand or raise reference_max_seconds.\n",
+            clipped.input_seconds,
+            static_cast<double>(clip_options.max_seconds));
+    } else if (clipped.clamped) {
+        std::fprintf(
+            stderr,
+            "[omnivoice] reference audio clamped from %.2f s to %.2f s at a %lld ms pause "
+            "(reference_max_seconds=%.2f); speaker conditioning is reduced accordingly.\n",
+            clipped.input_seconds,
+            clipped.output_seconds,
+            static_cast<long long>(clipped.pause_tier_ms),
+            static_cast<double>(clip_options.max_seconds));
+    }
+    engine::debug::trace_log_scalar("omnivoice.reference.clamped", clipped.clamped);
+    engine::debug::trace_log_scalar("omnivoice.reference.no_pause_found", clipped.no_pause_found);
+    engine::debug::trace_log_scalar("omnivoice.reference.pause_tier_ms", clipped.pause_tier_ms);
+    engine::debug::trace_log_scalar("omnivoice.reference.input_seconds", clipped.input_seconds);
+    engine::debug::trace_log_scalar("omnivoice.reference.output_seconds", clipped.output_seconds);
+    if (retained_fraction != nullptr) {
+        *retained_fraction = clipped.input_seconds > 0.0
+            ? std::min(1.0, clipped.output_seconds / clipped.input_seconds)
+            : 1.0;
+    }
+    return std::move(clipped.samples);
 }
 
 NormalizedReferenceAudio normalize_reference_audio(
@@ -426,7 +445,8 @@ NormalizedReferenceAudio normalize_reference_audio(
             sample *= scale;
         }
     }
-    mono = preprocess_reference_mono(std::move(mono), config.sample_rate, options);
+    mono = preprocess_reference_mono(
+        std::move(mono), config.sample_rate, options, &normalized.retained_fraction);
 
     const int64_t hop_length = checked_positive(config.hop_length, "hop_length");
     const int64_t remainder = static_cast<int64_t>(mono.size()) % hop_length;
@@ -1988,6 +2008,7 @@ struct EncoderGraph {
         tokens.frames = actual_frames;
         tokens.codebooks = static_cast<int64_t>(code_outputs_.size());
         tokens.reference_rms = audio.reference_rms;
+        tokens.retained_fraction = audio.retained_fraction;
         tokens.token_ids.assign(static_cast<size_t>(actual_frames * tokens.codebooks), 0);
         for (size_t codebook = 0; codebook < code_outputs_.size(); ++codebook) {
             std::vector<int32_t> values(static_cast<size_t>(frame_capacity_), 0);
@@ -2236,6 +2257,155 @@ private:
 };
 
 }  // namespace
+
+OmniVoiceReferenceClipResult clip_reference_mono(
+    const std::vector<float> & mono,
+    int sample_rate,
+    const OmniVoiceReferenceClipOptions & options) {
+    // 20 ms analysis windows, and silence-run tiers searched longest first so a
+    // real sentence pause is preferred over a between-words gap.
+    constexpr int64_t kWindowMs = 20;
+    constexpr int64_t kSilenceTiersMs[] = {250, 150, 80};
+
+    if (sample_rate <= 0) {
+        throw std::runtime_error("OmniVoice reference clip requires a positive sample rate");
+    }
+    OmniVoiceReferenceClipResult result;
+    result.samples = mono;
+    const int64_t total = static_cast<int64_t>(mono.size());
+    result.input_seconds = static_cast<double>(total) / static_cast<double>(sample_rate);
+    result.output_seconds = result.input_seconds;
+    result.cut_sample = total;
+    if (total <= 0 || options.max_seconds <= 0.0F) {
+        return result;
+    }
+
+    const int64_t hop = std::max<int64_t>(
+        1,
+        static_cast<int64_t>(static_cast<double>(sample_rate) * static_cast<double>(kWindowMs) / 1000.0));
+    const int64_t window_count = total / hop;
+    if (window_count <= 0) {
+        return result;
+    }
+
+    std::vector<float> levels(static_cast<size_t>(window_count), 0.0F);
+    for (int64_t window = 0; window < window_count; ++window) {
+        const int64_t base = window * hop;
+        double sum_squares = 0.0;
+        for (int64_t offset = 0; offset < hop; ++offset) {
+            const double value = static_cast<double>(mono[static_cast<size_t>(base + offset)]);
+            sum_squares += value * value;
+        }
+        levels[static_cast<size_t>(window)] =
+            static_cast<float>(std::sqrt(sum_squares / static_cast<double>(hop)));
+    }
+
+    // Threshold from this clip's own noise floor, so a quiet studio take and a
+    // noisy phone recording both segment sensibly. The absolute term is one
+    // 16-bit LSB, which keeps exact digital silence below threshold.
+    constexpr float kSilenceFloor = 1.0F / 32768.0F;
+    std::vector<float> ordered = levels;
+    std::sort(ordered.begin(), ordered.end());
+    const float floor_level = ordered[ordered.size() / 10];
+    const float peak_level = ordered.back();
+    float threshold = std::max({floor_level * 3.0F, peak_level * 0.02F, kSilenceFloor});
+    // A clip that is almost entirely speech puts a voiced window at the tenth
+    // percentile, and `floor * 3` then exceeds the peak -- which would classify
+    // the whole clip as silence and disable the clamp. Cap the threshold well
+    // under the peak so that cannot happen. Skipped when the clip has no signal
+    // at all, where every window really is silent.
+    const float peak_cap = peak_level * 0.5F;
+    if (peak_cap > kSilenceFloor) {
+        threshold = std::min(threshold, peak_cap);
+    }
+
+    std::vector<uint8_t> quiet(static_cast<size_t>(window_count), 0);
+    int64_t first_voiced = -1;
+    int64_t last_voiced = -1;
+    for (int64_t window = 0; window < window_count; ++window) {
+        const bool is_quiet = levels[static_cast<size_t>(window)] < threshold;
+        quiet[static_cast<size_t>(window)] = is_quiet ? uint8_t{1} : uint8_t{0};
+        if (!is_quiet) {
+            if (first_voiced < 0) {
+                first_voiced = window;
+            }
+            last_voiced = window;
+        }
+    }
+    if (first_voiced < 0) {
+        // Nothing above the noise floor. Leave the caller's audio alone rather
+        // than guessing at a cut.
+        return result;
+    }
+
+    const int64_t content_start = first_voiced * hop;
+    const int64_t content_end = std::min(total, (last_voiced + 1) * hop);
+    result.content_start_sample = content_start;
+    result.cut_sample = content_end;
+
+    const int64_t limit_samples = static_cast<int64_t>(std::llround(
+        static_cast<double>(options.max_seconds) * static_cast<double>(sample_rate)));
+    if ((content_end - content_start) <= limit_samples) {
+        // Within budget: hand back exactly what the caller gave us.
+        return result;
+    }
+
+    const int64_t budget_end = content_start + limit_samples;
+    int64_t cut = content_end;
+    for (const int64_t tier_ms : kSilenceTiersMs) {
+        const int64_t need_windows = std::max<int64_t>(1, tier_ms / kWindowMs);
+        int64_t chosen = -1;
+        int64_t window = 0;
+        while (window < window_count) {
+            if (quiet[static_cast<size_t>(window)] == 0) {
+                ++window;
+                continue;
+            }
+            const int64_t run_start = window;
+            while (window < window_count && quiet[static_cast<size_t>(window)] != 0) {
+                ++window;
+            }
+            if ((window - run_start) < need_windows) {
+                continue;
+            }
+            const int64_t run_start_sample = run_start * hop;
+            // Cutting at the START of the pause guarantees a whole word.
+            if (run_start_sample > content_start && run_start_sample <= budget_end) {
+                chosen = run_start_sample;
+            }
+        }
+        if (chosen >= 0) {
+            cut = chosen;
+            result.pause_tier_ms = tier_ms;
+            break;
+        }
+    }
+    if (result.pause_tier_ms == 0) {
+        // No pause anywhere inside the budget: keep the whole clip rather than
+        // slicing a word in half, and let the caller say so.
+        result.no_pause_found = true;
+    }
+
+    const int64_t body_end = std::clamp(cut, content_start, content_end);
+    const int64_t pad_samples = std::max<int64_t>(0, static_cast<int64_t>(std::llround(
+        static_cast<double>(options.pad_ms) * static_cast<double>(sample_rate) / 1000.0)));
+
+    std::vector<float> clipped;
+    clipped.reserve(static_cast<size_t>((2 * pad_samples) + (body_end - content_start)));
+    clipped.insert(clipped.end(), static_cast<size_t>(pad_samples), 0.0F);
+    clipped.insert(
+        clipped.end(),
+        mono.begin() + static_cast<std::ptrdiff_t>(content_start),
+        mono.begin() + static_cast<std::ptrdiff_t>(body_end));
+    clipped.insert(clipped.end(), static_cast<size_t>(pad_samples), 0.0F);
+
+    result.samples = std::move(clipped);
+    result.clamped = body_end < content_end;
+    result.cut_sample = body_end;
+    result.output_seconds =
+        static_cast<double>(result.samples.size()) / static_cast<double>(sample_rate);
+    return result;
+}
 
 struct OmniVoiceAudioTokenizerRuntime::Impl {
     std::shared_ptr<const OmniVoiceAssets> assets;

--- a/src/models/omnivoice/prompt_builder.cpp
+++ b/src/models/omnivoice/prompt_builder.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cctype>
 #include <cmath>
+#include <cstdio>
 #include <cstring>
 #include <iterator>
 #include <limits>
@@ -632,6 +633,50 @@ int64_t frame_rate(const OmniVoiceAssets & assets) {
         static_cast<double>(assets.config.audio_tokenizer.hop_length)));
 }
 
+// The reference-length clamp drops audio off the end of the clip but cannot
+// touch the caller's transcript, and estimate_target_tokens reads the
+// ref_text-to-ref_frames pair as a speaking-rate proxy. Leaving the full
+// transcript against clamped audio collapses that rate and truncates the
+// output -- measured at 1.75 s for a sentence that should run about 6 s.
+// The clamp keeps the head of the clip, so keep the matching head of the
+// transcript: whole words, proportional to the audio retained.
+std::string trim_reference_text_to_fraction(const std::string & text, double fraction) {
+    if (fraction >= 1.0 || fraction <= 0.0 || text.empty()) {
+        return text;
+    }
+    std::vector<std::string> words;
+    std::string current;
+    for (const char character : text) {
+        if (static_cast<unsigned char>(character) <= 0x20) {
+            if (!current.empty()) {
+                words.push_back(current);
+                current.clear();
+            }
+            continue;
+        }
+        current.push_back(character);
+    }
+    if (!current.empty()) {
+        words.push_back(current);
+    }
+    if (words.size() < 2) {
+        return text;
+    }
+    const auto keep = std::max<size_t>(
+        1, static_cast<size_t>(std::llround(static_cast<double>(words.size()) * fraction)));
+    if (keep >= words.size()) {
+        return text;
+    }
+    std::string trimmed;
+    for (size_t index = 0; index < keep; ++index) {
+        if (index > 0) {
+            trimmed.push_back(' ');
+        }
+        trimmed += words[index];
+    }
+    return trimmed;
+}
+
 int64_t estimate_target_tokens(
     const OmniVoiceAssets & assets,
     const std::string & text,
@@ -787,6 +832,20 @@ OmniVoicePrompt OmniVoicePromptBuilder::build(const OmniVoiceRequest & request) 
         prompt.instruct = resolve_instruct(request.instruct, contains_chinese(prompt.text));
     }
 
+    if (prompt.reference_audio_tokens.has_value() &&
+        prompt.reference_audio_tokens->retained_fraction < 1.0 &&
+        !prompt.reference_text.empty()) {
+        const auto fraction = prompt.reference_audio_tokens->retained_fraction;
+        auto trimmed = trim_reference_text_to_fraction(prompt.reference_text, fraction);
+        if (trimmed != prompt.reference_text) {
+            std::fprintf(
+                stderr,
+                "[omnivoice] reference transcript trimmed to %.0f%% to match the clamped reference audio; "
+                "supply a transcript of the trimmed clip for best cloning quality.\n",
+                fraction * 100.0);
+            prompt.reference_text = std::move(trimmed);
+        }
+    }
     prompt.target_audio_tokens = engine::models::omnivoice::estimate_target_tokens(
         *assets_,
         prompt.text,

--- a/src/models/omnivoice/session.cpp
+++ b/src/models/omnivoice/session.cpp
@@ -92,6 +92,17 @@ OmniVoiceGenerationOptions generation_options_from_options(const std::unordered_
     if (const auto value = runtime::find_option(options_map, {"preprocess_prompt"})) {
         options.preprocess_prompt = runtime::parse_bool_option(*value, "preprocess_prompt");
     }
+    options.reference_max_seconds = runtime::parse_float_option(
+        options_map,
+        {"reference_max_seconds", "ref_max_sec"})
+        .value_or(options.reference_max_seconds);
+    options.reference_pad_ms = runtime::parse_i64_option(
+        options_map,
+        {"reference_pad_ms", "ref_pad_ms"})
+        .value_or(options.reference_pad_ms);
+    if (options.reference_pad_ms < 0) {
+        throw std::runtime_error("OmniVoice reference_pad_ms must not be negative");
+    }
     if (const auto value = runtime::find_option(options_map, {"postprocess_output"})) {
         options.postprocess_output = runtime::parse_bool_option(*value, "postprocess_output");
     }
@@ -118,6 +129,14 @@ OmniVoiceGenerationOptions generation_options_from_options(const std::unordered_
     options.text_chunk_size = engine::text::parse_text_chunk_size_override(options_map);
     options.text_chunk_mode = engine::text::parse_text_chunk_mode_override(options_map)
         .value_or(engine::text::TextChunkMode::TagAware);
+    return options;
+}
+
+OmniVoiceReferenceAudioOptions reference_audio_options(const OmniVoiceGenerationOptions & generation) {
+    OmniVoiceReferenceAudioOptions options;
+    options.preprocess_prompt = generation.preprocess_prompt;
+    options.reference_max_seconds = generation.reference_max_seconds;
+    options.reference_pad_ms = generation.reference_pad_ms;
     return options;
 }
 
@@ -291,12 +310,9 @@ void OmniVoiceSession::prepare(const runtime::SessionPreparationRequest & reques
     if (session_defaults_.reference_audio.has_value()) {
         const auto merged_options = session_defaults_.options;
         const auto generation = generation_options_from_options(merged_options);
-        const bool reference_text_provided =
-            session_defaults_.reference_text.has_value() && !session_defaults_.reference_text->empty();
         (void) resolve_reference_audio_tokens(
             *session_defaults_.reference_audio,
-            generation.preprocess_prompt,
-            reference_text_provided);
+            reference_audio_options(generation));
         if (mem_saver_) {
             audio_tokenizer_.release_runtime_graphs();
         }
@@ -321,8 +337,7 @@ runtime::TaskResult OmniVoiceSession::run(const runtime::TaskRequest & request) 
         const auto encode_start = Clock::now();
         const auto reference_tokens = resolve_reference_audio_tokens(
             *omni_request.reference_audio,
-            omni_request.generation.preprocess_prompt,
-            !omni_request.reference_text.empty());
+            reference_audio_options(omni_request.generation));
         const auto encode_end = Clock::now();
         omni_request.reference_rms = reference_tokens.reference_rms;
         omni_request.reference_audio_tokens = std::move(reference_tokens);
@@ -672,25 +687,22 @@ std::unordered_map<std::string, std::string> OmniVoiceSession::merged_request_op
 
 OmniVoiceAudioTokens OmniVoiceSession::resolve_reference_audio_tokens(
     const runtime::AudioBuffer & audio,
-    bool preprocess_prompt,
-    bool reference_text_provided) {
+    const OmniVoiceReferenceAudioOptions & reference_options) {
     const uint64_t sample_count = static_cast<uint64_t>(audio.samples.size());
     const uint64_t sample_hash = hash_audio_samples(audio);
     const bool cache_hit = reference_prompt_cache_.has_value() &&
-        reference_prompt_cache_->preprocess_prompt == preprocess_prompt &&
-        reference_prompt_cache_->reference_text_provided == reference_text_provided &&
+        reference_prompt_cache_->preprocess_prompt == reference_options.preprocess_prompt &&
+        reference_prompt_cache_->reference_max_seconds == reference_options.reference_max_seconds &&
+        reference_prompt_cache_->reference_pad_ms == reference_options.reference_pad_ms &&
         reference_prompt_cache_->sample_rate == audio.sample_rate &&
         reference_prompt_cache_->channels == audio.channels &&
         reference_prompt_cache_->sample_count == sample_count &&
         reference_prompt_cache_->sample_hash == sample_hash;
     if (!cache_hit) {
-        const OmniVoiceReferenceAudioOptions reference_options = {
-            preprocess_prompt,
-            reference_text_provided,
-        };
         ReferencePromptCacheEntry entry;
-        entry.preprocess_prompt = preprocess_prompt;
-        entry.reference_text_provided = reference_text_provided;
+        entry.preprocess_prompt = reference_options.preprocess_prompt;
+        entry.reference_max_seconds = reference_options.reference_max_seconds;
+        entry.reference_pad_ms = reference_options.reference_pad_ms;
         entry.sample_rate = audio.sample_rate;
         entry.channels = audio.channels;
         entry.sample_count = sample_count;
@@ -749,8 +761,7 @@ void OmniVoiceSession::initialize_streaming_request(const runtime::TaskRequest &
     if (omni_request.reference_audio.has_value()) {
         const auto reference_tokens = resolve_reference_audio_tokens(
             *omni_request.reference_audio,
-            omni_request.generation.preprocess_prompt,
-            !omni_request.reference_text.empty());
+            reference_audio_options(omni_request.generation));
         omni_request.reference_rms = reference_tokens.reference_rms;
         omni_request.reference_audio_tokens = std::move(reference_tokens);
         omni_request.reference_audio.reset();

--- a/src/models/qwen3_tts/session.cpp
+++ b/src/models/qwen3_tts/session.cpp
@@ -8,16 +8,52 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstdio>
 #include <cstring>
 #include <limits>
 #include <stdexcept>
+#include <string>
 #include <utility>
 
 namespace engine::models::qwen3_tts {
 namespace {
 
 using Clock = std::chrono::steady_clock;
-constexpr int64_t kDefaultTextChunkSize = 8192;
+
+// Codec frames the talker may emit before the decode loop gives up, resolved
+// per request so an explicit --max-tokens also resizes the text chunk.
+int64_t effective_max_new_tokens(const runtime::TaskRequest & request, const Qwen3TTSConfig & config) {
+    if (const auto value = runtime::parse_int_option(request.options, {"max_tokens"})) {
+        if (*value > 0) {
+            return static_cast<int64_t>(*value);
+        }
+    }
+    return config.max_new_tokens;
+}
+
+// F6.5/F6.6: exiting the decode loop on the token cap used to be a bare
+// `break`, indistinguishable from a clean end-of-speech, so long-form output
+// truncated mid-sentence in silence. Record it in the trace and say so on
+// stderr, following the OuteTTS pattern.
+void report_talker_stop_reason(
+    const Qwen3TalkerCodes & codes,
+    size_t chunk_index,
+    size_t chunk_count,
+    int64_t max_new_tokens) {
+    debug::trace_log_scalar(
+        "qwen3_tts.chunk." + std::to_string(chunk_index) + ".stop_reason",
+        qwen3_talker_stop_reason_name(codes.stop_reason));
+    if (codes.stop_reason != Qwen3TalkerStopReason::MaxTokens) {
+        return;
+    }
+    std::fprintf(
+        stderr,
+        "[qwen3_tts] warning: text chunk %zu of %zu hit the %lld-token cap before an end-of-speech token; "
+        "its audio is truncated mid-utterance. Lower --text-chunk-size or raise --max-tokens.\n",
+        chunk_index + 1,
+        chunk_count,
+        static_cast<long long>(max_new_tokens));
+}
 
 std::shared_ptr<const Qwen3TTSAssets> require_assets(std::shared_ptr<const Qwen3TTSAssets> assets) {
     if (assets == nullptr) {
@@ -386,9 +422,14 @@ runtime::TaskResult Qwen3TTSSession::run(const runtime::TaskRequest & request) {
     require_prepared("Qwen3 TTS run");
     const auto wall_start = Clock::now();
     TalkerCachedStepReleaseGuard release_talker_cached_step_graph(talker_step_.get(), mem_saver_);
+    const int64_t max_new_tokens = effective_max_new_tokens(request, assets_->config);
     const int64_t text_chunk_size =
-        engine::text::parse_text_chunk_size_override(request.options).value_or(kDefaultTextChunkSize);
+        engine::text::parse_text_chunk_size_override(request.options)
+            .value_or(qwen3_tts_default_text_chunk_size(max_new_tokens));
     const auto chunk_requests = runtime::chunk_text_request(request, text_chunk_size);
+    debug::trace_log_scalar("qwen3_tts.max_new_tokens", max_new_tokens);
+    debug::trace_log_scalar("qwen3_tts.text_chunk_size", text_chunk_size);
+    debug::trace_log_scalar("qwen3_tts.text_chunk_count", static_cast<int64_t>(chunk_requests.size()));
     if (assets_->config.variant == Qwen3TTSVariant::VoiceDesign) {
         Qwen3TTSVoiceDesignPromptBuilder prompt_builder(
             text_tokenizer_,
@@ -398,6 +439,7 @@ runtime::TaskResult Qwen3TTSSession::run(const runtime::TaskRequest & request) {
         double talker_ms = 0.0;
         double decoder_ms = 0.0;
         runtime::AudioBuffer merged_audio;
+        size_t chunk_index = 0;
         for (const auto & chunk_request : chunk_requests) {
             const Qwen3TTSRequest qwen_request = make_request(chunk_request);
             const auto prefill_start = Clock::now();
@@ -409,6 +451,11 @@ runtime::TaskResult Qwen3TTSSession::run(const runtime::TaskRequest & request) {
                 qwen_request.generation,
                 qwen_request.generation.repetition_penalty);
             talker_ms += engine::debug::elapsed_ms(talker_start, Clock::now());
+            report_talker_stop_reason(
+                codes,
+                chunk_index++,
+                chunk_requests.size(),
+                qwen_request.generation.max_new_tokens);
             const auto decoder_start = Clock::now();
             runtime::append_audio_buffer(
                 merged_audio,
@@ -433,6 +480,7 @@ runtime::TaskResult Qwen3TTSSession::run(const runtime::TaskRequest & request) {
         double talker_ms = 0.0;
         double decoder_ms = 0.0;
         runtime::AudioBuffer merged_audio;
+        size_t chunk_index = 0;
         for (const auto & chunk_request : chunk_requests) {
             const Qwen3TTSRequest qwen_request = make_request(chunk_request);
             const auto prefill_start = Clock::now();
@@ -444,6 +492,11 @@ runtime::TaskResult Qwen3TTSSession::run(const runtime::TaskRequest & request) {
                 qwen_request.generation,
                 qwen_request.generation.repetition_penalty);
             talker_ms += engine::debug::elapsed_ms(talker_start, Clock::now());
+            report_talker_stop_reason(
+                codes,
+                chunk_index++,
+                chunk_requests.size(),
+                qwen_request.generation.max_new_tokens);
             const auto decoder_start = Clock::now();
             runtime::append_audio_buffer(
                 merged_audio,
@@ -476,6 +529,7 @@ runtime::TaskResult Qwen3TTSSession::run(const runtime::TaskRequest & request) {
     double talker_ms = 0.0;
     double decoder_ms = 0.0;
     runtime::AudioBuffer merged_audio;
+    size_t chunk_index = 0;
     for (const auto & chunk_request : chunk_requests) {
         const Qwen3TTSRequest qwen_request = make_request(chunk_request);
         const auto prompt_start = Clock::now();
@@ -490,6 +544,11 @@ runtime::TaskResult Qwen3TTSSession::run(const runtime::TaskRequest & request) {
             qwen_request.generation,
             qwen_request.generation.repetition_penalty);
         talker_ms += engine::debug::elapsed_ms(talker_start, Clock::now());
+        report_talker_stop_reason(
+            codes,
+            chunk_index++,
+            chunk_requests.size(),
+            qwen_request.generation.max_new_tokens);
         const auto decoder_start = Clock::now();
         runtime::AudioBuffer decoded = voice_prompt.reference_codes.has_value()
             ? speech_decoder_->decode_and_trim_reference(

--- a/src/models/qwen3_tts/talker.cpp
+++ b/src/models/qwen3_tts/talker.cpp
@@ -1788,9 +1788,11 @@ public:
                 : argmax_index(logits);
             processor_ms += engine::debug::elapsed_ms(processor_start, Clock::now());
             if (first_code == config.codec_eos_token_id) {
+                out.stop_reason = Qwen3TalkerStopReason::Eos;
                 break;
             }
             if (step + 1 >= max_new_tokens) {
+                out.stop_reason = Qwen3TalkerStopReason::MaxTokens;
                 break;
             }
             generated_first_codes.push_back(first_code);
@@ -1854,6 +1856,9 @@ public:
         debug::timing_log_scalar("qwen3_tts.talker.cached_step.output_read_ms", cached_step_timing.output_read_ms);
         debug::timing_log_scalar("qwen3_tts.talker.cached_step.kv_copy_ms", cached_step_timing.kv_copy_ms);
         debug::timing_log_scalar("qwen3_tts.talker.total_ms", engine::debug::elapsed_ms(total_start, Clock::now()));
+        debug::trace_log_scalar(
+            "qwen3_tts.talker.stop_reason",
+            qwen3_talker_stop_reason_name(out.stop_reason));
         return out;
     }
 
@@ -1892,6 +1897,16 @@ private:
     std::optional<PromptEmbeddingState> cached_prompt_state_;
     std::optional<TalkerPrefillGraph::OutputWithCache> cached_prefill_output_;
 };
+
+std::string_view qwen3_talker_stop_reason_name(Qwen3TalkerStopReason reason) noexcept {
+    switch (reason) {
+        case Qwen3TalkerStopReason::Eos:
+            return "eos";
+        case Qwen3TalkerStopReason::MaxTokens:
+            return "max_tokens";
+    }
+    return "unknown";
+}
 
 Qwen3TalkerStepRuntime::Qwen3TalkerStepRuntime(std::unique_ptr<Impl> impl) : impl_(std::move(impl)) {
     if (impl_ == nullptr) {

--- a/src/models/vibevoice/session.cpp
+++ b/src/models/vibevoice/session.cpp
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <cctype>
 #include <chrono>
+#include <cstdio>
 #include <filesystem>
 #include <stdexcept>
 #include <string>
@@ -22,8 +23,17 @@ namespace {
 using Clock = std::chrono::steady_clock;
 
 constexpr size_t kMaxReferenceVoiceStates = 4;
+// F6.8: these two arrived together in the initial VibeVoice release (95ec6ae)
+// with no comment and no measurement, and the gate is "CUDA/HIP get more"
+// rather than "Metal gets less" -- CPU and Vulkan take the 10 s value too. That
+// is the shape of untested caution, not of a known Metal memory or op limit, so
+// the split is documented and overridable rather than silently backend-specific.
+// Nothing here has been A/B tested; raising it on Metal is unverified.
 constexpr int64_t kCudaVoicePromptMaxSeconds = 30;
 constexpr int64_t kDefaultVoicePromptMaxSeconds = 10;
+// Equal-power-free linear fade applied at a truncation so the reference never
+// ends on a step discontinuity mid-phoneme.
+constexpr int64_t kVoicePromptFadeOutMs = 10;
 
 std::shared_ptr<const VibeVoiceAssets> require_assets(std::shared_ptr<const VibeVoiceAssets> assets) {
     if (assets == nullptr) {
@@ -158,15 +168,31 @@ runtime::AudioBuffer read_voice_sample(const std::string & path) {
     return runtime::AudioBuffer{wav.sample_rate, wav.channels, wav.samples};
 }
 
-runtime::AudioBuffer cap_voice_sample_duration(
-    runtime::AudioBuffer audio,
-    core::BackendType backend_type,
-    const std::string & path) {
-    const int64_t max_seconds = (backend_type == core::BackendType::Cuda || backend_type == core::BackendType::Hip)
+int64_t default_voice_prompt_max_seconds(core::BackendType backend_type) {
+    return (backend_type == core::BackendType::Cuda || backend_type == core::BackendType::Hip)
         ? kCudaVoicePromptMaxSeconds
         : kDefaultVoicePromptMaxSeconds;
-    const int64_t max_frames = static_cast<int64_t>(audio.sample_rate) * max_seconds;
-    const auto max_samples = static_cast<size_t>(max_frames * static_cast<int64_t>(audio.channels));
+}
+
+int64_t voice_prompt_max_seconds_from_options(const runtime::SessionOptions & options) {
+    const int64_t fallback = default_voice_prompt_max_seconds(options.backend.type);
+    const auto value = runtime::parse_i64_option(
+        options.options,
+        {"vibevoice.voice_prompt_max_seconds", "voice_prompt_max_seconds"});
+    if (!value.has_value()) {
+        return fallback;
+    }
+    if (*value < 0) {
+        throw std::runtime_error("vibevoice.voice_prompt_max_seconds must not be negative");
+    }
+    // 0 means "use the whole reference".
+    return *value;
+}
+
+runtime::AudioBuffer cap_voice_sample_duration(
+    runtime::AudioBuffer audio,
+    int64_t max_seconds,
+    const std::string & path) {
     engine::debug::trace_log_scalar("vibevoice.reference_voice.prompt_path", path);
     engine::debug::trace_log_scalar("vibevoice.reference_voice.prompt_sample_rate", audio.sample_rate);
     engine::debug::trace_log_scalar("vibevoice.reference_voice.prompt_channels", audio.channels);
@@ -174,8 +200,31 @@ runtime::AudioBuffer cap_voice_sample_duration(
         "vibevoice.reference_voice.prompt_input_samples",
         static_cast<int64_t>(audio.samples.size()));
     engine::debug::trace_log_scalar("vibevoice.reference_voice.prompt_max_seconds", max_seconds);
-    if (audio.samples.size() > max_samples) {
-        audio.samples.resize(max_samples);
+    if (max_seconds > 0) {
+        const int64_t max_frames = static_cast<int64_t>(audio.sample_rate) * max_seconds;
+        const auto max_samples = static_cast<size_t>(max_frames * static_cast<int64_t>(audio.channels));
+        if (audio.samples.size() > max_samples) {
+            const double input_seconds = static_cast<double>(audio.samples.size()) /
+                static_cast<double>(std::max(1, audio.sample_rate) * std::max(1, audio.channels));
+            audio.samples.resize(max_samples);
+            // A bare resize can land mid-phoneme; fade the last few milliseconds
+            // so the reference does not end on a discontinuity.
+            const auto fade_samples = static_cast<size_t>(std::min<int64_t>(
+                static_cast<int64_t>(audio.samples.size()),
+                (static_cast<int64_t>(audio.sample_rate) * kVoicePromptFadeOutMs / 1000) *
+                    static_cast<int64_t>(audio.channels)));
+            for (size_t i = 0; i < fade_samples; ++i) {
+                const float weight = static_cast<float>(fade_samples - i) / static_cast<float>(fade_samples);
+                audio.samples[audio.samples.size() - fade_samples + i] *= weight;
+            }
+            std::fprintf(
+                stderr,
+                "[vibevoice] reference voice %s truncated from %.2f s to %lld s "
+                "(vibevoice.voice_prompt_max_seconds); speaker conditioning is reduced accordingly.\n",
+                path.c_str(),
+                input_seconds,
+                static_cast<long long>(max_seconds));
+        }
     }
     engine::debug::trace_log_scalar(
         "vibevoice.reference_voice.prompt_used_samples",
@@ -204,6 +253,7 @@ VibeVoiceSession::VibeVoiceSession(
     : runtime::RuntimeSessionBase(require_supported_backend_options(options)),
       task_(task),
       assets_(apply_vibevoice_finetune_options(require_assets(std::move(assets)), options.options)),
+      voice_prompt_max_seconds_(voice_prompt_max_seconds_from_options(options)),
       text_tokenizer_(assets_),
       audio_tokenizer_(
           assets_,
@@ -373,7 +423,7 @@ std::vector<VibeVoiceSpeakerPrompt> VibeVoiceSession::resolve_voice_sample_promp
     std::vector<runtime::AudioBuffer> audio;
     audio.reserve(sample_paths.size());
     for (const auto & path : sample_paths) {
-        audio.push_back(cap_voice_sample_duration(read_voice_sample(path), options().backend.type, path));
+        audio.push_back(cap_voice_sample_duration(read_voice_sample(path), voice_prompt_max_seconds_, path));
     }
     auto acoustic_means = audio_tokenizer_.encode_acoustic_batch(audio);
     if (acoustic_means.size() != sample_paths.size()) {

--- a/tests/unittests/test_omnivoice_reference_clamp.cpp
+++ b/tests/unittests/test_omnivoice_reference_clamp.cpp
@@ -1,0 +1,285 @@
+// F6.1 -- OmniVoice's reference length clamp.
+//
+// The clamp used to sit behind `!options.has_reference_text`, a predicate no
+// working voice clone can satisfy, so a 101 s reference was encoded whole at
+// 75 Hz. These tests pin the arithmetic of the replacement on synthetic audio;
+// no model weights and no backend are needed.
+
+#include "engine/models/omnivoice/audio_tokenizer.h"
+
+#include "test_assert.h"
+
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+using engine::models::omnivoice::clip_reference_mono;
+using engine::models::omnivoice::OmniVoiceReferenceClipOptions;
+
+constexpr int kSampleRate = 24000;
+// The analysis window is 20 ms, so every synthetic boundary below is placed on
+// a 20 ms grid; that makes the expected cut positions exact rather than
+// approximate.
+constexpr int64_t kWindowMs = 20;
+
+int64_t ms_to_samples(int64_t ms) {
+    return ms * kSampleRate / 1000;
+}
+
+void append_silence(std::vector<float> & samples, int64_t ms) {
+    samples.insert(samples.end(), static_cast<size_t>(ms_to_samples(ms)), 0.0F);
+}
+
+// A 220 Hz tone at a fixed amplitude. Deterministic, and far enough above the
+// clip's own noise floor that the adaptive threshold classifies it as voiced.
+void append_tone(std::vector<float> & samples, int64_t ms, float amplitude = 0.3F) {
+    const int64_t count = ms_to_samples(ms);
+    const double step = 2.0 * 3.14159265358979323846 * 220.0 / static_cast<double>(kSampleRate);
+    const auto phase_base = static_cast<double>(samples.size());
+    for (int64_t i = 0; i < count; ++i) {
+        samples.push_back(
+            amplitude * static_cast<float>(std::sin(step * (phase_base + static_cast<double>(i)))));
+    }
+}
+
+double rms(const std::vector<float> & samples, size_t begin, size_t end) {
+    if (begin >= end || end > samples.size()) {
+        throw std::runtime_error("rms window out of range");
+    }
+    double sum = 0.0;
+    for (size_t i = begin; i < end; ++i) {
+        sum += static_cast<double>(samples[i]) * static_cast<double>(samples[i]);
+    }
+    return std::sqrt(sum / static_cast<double>(end - begin));
+}
+
+// A reference over the limit is cut at the START of a silence run, so the last
+// word survives whole. Asserted as a number: the 250 ms after the cut are
+// digital silence in the source, and the 100 ms before it are not.
+void test_long_reference_cuts_at_a_pause() {
+    // 500 ms lead silence, then 12 x (2000 ms speech + 300 ms pause).
+    std::vector<float> source;
+    append_silence(source, 500);
+    for (int i = 0; i < 12; ++i) {
+        append_tone(source, 2000);
+        append_silence(source, 300);
+    }
+
+    OmniVoiceReferenceClipOptions options;
+    options.max_seconds = 15.0F;
+    options.pad_ms = 150;
+    const auto result = clip_reference_mono(source, kSampleRate, options);
+
+    engine::test::require(result.clamped, "long reference is clamped");
+    engine::test::require(!result.no_pause_found, "long reference found a pause");
+    engine::test::require_eq(result.pause_tier_ms, int64_t{250}, "pause tier");
+
+    // Content starts at 500 ms. The budget ends at 15500 ms. Pause k starts at
+    // 2500 + 2300k ms, so the last one inside the budget is k = 5 at 14000 ms.
+    engine::test::require_eq(result.content_start_sample, ms_to_samples(500), "content start");
+    engine::test::require_eq(result.cut_sample, ms_to_samples(14000), "cut sample");
+
+    const auto cut = static_cast<size_t>(result.cut_sample);
+    engine::test::require_close(
+        static_cast<float>(rms(source, cut, cut + static_cast<size_t>(ms_to_samples(250)))),
+        0.0F,
+        1.0e-7F,
+        "source is silent for a full pause after the cut");
+    engine::test::require(
+        rms(source, cut - static_cast<size_t>(ms_to_samples(100)), cut) > 0.1,
+        "source carries speech right up to the cut, so no word was sliced");
+
+    // Kept body is 500 ms .. 14000 ms, plus one pad at each end.
+    const size_t expected =
+        static_cast<size_t>(ms_to_samples(13500) + (2 * ms_to_samples(options.pad_ms)));
+    engine::test::require_eq(result.samples.size(), expected, "clamped sample count");
+    engine::test::require_close(
+        static_cast<float>(result.output_seconds),
+        13.8F,
+        1.0e-3F,
+        "clamped duration");
+}
+
+// Both ends of a clamped reference carry exact digital silence of the
+// configured pad length -- not "quiet", zero.
+void test_clamped_reference_pads_with_exact_silence() {
+    std::vector<float> source;
+    append_silence(source, 500);
+    for (int i = 0; i < 12; ++i) {
+        append_tone(source, 2000);
+        append_silence(source, 300);
+    }
+
+    OmniVoiceReferenceClipOptions options;
+    options.max_seconds = 15.0F;
+    options.pad_ms = 150;
+    const auto result = clip_reference_mono(source, kSampleRate, options);
+
+    const auto pad = static_cast<size_t>(ms_to_samples(options.pad_ms));
+    engine::test::require(result.samples.size() > 2 * pad, "clamped output is longer than its padding");
+    engine::test::require_eq(rms(result.samples, 0, pad), 0.0, "head pad rms is exactly zero");
+    engine::test::require_eq(
+        rms(result.samples, result.samples.size() - pad, result.samples.size()),
+        0.0,
+        "tail pad rms is exactly zero");
+    // The pad is exactly one sample longer than the silence at either end: the
+    // sample just inside it is real signal, so nothing was over-trimmed.
+    engine::test::require(
+        std::fabs(result.samples[pad]) > 0.0F || std::fabs(result.samples[pad + 1]) > 0.0F,
+        "signal resumes immediately after the head pad");
+    engine::test::require(
+        std::fabs(result.samples[result.samples.size() - pad - 1]) > 0.0F,
+        "signal runs right up to the tail pad");
+
+    // A different pad length is honoured exactly.
+    OmniVoiceReferenceClipOptions wide = options;
+    wide.pad_ms = 300;
+    const auto wider = clip_reference_mono(source, kSampleRate, wide);
+    const auto wide_pad = static_cast<size_t>(ms_to_samples(wide.pad_ms));
+    engine::test::require_eq(
+        wider.samples.size(),
+        result.samples.size() + (2 * (wide_pad - pad)),
+        "pad length is applied verbatim at both ends");
+    engine::test::require_eq(rms(wider.samples, 0, wide_pad), 0.0, "wide head pad rms is exactly zero");
+    engine::test::require_eq(
+        rms(wider.samples, wider.samples.size() - wide_pad, wider.samples.size()),
+        0.0,
+        "wide tail pad rms is exactly zero");
+}
+
+// No pause anywhere inside the limit: keep the whole clip and take the warning
+// path rather than slicing a word in half.
+void test_reference_without_a_pause_is_kept_whole() {
+    // 500 ms silence, 40 s of unbroken speech, 500 ms silence. The only silence
+    // runs are the two edges: one starts at 0 (not after content start) and one
+    // starts at 40500 ms (far past the 15500 ms budget).
+    std::vector<float> source;
+    append_silence(source, 500);
+    append_tone(source, 40000);
+    append_silence(source, 500);
+
+    OmniVoiceReferenceClipOptions options;
+    options.max_seconds = 15.0F;
+    options.pad_ms = 150;
+    const auto result = clip_reference_mono(source, kSampleRate, options);
+
+    engine::test::require(result.no_pause_found, "warning path is taken");
+    engine::test::require(!result.clamped, "no speech was dropped");
+    engine::test::require_eq(result.pause_tier_ms, int64_t{0}, "no pause tier matched");
+    engine::test::require_eq(result.content_start_sample, ms_to_samples(500), "content start");
+    engine::test::require_eq(result.cut_sample, ms_to_samples(40500), "cut is the end of the content");
+
+    const size_t expected =
+        static_cast<size_t>(ms_to_samples(40000) + (2 * ms_to_samples(options.pad_ms)));
+    engine::test::require_eq(result.samples.size(), expected, "whole clip is preserved");
+    const auto pad = static_cast<size_t>(ms_to_samples(options.pad_ms));
+    engine::test::require_eq(rms(result.samples, 0, pad), 0.0, "head pad rms is exactly zero");
+    engine::test::require_eq(
+        rms(result.samples, result.samples.size() - pad, result.samples.size()),
+        0.0,
+        "tail pad rms is exactly zero");
+}
+
+// A reference inside the limit is returned byte-for-byte, so the shipped demo
+// voices (4.7-9.9 s) are untouched by the clamp.
+void test_short_reference_is_passed_through_unchanged() {
+    std::vector<float> source;
+    append_silence(source, 160);
+    append_tone(source, 6000);
+    append_silence(source, 160);
+
+    OmniVoiceReferenceClipOptions options;
+    options.max_seconds = 15.0F;
+    options.pad_ms = 150;
+    const auto result = clip_reference_mono(source, kSampleRate, options);
+
+    engine::test::require(!result.clamped, "short reference is not clamped");
+    engine::test::require(!result.no_pause_found, "short reference takes no warning path");
+    engine::test::require_eq(result.samples.size(), source.size(), "short reference keeps its length");
+    for (size_t i = 0; i < source.size(); ++i) {
+        if (result.samples[i] != source[i]) {
+            throw std::runtime_error("short reference altered at sample " + std::to_string(i));
+        }
+    }
+    engine::test::require_close(
+        static_cast<float>(result.output_seconds),
+        static_cast<float>(result.input_seconds),
+        0.0F,
+        "short reference duration");
+}
+
+// A larger limit turns the clamped case back into a pass-through, and a limit
+// of zero disables the clamp entirely.
+void test_limit_is_configurable() {
+    std::vector<float> source;
+    append_silence(source, 500);
+    for (int i = 0; i < 12; ++i) {
+        append_tone(source, 2000);
+        append_silence(source, 300);
+    }
+
+    OmniVoiceReferenceClipOptions generous;
+    generous.max_seconds = 60.0F;
+    const auto kept = clip_reference_mono(source, kSampleRate, generous);
+    engine::test::require(!kept.clamped, "a 60 s limit does not clamp a 28 s reference");
+    engine::test::require_eq(kept.samples.size(), source.size(), "generous limit is a pass-through");
+
+    OmniVoiceReferenceClipOptions disabled;
+    disabled.max_seconds = 0.0F;
+    const auto untouched = clip_reference_mono(source, kSampleRate, disabled);
+    engine::test::require(!untouched.clamped, "max_seconds=0 disables the clamp");
+    engine::test::require_eq(untouched.samples.size(), source.size(), "disabled limit is a pass-through");
+
+    // A tighter limit lands on the earlier pause: budget ends at 8500 ms, so the
+    // last qualifying pause starts at 2500 + 2300 * 2 = 7100 ms.
+    OmniVoiceReferenceClipOptions tight;
+    tight.max_seconds = 8.0F;
+    tight.pad_ms = 150;
+    const auto cut = clip_reference_mono(source, kSampleRate, tight);
+    engine::test::require(cut.clamped, "an 8 s limit clamps");
+    engine::test::require_eq(cut.cut_sample, ms_to_samples(7100), "tight cut sample");
+}
+
+// Silence entirely below the analysis threshold must not be mistaken for
+// content, and a clip with no signal at all is left alone rather than emptied.
+void test_silent_reference_is_left_alone() {
+    std::vector<float> source(static_cast<size_t>(ms_to_samples(30000)), 0.0F);
+    OmniVoiceReferenceClipOptions options;
+    options.max_seconds = 15.0F;
+    const auto result = clip_reference_mono(source, kSampleRate, options);
+    engine::test::require(!result.clamped, "a silent reference is not clamped");
+    engine::test::require_eq(result.samples.size(), source.size(), "a silent reference is untouched");
+}
+
+void test_window_grid_assumption() {
+    // Every boundary used above is a whole number of analysis windows, which is
+    // what makes the expected cut positions exact.
+    engine::test::require_eq(500 % kWindowMs, int64_t{0}, "lead silence on the window grid");
+    engine::test::require_eq(2000 % kWindowMs, int64_t{0}, "speech run on the window grid");
+    engine::test::require_eq(300 % kWindowMs, int64_t{0}, "pause on the window grid");
+    engine::test::require_eq(ms_to_samples(kWindowMs), int64_t{480}, "20 ms window at 24 kHz");
+}
+
+}  // namespace
+
+int main() {
+    try {
+        test_window_grid_assumption();
+        test_long_reference_cuts_at_a_pause();
+        test_clamped_reference_pads_with_exact_silence();
+        test_reference_without_a_pause_is_kept_whole();
+        test_short_reference_is_passed_through_unchanged();
+        test_limit_is_configurable();
+        test_silent_reference_is_left_alone();
+        std::cout << "omnivoice_reference_clamp_test passed\n";
+    } catch (const std::exception & ex) {
+        std::cerr << "omnivoice_reference_clamp_test failed: " << ex.what() << "\n";
+        return 1;
+    }
+    return 0;
+}

--- a/tests/unittests/test_qwen3_tts_chunk_budget.cpp
+++ b/tests/unittests/test_qwen3_tts_chunk_budget.cpp
@@ -1,0 +1,137 @@
+// F6.2 -- Qwen3-TTS's default text chunk must fit inside its token cap.
+//
+// The old default was a fixed 8192 codepoints against a 2048-frame cap. At the
+// 12.5 Hz codec frame rate 2048 frames is 163.8 s of audio, roughly a fifth of
+// what 8192 characters of prose needs, so any long-form input was truncated
+// mid-sentence on a bare `break`. These tests pin the replacement arithmetic;
+// no assets and no backend are needed.
+
+#include "engine/models/qwen3_tts/types.h"
+
+#include "test_assert.h"
+
+#include <cstdint>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+using engine::models::qwen3_tts::kQwen3TTSChunkSafetyMargin;
+using engine::models::qwen3_tts::kQwen3TTSCodecFrameRateHz;
+using engine::models::qwen3_tts::kQwen3TTSMinTextChunkSize;
+using engine::models::qwen3_tts::qwen3_tts_default_text_chunk_size;
+using engine::models::qwen3_tts::qwen3_tts_frames_for_codepoints;
+
+// The frame rate is 24000 / 1920 (tokenizer_speech_encoder.cpp:45-46).
+void test_frame_rate_matches_the_codec() {
+    engine::test::require_close(
+        static_cast<float>(kQwen3TTSCodecFrameRateHz),
+        12.5F,
+        1.0e-6F,
+        "codec frame rate");
+}
+
+// The contract: whatever the cap, a full default chunk needs fewer frames than
+// the cap can emit. This is the assertion the old 8192 constant failed.
+void test_default_chunk_always_fits_the_token_cap() {
+    const std::vector<int64_t> caps = {64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384};
+    for (const int64_t cap : caps) {
+        const int64_t chunk = qwen3_tts_default_text_chunk_size(cap);
+        const int64_t frames = qwen3_tts_frames_for_codepoints(chunk);
+        if (chunk > kQwen3TTSMinTextChunkSize && frames > cap) {
+            throw std::runtime_error(
+                "default chunk " + std::to_string(chunk) + " codepoints needs " +
+                std::to_string(frames) + " frames, past the cap of " + std::to_string(cap));
+        }
+    }
+}
+
+// The shipped cap. 2048 frames is 163.8 s of audio; the chunk must be a small
+// four-figure number of codepoints, not five.
+void test_shipped_cap_produces_a_synthesisable_chunk() {
+    const int64_t chunk = qwen3_tts_default_text_chunk_size(2048);
+    engine::test::require(chunk < 8192, "the shipped cap no longer defaults to the old 8192 chunk");
+    engine::test::require(chunk > 512, "the chunk is not so small that every sentence is split");
+    // 2048 / 12.5 = 163.84 s, x 13 codepoints/s x 0.75 margin = 1597.
+    engine::test::require_eq(chunk, int64_t{1597}, "default chunk for a 2048-frame cap");
+
+    const int64_t frames = qwen3_tts_frames_for_codepoints(chunk);
+    engine::test::require_eq(frames, int64_t{1536}, "frames a full default chunk needs");
+    engine::test::require(frames < 2048, "a full default chunk finishes inside the cap");
+    // The safety margin is real headroom, not a rounding accident.
+    const double headroom = 1.0 - (static_cast<double>(frames) / 2048.0);
+    engine::test::require(
+        headroom > 0.15,
+        "at least 15% of the token budget is left as headroom");
+}
+
+// The old default is exactly the failure the finding describes: 8192 codepoints
+// is several times what a 2048-frame cap can synthesise.
+void test_old_default_is_provably_unsynthesisable() {
+    const int64_t frames = qwen3_tts_frames_for_codepoints(8192);
+    engine::test::require(
+        frames > 2048,
+        "8192 codepoints needs more frames than the 2048 cap can emit");
+    engine::test::require(
+        frames > 3 * 2048,
+        "8192 codepoints needs more than three times the shipped cap");
+    engine::test::require_eq(frames, int64_t{7877}, "frames 8192 codepoints would need");
+}
+
+// Chunk size tracks the cap, so raising --max-tokens raises the chunk too.
+void test_chunk_size_scales_with_the_cap() {
+    engine::test::require(
+        qwen3_tts_default_text_chunk_size(4096) > qwen3_tts_default_text_chunk_size(2048),
+        "a larger cap allows a larger chunk");
+    engine::test::require(
+        qwen3_tts_default_text_chunk_size(1024) < qwen3_tts_default_text_chunk_size(2048),
+        "a smaller cap forces a smaller chunk");
+    // Linear in the cap, up to one codepoint of truncation on each side.
+    const int64_t doubled = qwen3_tts_default_text_chunk_size(4096);
+    const int64_t twice = 2 * qwen3_tts_default_text_chunk_size(2048);
+    engine::test::require(
+        doubled >= twice - 1 && doubled <= twice + 2,
+        "chunk size is linear in the cap up to truncation");
+}
+
+// Degenerate caps must not produce a zero or negative chunk, which would make
+// the splitter loop forever or throw.
+void test_degenerate_caps_clamp_to_the_floor() {
+    engine::test::require_eq(
+        qwen3_tts_default_text_chunk_size(0),
+        kQwen3TTSMinTextChunkSize,
+        "a zero cap falls back to the floor");
+    engine::test::require_eq(
+        qwen3_tts_default_text_chunk_size(-1),
+        kQwen3TTSMinTextChunkSize,
+        "a negative cap falls back to the floor");
+    engine::test::require_eq(
+        qwen3_tts_default_text_chunk_size(1),
+        kQwen3TTSMinTextChunkSize,
+        "a one-frame cap falls back to the floor");
+    engine::test::require_eq(
+        qwen3_tts_frames_for_codepoints(0),
+        int64_t{0},
+        "an empty chunk needs no frames");
+    engine::test::require(kQwen3TTSChunkSafetyMargin < 1.0, "the safety margin leaves headroom");
+}
+
+}  // namespace
+
+int main() {
+    try {
+        test_frame_rate_matches_the_codec();
+        test_default_chunk_always_fits_the_token_cap();
+        test_shipped_cap_produces_a_synthesisable_chunk();
+        test_old_default_is_provably_unsynthesisable();
+        test_chunk_size_scales_with_the_cap();
+        test_degenerate_caps_clamp_to_the_floor();
+        std::cout << "qwen3_tts_chunk_budget_test passed\n";
+    } catch (const std::exception & ex) {
+        std::cerr << "qwen3_tts_chunk_budget_test failed: " << ex.what() << "\n";
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
## What this changes

### OmniVoice's reference-length clamp was dead code

It sat behind `!options.has_reference_text` (`audio_tokenizer.cpp:381`), but `prompt_builder.cpp:772-775` **throws** if a voice-clone request arrives without reference text. The two conditions are mutually exclusive, so the clamp could never fire on a real clone. References were encoded whole at 75 Hz (24000 sample rate / 320 hop) with no guard and no warning.

The shipped demo voices run 4.7–9.9 s, i.e. 353–741 frames. A 101 s reference is **7,579 frames**, and measured on Metal it generated at 0.30× realtime and came out garbled, where a 12 s cut of the same voice ran at 2.26× and was clean.

The clamp now applies. It cuts at the **start of a silence run** rather than the quietest single window, tiered at 250/150/80 ms, so whole words survive; if no pause exists inside the limit it keeps the whole clip and warns rather than slicing a word; and it strips the edges and re-pads both ends with exact digital silence, which the model needs. `reference_max_seconds` (default 15) and `reference_pad_ms` (default 150) are request options and key the reference-prompt cache.

A reference with ≤15 s of speech content is returned **byte for byte unchanged**, so the demo voices are bit-identical — a `demo_1_man` render hashes the same before and after (SHA-256 `33b2d439…`).

### The clamp alone was not enough

Only an end-to-end run caught this. `estimate_target_tokens` derives the output duration from the ref_text-to-ref_frames pair as a **speaking-rate proxy**. Clamping the audio while leaving the caller's full transcript collapses that rate: the first fixed run produced **1.75 s** of audio for a sentence that should run about 6 s. `OmniVoiceAudioTokens` now carries `retained_fraction` and `prompt_builder` trims the transcript to the matching head, since the clamp keeps the head of the clip.

Measured on Metal, seed 42, 101 s reference, target text *"At three forty five in the afternoon I walked past twelve Saint Peter Street and bought a coffee."*, transcribed back with Parakeet TDT:

| | Wall clock | ASR of the output |
|---|---|---|
| before | 43.15 s | `Falf did sef sound right. Tapas 12 sex sex thoughts and session. Sayin' bit` |
| after | **6.90 s** | `At 3.45. In the afternoon, I walked past 12 St. Peter Street and bought a coffee.` |

The residual differences are Parakeet's own number and abbreviation normalisation.

### Qwen3-TTS could not synthesise its own default chunk

8192 codepoints against a 2048-token cap is 163 s at the 12.5 Hz codec frame rate, and the talker exited on a bare `break`, so long-form input truncated silently mid-sentence. The default is now derived from the frame rate and the actual cap, and resolved per request so `--max-tokens` resizes it too.

### Cap hits are no longer silent

In Qwen3-TTS and Chatterbox, following the stop-reason pattern OuteTTS already uses. Chatterbox also gained a bounds clamp on `speech_position_weight`: the decode loop indexes it at `step + 1` with no check, so raising the token cap could have overrun a short checkpoint table.

### Chatterbox defaults resolved from the repo's own harnesses

Not by guess. `tests/chatterbox/chatterbox_python_warm_bench.py:34-37` passes `repetition_penalty=1.2` and `top_p=1.0` — so `docs/tts.md` was wrong on both. `tests/chatterbox/chatterbox_warm_bench.cpp:174` defaults `--max-new-tokens` to 1000 — so the code was wrong there.

`top_p` stays 1.0: it is upstream's own default and a deliberate no-op, with `min_p=0.05` doing the filtering. Raising `max_new_tokens` 384 → 1000 is not a sampling change — with `stop_on_eos` any chunk that already finished under 384 tokens is bit-identical.

### VibeVoice reference cap documented and overridable

10 s on Metal, 30 s on CUDA (`session.cpp:25-26`), undocumented and with no override. Both constants arrived in the initial release with no comment and the gate is `Cuda || Hip`, so CPU and Vulkan take 10 s too — this reads as "CUDA was tested at 30 s", not "Metal has a limit". **Default unchanged**, but `vibevoice.voice_prompt_max_seconds` now overrides it, the truncation fades instead of cutting, and `docs/tts.md` states the split and that it is untested.

## Validation

**Build**
```
cmake -S . -B build -DENGINE_BUILD_TESTS=ON
cmake --build build
```

**Test**
```
ctest -R "omnivoice_reference_clamp_test|qwen3_tts_chunk_budget_test"
```

The OmniVoice test is gated on `omnivoice IN_LIST AUDIOCPP_LINKED_MODELS`. It asserts the cut lands at the start of a pause (source RMS over the 250 ms *after* the cut is 0, over the 100 ms *before* it is > 0.1), that head and tail pad RMS are **exactly 0.0**, that a pause-free clip is kept whole, and that a short reference is byte-for-byte identical.

**Run command used for the Metal A/B**
```
audiocpp_cli --task tts --family omnivoice --model models/OmniVoice-GGUF/omnivoice-q8_0.gguf \
  --backend metal --seed 42 --voice-ref long.wav --reference-text "..." --text "..." --out out.wav
```

**Backend tested:** Metal, Apple M4 Max. Full suite **40/40**.

## Affects

Output changes for OmniVoice references longer than the limit — that is the fix; shorter references are bit-identical. Chatterbox chunks that were being truncated now finish. Qwen3-TTS long-form produces roughly 5× more chunks.

## Known limitations

- Qwen3-TTS has no cross-chunk state, so more chunks means more joins. This trades a silent truncation for more seams, and pairs naturally with a chunk-seam crossfade change.
- Whether Metal can actually take a 30 s VibeVoice prompt is still unmeasured; the new override makes that a one-flag experiment.
- OmniVoice has no cap and no EOS — its length is fixed before generation — so it has no cap-hit stop reason to report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ATa5YkLUPMDPRL7w1gCo9p