### PR TITLE
model_specs: declare the ASR, forced-aligner and codec options the sessions read

### DIFF
--- a/model_specs/miocodec.json
+++ b/model_specs/miocodec.json
@@ -26,6 +26,60 @@
       "speaker_reference"
     ]
   },
+  "options": {
+    "request": [],
+    "session": [
+      {
+        "name": "weight_type",
+        "type": "enum",
+        "description": "Codec weight storage type; default f32.",
+        "preset": "weight_type_full",
+        "required": false,
+        "default": "f32"
+      },
+      {
+        "name": "weight_context_mb",
+        "type": "int",
+        "description": "Codec weight descriptor context size in MiB; default 256.",
+        "required": false,
+        "min": 1,
+        "default": 256
+      },
+      {
+        "name": "constant_context_mb",
+        "type": "int",
+        "description": "Reusable constant context size in MiB; default 256.",
+        "required": false,
+        "min": 1,
+        "default": 256
+      },
+      {
+        "name": "content_graph_arena_mb",
+        "type": "int",
+        "description": "Content encoder graph arena size in MiB; default 512.",
+        "required": false,
+        "min": 1,
+        "default": 512
+      },
+      {
+        "name": "global_graph_arena_mb",
+        "type": "int",
+        "description": "Global encoder graph arena size in MiB; default 256.",
+        "required": false,
+        "min": 1,
+        "default": 256
+      },
+      {
+        "name": "wave_graph_arena_mb",
+        "type": "int",
+        "description": "Wave decoder graph arena size in MiB; default 512.",
+        "required": false,
+        "min": 1,
+        "default": 512
+      }
+    ],
+    "load": []
+  },
   "runtime": {
     "tags": [
       "gguf"

--- a/model_specs/mms_forced_aligner.json
+++ b/model_specs/mms_forced_aligner.json
@@ -61,7 +61,7 @@
       {
         "name": "return_timestamps",
         "type": "bool",
-        "description": "Request word timestamps in the result; set automatically by --words-out.",
+        "description": "Accepted for cross-model compatibility (--words-out sets it) and ignored: the forced aligner always returns word timestamps.",
         "required": false,
         "default": true
       }

--- a/model_specs/parakeet_tdt.json
+++ b/model_specs/parakeet_tdt.json
@@ -55,6 +55,12 @@
   "options": {
     "request": [
       {
+        "name": "language",
+        "type": "string",
+        "description": "Transcription language from the OpenAI-compatible request field. Accepted for API compatibility; Parakeet TDT detects the language itself and does not use this value (see keep_language_tags).",
+        "required": false
+      },
+      {
         "name": "max_tokens",
         "type": "int",
         "description": "Maximum TDT generated tokens; 0 or omitted uses the model-derived limit.",

--- a/model_specs/qwen3_forced_aligner.json
+++ b/model_specs/qwen3_forced_aligner.json
@@ -37,6 +37,63 @@
         "required": false,
         "default": false
       }
+    ],
+    "session": [
+      {
+        "name": "weight_type",
+        "type": "enum",
+        "description": "Fallback weight storage type for the thinker; default native.",
+        "preset": "weight_type_full",
+        "required": false,
+        "default": "native"
+      },
+      {
+        "name": "thinker_weight_type",
+        "type": "enum",
+        "description": "Thinker matmul weight storage type; defaults to weight_type when set, otherwise native.",
+        "preset": "weight_type_full",
+        "required": false
+      },
+      {
+        "name": "audio_encoder_weight_type",
+        "type": "enum",
+        "description": "Audio encoder weight storage type; default native.",
+        "preset": "weight_type_conv",
+        "required": false,
+        "default": "native"
+      },
+      {
+        "name": "audio_encoder_graph_arena_mb",
+        "type": "int",
+        "description": "Audio encoder graph arena size in MiB; default 128.",
+        "required": false,
+        "min": 1,
+        "default": 128
+      },
+      {
+        "name": "thinker_prefill_graph_arena_mb",
+        "type": "int",
+        "description": "Thinker prefill graph arena size in MiB; default 256.",
+        "required": false,
+        "min": 1,
+        "default": 256
+      },
+      {
+        "name": "thinker_decode_graph_arena_mb",
+        "type": "int",
+        "description": "Thinker decode graph arena size in MiB; default 256.",
+        "required": false,
+        "min": 1,
+        "default": 256
+      },
+      {
+        "name": "thinker_weight_context_mb",
+        "type": "int",
+        "description": "Thinker weight descriptor context size in MiB; default 64.",
+        "required": false,
+        "min": 1,
+        "default": 64
+      }
     ]
   },
   "runtime": {

--- a/model_specs/sense_asr.json
+++ b/model_specs/sense_asr.json
@@ -69,10 +69,11 @@
       {
         "name": "audio_chunk_mode",
         "type": "enum",
-        "description": "Audio chunking mode: auto, fixed, or none.",
+        "description": "Audio chunking mode: auto, fixed, vad, or none.",
         "values": [
           "auto",
           "fixed",
+          "vad",
           "none"
         ],
         "required": false,


### PR DESCRIPTION
Split out of #372 as requested. This PR declares options the ASR, forced-aligner and codec sessions already read; the description-only fixes, the VoxCPM1 defaults, the strict contract fixes and the MiniMax declarations are separate PRs.

Additive throughout: no existing declaration changes, so nothing that validated before fails now.

## The changes

| Spec | Added | Code that reads it |
|---|---|---|
| `parakeet_tdt` | `language`, accepted and ignored | `language` is part of the OpenAI-compatible transcription contract and every other strict ASR family declares it, so a per-model rejection was a protocol violation. Parakeet reads only `keep_language_tags` (`src/community_models/parakeet_tdt/session.cpp:285-286`), which the description now states |
| `sense_asr` | `"vad"` in the `audio_chunk_mode` enum | `src/community_models/sense_asr/session.cpp:512-524` throws only for `QuietEnergy` and implements the `Vad` branch — the mode worked and could not be requested |
| `qwen3_forced_aligner` | seven prefixed session options | `src/models/qwen3_forced_aligner/session.cpp`: `weight_type`, `thinker_weight_type`, `audio_encoder_weight_type`, `audio_encoder_graph_arena_mb`, `thinker_prefill_graph_arena_mb`, `thinker_decode_graph_arena_mb`, `thinker_weight_context_mb` |
| `miocodec` | six prefixed session options | `src/models/miocodec/session.cpp`: `weight_type`, `weight_context_mb`, `constant_context_mb`, `content_graph_arena_mb`, `global_graph_arena_mb`, `wave_graph_arena_mb` |
| `mms_forced_aligner` | description only for `return_timestamps` | The option is never read, but the family validates strictly and the CLI's `--words-out` injects the key, so removing it would break forced alignment from the command line. It is now documented as accepted and ignored |

## Validation

Backend: Metal, Apple M4 Max, macOS 15. Parakeet-TDT (`parakeet-tdt-0.6b-v3-q8_0.gguf`) loaded with `model_spec_override` pointing at the repository spec, because `default_contract_spec_path` (`src/framework/model_spec/package.cpp:504+`) prefers the spec embedded in the GGUF over the on-disk one:

```
POST /v1/audio/transcriptions {"model":"pk","audio":"...wav","options":{"language":"en"}}

main's spec:      500  {"error":{"message":"unknown Parakeet TDT request option: language"}}
this branch:      200  {"text":"At 3:45 pm on 14 October 2025, I jogged past 12 St. Peter Street, ..."}
```

Worth noting for release planning: because published GGUFs embed their own contract, this declaration reaches users of existing packages only when those packages are regenerated. It is correct in the repository either way, and it is what a freshly converted package will carry.

```bash
python3 tools/check_loader_catalog_sync.py
# ok: runtime loaders, model_specs, and model_manager_v2 are in sync

audiocpp_model_manager list --repository-root .        # exit 0
```

## Scope

Five spec files, +120/-2. The generated WebUI bundle is deliberately excluded — `catalog.ts` inlines `model_specs/*.json` at frontend build time and the bundle is not byte-reproducible, so regenerating it in every PR of this split would make the PRs conflict with each other. Happy to send one bundle-regeneration PR once the series lands.
