### PR TITLE
Fix ACE-Step auto-duration planner budget

### DIFF
--- a/src/models/ace_step/planner.cpp
+++ b/src/models/ace_step/planner.cpp
@@ -1085,15 +1085,9 @@ std::vector<std::string> planner_keyscale_values() {
     return values;
 }
 
-int64_t planner_codes_phase_max_new_tokens(
-    const AceStepRequest & request,
-    int64_t fallback_max_new_tokens) {
-    if (request.generation.duration_seconds > 0.0F) {
-        const float clamped_duration = std::clamp(
-            request.generation.duration_seconds,
-            static_cast<float>(kPlannerDurationMin),
-            static_cast<float>(kPlannerDurationMax));
-        return static_cast<int64_t>(clamped_duration * 5.0F) + kPlannerCodesPhaseExtraBudget;
+int64_t planner_codes_phase_max_new_tokens(int64_t target_codes, int64_t fallback_max_new_tokens) {
+    if (target_codes > 0) {
+        return std::min(target_codes + kPlannerCodesPhaseExtraBudget, fallback_max_new_tokens);
     }
     return fallback_max_new_tokens;
 }
@@ -2889,7 +2883,7 @@ AceStepPlan AceStepPlannerRuntime::generate(const AceStepRequest & request, bool
         if (desired_codes > generation_.max_code_tokens) {
             throw std::runtime_error("ACE-Step planner target audio-code count exceeds configured decode budget");
         }
-        const int64_t max_new_tokens = planner_codes_phase_max_new_tokens(request, generation_.max_code_tokens);
+        const int64_t max_new_tokens = planner_codes_phase_max_new_tokens(desired_codes, generation_.max_code_tokens);
         std::vector<int32_t> generated;
         generated.reserve(static_cast<size_t>(max_new_tokens));
         std::mt19937 rng(request.generation.seed);


### PR DESCRIPTION
Fixes #389.

## Summary

- Size ACE-Step planner code-phase decode budget from the resolved target audio-code count.
- This lets auto duration use the CoT-inferred duration for phase-2 graph/cache sizing instead of falling back to the full planner token budget.
- Explicit duration behavior remains unchanged.

## Validation

- Built `audiocpp_cli` in the debug build.
- Ran ACE-Step Turbo Q8 on CUDA with the same prompt/options before and after the change.

| Case | Before | After | Change |
|---|---:|---:|---:|
| auto `prefill_cache_steps` | 4570 | 1298 | -71.6% |
| auto `code.cfg_decode.graph.prepare_ms` | 845.5 | 54.9 | -93.5% |
| auto `code.decode.graph.step_ms` | 7819.3 | 3696.9 | -52.7% |
| auto `planner.total_ms` | 10345.9 | 5417.3 | -47.6% |
| auto `wall_ms` | 21668.6 | 10738.0 | -50.4% |
| auto RTF | 0.1445 | 0.0716 | -50.4% |

Explicit `duration=160` control remained byte-identical before/after.