### PR TITLE
fix(qwen): preserve compact logits indices across graph reuse

### DIFF
--- a/src/framework/modules/transformers/qwen_causal_decode_runtime.cpp
+++ b/src/framework/modules/transformers/qwen_causal_decode_runtime.cpp
@@ -291,10 +291,15 @@ ggml_tensor * make_logits_readback_token_ids(
     if (config.logits_readback_token_ids.empty()) {
         return nullptr;
     }
-    return ggml_new_tensor_1d(
+    auto * tensor = ggml_new_tensor_1d(
         ctx,
         GGML_TYPE_I32,
         static_cast<int64_t>(config.logits_readback_token_ids.size()));
+    // This leaf is populated by the host after graph allocation. Marking it as
+    // an input keeps the graph allocator from aliasing its storage with a
+    // temporary that executes before ggml_get_rows consumes the token ids.
+    ggml_set_input(tensor);
+    return tensor;
 }
 
 core::TensorValue wrap_logits_readback_token_ids(
@@ -784,6 +789,9 @@ private:
             prefill_attention_mask_values_.data(),
             0,
             prefill_attention_mask_values_.size() * sizeof(ggml_fp16_t));
+        if (prefill_logits_readback_token_ids_ != nullptr) {
+            upload_logits_readback_token_ids(prefill_logits_readback_token_ids_, config_);
+        }
         core::set_backend_threads(backend_, threads_);
         const ggml_status status = core::compute_backend_graph(backend_, prefill_graph_);
         ggml_backend_synchronize(backend_);
@@ -970,6 +978,10 @@ private:
             batched_prefill_attention_mask_values_.data(),
             0,
             batched_prefill_attention_mask_values_.size() * sizeof(ggml_fp16_t));
+        if (batched_prefill_logits_readback_token_ids_ != nullptr) {
+            upload_logits_readback_token_ids(
+                batched_prefill_logits_readback_token_ids_, config_);
+        }
         core::set_backend_threads(backend_, threads_);
         const ggml_status status = core::compute_backend_graph(backend_, batched_prefill_graph_);
         ggml_backend_synchronize(backend_);


### PR DESCRIPTION
## Summary

Fix compact-logit row-index tensors in the shared Qwen causal decode runtime being overwritten when a cached prefill graph is reused.

The compact readback path creates an I32 tensor consumed by `ggml_get_rows`. It is populated by the host after graph allocation, but it was not marked as a graph input. The allocator could therefore alias its storage with an intermediate tensor. A first request could succeed while leaving corrupted indices for the next execution, which was observed as an illegal CUDA memory access on the second request.

## Changes

- mark compact-logit token IDs as a persistent ggml input
- re-upload the IDs immediately before every cached prefill execution
- cover both single and batched prefill paths
- retain cached graph reuse rather than rebuilding compact-logit graphs

## Validation

- Windows CPU full-composite `audiocpp_cli` build: passed
- Windows CPU `engine_core` rebuild: passed
- Windows CUDA 12.4 `engine_core` build for SM 86: passed
- `git diff --check`: passed

This is isolated from the MiraTTS model work and changes only the shared Qwen runtime lifecycle for configurations using `logits_readback_token_ids`.