### PR TITLE
Inject build version in CI and release packages

### DIFF
--- a/.devops/cpu.Dockerfile
+++ b/.devops/cpu.Dockerfile
@@ -13,6 +13,7 @@ ARG GCC_VERSION=14
 FROM docker.io/ubuntu:$UBUNTU_VERSION AS build
 
 ARG GCC_VERSION=14
+ARG AUDIOCPP_VERSION=dev
 
 # Install build toolchain
 RUN apt-get update && \
@@ -44,6 +45,7 @@ RUN cmake -S . -B build \
         -DENGINE_ENABLE_VULKAN=OFF \
         -DENGINE_ENABLE_OPENMP=ON \
         -DAUDIOCPP_BUILD_NATIVE_MODEL_MANAGER=ON \
+        -DAUDIOCPP_VERSION="${AUDIOCPP_VERSION}" \
         -DENGINE_BUILD_EXAMPLES=OFF \
         -DENGINE_BUILD_TESTS=OFF \
         -DENGINE_BUILD_WARMBENCH=OFF && \

--- a/.devops/cuda.Dockerfile
+++ b/.devops/cuda.Dockerfile
@@ -17,6 +17,7 @@ ARG BASE_CUDA_RUN_CONTAINER=docker.io/nvidia/cuda:${CUDA_VERSION}-runtime-ubuntu
 FROM ${BASE_CUDA_DEV_CONTAINER} AS build
 
 ARG GCC_VERSION=14
+ARG AUDIOCPP_VERSION=dev
 # CUDA architectures to compile for.
 # - default = the portable default list from CMakeLists.txt
 # - for a custom arch set build with --build-arg CUDA_DOCKER_ARCH="89-real;...".
@@ -46,6 +47,7 @@ RUN if [ "${CUDA_DOCKER_ARCH}" != "default" ]; then \
         -DENGINE_ENABLE_VULKAN=OFF \
         -DENGINE_ENABLE_OPENMP=ON \
         -DAUDIOCPP_BUILD_NATIVE_MODEL_MANAGER=ON \
+        -DAUDIOCPP_VERSION="${AUDIOCPP_VERSION}" \
         -DENGINE_BUILD_EXAMPLES=OFF \
         -DENGINE_BUILD_TESTS=OFF \
         -DENGINE_BUILD_WARMBENCH=OFF \

--- a/.devops/vulkan.Dockerfile
+++ b/.devops/vulkan.Dockerfile
@@ -13,6 +13,7 @@ ARG GCC_VERSION=14
 FROM docker.io/ubuntu:$UBUNTU_VERSION AS build
 
 ARG GCC_VERSION=14
+ARG AUDIOCPP_VERSION=dev
 
 # Install build toolchain and Vulkan shader/compiler headers.
 RUN apt-get update && \
@@ -46,6 +47,7 @@ RUN cmake -S . -B build \
         -DENGINE_ENABLE_VULKAN=ON \
         -DENGINE_ENABLE_OPENMP=ON \
         -DAUDIOCPP_BUILD_NATIVE_MODEL_MANAGER=ON \
+        -DAUDIOCPP_VERSION="${AUDIOCPP_VERSION}" \
         -DENGINE_BUILD_EXAMPLES=OFF \
         -DENGINE_BUILD_TESTS=OFF \
         -DENGINE_BUILD_WARMBENCH=OFF && \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,6 +23,10 @@ on:
         description: 'Force build even if no new commits'
         type: boolean
         default: true
+      version:
+        description: 'audio.cpp version string embedded in the binaries'
+        type: string
+        default: dev
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
@@ -82,6 +86,7 @@ jobs:
     outputs:
       build_date: ${{ steps.date.outputs.date }}
       date_tag:   ${{ steps.date.outputs.tag }}
+      app_version: ${{ steps.version.outputs.version }}
       image_repo: ${{ steps.image_repo.outputs.image_repo }}
     steps:
       - name: Get build date
@@ -89,6 +94,16 @@ jobs:
         run: |
           echo "date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
           echo "tag=$(date -u +'%Y%m%d')" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve app version
+        id: version
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          if [[ -z "$VERSION" ]]; then
+            VERSION="dev"
+          fi
+          VERSION="${VERSION#v}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Determine lowercase image repository
         id: image_repo
