### PR TITLE
fix(build): guard CUDA driver probe out of HIP builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1911,6 +1911,11 @@ target_link_libraries(engine_runtime PRIVATE sentencepiece cjson_vendor yaml_ven
 if (AUDIOCPP_HIP_STRIX_HALO_OPTIMIZATIONS_ACTIVE)
     target_compile_definitions(engine_runtime PRIVATE ENGINE_HIP_STRIX_HALO_OPTIMIZATIONS=1)
 endif()
+if (ENGINE_ENABLE_HIP)
+    # ggml-hip publicly defines GGML_USE_CUDA for consumers, so engine code
+    # needs this marker to tell a real CUDA build apart from a HIP build.
+    target_compile_definitions(engine_core PRIVATE ENGINE_GGML_HIP_BACKEND=1)
+endif()
 if (ENGINE_ENABLE_OPENMP)
     target_link_libraries(engine_runtime PRIVATE OpenMP::OpenMP_CXX)
     if (MSVC)

--- a/src/framework/core/attention_fallback.cpp
+++ b/src/framework/core/attention_fallback.cpp
@@ -10,7 +10,11 @@
 #include "ggml.h"
 #include "ggml-backend.h"
 
-#ifdef GGML_USE_CUDA
+// ggml-hip publicly defines GGML_USE_CUDA for its consumers (hipified CUDA
+// sources), so GGML_USE_CUDA alone does not imply a real CUDA toolchain with
+// the driver library linked. ENGINE_GGML_HIP_BACKEND marks the HIP case.
+#if defined(GGML_USE_CUDA) && !defined(ENGINE_GGML_HIP_BACKEND)
+#define AUDIOCPP_CUDA_DRIVER_PROBE 1
 // CUDA driver API, declared manually so this translation unit needs neither
 // the CUDA headers on its include path nor any CMake changes. The driver
 // library is already linked transitively through ggml-cuda. Attribute ids
@@ -21,7 +25,7 @@ typedef int kCcProbeCuResult;
 kCcProbeCuResult cuDeviceGet(kCcProbeCuDevice * device, int ordinal);
 kCcProbeCuResult cuDeviceGetAttribute(int * value, int attrib, kCcProbeCuDevice device);
 }
-#endif  // GGML_USE_CUDA
+#endif
 
 namespace engine::core {
 namespace {
@@ -59,7 +63,7 @@ AttentionPreference parse_preference_value(const std::string & value, const char
 // select the MMA kernel with no usable device code. Unknown backends and
 // query failures fail OPEN to preserve current behavior.
 bool cuda_device_wants_eager(ggml_backend_t backend) {
-#ifdef GGML_USE_CUDA
+#ifdef AUDIOCPP_CUDA_DRIVER_PROBE
     if (backend == nullptr) {
         return false;
     }
@@ -96,7 +100,7 @@ bool cuda_device_wants_eager(ggml_backend_t backend) {
 #else
     (void) backend;
     return false;
-#endif  // GGML_USE_CUDA
+#endif  // AUDIOCPP_CUDA_DRIVER_PROBE
 }
 
 }  // namespace


### PR DESCRIPTION
I haven't updated the program for a while. Today when I pulled the latest branch and compiled with ROCm, I got an error. Upon investigation, I found that a recent commit caused a conflict. Here is a fix patch that bypasses the CUDA-related paths when building with HIP/ROCm.

```
[918/919] Linking CXX executable bin/audiocpp_server FAILED: bin/audiocpp_server : && /opt/rocm/core-7.14/lib/llvm/bin/clang++ -O2 -g -DNDEBUG -Xlinker --dependency-file=CMakeFiles/audiocpp_server.dir/link.d CMakeFiles/audiocpp_server.dir/app/common/build_info.cpp.o CMakeFiles/audiocpp_server.dir/app/server/main.cpp.o CMakeFiles/audiocpp_server.dir/app/server/base64.cpp.o CMakeFiles/audiocpp_server.dir/app/server/config.cpp.o CMakeFiles/audiocpp_server.dir/app/server/http.cpp.o CMakeFiles/audiocpp_server.dir/app/server/model_memory.cpp.o CMakeFiles/audiocpp_server.dir/app/server/multipart.cpp.o CMakeFiles/audiocpp_server.dir/app/server/runtime.cpp.o CMakeFiles/audiocpp_server.dir/app/server/ui_assets.cpp.o CMakeFiles/audiocpp_server.dir/app/cli/args.cpp.o CMakeFiles/audiocpp_server.dir/app/cli/request.cpp.o CMakeFiles/audiocpp_server.dir/app/streaming/pcm_source.cpp.o CMakeFiles/audiocpp_server.dir/app/streaming/streaming.cpp.o -o bin/audiocpp_server -Wl,-rpath,/opt/rocm/core-7.14/lib:/opt/rocm/lib:/opt/rocm/core-7.14/lib/llvm/lib libengine_runtime.a ggml/src/libggml.a -ldl ggml/src/libggml-cpu.a ggml/src/ggml-hip/libggml-hip.a ggml/src/libggml-base.a -lm /opt/rocm/core-7.14/lib/libhipblas.so.3.5 /opt/rocm/core-7.14/lib/librocblas.so.5.5 /opt/rocm/lib/libamdhip64.so.7.14.60850-0000000 /opt/rocm/core-7.14/lib/llvm/lib/clang/23/lib/linux/libclang_rt.builtins-x86_64.a /opt/rocm/lib/libhipblaslt.so.1.4 /opt/rocm/core-7.14/lib/libamdhip64.so.7.14.60850-0000000 /opt/rocm/core-7.14/lib/llvm/lib/libomp.so /lib/x86_64-linux-gnu/libpthread.a external/sentencepiece/src/libsentencepiece.a libcjson_vendor.a libyaml_vendor.a && : ld.lld: error: undefined symbol: cuDeviceGet

referenced by attention_fallback.cpp:83 (/home/mark/App/audio.cpp-hub/audiocpp/audio.cpp-main-bc75bab/audio.cpp-main/src/framework/core/attention_fallback.cpp:83) attention_fallback.cpp.o:(engine::core::resolve_flash_attention(ggml_backend*, long, engine::core::AttentionPreference)) in archive libengine_runtime.a

ld.lld: error: undefined symbol: cuDeviceGetAttribute

referenced by attention_fallback.cpp:88 (/home/mark/App/audio.cpp-hub/audiocpp/audio.cpp-main-bc75bab/audio.cpp-main/src/framework/core/attention_fallback.cpp:88) attention_fallback.cpp.o:(engine::core::resolve_flash_attention(ggml_backend*, long, engine::core::AttentionPreference)) in archive libengine_runtime.a referenced by attention_fallback.cpp:91 (/home/mark/App/audio.cpp-hub/audiocpp/audio.cpp-main-bc75bab/audio.cpp-main/src/framework/core/attention_fallback.cpp:91) attention_fallback.cpp.o:(engine::core::resolve_flash_attention(ggml_backend*, long, engine::core::AttentionPreference)) in archive libengine_runtime.a clang++: error: linker command failed with exit code 1 (use -v to see invocation) ninja: build stopped: subcommand failed.
```

see also: #423 



AI usage: Kimi k3