### PR TITLE
model_specs: fix declarations that accept or reject the wrong requests

### DIFF
--- a/model_specs/firered_audio.json
+++ b/model_specs/firered_audio.json
@@ -183,14 +183,6 @@
         "default": 1024
       },
       {
-        "name": "helper_graph_arena_mb",
-        "type": "int",
-        "description": "Helper graph arena size in MiB; default 256.",
-        "required": false,
-        "min": 1,
-        "default": 256
-      },
-      {
         "name": "weight_context_mb",
         "type": "int",
         "description": "Weight loading context size in MiB; default 1024.",

--- a/model_specs/granite5asr.json
+++ b/model_specs/granite5asr.json
@@ -23,13 +23,6 @@
   "options": {
     "request": [
       {
-        "name": "language",
-        "type": "string",
-        "description": "Recognition language (currently English).",
-        "required": false,
-        "default": "en"
-      },
-      {
         "name": "audio_chunk_mode",
         "type": "enum",
         "description": "Audio chunking mode: auto, fixed, or none.",

--- a/model_specs/heartmula.json
+++ b/model_specs/heartmula.json
@@ -26,13 +26,13 @@
         "name": "lyrics",
         "type": "string",
         "description": "Lyrics text.",
-        "required": false
+        "required": true
       },
       {
         "name": "tags",
         "type": "string",
         "description": "Comma-separated music tags.",
-        "required": false
+        "required": true
       },
       {
         "name": "duration_sec",

--- a/model_specs/irodori_tts.json
+++ b/model_specs/irodori_tts.json
@@ -74,6 +74,8 @@
         "type": "enum",
         "description": "Text chunking mode; default endline.",
         "values": [
+          "default",
+          "tag_aware",
           "japanese",
           "endline"
         ],

--- a/model_specs/midashenglm_gen.json
+++ b/model_specs/midashenglm_gen.json
@@ -67,9 +67,9 @@
       {
         "name": "seed",
         "type": "int",
-        "description": "Generation seed; -1 selects a random seed.",
+        "description": "Generation seed; parsed as an unsigned 32-bit value, so negative seeds are rejected.",
         "required": false,
-        "min": -1,
+        "min": 0,
         "max": 2147483647,
         "default": 0
       }


### PR DESCRIPTION
Split out of #372 as requested. This PR holds only the changes that alter which requests validate; the description-only fixes, the VoxCPM1 defaults, the ASR/aligner/codec declarations and the MiniMax declarations are separate PRs.

Each change is listed with the exact parser that reads the option.

## The changes

**`midashenglm_gen.seed`: `min` -1 → 0.** `src/models/midashenglm_gen/session.cpp:176` reads the seed through `runtime::parse_u32_option`, and `parse_u32_value` (`src/framework/runtime/options.cpp:36-39`) throws `"seed must be an unsigned integer"` on any leading minus. A spec-legal `-1` was therefore a guaranteed runtime error, and the "-1 selects a random seed" description promised behaviour that could not happen.

**`heartmula.lyrics`, `heartmula.tags`: `required` false → true.** `src/models/heartmula/session.cpp` throws `"HeartMuLa requires non-empty tags"` and `"HeartMuLa requires non-empty lyrics"`. The engine already rejected what the spec described as valid, so a client could not learn the constraint until the request failed.

**`irodori_tts.text_chunk_mode`: `default` and `tag_aware` added to the enum.** The session takes the shared override (`src/models/irodori_tts/session.cpp:453-454` → `text::parse_text_chunk_mode_override`), and `src/framework/text/chunking.cpp:572-586` accepts `default`, `word_budget`, `tag_aware`, `japanese`, `endline`. Two working modes were undeclared and so unreachable from a spec-driven client.

**`granite5asr.language`: removed.** The session never reads a language option — it hard-codes `"en"` (`src/community_models/granite5asr/session.cpp:137, 174, 252, 270, 277`). The declaration invited a value that could not have an effect.

**`firered_audio` session option `helper_graph_arena_mb`: removed.** The only key that exists is `fireredtts3.helper_graph_arena_mb` (`src/models/fireredtts3/session.cpp:251`). FireRedAudio validates session options strictly, so sending the declared name failed the request outright.

## Validation

```bash
python3 tools/check_loader_catalog_sync.py
# ok: runtime loaders, model_specs, and model_manager_v2 are in sync

audiocpp_model_manager list --repository-root .        # exit 0
# parses every on-disk spec through the C++ schema loader
```

Verified by reading the parser that consumes each option, with the file and line above. None of these five families has a package installed on this machine, so they were not exercised end to end; the sibling ASR PR carries a live request check for the one family that is installed here.

## Scope

Five spec files, 6 insertions / 19 deletions. The generated WebUI bundle is deliberately excluded: `catalog.ts` inlines `model_specs/*.json` at frontend build time and the bundle is not byte-reproducible, so regenerating it in every PR of this split would make the PRs conflict with each other. Happy to send one bundle-regeneration PR once the series lands.