@@ -194,7 +209,8 @@ jobs:
           outputs: type=image,name=ghcr.io/${{ needs.metadata.outputs.image_repo }},push-by-digest=true,name-canonical=true,push=true,oci-mediatypes=true
           build-args: |
             BUILD_DATE=${{ needs.metadata.outputs.build_date }}
-            APP_VERSION=${{ github.sha }}
+            APP_VERSION=${{ needs.metadata.outputs.app_version }}
+            AUDIOCPP_VERSION=${{ needs.metadata.outputs.app_version }}
             APP_REVISION=${{ github.sha }}
             IMAGE_URL=${{ github.server_url }}/${{ github.repository }}
             IMAGE_SOURCE=${{ github.server_url }}/${{ github.repository }}

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -51,6 +51,7 @@ jobs:
         run: |
           cmake -S . -B "$BUILD_DIR" \
             -DCMAKE_BUILD_TYPE=Debug \
+            -DAUDIOCPP_VERSION=ci \
             -DENGINE_ENABLE_CUDA=OFF \
             -DENGINE_ENABLE_VULKAN=${{ matrix.enable_vulkan }}
 

--- a/.github/workflows/mac-build.yml
+++ b/.github/workflows/mac-build.yml
@@ -35,6 +35,7 @@ jobs:
         run: |
           cmake -S . -B "$BUILD_DIR" \
             -DCMAKE_BUILD_TYPE=Debug \
+            -DAUDIOCPP_VERSION=ci \
             -DENGINE_ENABLE_CUDA=OFF \
             -DENGINE_ENABLE_VULKAN=OFF \
             -DENGINE_ENABLE_METAL=OFF \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.version.outputs.tag }}
+      version: ${{ steps.version.outputs.version }}
     needs: check-release
     if: ${{ needs.check-release.outputs.should_release == 'true' }}
     steps:
@@ -76,7 +77,9 @@ jobs:
             exit 1
           fi
           [[ "$TAG" == v* ]] || TAG="v${TAG}"
+          VERSION="${TAG#v}"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
   macos-metal:
     name: macOS (${{ matrix.build }})
@@ -105,6 +108,7 @@ jobs:
           cmake -S . -B build -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_RPATH='@loader_path' -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
             -DENGINE_ENABLE_CUDA=OFF -DENGINE_ENABLE_VULKAN=OFF \
+            -DAUDIOCPP_VERSION=${{ needs.get-version.outputs.version }} \
             ${{ matrix.defines }} ${{ env.CMAKE_ARGS }}
       - name: Build
         run: cmake --build build --config Release --parallel "$(sysctl -n hw.logicalcpu)" --target ${{ env.BUILD_TARGETS }}
@@ -132,7 +136,9 @@ jobs:
       - name: Configure
         run: |
           cmake -S . -B build -DCMAKE_BUILD_TYPE=Release \
-            -DENGINE_ENABLE_CUDA=OFF -DENGINE_ENABLE_VULKAN=OFF ${{ env.CMAKE_ARGS }}
+            -DENGINE_ENABLE_CUDA=OFF -DENGINE_ENABLE_VULKAN=OFF \
+            -DAUDIOCPP_VERSION=${{ needs.get-version.outputs.version }} \
+            ${{ env.CMAKE_ARGS }}
       - name: Build
         run: cmake --build build --config Release --parallel "$(nproc)" --target ${{ env.BUILD_TARGETS }}
       - name: Stage bundle
@@ -159,7 +165,9 @@ jobs:
       - name: Configure
         run: |
           cmake -S . -B build -DCMAKE_BUILD_TYPE=Release \
-            -DENGINE_ENABLE_CUDA=OFF -DENGINE_ENABLE_VULKAN=ON ${{ env.CMAKE_ARGS }}
+            -DENGINE_ENABLE_CUDA=OFF -DENGINE_ENABLE_VULKAN=ON \
+            -DAUDIOCPP_VERSION=${{ needs.get-version.outputs.version }} \
+            ${{ env.CMAKE_ARGS }}
       - name: Build
         run: cmake --build build --config Release --parallel "$(nproc)" --target ${{ env.BUILD_TARGETS }}
       - name: Stage bundle
@@ -184,9 +192,9 @@ jobs:
       - name: Build
         shell: pwsh
         run: |
