### PR TITLE
moss_voicegen: accept the instruction spelling the speech route sends

### DIFF
--- a/src/community_models/moss_voicegen/session.cpp
+++ b/src/community_models/moss_voicegen/session.cpp
@@ -255,7 +255,10 @@ runtime::TaskResult MossVoiceGenSession::run(const runtime::TaskRequest & reques
 
     // The voice description arrives either as a request option or as a style tag on the
     // voice condition, matching how qwen3_tts takes its voice-design instruction.
-    std::string instruction = option_string(request.options, {"instruct"}, "");
+    // Accept both spellings: the OpenAI-compatible speech route maps its
+    // `instructions` body field to `instruction`, which is the only name a
+    // WebUI voice-design request can arrive under.
+    std::string instruction = option_string(request.options, {"instruct", "instruction"}, "");
     if (instruction.empty() && request.voice.has_value() && request.voice->style.has_value()) {
         const auto tag = request.voice->style->tags.find("instruct");
         if (tag != request.voice->style->tags.end()) {


### PR DESCRIPTION
## Summary

MOSS-VoiceGen read only the option key `instruct`, while the server's speech route sends `instruction`. Every instruction sent from the WebUI or `/v1/audio/speech` was silently dropped, and the model generated as if none had been given.

## What changed

`src/community_models/moss_voicegen/session.cpp` now reads the option through `option_string(request.options, {"instruct", "instruction"}, "")`, accepting either spelling. The existing `instruct` key keeps working, so CLI callers and any saved presets are unaffected.

## Scope

One community model. The change affects generated output only in the case that was broken — a request that carries `instruction` now steers the model instead of being ignored. No performance or memory impact.

## Validation

```bash
cmake --build build/macos-metal-tests -j 12
ctest --test-dir build/macos-metal-tests --output-on-failure
python3 tools/check_loader_catalog_sync.py
```

Full suite green (39/39), sync check exit 0. Backend tested: Metal, Apple M4 Max.

## Known limitations

The fix was verified by reading both sides of the key — the server's speech route and the session's option read — not by generating audio: no MOSS-VoiceGen package is installed on this machine. The change is a one-line alias in the option lookup and does not touch the generation path.
