### PR TITLE
Add Vulkan Docker image support

### DIFF
--- a/.devops/vulkan.Dockerfile
+++ b/.devops/vulkan.Dockerfile
@@ -1,0 +1,114 @@
+# audio.cpp — Vulkan Dockerfile
+#
+# Usage:
+#   docker build -f .devops/vulkan.Dockerfile -t local/audiocpp:full-vulkan .
+
+# ── BUILD: Compile all release binaries with Vulkan ──────────────────────────
+ARG UBUNTU_VERSION=24.04
+ARG BUILD_DATE=N/A
+ARG APP_VERSION=N/A
+ARG APP_REVISION=N/A
+ARG GCC_VERSION=14
+
+FROM docker.io/ubuntu:$UBUNTU_VERSION AS build
+
+ARG GCC_VERSION=14
+
+# Install build toolchain and Vulkan shader/compiler headers.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        gcc-${GCC_VERSION} g++-${GCC_VERSION} make cmake libgomp1 ca-certificates \
+        glslc libvulkan-dev spirv-headers \
+        libxcb-xinput0 libxcb-xinerama0 libxcb-cursor-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV CC=gcc-${GCC_VERSION} CXX=g++-${GCC_VERSION}
+
+WORKDIR /app
+COPY . .
+
+# Validate architecture (Vulkan backend is only supported on amd64 and arm64)
+ARG TARGETARCH=amd64
+RUN if [ "$TARGETARCH" = "amd64" ] || [ "$TARGETARCH" = "arm64" ]; then \
+        echo "Building for $TARGETARCH"; \
+    else \
+        echo "Unsupported architecture: $TARGETARCH"; \
+        exit 1; \
+    fi
+
+# Configure and build
+RUN cmake -S . -B build \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DAUDIOCPP_MODEL_SET=full \
+        -DENGINE_ENABLE_CPU_ALL_VARIANTS=ON \
+        -DENGINE_ENABLE_CUDA=OFF \
+        -DENGINE_ENABLE_VULKAN=ON \
+        -DENGINE_ENABLE_OPENMP=ON \
+        -DAUDIOCPP_BUILD_NATIVE_MODEL_MANAGER=ON \
+        -DENGINE_BUILD_EXAMPLES=OFF \
+        -DENGINE_BUILD_TESTS=OFF \
+        -DENGINE_BUILD_WARMBENCH=OFF && \
+    cmake --build build --parallel $(nproc) \
+        --target audiocpp_cli \
+        --target audiocpp_server \
+        --target audiocpp_model_manager \
+        --target model_perf
+
+# Collect shared libraries
+RUN mkdir -p /app/lib && \
+    find build -name "*.so*" -exec cp -P {} /app/lib \;
+
+# Collect binaries + multiplexer into /app/full
+RUN mkdir -p /app/full && \
+    cp build/bin/audiocpp_cli build/bin/audiocpp_server build/bin/audiocpp_model_manager \
+       build/bin/model_perf /app/full/ && \
+    cp .devops/entrypoint.sh /app/full/entrypoint.sh && \
+    chmod +x /app/full/entrypoint.sh
+
+# ── BASE: Shared runtime (OS + Vulkan runtime libs) ──────────────────────────
+FROM docker.io/ubuntu:$UBUNTU_VERSION AS base
+
+ARG BUILD_DATE=N/A
+ARG APP_VERSION=N/A
+ARG APP_REVISION=N/A
+ARG IMAGE_URL=N/A
+ARG IMAGE_SOURCE=N/A
+
+LABEL org.opencontainers.image.created=$BUILD_DATE \
+      org.opencontainers.image.version=$APP_VERSION \
+      org.opencontainers.image.revision=$APP_REVISION \
+      org.opencontainers.image.title="audio.cpp" \
+      org.opencontainers.image.description="An all-in-one, pure C++ inference engine for audio models, powered by ggml" \
+      org.opencontainers.image.url=$IMAGE_URL \
+      org.opencontainers.image.source=$IMAGE_SOURCE
+
+# Runtime deps: OpenMP threading, Vulkan loader/Mesa ICDs, curl (healthcheck),
+# ffmpeg (audio I/O), python3 for the native WebUI's spec-backed model installer.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        libgomp1 libvulkan1 mesa-vulkan-drivers \
+        libglvnd0 libgl1 libglx0 libegl1 libgles2 \
+        curl ffmpeg python3 ca-certificates && \
+    apt-get autoremove -y && \
+    apt-get clean -y && \
+    rm -rf /tmp/* /var/tmp/* && \
+    find /var/cache/apt/archives /var/lib/apt/lists -not -name lock -type f -delete && \
+    find /var/cache -type f -delete
+
+COPY --from=build /app/lib/ /app
+
+WORKDIR /app
+
+# ── FULL: All binaries + entrypoint.sh multiplexer ────────────────────────────
+FROM base AS full
+
+COPY --from=build /app/full /app
+COPY model_specs/ /app/model_specs/
+COPY tools/model_manager_v2.py /app/tools/model_manager_v2.py
+
+RUN mkdir -p /app/models && chown ubuntu:ubuntu /app/models
+
+USER ubuntu
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,8 @@
 #   full-cuda12-YYYYMMDD-HHHHHHH (pinned to date + short SHA, immutable)
 #   full-cuda13                  (latest, mutable)
 #   full-cuda13-YYYYMMDD-HHHHHHH (pinned to date + short SHA, immutable)
+#   full-vulkan                  (latest, mutable)
+#   full-vulkan-YYYYMMDD-HHHHHHH (pinned to date + short SHA, immutable)
 
 name: Build and publish Docker images
 
@@ -145,6 +147,19 @@ jobs:
             runs_on: ubuntu-24.04-arm
             cuda_version: "13.3.0"
             enabled: true
+          # ── Vulkan ──
+          - tag: vulkan
+            dockerfile: .devops/vulkan.Dockerfile
+            platforms: linux/amd64
+            arch: amd64
+            runs_on: ubuntu-24.04
+            enabled: true
+          - tag: vulkan
+            dockerfile: .devops/vulkan.Dockerfile
+            platforms: linux/arm64
+            arch: arm64
+            runs_on: ubuntu-24.04-arm
+            enabled: true
     steps:
       - name: Skip when not enabled
         if: ${{ matrix.enabled != true }}
@@ -222,7 +237,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: [cpu, cuda12, cuda13]
+        tag: [cpu, cuda12, cuda13, vulkan]
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -14,6 +14,9 @@
 - Docker must be installed and running on your system.
 - For CUDA:
   - The [NVIDIA container toolkit](https://github.com/NVIDIA/nvidia-container-toolkit) must be installed.
+- For Vulkan:
+  - The host must expose a working Vulkan device to Docker, typically through `/dev/dri` on Linux.
+  - The container user needs access to the host render/video device groups.
 
 ## Image Variants
 
@@ -24,6 +27,7 @@ The following image variants are available:
 The following backends are supported:
 - **cuda12**
 - **cuda13**
+- **vulkan**
 - **cpu**
 
 The following architectures are supported:
@@ -38,6 +42,7 @@ as multiarch images (amd64/arm64).
 Pull the latest images using these tags:
 - **cuda12**: `ghcr.io/0xshug0/audio.cpp:full-cuda12`
 - **cuda13**: `ghcr.io/0xshug0/audio.cpp:full-cuda13`
+- **vulkan**: `ghcr.io/0xshug0/audio.cpp:full-vulkan`
 - **cpu**: `ghcr.io/0xshug0/audio.cpp:full-cpu`
 
 Images for a specific day/commit can be found in the
@@ -71,6 +76,12 @@ Build for a specific set of GPU architectures (e.g. for faster, less portable bu
 docker build -f .devops/cuda.Dockerfile -t local/audio.cpp:full-cuda12 --build-arg CUDA_DOCKER_ARCH="86;89" .
 ```
 
+### Vulkan
+
+```bash
+docker build -f .devops/vulkan.Dockerfile -t local/audio.cpp:full-vulkan .
+```
+
 ### CPU
 
 ```bash
@@ -88,6 +99,17 @@ An additional `<output-dir>` should be mounted for tasks that write files.
 docker run --rm --gpus all -v "<models-dir>:/models:ro" ghcr.io/0xshug0/audio.cpp:full-cuda12 <cli|server> --model /models/<model> <...>
 ```
 
+### Vulkan
+
+```bash
+docker run --rm --device /dev/dri \
+  --group-add "$(getent group render | cut -d: -f3)" \
+  --group-add "$(getent group video | cut -d: -f3)" \
+  -v "<models-dir>:/models:ro" \
+  ghcr.io/0xshug0/audio.cpp:full-vulkan \
+  <cli|server> --backend vulkan --model /models/<model> <...>
+```
+
 ### Native WebUI
 
 For the native WebUI with model downloads and dynamic model management, mount a
@@ -99,6 +121,18 @@ docker run --rm --gpus all \
   -v "<models-dir>:/app/models" \
   ghcr.io/0xshug0/audio.cpp:full-cuda12 \
   server --ui --ui-management --host 0.0.0.0 --port 8080 --backend cuda
+```
+
+For Vulkan, expose the host render device and use the Vulkan backend:
+
+```bash
+docker run --rm --device /dev/dri \
+  --group-add "$(getent group render | cut -d: -f3)" \
+  --group-add "$(getent group video | cut -d: -f3)" \
+  -p 8080:8080 \
+  -v "<models-dir>:/app/models" \
+  ghcr.io/0xshug0/audio.cpp:full-vulkan \
+  server --ui --ui-management --host 0.0.0.0 --port 8080 --backend vulkan
 ```
 
 Open `http://127.0.0.1:8080` on the host. Use a writable mount when the UI


### PR DESCRIPTION
Resolves https://github.com/0xShug0/audio.cpp/issues/459
## Summary

- add a Vulkan Dockerfile for full audio.cpp builds
- publish full-vulkan Docker images in the existing Docker workflow
- document Vulkan Docker build/run commands, including /dev/dri and render/video group access

## Validation

Built the local Vulkan image and verified the runtime image contains the CLI, server, model manager, model_perf, and libggml-vulkan.so. Also verified libggml-vulkan.so links against libvulkan.so.1.

End-to-end checks inside the Vulkan Docker image:

| Case | Result |
|---|---|
| Soprano TTS CLI | generated WAV successfully; logs show Vulkan backend/device |
| Qwen3 ASR CLI | transcribed the sample correctly; logs show Vulkan backend/device |
| PocketTTS CLI | generated WAV successfully; logs show Vulkan backend/device |
| Server HTTP TTS | /health reported backend=vulkan and /v1/audio/speech returned WAV |

One deployment detail from validation: the default container user needs the host render/video groups passed through, otherwise Vulkan device enumeration may see no devices.