### PR TITLE
Fix Chatterbox request sequence voice references

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -86,6 +86,29 @@ audiocpp_cli --task tts --family pocket_tts \
   --metrics
 ```
 
+The JSON may be either an array or an object with a `requests` array. Each item is parsed like one CLI request. Use `id` as the request name; with `--out-dir`, primary audio is written as `<out-dir>/<id>.wav`. There is no per-request `out` field.
+
+```json
+{
+  "requests": [
+    {
+      "id": "speaker1_output",
+      "text": "First text",
+      "voice_ref": "voices/speaker1.wav",
+      "reference_text": "Reference transcript 1",
+      "seed": 1234
+    },
+    {
+      "id": "speaker2_output",
+      "text": "Second text",
+      "voice_ref": "voices/speaker2.wav",
+      "reference_text": "Reference transcript 2",
+      "seed": 1234
+    }
+  ]
+}
+```
+
 For each request id, `--metrics` prints `metrics[<id>].wall_ms`, `audio_duration_ms`, `rtf`, `x_realtime`, `sample_rate`, and `channels`.
 
 ## Model Docs

--- a/src/models/chatterbox/session.cpp
+++ b/src/models/chatterbox/session.cpp
@@ -526,6 +526,51 @@ runtime::TaskResult ChatterboxSession::run_voice_cloning(const runtime::TaskRequ
         throw std::runtime_error("Chatterbox voice cloning session config is fixed; create a new session for different config");
     }
 
+    const ChatterboxConditionalsOutputs * conditionals = &*cached_conditionals_;
+    double prompt_prep_ms = cached_prompt_prep_ms_;
+    std::optional<ChatterboxConditionalsOutputs> uncached_conditionals;
+    if (request.voice.has_value() &&
+        request.voice->speaker.has_value() &&
+        request.voice->speaker->audio.has_value()) {
+        const auto & reference_audio = *request.voice->speaker->audio;
+        ChatterboxConditionalsCacheKey conditionals_key{
+            reference_audio,
+            request_config.exaggeration,
+            request_config.language,
+        };
+        if (const auto * cache_entry = conditionals_cache_.find(conditionals_key)) {
+            conditionals = cache_entry;
+            prompt_prep_ms = 0.0;
+            engine::debug::trace_log_scalar("chatterbox.conditionals.cache_hit", 1);
+        } else {
+            const auto prompt_prep_started = std::chrono::steady_clock::now();
+            auto prepared_conditionals = component_->prepare_voice_clone_conditionals(
+                reference_audio,
+                request_config);
+            prompt_prep_ms =
+                std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - prompt_prep_started).count();
+            if (conditionals_cache_.capacity() == 0) {
+                uncached_conditionals = std::move(prepared_conditionals);
+                conditionals = &*uncached_conditionals;
+            } else {
+                conditionals_cache_.put(std::move(conditionals_key), std::move(prepared_conditionals));
+                const auto * cache_entry = conditionals_cache_.find(ChatterboxConditionalsCacheKey{
+                    reference_audio,
+                    request_config.exaggeration,
+                    request_config.language,
+                });
+                if (cache_entry == nullptr) {
+                    throw std::runtime_error("Chatterbox conditionals cache insert failed");
+                }
+                conditionals = cache_entry;
+            }
+            engine::debug::trace_log_scalar("chatterbox.conditionals.cache_hit", 0);
+        }
+        engine::debug::trace_log_scalar(
+            "chatterbox.conditionals.cache_slots",
+            static_cast<int64_t>(conditionals_cache_.capacity()));
+    }
+
     runtime::TaskResult result;
     runtime::AudioBuffer merged_audio;
     const int64_t text_chunk_size =
@@ -536,9 +581,9 @@ runtime::TaskResult ChatterboxSession::run_voice_cloning(const runtime::TaskRequ
     for (const auto & chunk_request : chunk_requests) {
         auto outputs = component_->synthesize_voice_clone_with_conditionals(
             chunk_request.text_input->text,
-            *cached_conditionals_,
+            *conditionals,
             *voice_clone_config_);
-        outputs.prompt_prep_ms = cached_prompt_prep_ms_;
+        outputs.prompt_prep_ms = prompt_prep_ms;
         runtime::append_audio_buffer(merged_audio, runtime::AudioBuffer{
             24000,
             1,


### PR DESCRIPTION
## Summary
- Resolve Chatterbox voice-clone conditionals from each request when `voice_ref` is provided in a request sequence.
- Reuse the existing Chatterbox conditionals cache, so repeated references still hit the cache.
- Document the current `--request-sequence` JSON schema: `id` controls the output basename and there is no per-request `out` field.

## Validation
- `cmake --build build/debug --target audiocpp_cli -j "$(nproc)"`
- Ran a two-request Chatterbox `--request-sequence` case with different `voice_ref` files and `--log`; the second request produced a new conditionals cache miss instead of reusing the first voice.

Resolves #378