### PR TITLE
Add opt-in Qwen3 ASR punctuated text output

### DIFF
--- a/model_specs/qwen3_asr.json
+++ b/model_specs/qwen3_asr.json
@@ -59,6 +59,13 @@
         "description": "Opt-in guard for word timestamp output: keep repaired forced-aligner word spans inside the local audio chunk. Defaults to false to preserve existing timestamp repair behavior.",
         "required": false,
         "default": false
+      },
+      {
+        "name": "qwen3_asr.preserve_punctuation",
+        "type": "bool",
+        "description": "Opt-in text output mode for timestamped chunked ASR: preserve ASR punctuation in text_output instead of rebuilding text from aligned words.",
+        "required": false,
+        "default": false
       }
     ]
   },

--- a/src/models/qwen3_asr/session.cpp
+++ b/src/models/qwen3_asr/session.cpp
@@ -88,6 +88,15 @@ bool request_clamp_timestamps_to_audio(const runtime::TaskRequest & request) {
     return false;
 }
 
+bool request_preserve_punctuation(const runtime::TaskRequest & request) {
+    if (const auto value = runtime::find_option(
+            request.options,
+            {"qwen3_asr.preserve_punctuation", "preserve_punctuation"})) {
+        return runtime::parse_bool_option(*value, "qwen3_asr.preserve_punctuation");
+    }
+    return false;
+}
+
 void log_chunk_word_diagnostics(
     int64_t chunk_index,
     int64_t chunk_count,
@@ -345,7 +354,8 @@ runtime::TaskResult Qwen3ASRSession::run(const runtime::TaskRequest & request) {
             assets_->config.sample_rate);
     }
     if (merged.text_output.has_value()) {
-        if (request_return_timestamps(request) && !merged.word_timestamps.empty()) {
+        if (request_return_timestamps(request) && !merged.word_timestamps.empty() &&
+            !request_preserve_punctuation(request)) {
             std::ostringstream word_text;
             for (const auto & word : merged.word_timestamps) {
                 if (word_text.tellp() > 0) {


### PR DESCRIPTION
Fixes #430

## Summary

This adds an opt-in Qwen3 ASR request option, `qwen3_asr.preserve_punctuation`, for timestamped chunked ASR output.

By default, the existing `--words-out` behavior is unchanged: merged `text_output` is rebuilt from aligned word timestamps, so punctuation is omitted. When the new option is enabled, merged `text_output` keeps the punctuated ASR chunk text while still returning word timestamps.

## Root cause

For multi-chunk Qwen3 ASR requests with timestamps enabled, the merge path rebuilds `text_output` from `WordTimestamp.word`. Those aligned words are word-only, so punctuation is lost even though the ASR chunk text has punctuation.

## Behavior

| Case | Command shape | Result |
|---|---|---|
| VAD + timestamps, default | `--audio-chunk-mode vad --words-out` | Unchanged: `text_output` is rebuilt from aligned words, so punctuation is omitted. |
| VAD + timestamps, opt-in | `--audio-chunk-mode vad --words-out --request-option qwen3_asr.preserve_punctuation=true` | `text_output` preserves ASR punctuation. |
| VAD without timestamps | `--audio-chunk-mode vad` | Unchanged: ASR punctuation is preserved. |
| Fixed chunking + timestamps, default | `--audio-chunk-mode fixed --words-out` | Unchanged: `text_output` is rebuilt from aligned words. |

## Validation

Built and validated with the Qwen3 ASR CLI path on CUDA using the repo sample audio asset.

| Validation | Output |
|---|---|
| Default VAD + timestamps | `Some call me nature Others call me Mother Nature I've been here for over four point five billion years Twentytwo thousand five hundred times longer than you` |
| Opt-in VAD + timestamps | `Some call me nature. Others call me Mother Nature. I've been here for over four point five billion years. Twenty-two thousand five hundred times longer than you.` |
| VAD without timestamps | `Some call me nature. Others call me Mother Nature. I've been here for over four point five billion years. Twenty-two thousand five hundred times longer than you.` |
| Default fixed chunking + timestamps | `Some call me nature others call me Mother Nature I've been here for over four point five billion years Twentytwo thousand five hundred times longer than you` |

Commands checked:

```bash
cmake --build build/debug -j$(nproc) --target audiocpp_cli
jq empty model_specs/qwen3_asr.json
audiocpp_cli --task asr --family qwen3_asr --backend cuda --audio assets/resources/sample_16k.wav --audio-chunk-mode vad --audio-chunk-seconds 5 --session-option qwen3_asr.forced_aligner_model_path=<Qwen3-ForcedAligner-GGUF> --text-out <out.txt> --words-out <words.json> --metrics --log --log-file <run.log>
audiocpp_cli --task asr --family qwen3_asr --backend cuda --audio assets/resources/sample_16k.wav --audio-chunk-mode vad --audio-chunk-seconds 5 --session-option qwen3_asr.forced_aligner_model_path=<Qwen3-ForcedAligner-GGUF> --request-option qwen3_asr.preserve_punctuation=true --text-out <out.txt> --words-out <words.json> --metrics --log --log-file <run.log>
```