-          .\scripts\build_windows.ps1 -Preset windows-cpu-release -Target audiocpp_cli -DeploymentBuild -NativeModelManager
-          .\scripts\build_windows.ps1 -Preset windows-cpu-release -Target audiocpp_server -DeploymentBuild -NativeModelManager
-          .\scripts\build_windows.ps1 -Preset windows-cpu-release -Target audiocpp_gguf -DeploymentBuild -NativeModelManager
+          .\scripts\build_windows.ps1 -Preset windows-cpu-release -Target audiocpp_cli -DeploymentBuild -NativeModelManager -Version ${{ needs.get-version.outputs.version }}
+          .\scripts\build_windows.ps1 -Preset windows-cpu-release -Target audiocpp_server -DeploymentBuild -NativeModelManager -Version ${{ needs.get-version.outputs.version }}
+          .\scripts\build_windows.ps1 -Preset windows-cpu-release -Target audiocpp_gguf -DeploymentBuild -NativeModelManager -Version ${{ needs.get-version.outputs.version }}
       - name: Bundle VC runtime
         shell: pwsh
         working-directory: build/windows-cpu-release/bin
@@ -233,9 +241,9 @@ jobs:
       - name: Build
         shell: pwsh
         run: |
-          .\scripts\build_windows.ps1 -Preset windows-cpu-release -Target audiocpp_cli -DeploymentBuild -NativeModelManager -CpuArch baseline -Llamafile OFF
-          .\scripts\build_windows.ps1 -Preset windows-cpu-release -Target audiocpp_server -DeploymentBuild -NativeModelManager -CpuArch baseline -Llamafile OFF
-          .\scripts\build_windows.ps1 -Preset windows-cpu-release -Target audiocpp_gguf -DeploymentBuild -NativeModelManager -CpuArch baseline -Llamafile OFF
+          .\scripts\build_windows.ps1 -Preset windows-cpu-release -Target audiocpp_cli -DeploymentBuild -NativeModelManager -CpuArch baseline -Llamafile OFF -Version ${{ needs.get-version.outputs.version }}
+          .\scripts\build_windows.ps1 -Preset windows-cpu-release -Target audiocpp_server -DeploymentBuild -NativeModelManager -CpuArch baseline -Llamafile OFF -Version ${{ needs.get-version.outputs.version }}
+          .\scripts\build_windows.ps1 -Preset windows-cpu-release -Target audiocpp_gguf -DeploymentBuild -NativeModelManager -CpuArch baseline -Llamafile OFF -Version ${{ needs.get-version.outputs.version }}
       - name: Bundle VC runtime
         shell: pwsh
         working-directory: build/windows-cpu-release/bin
@@ -289,9 +297,9 @@ jobs:
       - name: Build
         shell: pwsh
         run: |
-          .\scripts\build_windows.ps1 -Preset windows-vulkan-release -Target audiocpp_cli -DeploymentBuild -NativeModelManager
-          .\scripts\build_windows.ps1 -Preset windows-vulkan-release -Target audiocpp_server -DeploymentBuild -NativeModelManager
-          .\scripts\build_windows.ps1 -Preset windows-vulkan-release -Target audiocpp_gguf -DeploymentBuild -NativeModelManager
+          .\scripts\build_windows.ps1 -Preset windows-vulkan-release -Target audiocpp_cli -DeploymentBuild -NativeModelManager -Version ${{ needs.get-version.outputs.version }}
+          .\scripts\build_windows.ps1 -Preset windows-vulkan-release -Target audiocpp_server -DeploymentBuild -NativeModelManager -Version ${{ needs.get-version.outputs.version }}
+          .\scripts\build_windows.ps1 -Preset windows-vulkan-release -Target audiocpp_gguf -DeploymentBuild -NativeModelManager -Version ${{ needs.get-version.outputs.version }}
       - name: Bundle VC runtime
         shell: pwsh
         working-directory: build/windows-vulkan-release/bin
@@ -373,6 +381,7 @@ jobs:
             -DENGINE_ENABLE_LLAMAFILE=ON -DENGINE_ENABLE_NATIVE_CPU=ON -DENGINE_BUILD_TESTS=OFF ^
             -DENGINE_ENABLE_CPU_ALL_VARIANTS=ON ^
             "-DCMAKE_CUDA_ARCHITECTURES=${{ matrix.cuda_archs }}" ^
