### PR TITLE
Buffer chunked HTTP uploads

### DIFF
--- a/.github/workflows/server-memory-guard.yml
+++ b/.github/workflows/server-memory-guard.yml
@@ -38,6 +38,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release \
             -DAUDIOCPP_VERSION=ci \
             -DENGINE_BUILD_TESTS=ON \
+            -DENGINE_BUILD_EXTENDED_TESTS=ON \
             -DENGINE_ENABLE_OPENMP=OFF \
             -DENGINE_ENABLE_CUDA=OFF \
             -DENGINE_ENABLE_VULKAN=OFF \
@@ -51,6 +52,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release `
             -DAUDIOCPP_VERSION=ci `
             -DENGINE_BUILD_TESTS=ON `
+            -DENGINE_BUILD_EXTENDED_TESTS=ON `
             -DENGINE_ENABLE_OPENMP=OFF `
             -DENGINE_ENABLE_CUDA=OFF `
             -DENGINE_ENABLE_VULKAN=OFF `

--- a/app/server/http.cpp
+++ b/app/server/http.cpp
@@ -597,8 +597,32 @@ HttpRequest read_http_request(
         request.headers[name] = value;
     }
 
+    const auto transfer_encoding_it = request.headers.find("transfer-encoding");
+    const bool chunked_body =
+        transfer_encoding_it != request.headers.end() &&
+        is_chunked_only(transfer_encoding_it->second);
+
     if (wants_incremental_body(request)) {
         leftover = data.substr(header_end + 4);
+        return request;
+    }
+
+    if (chunked_body) {
+        LiveIngestLimits limits;
+        limits.max_body_bytes = static_cast<size_t>(std::min<uint64_t>(
+            max_request_body_bytes,
+            static_cast<uint64_t>(std::numeric_limits<size_t>::max())));
+        ChunkedSocketStreambuf body_buffer(
+            socket,
+            data.substr(header_end + 4),
+            limits);
+        std::istream body_stream(&body_buffer);
+        body_stream.exceptions(std::ios::badbit);
+        std::array<char, 8192> chunk_buffer{};
+        while (body_stream) {
+            body_stream.read(chunk_buffer.data(), static_cast<std::streamsize>(chunk_buffer.size()));
+            request.body.append(chunk_buffer.data(), static_cast<size_t>(body_stream.gcount()));
+        }
         return request;
     }
 


### PR DESCRIPTION
## Summary
- buffer non-live HTTP/1.1 requests that use exact `Transfer-Encoding: chunked`
- keep `/v1/audio/transcriptions/live` and `/v1/audio/speech/live` on the existing incremental body-stream path
- fixes Open WebUI-style chunked multipart uploads reaching `/v1/audio/transcriptions` as an empty body

## Validation
- `cmake --build build/debug -j$(nproc) --target audiocpp_server`
- chunked multipart MP3 upload reaches multipart parsing and returns the same existing 400 as a content-length MP3 upload: `only WAV audio uploads are currently supported for transcription; MP3 support is planned`
- chunked JSON reaches JSON parsing instead of an empty body path
- `/v1/audio/transcriptions/live` still follows the live incremental route
