### PR TITLE
model_specs: declare the MiniMax Music3 and H3 options the sessions read

### DIFF
--- a/model_specs/minimax_h3.json
+++ b/model_specs/minimax_h3.json
@@ -193,6 +193,24 @@
         "default": 0.1
       },
       {
+        "name": "first_block_cache_start_percent",
+        "type": "float",
+        "description": "Start of the denoise window where the first-block cache may be used, as a fraction of the schedule.",
+        "required": false,
+        "min": 0.0,
+        "max": 1.0,
+        "default": 0.1
+      },
+      {
+        "name": "first_block_cache_end_percent",
+        "type": "float",
+        "description": "End of the denoise window where the first-block cache may be used, as a fraction of the schedule; must be greater than first_block_cache_start_percent.",
+        "required": false,
+        "min": 0.0,
+        "max": 1.0,
+        "default": 0.95
+      },
+      {
         "name": "first_block_cache_start_sigma",
         "type": "float",
         "description": "Largest video sigma where first-block cache may be used.",

--- a/model_specs/minimax_music3.json
+++ b/model_specs/minimax_music3.json
@@ -80,6 +80,47 @@
         "required": false,
         "min": 0,
         "default": 0
+      },
+      {
+        "name": "flow_uncond_interval",
+        "type": "int",
+        "description": "Evaluate the flow unconditional CFG branch only every N-th step and reuse the cached guidance delta in between; 1 keeps the exact reference trajectory.",
+        "required": false,
+        "min": 1,
+        "default": 1
+      },
+      {
+        "name": "flow_uncond_warmup",
+        "type": "int",
+        "description": "Number of initial flow steps that always evaluate both CFG branches when delta reuse is enabled.",
+        "required": false,
+        "min": 0,
+        "default": 2
+      },
+      {
+        "name": "ensemble_takes",
+        "type": "int",
+        "description": "Decode N independent takes of the same prompt in one batched AR pass (seeds seed..seed+N-1); outputs are returned as named audio take_01..take_NN.",
+        "required": false,
+        "min": 1,
+        "max": 16,
+        "default": 1
+      },
+      {
+        "name": "ensemble_prefix_frames",
+        "type": "int",
+        "description": "Intro-lock for ensembles: decode the first N AR frames once as a shared master trajectory (~25 frames per second), then fork the takes; 0 disables.",
+        "required": false,
+        "min": 0,
+        "default": 0
+      },
+      {
+        "name": "flow_chunk_hop_frames",
+        "type": "int",
+        "description": "Flow chunk hop in AR frames (~25/sec); 0 keeps the model config (100, 50% chunk overlap).",
+        "required": false,
+        "min": 0,
+        "default": 0
       }
     ],
     "session": [
@@ -141,6 +182,13 @@
         "description": "Load large generation stages only while they are needed to reduce peak VRAM.",
         "required": false,
         "default": true
+      },
+      {
+        "name": "pipeline_overlap",
+        "type": "bool",
+        "description": "Overlap AR decoding with per-chunk condition/flow/vocoder work on a second backend stream. Requires mem_saver=false; falls back to the sequential pipeline otherwise.",
+        "required": false,
+        "default": false
       }
     ],
     "load": []


### PR DESCRIPTION
Split out of #372 as requested. This PR declares the MiniMax Music3 and H3 options their sessions already read; the description-only fixes, the VoxCPM1 defaults, the strict contract fixes and the ASR/aligner/codec declarations are separate PRs.

Additive throughout: no existing declaration changes, so nothing that validated before fails now.

## The changes

**`minimax_music3`** — five request options and one session option, all read today:

| Option | Read in |
|---|---|
| `flow_uncond_interval` | `src/community_models/minimax_music3/flow_sampler.cpp`, `session.cpp` |
| `flow_uncond_warmup` | `src/community_models/minimax_music3/flow_sampler.cpp`, `session.cpp` |
| `ensemble_takes` | `src/community_models/minimax_music3/session.cpp` |
| `ensemble_prefix_frames` | `src/community_models/minimax_music3/pipeline.cpp`, `session.cpp` |
| `flow_chunk_hop_frames` | `src/community_models/minimax_music3/pipeline.cpp`, `session.cpp` |
| session `minimax_music3.pipeline_overlap` | `src/community_models/minimax_music3/pipeline.cpp`, `session.cpp` |

These arrived with the performance pack and none were declared. `ensemble_takes` returns several named outputs and had no way to be requested at all.

**`minimax_h3`** — `first_block_cache_start_percent` and `first_block_cache_end_percent` (`src/community_models/minimax_h3/session.cpp`, `pipeline.cpp`). This is the primary cache window whose `_sigma` override was already declared, so the spec exposed the fine adjustment while hiding the control it adjusts.

## Validation

```bash
python3 tools/check_loader_catalog_sync.py
# ok: runtime loaders, model_specs, and model_manager_v2 are in sync

audiocpp_model_manager list --repository-root .        # exit 0
# parses every on-disk spec through the C++ schema loader
```

Verified by reading the option-parsing code named above. Neither package is installed on this machine, so no end-to-end generation was run.

## Scope

Two spec files, +66. The generated WebUI bundle is deliberately excluded — `catalog.ts` inlines `model_specs/*.json` at frontend build time and the bundle is not byte-reproducible, so regenerating it in every PR of this split would make the PRs conflict with each other. Happy to send one bundle-regeneration PR once the series lands.
