### PR TITLE
docs(server): explain host and port options

### DIFF
--- a/app/server/main.cpp
+++ b/app/server/main.cpp
@@ -70,6 +70,8 @@ void print_help() {
         << "  --no-ui                          disable the embedded WebUI\n"
         << "  --ui-management                  allow WebUI model management and downloads; requires\n"
         << "                                   AUDIOCPP_BUILD_NATIVE_MODEL_MANAGER=ON at build time\n"
+        << "  --host <ip>                      server bind address; default 127.0.0.1\n"
+        << "  --port <port>                    server listening port; default 8080\n"
         << "  --backend cpu|cuda|hip|rocm|vulkan|metal  default cuda (rocm is an alias for hip)\n"
         << "  --list-devices                   list available backend devices and exit\n"
         << "  --busy-timeout-ms <ms>           fail a request with 503 when the model has been\n"


### PR DESCRIPTION
Documents the server host bind-address and listening-port options in the detailed help output, including their current defaults (127.0.0.1 and 8080). Verified by rebuilding the Windows CUDA and Vulkan server targets and checking the help output from both binaries.

<img width="1417" height="536" alt="Screenshot 2026-08-31 134629" src="https://github.com/user-attachments/assets/9046bcf8-d184-43a6-96a8-e003b077967e" />

