### PR TITLE
model_specs: correct descriptions that contradict the code

### DIFF
--- a/model_specs/dramabox.json
+++ b/model_specs/dramabox.json
@@ -57,7 +57,7 @@
       {
         "name": "num_inference_steps",
         "type": "int",
-        "description": "Diffusion sampling step count; default comes from config.json, 30 in the current package.",
+        "description": "Diffusion sampling step count; default 30.",
         "required": false,
         "min": 1,
         "default": 30
@@ -65,7 +65,7 @@
       {
         "name": "guidance_scale",
         "type": "float",
-        "description": "Classifier-free guidance scale; default comes from config.json, 2.5 in the current package. Values greater than 1 enable CFG.",
+        "description": "Classifier-free guidance scale; default 2.5. Values greater than 1 enable CFG.",
         "required": false,
         "min": 0.0,
         "default": 2.5
@@ -73,7 +73,7 @@
       {
         "name": "spatio_temporal_guidance_scale",
         "type": "float",
-        "description": "Spatio-temporal guidance scale; default comes from config.json, 1.5 in the current package. Values greater than 0 enable STG.",
+        "description": "Spatio-temporal guidance scale; default 1.5. Values greater than 0 enable STG.",
         "required": false,
         "min": 0.0,
         "default": 1.5
@@ -81,7 +81,7 @@
       {
         "name": "duration_scale",
         "type": "float",
-        "description": "Multiplier applied to the estimated prompt duration when duration_sec is 0; default comes from config.json, 1.1 in the current package.",
+        "description": "Multiplier applied to the estimated prompt duration when duration_sec is 0; default 1.1.",
         "required": false,
         "min": 0.0,
         "default": 1.1
@@ -89,7 +89,7 @@
       {
         "name": "reference_duration_sec",
         "type": "float",
-        "description": "Reference voice crop/repeat duration in seconds; default comes from config.json, 10.0 in the current package.",
+        "description": "Reference voice crop/repeat duration in seconds; default 10.0.",
         "required": false,
         "min": 0.0,
         "default": 10.0

--- a/model_specs/fish_audio.json
+++ b/model_specs/fish_audio.json
@@ -29,7 +29,7 @@
       {
         "name": "reference_text",
         "type": "string",
-        "description": "Reference transcript used with speaker reference audio.",
+        "description": "Reference transcript used with speaker reference audio. Required whenever the request carries inline reference audio; the model rejects the request without it.",
         "required": false
       },
       {

--- a/model_specs/outetts.json
+++ b/model_specs/outetts.json
@@ -107,7 +107,7 @@
       {
         "name": "reference_text",
         "type": "string",
-        "description": "Transcript matching the reference voice audio for voice cloning.",
+        "description": "Transcript matching the reference voice audio for voice cloning. Required whenever reference audio is supplied; the model rejects voice cloning without it.",
         "required": false
       },
       {


### PR DESCRIPTION
Split out of #372 as requested. This PR is description text only; the strict contract fixes, the VoxCPM1 defaults, the ASR/aligner/codec declarations and the MiniMax declarations are separate PRs.

Nothing here changes a declared type, bound, default or required flag, so no request that was accepted or rejected before changes state.

## The changes

| Spec | Change | Code it matches |
|---|---|---|
| `dramabox` | five descriptions dropped the claim that their default "comes from `config.json`" | `dramabox/assets.cpp` reads `config.json` for the architecture only; the values named are the engine's own |
| `fish_audio.reference_text` | says it is required whenever the request carries inline reference audio | `src/models/fish_audio/session.cpp:255-258` throws `"<role> with inline reference audio requires reference_text option"` |
| `outetts.reference_text` | same, for voice cloning | `src/community_models/outetts/session.cpp:695-698` and `722-728` throw `"OuteTTS voice cloning requires --reference-text"` |

Both `reference_text` options stay `required: false` on purpose: they are required only when reference audio is present, and the schema's `required` is a plain bool with no conditional form, so marking them required would break plain TTS with a built-in voice. The description is the only place that distinction can currently live.

## Validation

```bash
python3 tools/check_loader_catalog_sync.py
# ok: runtime loaders, model_specs, and model_manager_v2 are in sync

audiocpp_model_manager list --repository-root .        # exit 0
# parses every on-disk spec through the C++ schema loader
```

## Scope

Three spec files, 7 lines. The generated WebUI bundle (`webui/native/dist/index.html`) is deliberately not included: `catalog.ts` inlines `model_specs/*.json` at frontend build time and the bundle is not byte-reproducible, so regenerating it in each PR of this split would produce conflicts between them. Happy to send one bundle-regeneration PR once the series has landed.
