### PR TITLE
webui: stop overriding engine defaults on every request

### DIFF
--- a/webui/native/src/routes/+page.svelte
+++ b/webui/native/src/routes/+page.svelte
@@ -72,8 +72,12 @@
   let instructions = '';
   let lyrics = '';
   let duration = 30;
-  let seed = 1234;
-      let maxTokens = 1024;
+  // -1 means "let the engine pick", matching the field label. A fixed default
+  // here would silently pin every model whose own default is a random seed.
+  let seed = -1;
+  // Blank means "use the model's own limit". A shared constant here overrode
+  // per-model ceilings ranging from 300 to 4096, halving some and doubling others.
+  let maxTokens: number | '' = '';
       let sourceFile: File | null = null;
       let videoFile: File | null = null;
       let voiceFile: File | null = null;
@@ -402,18 +406,30 @@
   $: usesVibeVoiceSpeakerFiles = selected?.family === 'vibevoice';
   $: isQwenBase = selected?.task === 'tts' && selected?.family === 'qwen3_tts' &&
     !selected?.id.includes('custom');
-  $: allowsQuickStartVoice = ['tts', 'clon'].includes(selected?.task);
+  // Voice design also picks a named voice, and any model shipping built-in
+  // voices should offer them whatever its task.
+  $: allowsQuickStartVoice = ['tts', 'clon', 'vdes'].includes(selected?.task) ||
+    (selected?.builtin_voices || []).length > 0;
   $: referenceVoiceRequired = !(allowsQuickStartVoice && quickStartVoice) && (
     (['clon', 'vc', 'svc'].includes(selected?.task) && selected?.family !== 'rvc') || isQwenBase);
   $: lyricsRequired = requiresRequestOption(selected, 'lyrics');
   $: referenceTextRequired = requiresRequestOption(selected, 'reference_text') ||
     (Boolean(voiceFile) && isQwenBase);
-  $: quickStartVoices = server && !server.ui_management
-    ? configuredVoices
+  // Voices come from three places: the spec's built-in list, whatever the server
+  // reports for this model, and the bundled demo clips. The demo clips only make
+  // sense for models that take an arbitrary reference.
+  $: demoQuickStartVoices = server && !server.ui_management
+    ? []
     : Object.entries(demoVoiceSources)
       .filter(([, source]) => bundledVoices.includes(source))
       .map(([voice]) => voice);
-  $: quickStartVoicePreview = quickStartVoice && server?.ui_management !== false
+  $: quickStartVoices = Array.from(new Set([
+    ...(selected?.builtin_voices || []),
+    ...configuredVoices,
+    ...demoQuickStartVoices
+  ]));
+  $: quickStartVoicePreview = quickStartVoice && server?.ui_management !== false &&
+    demoQuickStartVoices.includes(quickStartVoice)
     ? voicePreviewUrl(demoVoiceSources[quickStartVoice] || quickStartVoice)
     : '';
   $: showsText = ['tts', 'clon', 'gen', 's2s', 'align', 'vdes'].includes(selected?.task);
