### PR TITLE
webui: fix two strings that rendered wrong

### DIFF
--- a/webui/native/src/lib/i18n.ts
+++ b/webui/native/src/lib/i18n.ts
@@ -122,6 +122,11 @@ const english: Record<string, string> = {
   'studio.subtitle.music': 'Create music and sound from a prompt, lyrics, or reference audio when supported.',
   'studio.subtitle.vc': 'Transform a recording into another voice while preserving the spoken or sung performance.',
   'studio.subtitle.sep': 'Split a recording into vocals, instruments, or other available audio stems.',
+  // The workflow tabs are keyed 'conversion' and 'separation' while the task
+  // labels above use 'vc' and 'sep'. Both spellings resolve so the hero subtitle
+  // renders text rather than the lookup key itself.
+  'studio.subtitle.conversion': 'Transform a recording into another voice while preserving the spoken or sung performance.',
+  'studio.subtitle.separation': 'Split a recording into vocals, instruments, or other available audio stems.',
   'studio.subtitle.analysis': 'Analyze audio for speech activity, speakers, timing, and alignment.',
   'studio.subtitle.design': 'Create or refine a voice from a written description and supported reference controls.',
   'studio.model': 'Model',

--- a/webui/native/src/routes/+page.svelte
+++ b/webui/native/src/routes/+page.svelte
@@ -922,7 +922,7 @@
     applyingModelsFolder = true;
     warningStatus = '';
     errorStatus = '';
-    status = useDefault ? 'Restoring the default models folderâ€¦' : 'Changing models folderâ€¦';
+    status = useDefault ? 'Restoring the default models folder…' : 'Changing models folder…';
     try {
       const root = await setModelsRoot(useDefault ? '' : modelsFolderInput.trim());
       acceptModelsRoot(root);


### PR DESCRIPTION
Split out of #373 as requested. Two string fixes, nothing else; the package resolver, the catalog entries, the request wiring and the transcript display are separate PRs.

## The changes

**Hero subtitle rendered its lookup key.** The workflow tabs are keyed `conversion` and `separation`, while `studio.subtitle.*` was defined only for `vc` and `sep`. The Voice conversion and Source separation tabs printed `studio.subtitle.conversion` and `studio.subtitle.separation` verbatim where their description should be. Adds the two missing keys.

**Double-encoded ellipsis in the models-folder status line.** `folderâ€¦` is what a UTF-8 ellipsis looks like after being decoded as Latin-1. Replaced with the character itself.

## Validation

```
npx svelte-check --tsconfig ./tsconfig.json
# 153 FILES 0 ERRORS 0 WARNINGS
```

## Scope

Two English strings in `i18n.ts`, one status line in `+page.svelte`. No behaviour change. The generated bundle is deliberately excluded — it is not byte-reproducible, so regenerating it in each PR of this split would make the PRs conflict; happy to send one bundle-regeneration PR once the series lands.