+            -DAUDIOCPP_VERSION=${{ needs.get-version.outputs.version }} ^
             -DAUDIOCPP_DEPLOYMENT_BUILD=ON -DAUDIOCPP_BUILD_NATIVE_MODEL_MANAGER=ON -DCUDAToolkit_ROOT="%CUDA_PATH%"
           cmake --build build --config Release -j %NUMBER_OF_PROCESSORS% --target ${{ env.BUILD_TARGETS }}
       - name: Bundle CUDA runtime

--- a/.github/workflows/server-memory-guard.yml
+++ b/.github/workflows/server-memory-guard.yml
@@ -36,6 +36,7 @@ jobs:
         run: |
           cmake -S . -B build \
             -DCMAKE_BUILD_TYPE=Release \
+            -DAUDIOCPP_VERSION=ci \
             -DENGINE_BUILD_TESTS=ON \
             -DENGINE_ENABLE_OPENMP=OFF \
             -DENGINE_ENABLE_CUDA=OFF \
@@ -48,6 +49,7 @@ jobs:
         run: |
           cmake -S . -B build `
             -DCMAKE_BUILD_TYPE=Release `
+            -DAUDIOCPP_VERSION=ci `
             -DENGINE_BUILD_TESTS=ON `
             -DENGINE_ENABLE_OPENMP=OFF `
             -DENGINE_ENABLE_CUDA=OFF `

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -34,18 +34,21 @@ jobs:
         run: |
           .\scripts\build_windows.ps1 `
             -Preset windows-cpu-release `
-            -Target audiocpp_cli
+            -Target audiocpp_cli `
+            -Version ci
 
       - name: Build audiocpp_server
         shell: pwsh
         run: |
           .\scripts\build_windows.ps1 `
             -Preset windows-cpu-release `
-            -Target audiocpp_server
+            -Target audiocpp_server `
+            -Version ci
 
       - name: Build audiocpp_gguf
         shell: pwsh
         run: |
           .\scripts\build_windows.ps1 `
             -Preset windows-cpu-release `
-            -Target audiocpp_gguf
+            -Target audiocpp_gguf `
+            -Version ci

--- a/scripts/build_windows.ps1
+++ b/scripts/build_windows.ps1
@@ -19,6 +19,7 @@ param(
     [ValidateSet("full", "core", "custom")]
     [string]$ModelSet = "full",
     [string]$Models = "",
+    [string]$Version = "dev",
     [string]$VsInstall = ""
 )
 
@@ -551,6 +552,7 @@ Write-Host "Model composite: $ModelSet"
 if ($Models -ne "") {
     Write-Host "Selected models: $Models"
 }
+Write-Host "audio.cpp version: $Version"
 
 if ($Clean) {
     $buildDirForClean = Join-Path (Join-Path (Split-Path $PSScriptRoot -Parent) "build") $Preset
@@ -587,6 +589,7 @@ $configureArgs = @(
     "-DAUDIOCPP_DEPLOYMENT_BUILD=$deploymentBuildValue",
     "-DAUDIOCPP_BUILD_NATIVE_MODEL_MANAGER=$nativeModelManagerValue",
     "-DAUDIOCPP_USE_SYSTEM_OPENSSL=$systemOpenSslValue",
+    "-DAUDIOCPP_VERSION=$Version",
     "-U", "AUDIOCPP_BORINGSSL_ARCHIVE",
     "-DAUDIOCPP_MODEL_SET=$ModelSet",
     "-DAUDIOCPP_MODELS=$Models"


### PR DESCRIPTION
## Summary
- pass `AUDIOCPP_VERSION` through release builds so tagged releases embed the release version
- add a `-Version` parameter to the Windows build helper
- pass `AUDIOCPP_VERSION` through CPU/CUDA/Vulkan Docker builds
- exercise the version parameter in regular Linux/macOS/Windows CI and server-memory CI

Follow-up to #469.

## Validation
- parsed touched GitHub workflow YAML files successfully
- parsed `scripts/build_windows.ps1` with PowerShell successfully
- ran `git diff --check`
- locally built Debug CPU/CUDA/Vulkan CLI and server with `AUDIOCPP_VERSION=0.7.2-dev`; both report `audio.cpp 0.7.2-dev`
- locally built Debug CPU/Vulkan-only CLI and server with `AUDIOCPP_VERSION=ci`; both report `audio.cpp ci` and `backends: cpu,vulkan`
- checked release tag normalization: `v0.7.2` and `0.7.2` both resolve to `0.7.2`
