### PR TITLE
Fix Higgs Audio codec decode seams

### DIFF
--- a/src/models/higgs_audio_tts/codec.cpp
+++ b/src/models/higgs_audio_tts/codec.cpp
@@ -62,7 +62,7 @@ constexpr int64_t kCodecDecodeCapacityBucketFrames = 32;
 constexpr int64_t kCodecHopLength = 960;
 constexpr int64_t kCodecPadSamples = kCodecHopLength / 2;
 constexpr int64_t kCodecDecodeWindowFrames = 128;
-constexpr int64_t kCodecDecodeOverlapFrames = 8;
+constexpr int64_t kCodecDecodeContextFrames = 32;
 constexpr int64_t kCodecFullDecodeMaxFrames = 512;
 constexpr int64_t kResidualDilations[] = {1, 3, 9};
 
@@ -1584,11 +1584,14 @@ HiggsCodecDecodeOutput HiggsCodecRuntime::decode_codes(const std::vector<int32_t
     std::vector<int32_t> window_codes;
     int64_t emitted_frames = 0;
     while (emitted_frames < frames) {
-        const int64_t window_begin =
-            std::max<int64_t>(0, emitted_frames - kCodecDecodeOverlapFrames);
+        const int64_t emit_begin = emitted_frames;
         const int64_t emit_end =
-            std::min<int64_t>(frames, emitted_frames + kCodecDecodeWindowFrames);
-        const int64_t window_frames = emit_end - window_begin;
+            std::min<int64_t>(frames, emit_begin + kCodecDecodeWindowFrames);
+        const int64_t window_begin =
+            std::max<int64_t>(0, emit_begin - kCodecDecodeContextFrames);
+        const int64_t window_end =
+            std::min<int64_t>(frames, emit_end + kCodecDecodeContextFrames);
+        const int64_t window_frames = window_end - window_begin;
         window_codes.resize(static_cast<size_t>(window_frames * kCodecCodebooks));
         for (int64_t frame = 0; frame < window_frames; ++frame) {
             const auto src =
@@ -1602,9 +1605,9 @@ HiggsCodecDecodeOutput HiggsCodecRuntime::decode_codes(const std::vector<int32_t
         const auto window = run_window(
             window_codes,
             window_frames,
-            kCodecDecodeWindowFrames + kCodecDecodeOverlapFrames);
-        const int64_t trim_frames = emitted_frames - window_begin;
-        const int64_t emit_frames = emit_end - emitted_frames;
+            kCodecDecodeWindowFrames + 2 * kCodecDecodeContextFrames);
+        const int64_t trim_frames = emit_begin - window_begin;
+        const int64_t emit_frames = emit_end - emit_begin;
         const int64_t sample_begin = trim_frames * kCodecHopLength;
         const int64_t sample_count = emit_frames * kCodecHopLength;
         if (sample_begin < 0 || sample_count <= 0 ||


### PR DESCRIPTION
## Summary

Fixes #429.

Higgs Audio TTS used a small left-only context when chunking codec decode for generated code sequences longer than the full-decode limit. The codec decoder has a wider convolutional receptive field, so hard-concatenating chunks with only 8 frames of left context could leave audible clicks at chunk boundaries.

This changes the chunked decode path to borrow 32 frames of context on both sides of each emitted window, then trim back to the center emitted frames.

## Validation

Built `audiocpp_cli` in debug mode with CUDA and ran the two issue repro cases using the same seed/reference/text pattern from the report.

| Case | Before seam jump/rms | After seam jump/rms | Result |
|---|---:|---:|---|
| English, 10.24s boundary | 1.808 | 0.039 | fixed |
| English, 20.48s boundary | 1.014 | 0.089 | fixed |
| Chinese, 10.24s boundary | 0.555 | 0.029 | fixed |
| Chinese, 20.48s boundary | 1.471 | 0.213 | improved |

Runtime cost from the larger context window:

| Case | Before RTF | After RTF | Change |
|---|---:|---:|---:|
English | 0.1156 | 0.1161 | +0.4%
Chinese | 0.1201 | 0.1218 | +1.4%

</body></html>

The cost only applies to the chunked codec decode path for longer generated outputs; short outputs that fit the full-decode path are unchanged.
