### PR TITLE
higgs_audio_tts: give the codec decoder right-hand context at the end of the stream

### DIFF
--- a/include/engine/models/higgs_audio_tts/codec.h
+++ b/include/engine/models/higgs_audio_tts/codec.h
@@ -117,6 +117,11 @@ public:
     void release_runtime_graphs();
 
 private:
+    HiggsCodecDecodeOutput decode_codes_impl(
+        const std::vector<int32_t> & codes,
+        int64_t frames,
+        int64_t codebooks) const;
+
     std::shared_ptr<const HiggsAssets> assets_;
     ggml_backend_t backend_ = nullptr;
     core::BackendType backend_type_ = core::BackendType::Cpu;

--- a/src/models/higgs_audio_tts/codec.cpp
+++ b/src/models/higgs_audio_tts/codec.cpp
@@ -64,6 +64,12 @@ constexpr int64_t kCodecPadSamples = kCodecHopLength / 2;
 constexpr int64_t kCodecDecodeWindowFrames = 128;
 constexpr int64_t kCodecDecodeContextFrames = 32;
 constexpr int64_t kCodecFullDecodeMaxFrames = 512;
+// The decoder is a non-causal conv stack, so the last frames of a stream see zero padding
+// on their right instead of real context and decode as a rising hiss over the final
+// ~300 ms (worst on short utterances). Repeating the last frame past the end gives those
+// frames context; the extra audio is trimmed again. Eight frames is enough — 16 and 32
+// produce identical samples.
+constexpr int64_t kCodecTailContextFrames = 8;
 constexpr int64_t kResidualDilations[] = {1, 3, 9};
 
 struct GgmlContextDeleter {
@@ -1540,6 +1546,40 @@ HiggsCodecRuntime::encode_reference(const runtime::AudioBuffer & audio) const {
 HiggsCodecDecodeOutput HiggsCodecRuntime::decode_codes(const std::vector<int32_t> & codes,
                                                        int64_t frames,
                                                        int64_t codebooks) const {
+    if (frames <= 0) {
+        throw std::runtime_error("Higgs TTS codec decode requires positive frame count");
+    }
+    if (codebooks != kCodecCodebooks) {
+        throw std::runtime_error("Higgs TTS codec decode requires exactly 8 codebooks");
+    }
+    if (static_cast<int64_t>(codes.size()) != frames * codebooks) {
+        throw std::runtime_error("Higgs TTS codec decode code count mismatch");
+    }
+    if (kCodecTailContextFrames <= 0) {
+        return decode_codes_impl(codes, frames, codebooks);
+    }
+
+    std::vector<int32_t> padded_codes;
+    padded_codes.reserve(static_cast<size_t>((frames + kCodecTailContextFrames) * codebooks));
+    padded_codes.insert(padded_codes.end(), codes.begin(), codes.end());
+    const auto last_frame_begin = codes.end() - static_cast<ptrdiff_t>(codebooks);
+    for (int64_t i = 0; i < kCodecTailContextFrames; ++i) {
+        padded_codes.insert(padded_codes.end(), last_frame_begin, codes.end());
+    }
+
+    auto out = decode_codes_impl(padded_codes, frames + kCodecTailContextFrames, codebooks);
+    const int64_t keep_samples = frames * kCodecHopLength;
+    if (keep_samples <= 0 || keep_samples > static_cast<int64_t>(out.values.size())) {
+        throw std::runtime_error("Higgs TTS codec tail-context decode produced too few samples");
+    }
+    out.values.resize(static_cast<size_t>(keep_samples));
+    out.samples = keep_samples;
+    return out;
+}
+
+HiggsCodecDecodeOutput HiggsCodecRuntime::decode_codes_impl(const std::vector<int32_t> & codes,
+                                                            int64_t frames,
+                                                            int64_t codebooks) const {
     if (frames <= 0) {
         throw std::runtime_error("Higgs TTS codec decode requires positive frame count");
     }


### PR DESCRIPTION
## Problem

Higgs Audio v3 TTS output ends with a rising hiss over the final ~300 ms that is cut off abruptly. It is most audible on short utterances (e.g. `Hello, how are you doing?` with a cloned voice) but a faint version is there on long ones too. It is independent of sampling settings, seed, `reference_text`, punctuation, and it reproduces on v0.7.1 and current `main`.

The codec decoder is a non-causal conv stack. At the end of the stream the last frames see zero padding on their right instead of real context and decode to garbage that ramps up towards the edge. This is the same mechanism as the periodic click at chunk seams (#429 / #436), but at the end of the stream, where the chunked path's context frames do not help.

## Fix

`HiggsCodecRuntime::decode_codes()` now repeats the last frame `kCodecTailContextFrames` (8) times before decoding and trims the extra samples again, so the public contract (sample count) is unchanged. The previous body becomes `decode_codes_impl()`. 16 and 32 context frames give sample-identical output to 8, so 8 is enough. Cost is 8 extra frames per decode.

## Measurements

Metal (Apple M4), Q8_0 GGUF, `higgs_audio_tts` clone with a fixed seed, before → after. RMS of the last three 40 ms frames (dBFS) and peak sample of the last 100 ms:

| request | before | after |
|---|---|---|
| short, seed 1 | -39 -44 **-34**, peak 3990 | -41 -48 **-46**, peak 864 |
| short, seed 2 | -39 -46 **-32**, peak 3951 | -40 -47 **-41**, peak 1121 |
| long, 11.4 s | -48 -53 **-46** | -48 -53 **-53**, peak 334 |

The delayed/raw code tail was dumped to rule out stray BOC/EOC ids in the kept frames (there are none), and forcing EOC on finished codebooks during the delay flush like the reference implementation does gave bit-identical output, so the issue is purely in the codec decode edge.

Tested with `scripts/build_metal.sh --model-set custom --models higgs_audio_tts --deployment-build`, server mode, multiple requests in one session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)