### PR TITLE
server: validate the backend before binding the port

### DIFF
--- a/app/server/main.cpp
+++ b/app/server/main.cpp
@@ -229,6 +229,21 @@ int main(int argc, char ** argv) {
             throw std::runtime_error("--min-free-memory-mb must be >= 0 (0 disables the memory guard)");
         }
 
+        // Prove the requested backend and device exist before binding a port.
+        // The backend defaults to CUDA, and nothing else checks it until the
+        // first generate, so a machine without CUDA would otherwise serve the
+        // whole UI — health, model list, downloads — and only fail once the
+        // user pressed Run. Failing here reports the same message the engine
+        // would have raised, at the point the operator can still act on it.
+        {
+            engine::core::BackendConfig probe;
+            probe.type = config.backend;
+            probe.device = config.device;
+            probe.threads = config.threads;
+            ggml_backend_t backend = engine::core::init_backend(probe);
+            ggml_backend_free(backend);
+        }
+
         const auto ui_resource_anchor = executable_directory(argc > 0 ? argv[0] : nullptr);
         minitts::server::ServerState state(
             config,


### PR DESCRIPTION
Split out of #369 as requested: this PR is only the startup backend probe. The `language` contract gate, the ASR detail fields and the unload locking are separate PRs.

## The problem

`--backend` defaults to `cuda` and nothing verified it at startup. On a host where that backend is not registered the server still bound its port and served the whole UI — health, model list, downloads — with an engine that could not run anything:

```
$ audiocpp_server --ui --backend cuda --port 8096
$ curl localhost:8096/health
{"status":"ok","backend":"cuda","models":0,"ui":true,"ui_management":false}
```

`/health` reports `ok` on an Apple-silicon machine with no CUDA device. The operator only finds out at the first model load or generate, by which time the failure looks like a model problem rather than a startup flag.

## The change

`main()` initialises the requested backend and device once before constructing the server, then frees it. A missing backend or device now aborts startup with the message the engine would have raised later:

```
$ audiocpp_server --ui --backend cuda --port 8096
audiocpp_server failed: CUDA backend requested but it is not registered in this build
(available: MTL:0 "Apple M4 Max" [GPU], BLAS:0 "Accelerate" [ACCEL], CPU:0 "Apple M4 Max" [CPU])
```

The message already names the devices that *are* available, so the operator can correct `--backend`/`--device` immediately. The probe runs on a path that loads the backend libraries anyway and does not touch the request path.

## Validation

Backend: Metal, Apple M4 Max, macOS 15.

| Command | `main` | this branch |
|---|---|---|
| `--ui --backend cuda` | binds, `/health` → `{"status":"ok","backend":"cuda"}` | exits, `CUDA backend requested but it is not registered in this build` |
| `--ui --backend metal` | binds, `/health` → `{"status":"ok","backend":"metal"}` | binds, `/health` → `{"status":"ok","backend":"metal"}` |

Build and tests:

```bash
cmake --build build/macos-metal-tests -j 12
ctest --test-dir build/macos-metal-tests        # 40/40
```

## Scope

One file, `app/server/main.cpp`, 15 added lines. Startup only; no request, model or response behaviour changes.
