### PR TITLE
perf(fish_audio): add HIP Fast-AR top-k sampler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -945,6 +945,33 @@ audiocpp_add_model(fish_audio
         engine::models::fish_audio::make_fish_audio_loader
 )
 
+# Fish Fast-AR emits a 4096-entry logits tensor for each acoustic codebook.
+# On Linux HIP, use a small device-side exact top-k helper so only the compact
+# sampling candidates cross back to the host. Other backends stay unchanged.
+if (ENGINE_ENABLE_HIP AND UNIX AND NOT APPLE)
+    find_program(AUDIOCPP_HIPCC hipcc REQUIRED)
+    set(AUDIOCPP_FISH_HIP_FAST_SAMPLER_OBJ "${CMAKE_CURRENT_BINARY_DIR}/fish_hip_fast_sampler.o")
+    set(AUDIOCPP_FISH_HIP_TARGETS ${CMAKE_HIP_ARCHITECTURES})
+    if (NOT AUDIOCPP_FISH_HIP_TARGETS)
+        set(AUDIOCPP_FISH_HIP_TARGETS ${GPU_TARGETS})
+    endif()
+    set(AUDIOCPP_FISH_HIP_ARCH_FLAGS)
+    foreach(AUDIOCPP_FISH_HIP_ARCH IN LISTS AUDIOCPP_FISH_HIP_TARGETS)
+        list(APPEND AUDIOCPP_FISH_HIP_ARCH_FLAGS "--offload-arch=${AUDIOCPP_FISH_HIP_ARCH}")
+    endforeach()
+    add_custom_command(
+        OUTPUT ${AUDIOCPP_FISH_HIP_FAST_SAMPLER_OBJ}
+        COMMAND ${AUDIOCPP_HIPCC} -O3 -fPIC ${AUDIOCPP_FISH_HIP_ARCH_FLAGS} -std=c++17
+            -c ${CMAKE_CURRENT_SOURCE_DIR}/src/models/fish_audio/hip_fast_sampler.cu
+            -o ${AUDIOCPP_FISH_HIP_FAST_SAMPLER_OBJ}
+        DEPENDS
+            ${CMAKE_CURRENT_SOURCE_DIR}/src/models/fish_audio/hip_fast_sampler.cu
+            ${CMAKE_CURRENT_SOURCE_DIR}/src/models/fish_audio/hip_fast_sampler.h
+        VERBATIM)
+    set_source_files_properties(${AUDIOCPP_FISH_HIP_FAST_SAMPLER_OBJ} PROPERTIES GENERATED TRUE EXTERNAL_OBJECT TRUE)
+    target_compile_definitions(engine_model_fish_audio PRIVATE ENGINE_HAS_HIP_FISH_FAST_SAMPLER=1)
+endif()
+
 audiocpp_add_model(audio8_tts
     SOURCES
         src/community_models/audio8_tts/ar.cpp
@@ -1656,6 +1683,9 @@ set(AUDIOCPP_RUNTIME_OBJECTS
 foreach(model_name IN LISTS AUDIOCPP_LINKED_MODELS)
     list(APPEND AUDIOCPP_RUNTIME_OBJECTS $<TARGET_OBJECTS:engine_model_${model_name}>)
 endforeach()
+if (ENGINE_ENABLE_HIP AND UNIX AND NOT APPLE AND "fish_audio" IN_LIST AUDIOCPP_LINKED_MODELS)
+    list(APPEND AUDIOCPP_RUNTIME_OBJECTS ${AUDIOCPP_FISH_HIP_FAST_SAMPLER_OBJ})
+endif()
 
 message(STATUS "audio.cpp model composite: ${AUDIOCPP_MODEL_SET} selected [${AUDIOCPP_ENABLED_MODELS}] linked [${AUDIOCPP_LINKED_MODELS}]")
 add_library(engine_runtime STATIC

--- a/src/models/fish_audio/ar.cpp
+++ b/src/models/fish_audio/ar.cpp
@@ -11,6 +11,10 @@
 #include "engine/framework/modules/weight_binding.h"
 #include "engine/framework/sampling/torch_random.h"
 
+#ifdef ENGINE_HAS_HIP_FISH_FAST_SAMPLER
+#include "hip_fast_sampler.h"
+#endif
+
 #include "engine/framework/core/constant_tensor_cache.h"
 
 #include <ggml-alloc.h>
@@ -534,14 +538,10 @@ SampleDistribution logits_to_distribution(
     return {logits.size(), std::move(kept)};
 }
 
-int32_t sample_from_logits(
-    const std::vector<float> & logits,
-    float temperature,
-    float top_p,
-    int top_k,
+int32_t sample_from_distribution(
+    const SampleDistribution & distribution,
     SampleState & state,
     const sampling::TorchCudaSamplingPolicy & policy) {
-    const auto distribution = logits_to_distribution(logits, temperature, top_p, top_k);
     const uint64_t call_index = state.call_index++;
     if (!policy.cuda_fast_path) {
         std::vector<double> weights;
@@ -576,6 +576,65 @@ int32_t sample_from_logits(
     }
     return best;
 }
+
+int32_t sample_from_logits(
+    const std::vector<float> & logits,
+    float temperature,
+    float top_p,
+    int top_k,
+    SampleState & state,
+    const sampling::TorchCudaSamplingPolicy & policy) {
+    const auto distribution = logits_to_distribution(logits, temperature, top_p, top_k);
+    return sample_from_distribution(distribution, state, policy);
+}
+
+#ifdef ENGINE_HAS_HIP_FISH_FAST_SAMPLER
+int32_t sample_from_hip_topk(
+    const detail::HipFastTopKResult & result,
+    size_t source_size,
+    float temperature,
+    float top_p,
+    SampleState & state,
+    const sampling::TorchCudaSamplingPolicy & policy) {
+    if (result.count <= 0 || !(result.denom > 0.0)) {
+        throw std::runtime_error("HIP Fish fast sampler produced an invalid distribution");
+    }
+
+    double cumulative = 0.0;
+    int32_t kept_count = 0;
+    for (int32_t i = 0; i < result.count; ++i) {
+        const float probability = static_cast<float>(std::exp(result.logits[i] - result.max_logit) / result.denom);
+        cumulative += probability;
+        if (cumulative > static_cast<double>(top_p) && i != 0) {
+            break;
+        }
+        ++kept_count;
+    }
+
+    const float temperature_scale = std::max(temperature, 1.0e-5F);
+    float filtered_max = -std::numeric_limits<float>::infinity();
+    for (int32_t i = 0; i < kept_count; ++i) {
+        filtered_max = std::max(filtered_max, result.logits[i] / temperature_scale);
+    }
+    std::vector<SampleCandidate> candidates;
+    candidates.reserve(static_cast<size_t>(kept_count));
+    double filtered_denom = 0.0;
+    for (int32_t i = 0; i < kept_count; ++i) {
+        const float weight = std::exp(result.logits[i] / temperature_scale - filtered_max);
+        candidates.push_back({result.indices[i], weight});
+        filtered_denom += weight;
+    }
+    if (!(filtered_denom > 0.0)) {
+        throw std::runtime_error("HIP Fish fast sampler produced zero filtered probability mass");
+    }
+    for (auto & candidate : candidates) {
+        candidate.probability = static_cast<float>(static_cast<double>(candidate.probability) / filtered_denom);
+    }
+
+    const SampleDistribution distribution{source_size, std::move(candidates)};
+    return sample_from_distribution(distribution, state, policy);
+}
+#endif
 
 std::vector<float> apply_semantic_bias(
     const FishAudioConfig & config,
@@ -1325,9 +1384,18 @@ private:
                 throw std::runtime_error("failed to allocate Fish Audio fast AR graph");
             }
             mask_scratch_.assign(static_cast<size_t>(config.num_codebooks), ggml_fp32_to_fp16(-INFINITY));
+#ifdef ENGINE_HAS_HIP_FISH_FAST_SAMPLER
+            if (runtime_->backend_type() == core::BackendType::Hip) {
+                hip_sampler_ = detail::hip_fast_sampler_create(static_cast<int32_t>(config.vocab_size));
+            }
+#endif
         }
 
         ~FastGraph() {
+#ifdef ENGINE_HAS_HIP_FISH_FAST_SAMPLER
+            detail::hip_fast_sampler_destroy(hip_sampler_);
+            hip_sampler_ = nullptr;
+#endif
             core::release_backend_graph_resources(runtime_->backend(), graph_);
             if (gallocr_ != nullptr) {
                 ggml_gallocr_free(gallocr_);
@@ -1378,6 +1446,57 @@ private:
             return logits;
         }
 
+#ifdef ENGINE_HAS_HIP_FISH_FAST_SAMPLER
+        detail::HipFastTopKResult run_topk(
+            const std::vector<float> & input,
+            int64_t position,
+            int top_k,
+            FishARProfile & profile) {
+            const auto & config = runtime_->assets().config.fast;
+            if (hip_sampler_ == nullptr || static_cast<int64_t>(input.size()) != config.dim) {
+                throw std::runtime_error("HIP Fish fast AR sampler is unavailable or input size is invalid");
+            }
+            ++profile.fast_runs;
+            auto timing_start = Clock::now();
+            const int32_t pos = static_cast<int32_t>(position);
+            ggml_backend_tensor_set(position_, &pos, 0, sizeof(pos));
+            const auto visible = ggml_fp32_to_fp16(0.0F);
+            if (position == 0) {
+                std::fill(mask_scratch_.begin(), mask_scratch_.end(), ggml_fp32_to_fp16(-INFINITY));
+                mask_scratch_[0] = visible;
+                ggml_backend_tensor_set(mask_, mask_scratch_.data(), 0, mask_scratch_.size() * sizeof(ggml_fp16_t));
+            } else {
+                mask_scratch_[static_cast<size_t>(position)] = visible;
+                ggml_backend_tensor_set(
+                    mask_,
+                    &visible,
+                    static_cast<size_t>(position) * sizeof(ggml_fp16_t),
+                    sizeof(ggml_fp16_t));
+            }
+            profile.fast_mask_upload_ms += engine::debug::elapsed_ms(timing_start, Clock::now());
+            timing_start = Clock::now();
+            ggml_backend_tensor_set(input_, input.data(), 0, input.size() * sizeof(float));
+            profile.fast_input_upload_ms += engine::debug::elapsed_ms(timing_start, Clock::now());
+            core::set_backend_threads(runtime_->backend(), runtime_->threads());
+            timing_start = Clock::now();
+            const ggml_status status = core::compute_backend_graph(runtime_->backend(), graph_, nullptr, "fish_audio.ar.fast");
+            ggml_backend_synchronize(runtime_->backend());
+            profile.fast_graph_ms += engine::debug::elapsed_ms(timing_start, Clock::now());
+            if (status != GGML_STATUS_SUCCESS) {
+                throw std::runtime_error("Fish Audio fast AR graph compute failed");
+            }
+            detail::HipFastTopKResult result;
+            timing_start = Clock::now();
+            detail::hip_fast_sampler_topk(
+                hip_sampler_,
+                static_cast<const float *>(logits_->data),
+                top_k,
+                &result);
+            profile.fast_output_read_ms += engine::debug::elapsed_ms(timing_start, Clock::now());
+            return result;
+        }
+#endif
+
     private:
         std::shared_ptr<const FishARWeightsRuntime> runtime_;
         std::unique_ptr<ggml_context, GgmlContextDeleter> state_ctx_;
@@ -1390,6 +1509,9 @@ private:
         ggml_cgraph * graph_ = nullptr;
         ggml_gallocr_t gallocr_ = nullptr;
         ggml_backend_buffer_t state_buffer_ = nullptr;
+#ifdef ENGINE_HAS_HIP_FISH_FAST_SAMPLER
+        void * hip_sampler_ = nullptr;
+#endif
     };
 
     void ensure_prefill_graph(int64_t steps, FishARProfile & profile) {
@@ -1483,16 +1605,33 @@ private:
             timing_start = Clock::now();
             const auto embedding = build_fast_embedding(config, weights, code);
             profile.fast_embedding_ms += engine::debug::elapsed_ms(timing_start, Clock::now());
-            const auto logits = fast_graph_->run(embedding, codebook, profile);
-            timing_start = Clock::now();
-            code = sample_from_logits(
-                logits,
-                options.temperature,
-                options.top_p,
-                options.top_k,
-                sample,
-                sampling_policy_);
-            profile.sample_fast_ms += engine::debug::elapsed_ms(timing_start, Clock::now());
+#ifdef ENGINE_HAS_HIP_FISH_FAST_SAMPLER
+            if (runtime_->backend_type() == core::BackendType::Hip &&
+                options.top_k > 0 && options.top_k <= detail::kHipFastSamplerMaxTopK) {
+                const auto topk = fast_graph_->run_topk(embedding, codebook, options.top_k, profile);
+                timing_start = Clock::now();
+                code = sample_from_hip_topk(
+                    topk,
+                    static_cast<size_t>(config.fast.vocab_size),
+                    options.temperature,
+                    options.top_p,
+                    sample,
+                    sampling_policy_);
+                profile.sample_fast_ms += engine::debug::elapsed_ms(timing_start, Clock::now());
+            } else
+#endif
+            {
+                const auto logits = fast_graph_->run(embedding, codebook, profile);
+                timing_start = Clock::now();
+                code = sample_from_logits(
+                    logits,
+                    options.temperature,
+                    options.top_p,
+                    options.top_k,
+                    sample,
+                    sampling_policy_);
+                profile.sample_fast_ms += engine::debug::elapsed_ms(timing_start, Clock::now());
+            }
             frame[static_cast<size_t>(codebook + 1)] = code;
         }
         return frame;

--- a/src/models/fish_audio/hip_fast_sampler.cu
+++ b/src/models/fish_audio/hip_fast_sampler.cu
@@ -1,0 +1,179 @@
+#include "hip_fast_sampler.h"
+
+#include <hip/hip_runtime.h>
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+namespace engine::models::fish_audio::detail {
+namespace {
+
+void check_hip(hipError_t status, const char * label) {
+    if (status != hipSuccess) {
+        throw std::runtime_error(std::string(label) + ": " + hipGetErrorString(status));
+    }
+}
+
+struct Workspace {
+    int32_t vocab_size = 0;
+    HipFastTopKResult * packed = nullptr;
+};
+
+__device__ __forceinline__ bool better(float av, int32_t ai, float bv, int32_t bi) {
+    return av > bv || (av == bv && ai < bi);
+}
+
+// Exact top-k for Fish Fast-AR (4096 entries for S2 Pro). Keeping only the
+// compact result on the host avoids copying and sorting the full logits tensor
+// for every acoustic codebook step.
+__global__ void exact_topk_kernel(
+    const float * logits,
+    int32_t count,
+    int32_t top_k,
+    HipFastTopKResult * result) {
+    extern __shared__ unsigned char smem_raw[];
+    float * shared_logits = reinterpret_cast<float *>(smem_raw);
+    float * best_values = shared_logits + count;
+    int32_t * best_indices = reinterpret_cast<int32_t *>(best_values + blockDim.x);
+    double * denom_parts = reinterpret_cast<double *>(best_indices + blockDim.x);
+
+    const int32_t tid = static_cast<int32_t>(threadIdx.x);
+    for (int32_t i = tid; i < count; i += static_cast<int32_t>(blockDim.x)) {
+        const float v = logits[i];
+        shared_logits[i] = isfinite(v) ? v : -INFINITY;
+    }
+    __syncthreads();
+
+    float max_logit = -INFINITY;
+    for (int32_t rank = 0; rank < top_k; ++rank) {
+        float local_value = -INFINITY;
+        int32_t local_index = INT32_MAX;
+        for (int32_t i = tid; i < count; i += static_cast<int32_t>(blockDim.x)) {
+            const float v = shared_logits[i];
+            if (better(v, i, local_value, local_index)) {
+                local_value = v;
+                local_index = i;
+            }
+        }
+        best_values[tid] = local_value;
+        best_indices[tid] = local_index;
+        __syncthreads();
+
+        for (int32_t stride = static_cast<int32_t>(blockDim.x) / 2; stride > 0; stride >>= 1) {
+            if (tid < stride) {
+                const float other_value = best_values[tid + stride];
+                const int32_t other_index = best_indices[tid + stride];
+                if (better(other_value, other_index, best_values[tid], best_indices[tid])) {
+                    best_values[tid] = other_value;
+                    best_indices[tid] = other_index;
+                }
+            }
+            __syncthreads();
+        }
+
+        const float selected_value = best_values[0];
+        const int32_t selected_index = best_indices[0];
+        if (tid == 0) {
+            if (rank == 0) {
+                max_logit = selected_value;
+                result->max_logit = selected_value;
+                result->count = top_k;
+            }
+            result->logits[rank] = selected_value;
+            result->indices[rank] = selected_index;
+            shared_logits[selected_index] = -INFINITY;
+        }
+        __syncthreads();
+        if (rank == 0) {
+            max_logit = result->max_logit;
+        }
+    }
+
+    double local_denom = 0.0;
+    for (int32_t i = tid; i < count; i += static_cast<int32_t>(blockDim.x)) {
+        const float v = logits[i];
+        if (isfinite(v)) {
+            local_denom += static_cast<double>(expf(v - max_logit));
+        }
+    }
+    denom_parts[tid] = local_denom;
+    __syncthreads();
+    for (int32_t stride = static_cast<int32_t>(blockDim.x) / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) {
+            denom_parts[tid] += denom_parts[tid + stride];
+        }
+        __syncthreads();
+    }
+    if (tid == 0) {
+        result->denom = denom_parts[0];
+    }
+}
+
+void free_workspace(Workspace * ws) {
+    if (ws == nullptr) {
+        return;
+    }
+    if (ws->packed != nullptr) {
+        (void) hipFree(ws->packed);
+    }
+    delete ws;
+}
+
+}  // namespace
+
+void * hip_fast_sampler_create(int32_t vocab_size) {
+    if (vocab_size <= 0) {
+        throw std::invalid_argument("HIP Fish fast sampler requires positive vocab_size");
+    }
+    auto * ws = new Workspace{};
+    ws->vocab_size = vocab_size;
+    try {
+        check_hip(hipMalloc(&ws->packed, sizeof(HipFastTopKResult)), "hipMalloc Fish sampler result");
+    } catch (...) {
+        free_workspace(ws);
+        throw;
+    }
+    return ws;
+}
+
+void hip_fast_sampler_destroy(void * workspace) {
+    free_workspace(static_cast<Workspace *>(workspace));
+}
+
+void hip_fast_sampler_topk(
+    void * workspace,
+    const float * device_logits,
+    int32_t top_k,
+    HipFastTopKResult * host_result) {
+    auto * ws = static_cast<Workspace *>(workspace);
+    if (ws == nullptr || device_logits == nullptr || host_result == nullptr) {
+        throw std::invalid_argument("HIP Fish fast sampler received a null argument");
+    }
+    if (top_k <= 0 || top_k > ws->vocab_size || top_k > kHipFastSamplerMaxTopK) {
+        throw std::invalid_argument("HIP Fish fast sampler top_k is out of range");
+    }
+
+    constexpr int threads = 256;
+    const size_t shared_bytes =
+        static_cast<size_t>(ws->vocab_size) * sizeof(float) +
+        static_cast<size_t>(threads) * (sizeof(float) + sizeof(int32_t) + sizeof(double));
+    hipLaunchKernelGGL(
+        exact_topk_kernel,
+        dim3(1),
+        dim3(threads),
+        shared_bytes,
+        0,
+        device_logits,
+        ws->vocab_size,
+        top_k,
+        ws->packed);
+    check_hip(hipGetLastError(), "exact_topk_kernel Fish sampler");
+    check_hip(
+        hipMemcpy(host_result, ws->packed, sizeof(HipFastTopKResult), hipMemcpyDeviceToHost),
+        "hipMemcpy Fish sampler result");
+}
+
+}  // namespace engine::models::fish_audio::detail

--- a/src/models/fish_audio/hip_fast_sampler.h
+++ b/src/models/fish_audio/hip_fast_sampler.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <cstdint>
+
+namespace engine::models::fish_audio::detail {
+
+constexpr int kHipFastSamplerMaxTopK = 256;
+
+struct HipFastTopKResult {
+    int32_t count = 0;
+    float max_logit = 0.0F;
+    double denom = 0.0;
+    float logits[kHipFastSamplerMaxTopK]{};
+    int32_t indices[kHipFastSamplerMaxTopK]{};
+};
+
+void * hip_fast_sampler_create(int32_t vocab_size);
+void hip_fast_sampler_destroy(void * workspace);
+void hip_fast_sampler_topk(
+    void * workspace,
+    const float * device_logits,
+    int32_t top_k,
+    HipFastTopKResult * host_result);
+
+}  // namespace engine::models::fish_audio::detail


### PR DESCRIPTION
## Summary

This is the first small HIP-scoped piece from the Fish S2 Pro AMD optimization work discussed in https://github.com/0xShug0/audio.cpp/discussions/317.

Fish Fast-AR produces a 4096-entry logits tensor for each acoustic codebook step. On the HIP path this PR:

- adds an exact device-side top-k helper for the Fast-AR logits;
- copies only the compact top-k result back to the host instead of all 4096 logits;
- keeps the existing temperature/top-p filtering and RNG selection path, so sampling behavior stays aligned with the current implementation;
- gates the new code on Linux HIP and only links it when `fish_audio` is part of the model composite.

Other backends keep the existing path unchanged.

This intentionally does **not** include the more aggressive experiments from the original patch set: chained Fast-AR, resident embedding gather, device-side mask/position updates, backend stream access, or the GGML convolution fixes. Those can be reviewed separately if useful.

## Validation

Tested against current `main` at `3497b7cc44753e2c141d8fe60ac42cec433e3281`.

System:
- AMD Radeon RX 7900 XTX (`gfx1100`)
- ROCm 7.2.1 / HIP
- Linux
- Fish Audio S2 Pro Q8_0 GGUF (`fish-audio-s2-pro-q8_0.gguf`)

Build:

```bash
bash scripts/build_linux.sh \
  --backend hip \
  --gpu-targets gfx1100 \
  --model-set custom \
  --models fish_audio \
  --target audiocpp_cli
```

Benchmark input:

```text
This benchmark measures speech generation on an AMD graphics card. The same sentence, random seed, and sampling settings are used for every run so that the timing results can be compared fairly.
```

Generation settings:

```text
language=en
seed=1234
max_tokens=96
temperature=0.8
top_k=50
top_p=0.8
```

Five identical requests were run in one loaded process. Request 1 was treated as graph/model warmup; requests 2-5 are the warm measurements below. Each output was 4411.79 ms of audio.

| Path | Warm #2 | Warm #3 | Warm #4 | Warm #5 | Warm mean |
| --- | ---: | ---: | ---: | ---: | ---: |
| current main | 4252.08 ms | 4316.97 ms | 4232.65 ms | 4229.31 ms | 4257.75 ms |
| HIP Fast-AR top-k | 4064.28 ms | 4133.41 ms | 4059.36 ms | 4055.67 ms | 4078.18 ms |

That is about **4.22% lower warm wall time** for this isolated optimization.

Output parity: all five baseline WAVs and all five patched WAVs were bit-identical:

```text
SHA-256: dfbc6ec75603a05c85d97e5dbf24b75a77dcc2386e5087159cd9d7d673989533
```

After a small code cleanup/refactor, I rebuilt/relinked and reran three requests; the warm times were 4038.98 / 4106.59 ms and the same SHA-256 was preserved for all three outputs.

I also compiled `src/models/fish_audio/ar.cpp` with the HIP Fish sampler macro removed to verify the existing non-HIP fallback path still compiles.

## Known limitations

- Runtime benchmark coverage is currently RX 7900 XTX / Linux HIP only.
- The fast path is used for positive `top_k <= 256`; unsupported values fall back to the existing full-logits path.
- This is intentionally only the Fast-AR top-k/readback optimization; the larger GPU-resident/chained work is not part of this PR.
