### PR TITLE
fix(granite5asr): build mel filterbank on the continuous frequency axis

### DIFF
--- a/src/community_models/granite5asr/frontend.cpp
+++ b/src/community_models/granite5asr/frontend.cpp
@@ -44,37 +44,36 @@ audio::AudioTensor build_htk_mel_filterbank(int64_t sample_rate, int64_t n_fft, 
     const double min_mel = hz_to_htk_mel(f_min);
     const double max_mel = hz_to_htk_mel(f_max);
 
-    std::vector<double> mel_points(static_cast<size_t>(n_mels + 2));
-    for (size_t i = 0; i < mel_points.size(); ++i) {
-        mel_points[i] = min_mel + (max_mel - min_mel) * static_cast<double>(i) / static_cast<double>(n_mels + 1);
-    }
-
-    std::vector<int64_t> fft_bins(static_cast<size_t>(n_mels + 2));
-    for (size_t i = 0; i < fft_bins.size(); ++i) {
-        const double hz = htk_mel_to_hz(mel_points[i]);
-        fft_bins[i] = static_cast<int64_t>(std::floor((static_cast<double>(n_fft) + 1.0) * hz / static_cast<double>(sample_rate)));
-        fft_bins[i] = std::clamp(fft_bins[i], static_cast<int64_t>(0), num_bins - 1);
+    // Triangle edges stay in Hz. Snapping them to integer FFT bins collapses the narrow
+    // low-frequency filters: at 16 kHz / n_fft 512 the bin spacing is 31.25 Hz while the
+    // lowest mel bands are ~20 Hz wide, so several of them land on the same bin (mel[2]
+    // became an all-zero row) and no longer match the torchaudio filterbank the encoder
+    // was trained against.
+    std::vector<double> edges_hz(static_cast<size_t>(n_mels + 2));
+    for (size_t i = 0; i < edges_hz.size(); ++i) {
+        const double mel = min_mel + (max_mel - min_mel) * static_cast<double>(i) / static_cast<double>(n_mels + 1);
+        edges_hz[i] = htk_mel_to_hz(mel);
     }
 
     audio::AudioTensor fb;
     fb.shape = {n_mels, num_bins};
     fb.values.assign(static_cast<size_t>(n_mels * num_bins), 0.0f);
 
-    for (int64_t m = 1; m <= n_mels; ++m) {
-        const int64_t f_left = fft_bins[static_cast<size_t>(m - 1)];
-        const int64_t f_center = fft_bins[static_cast<size_t>(m)];
-        const int64_t f_right = fft_bins[static_cast<size_t>(m + 1)];
+    // Frequency of FFT bin k, matching torch.linspace(0, sample_rate / 2, num_bins).
+    const double bin_hz = f_max / static_cast<double>(num_bins - 1);
 
-        for (int64_t k = f_left; k < f_center; ++k) {
-            if (f_center > f_left) {
-                fb.values[static_cast<size_t>((m - 1) * num_bins + k)] =
-                    static_cast<float>(k - f_left) / static_cast<float>(f_center - f_left);
-            }
-        }
-        for (int64_t k = f_center; k < f_right; ++k) {
-            if (f_right > f_center) {
-                fb.values[static_cast<size_t>((m - 1) * num_bins + k)] =
-                    static_cast<float>(f_right - k) / static_cast<float>(f_right - f_center);
+    for (int64_t m = 1; m <= n_mels; ++m) {
+        const double f_left = edges_hz[static_cast<size_t>(m - 1)];
+        const double f_center = edges_hz[static_cast<size_t>(m)];
+        const double f_right = edges_hz[static_cast<size_t>(m + 1)];
+
+        for (int64_t k = 0; k < num_bins; ++k) {
+            const double hz = bin_hz * static_cast<double>(k);
+            const double rising = f_center > f_left ? (hz - f_left) / (f_center - f_left) : 0.0;
+            const double falling = f_right > f_center ? (f_right - hz) / (f_right - f_center) : 0.0;
+            const double weight = std::min(rising, falling);
+            if (weight > 0.0) {
+                fb.values[static_cast<size_t>((m - 1) * num_bins + k)] = static_cast<float>(weight);
             }
         }
     }


### PR DESCRIPTION
## Summary

`build_htk_mel_filterbank()` in `src/community_models/granite5asr/frontend.cpp` snapped each triangle's edges to integer FFT bin indices:

```cpp
fft_bins[i] = floor((n_fft + 1) * hz / sample_rate);
```

The encoder was trained against `torchaudio.transforms.MelSpectrogram`, whose `melscale_fbanks()` builds the triangles on the **continuous** frequency axis `linspace(0, sample_rate / 2, n_fft / 2 + 1)` with no quantization. This PR builds them the same way.

At the model's 16 kHz / `n_fft` 512 the FFT bin spacing is 31.25 Hz while the lowest mel bands are ~20 Hz wide, so the quantization was destructive exactly where the bands are narrowest. Comparing the two banks directly:

- **`mel[2]` was an all-zero row**, emitting a constant floored value for every frame
- **`mel[0]` and `mel[3]` had cosine similarity 0.000** against the reference filter — single-bin filters landing on a different bin with zero overlap
- relative L1 error was **134% over `mel[0:10]`**, decaying to 7% over `mel[70:80]`
- row-sum ratio was 1.013, so total gain was nearly correct — this was a low-frequency *shape* error, not a scale error

Because the corrupted bands carry voicing and energy cues, CTC was biased toward blank on short low-energy function words, making the errors deletion-dominated.

The rest of the frontend already matches the reference exactly and is untouched: periodic Hann, `center=true` + reflect padding, `power = mag*mag`, `log10`, per-clip `max - 8 dB` floor, `/4 + 1`, and central-difference deltas with replicate edges.

## Validation

**Reference:** `transformers` 5.16.0.dev0 `GraniteSpeech5ForCTC` (`ibm-granite/granite-speech-5.0-470m-turboctc`), CPU/fp32.

**Data:** 150 utterances sampled across shards 0/7/14 of `hf-audio/esb-datasets-test-only-sorted` config `ami` split `test` — 9.6 min, durations 0.1–26.2 s. Scored with the `open_asr_leaderboard` `EnglishTextNormalizer` + `jiwer`, dropping the 11 utterances whose normalized reference is empty.

**Backend:** Metal, Apple M1 Max, macOS 15.6.

| Run | WER | S | D | I |
|---|---|---|---|---|
| transformers reference | 8.34% | 59 | 44 | 20 |
| audio.cpp v0.7.1 release binary | 8.96% | 58 | 56 | 18 |
| audio.cpp, this branch | **8.28%** | 60 | 42 | 20 |

Exact-match agreement with the reference rose from **133/150 to 146/150**. Deletions fell 56 → 42, against the reference's 44.

Two controls:

- **The gap was entirely this filterbank.** Swapping only this bank into the reference pipeline (monkeypatching `fe.mel_filters.mel_scale.fb`) reproduced 8.96% with D=55, and raised agreement with audio.cpp's output to 146/150.
- **My baseline build reproduces the release binary bit-for-bit** on WER/S/D/I (8.96%, 58/56/18), so the patch is the only variable.

The patched bank matches torchaudio's to within float32 rounding — max abs difference 5.3e-06 (~44 ULP, because torchaudio computes its mel edges in float32 while this builds them in double), per-filter cosine similarity 1.000000, zero dead filters.

`Q8_0` and `bf16` score identically (8.96% before the fix, both), so quantization was never a factor here.

**No regression on the existing golden test.** `assets/asr_validation/librispeech/librispeech_test_clean_6930-75918-0000.wav` transcribes to `concord returned to its place amidst the tents` both before and after, matching `kExpectedText`.

**No runtime cost** — the bank is built once in the `Granite5Frontend` constructor, and the per-frame mel loop already iterated all `freq_bins`. Like-for-like builds, 6 runs each on the 26.2 s clip (Metal, Q8_0), `metrics.x_realtime`:

```
baseline: 140.964 143.714 141.246 141.575 139.856 147.844   (median 141.4)
patched:  143.349 136.030 146.303 140.921 142.769 147.787   (median 142.8)
```

`python3 tools/check_loader_catalog_sync.py --self-test` passes; this PR touches no loader or catalog entries.

## Reproducing

```bash
# build (only this family needed)
cmake -S . -B build -DCMAKE_BUILD_TYPE=Release \
  -DAUDIOCPP_MODEL_SET=custom -DAUDIOCPP_MODELS=granite5asr -DGGML_METAL=ON
cmake --build build --target audiocpp_cli -j 10

# model: package id granite5asr_q8_0
#   audio-cpp/audio.cpp-gguf : Granite-Speech-5.0-470M-TurboCTC-GGUF/granite-speech-5.0-470m-turboctc-q8_0.gguf

# run
./build/bin/audiocpp_cli --task asr --family granite5asr \
  --model models/Granite-Speech-5.0-470M-TurboCTC-GGUF --backend metal \
  --batch-audio-dir <wav_dir> --request-option audio_chunk_mode=none
```

## Known limitations / notes

- Measured on 9.6 min of AMI test on Metal only. A full-set run and a CPU/CUDA/Vulkan check would firm the number up; I expect the effect to be backend-independent since it is a filterbank construction change.
- The patch builds edges in double where torchaudio uses float32, so results are marginally *more* accurate than the reference rather than bit-identical. That is why this branch lands 0.06 pp below the reference WER rather than exactly on it.
- I did not add a unit test because `build_htk_mel_filterbank()` lives in an anonymous namespace and testing it would mean widening its visibility. Happy to add one asserting no all-zero filters plus a few reference weights if you'd like it exposed — a golden transcription test on clean LibriSpeech does not catch this class of bug, as the unchanged output above shows.
- Unrelated, spotted while testing: `docs/community_models/granite5asr.md` documents `--input`, but the CLI only accepts `--audio`, so the documented commands fail. Left alone to keep this diff focused.