@@ -703,6 +719,13 @@
   function supportsMaxTokens(entry: CatalogEntry) {
     if (entry.request_options !== undefined) return entry.request_options.includes('max_tokens');
     return ['tts', 'clon', 'gen', 's2s', 'vdes'].includes(entry.task);
+  }
+
+  // Seed has a dedicated input rather than a parameter widget, so tasks that
+  // never declared one could not be made reproducible at all. Trust the spec
+  // where it publishes request metadata.
+  function supportsSeed(entry: CatalogEntry) {
+    return entry.request_options?.includes('seed') === true;
   }
 
   function supportsRequestOption(entry: CatalogEntry, option: string) {
@@ -1405,10 +1428,13 @@
   }
 
   async function refreshConfiguredVoices() {
-    if (!selectedId || server?.ui_management !== false) {
+    if (!selectedId) {
       configuredVoices = [];
       return;
     }
+    // Ask for this model's own voices regardless of management mode. The server
+    // returns its configured presets plus any embeddings shipped beside the
+    // weights, and skipping the call in managed mode made both unreachable.
     try {
       configuredVoices = await availableVoices(selectedId);
       if (quickStartVoice && !configuredVoices.includes(quickStartVoice)) quickStartVoice = '';
@@ -1569,6 +1595,22 @@
       if (lyricsRequired && !lyrics.trim()) {
         throw new StatusWarning(`${selected.display_name_en || selected.display_name} requires lyrics.`);
       }
+      if (selected.task === 'vdes' && !instructions.trim()) {
+        throw new StatusWarning(
+          `${selected.display_name_en || selected.display_name} requires a voice description.`);
+      }
+      if (selected.task === 'align') {
+        // Forced aligners need both halves; the engine throws for either, and a
+        // form message is a better place to learn that than a raw engine error.
+        if (!text.trim()) {
+          throw new StatusWarning(
+            `${selected.display_name_en || selected.display_name} requires the transcript to align.`);
+        }
+        if (!language.trim()) {
+          throw new StatusWarning(
+            `${selected.display_name_en || selected.display_name} requires a transcript language.`);
+        }
+      }
       await ensureLoaded();
         const options = requestOptions();
         if (usesVibeVoiceSpeakerFiles) {
@@ -1601,7 +1643,7 @@
             seed: chunkSeed(resolvedSeed, index),
             options
           };
-          if (supportsMaxTokens(selected)) body.max_tokens = maxTokens;
+          if (supportsMaxTokens(selected) && maxTokens !== '') body.max_tokens = maxTokens;
           if (voiceRef) body.voice_ref = voiceRef;
           else if (quickStartVoice) body.voice = demoVoiceSources[quickStartVoice] || quickStartVoice;
           else if (selected.default_voice) body.voice = selected.default_voice;
@@ -1650,10 +1692,15 @@
             else request.duration_seconds = duration;
           }
           request.seed = resolvedSeed;
-          if (supportsMaxTokens(selected)) request.max_tokens = maxTokens;
+          if (supportsMaxTokens(selected) && maxTokens !== '') request.max_tokens = maxTokens;
         } else if (selected.task === 's2s') {
           request.seed = resolvedSeed;
-          if (supportsMaxTokens(selected)) request.max_tokens = maxTokens;
+          if (supportsMaxTokens(selected) && maxTokens !== '') request.max_tokens = maxTokens;
+        } else if (supportsSeed(selected)) {
+          // Voice conversion and the analysis tasks declare a seed but were never
+          // sent one, so their engines fell back to a fresh random value on every
+          // run and identical inputs could not be reproduced.
+          request.seed = resolvedSeed;
         }
         if (audio) request.audio = audio;
         if (voiceRef) request.voice_ref = voiceRef;
@@ -2181,7 +2228,7 @@
           </div>
         {/if}
 
-        {#if selected.task === 'gen'}
+        {#if selected.task === 'gen' && supportsRequestOption(selected, 'lyrics') && !isFireRedAudioEdit}
           <label for="lyrics">{tr('request.lyrics')} <span>{lyricsRequired ? tr('voice.required') : tr('request.optional')}</span></label>
           <textarea id="lyrics" rows="3" bind:value={lyrics} required={lyricsRequired}
             aria-required={lyricsRequired} placeholder="[Verse]…"></textarea>
@@ -2213,7 +2260,7 @@
               <input id="language" bind:value={language} placeholder="auto" />
             </div>
           {/if}
-          {#if ['tts', 'clon', 'gen', 's2s', 'vdes'].includes(selected.task)}
+          {#if ['tts', 'clon', 'gen', 's2s', 'vdes'].includes(selected.task) || supportsSeed(selected)}
             <div>
               <label for="seed">{tr('request.seed')} <span>{tr('request.randomSeed')}</span></label>
               <input id="seed" type="number" min="-1" max="4294967295" step="1" bind:value={seed} />
@@ -2225,7 +2272,7 @@
               <input id="tokens" type="number" min="1" bind:value={maxTokens} />
             </div>
           {/if}
-          {#if selected.task === 'gen'}
+          {#if selected.task === 'gen' && !isFireRedAudioEdit}
             <div>
               <label for="duration">{tr('request.duration')}</label>
               <input id="duration" type="number" min={allowsAutoDuration ? -1 : 1} step="0.1" value={duration}

--- a/webui/native/src/routes/Arena.svelte
+++ b/webui/native/src/routes/Arena.svelte
@@ -20,7 +20,7 @@
   export let loadedModels: LoadedModel[] = [];
   export let server: ServerHealth | null = null;
   export let modelsFolder = '';
-  export let maxTokens = 1024;
+  export let maxTokens: number | '' = '';
   export let entrySelectable: (entry: CatalogEntry) => boolean = () => true;
   export let studioPackageSlots: (entry: CatalogEntry) =>
     Array<{ key: string; label: string; choice?: InstallPackageChoice }> = () => [];
@@ -483,7 +483,7 @@
           seed: resolveRequestSeed(arenaSeed),
           options
         };
-        if (supportsMaxTokens(entry)) body.max_tokens = maxTokens;
+        if (supportsMaxTokens(entry) && maxTokens !== '') body.max_tokens = maxTokens;
         if (voiceRef) body.voice_ref = voiceRef;
         else if (builtinVoice) body.voice = builtinVoice;
         else if (entry.default_voice) body.voice = entry.default_voice;


### PR DESCRIPTION
Split out of #373 as requested. This PR is the request wiring only; the package resolver, the catalog entries, the transcript display and the UI text fixes are separate PRs.

## The problem

Three request fields were filled in by the UI regardless of what the model asked for.

**`max_tokens`** — every request carried a fixed `1024`. Engine defaults across the shipped specs range from 500 (`dots_tts`, `magpie_tts`) through 1520 (`confucius4_tts`) to 2000 (`muscriptor`), and several families default to 0, meaning no cap at all. The UI's number was neither the model's default nor the user's choice.

**`seed`** — the UI defaulted to `1234` in a field whose own label describes a random seed. Families whose engine default is a fresh random seed therefore returned identical audio on every run.

**Controls the model rejects** — lyrics and duration were offered for models that throw on them; voice design and forced alignment did not require the inputs their engines demand; the conversion and analysis tasks declare a seed and were never sent one, so their runs could not be reproduced at all.

## The change

- `max_tokens` is blank by default and sent only when the user types a value.
- `seed` defaults to `-1`, resolved client-side to a random uint32 before sending, so the engine never sees a negative value (it parses seeds as unsigned — `-1` on the wire is a 500).
- Tasks that declare a seed in their spec now receive the resolved seed.
- Lyrics and duration are hidden for models that reject them; voice design requires a voice description; forced alignment requires a transcript and a language. The engine throws for each of these — a form message is a better place to learn it than a raw engine error.
- Built-in voices from the spec and per-model voices from the server were both plumbed and never read; they are now offered together with the bundled demo clips, and the server is asked for its voices whether or not the UI is in management mode.

## Validation

```
npx svelte-check --tsconfig ./tsconfig.json
# 153 FILES 0 ERRORS 0 WARNINGS
```

Live server, Metal, Apple M4 Max, request shapes matching what the UI sends before and after:

| Check | Old shape | New shape |
|---|---|---|
| MOSS-TTS-Local, same text and seed | `max_tokens: 1024` → 24.2 s of audio | no `max_tokens` → 29.4 s |
| DotTTS-SOAR, same text and seed | `max_tokens: 1024` → md5 `8a1064a9…` | no `max_tokens` → md5 `8a1064a9…` (cap inert for this input) |
| DotTTS-SOAR, seed reproducibility | seed 1234 twice → identical md5 `8a1064a9…` | seed 2864434397 → `7d100930…` |

Both MOSS renderings transcribe back to the full input text through Parakeet-TDT, so on that family the cap changed the realisation rather than truncating content. The point stands either way: the UI was imposing a limit the model never asked for, and the effect is model-dependent, which is exactly why the client should not pick the number.

## Scope

`+page.svelte` and `Arena.svelte`. No catalog, spec or engine change. The generated bundle is deliberately excluded — it is not byte-reproducible, so regenerating it in each PR of this split would make the PRs conflict; happy to send one bundle-regeneration PR once the series lands.
