### PR TITLE
Fix CosyVoice3 Metal flow layout

### DIFF
--- a/src/models/cosyvoice3/flow.cpp
+++ b/src/models/cosyvoice3/flow.cpp
@@ -445,7 +445,11 @@ private:
         ggml_set_input(token_ids_);
         auto h = modules::EmbeddingModule({config_.speech_token_size, config_.flow_mel_channels})
                      .build(ctx, ids, weights_->token_embedding);
+        const auto residual = h;
         h = modules::TransposeModule({{0, 2, 1, 3}, h.shape.rank}).build(ctx, h);
+        if (execution_.backend_type() == core::BackendType::Metal) {
+            h = core::ensure_backend_addressable_layout(ctx, h);
+        }
         h = core::wrap_tensor(
             ggml_pad_ext(ctx.ggml, h.tensor, 0, config_.pre_lookahead_len, 0, 0, 0, 0, 0, 0),
             core::TensorShape::from_dims({1, config_.flow_mel_channels, tokens + config_.pre_lookahead_len}),
@@ -460,11 +464,7 @@ private:
         h = modules::Conv1dModule({config_.flow_hidden_size, config_.flow_mel_channels, 3, 1, 0, 1, true})
                 .build(ctx, h, weights_->pre_lookahead_conv2);
         h = modules::TransposeModule({{0, 2, 1, 3}, h.shape.rank}).build(ctx, h);
-        h = modules::AddModule().build(
-            ctx,
-            h,
-            modules::EmbeddingModule({config_.speech_token_size, config_.flow_mel_channels})
-                .build(ctx, ids, weights_->token_embedding));
+        h = modules::AddModule().build(ctx, h, residual);
         h = modules::Interpolate1dModule({tokens * config_.token_mel_ratio, modules::Interpolate1dMode::Nearest})
                 .build(ctx, modules::TransposeModule({{0, 2, 1, 3}, h.shape.rank}).build(ctx, h));
         h = modules::TransposeModule({{0, 2, 1, 3}, h.shape.rank}).build(ctx, h);

--- a/src/models/cosyvoice3/session.cpp
+++ b/src/models/cosyvoice3/session.cpp
@@ -91,10 +91,6 @@ CosyVoice3Session::CosyVoice3Session(
     if (task_.mode != runtime::RunMode::Offline) {
         throw std::runtime_error("CosyVoice3 supports offline sessions");
     }
-    if (execution_context().backend_type() == core::BackendType::Metal) {
-        throw std::runtime_error("CosyVoice3 has an unresolved Metal backend issue, so Metal is temporarily blocked");
-    }
-
     using T = engine::assets::TensorStorageType;
     const auto storage_type = runtime::parse_tensor_storage_option(
         options.options,


### PR DESCRIPTION
## Summary
- Materialize the CosyVoice3 pre-lookahead conditioning tensor after transpose before `ggml_pad_ext()` on Metal.
- Reuse the original token embedding as the residual instead of rebuilding the same embedding node.
- Remove the temporary CosyVoice3 Metal backend block.

## Validation
Built `audiocpp_cli` from `build/debug`, then ran the CosyVoice3 official path case against this branch and a fresh `main` baseline.

| Backend | Path case | Result | Compare |
|---|---|---|---|
| CUDA | `cosyvoice3_official_paths` | Pass | artifacts/text match, `0 difference(s)` |
| Vulkan | `cosyvoice3_official_paths` | Pass | artifacts/text match, `0 difference(s)` |

Timing movement for the short path case was small: CUDA `+1.87%`, Vulkan `+1.78%`.

