### PR TITLE
Tighten BreezeTTS streaming path

### DIFF
--- a/docs/models/breeze_tts.md
+++ b/docs/models/breeze_tts.md
@@ -39,6 +39,22 @@ audiocpp_cli \
   --out breeze_tts_design.wav
 ```
 
+Streaming:
+
+```bash
+audiocpp_cli \
+  --task tts \
+  --mode streaming \
+  --family breeze_tts \
+  --model models/Breeze-TTS-2-GGUF/breeze-tts-2-q8_0.gguf \
+  --backend cuda \
+  --text "Welcome to the BreezeTTS 2 streaming demo." \
+  --request-option instruction="A confident product demo narrator with steady pacing." \
+  --request-option stream_frames_per_event=16 \
+  --out breeze_tts_stream.wav \
+  --out-dir breeze_tts_stream_chunks
+```
+
 ## Model
 
 | Field | Value |
@@ -46,7 +62,7 @@ audiocpp_cli \
 | Family | `breeze_tts` |
 | Default GGUF | `models/Breeze-TTS-2-GGUF/breeze-tts-2-q8_0.gguf` |
 | Tasks | `tts`, `clon` |
-| Modes | `offline` |
+| Modes | `offline`, `streaming` |
 | Languages | `zh`, `en` |
 | Voice input | Optional for `tts`; required for `clon` |
 
@@ -66,9 +82,31 @@ audiocpp_cli \
 | `--request-option top_k=<n>` | integer >= 0 | `50` | Top-k sampling limit; `0` disables top-k filtering. |
 | `--request-option top_p=<f>` | `0..1` | `1.0` | Top-p sampling limit. |
 | `--request-option seed=<n>` | integer >= 0 | `0` | Generation seed. |
+| `--request-option stream_frames_per_event=<n>` | integer > 0 | `16` | Streaming codec frames per emitted audio event. Smaller values can reduce TTFT but increase event/decoder overhead. |
+| `--request-option stream_lookahead_margin=<n>` | integer >= 0 | `12` | Trailing codec frames held before emission to reduce streaming boundary artifacts. |
 | `--session-option breeze_tts.reference_cache_slots=<n>` | integer >= 0 | `1` | Prepared reference-audio cache slots. |
 | `--session-option breeze_tts.attention=<mode>` | `auto`, `flash`, `eager` | `auto` | Attention kernel. `auto` uses flash except on Volta/Turing GPUs (e.g. V100), where it falls back to eager to avoid missing MMA kernels. |
 | `--session-option weight_type=<type>` | `native`, `f32`, `f16`, `bf16`, `q8_0`, `q4_0`, `q4_k` | `native` | Weight storage type; quantized types convert at load time from the BF16 package. |
+
+BreezeTTS streaming is incremental by default. It emits audio events from the
+generated codec-frame stream instead of waiting for a whole text chunk. For the
+OpenAI-compatible speech endpoint, pass streaming options inside the request
+`options` object:
+
+```json
+{
+  "model": "breeze-stream",
+  "input": "Welcome to the BreezeTTS 2 streaming demo.",
+  "stream": true,
+  "stream_format": "sse",
+  "response_format": "pcm",
+  "options": {
+    "instruction": "A confident product demo narrator with steady pacing.",
+    "stream_frames_per_event": "16",
+    "stream_lookahead_margin": "12"
+  }
+}
+```
 
 Quantized weight storage is the largest measured speedup and applies to CUDA
 and HIP alike: `q8_0` cut the fixed 100-token regression case from RTF ~1.5 to

--- a/include/engine/models/breeze_tts/generator.h
+++ b/include/engine/models/breeze_tts/generator.h
@@ -29,6 +29,11 @@ struct BreezeGenerationRequest {
     uint64_t seed = 0;
 };
 
+struct BreezeStreamEvent {
+    engine::runtime::AudioBuffer audio;
+    bool done = false;
+};
+
 class BreezeGeneratorRuntime {
 public:
     BreezeGeneratorRuntime(
@@ -42,6 +47,9 @@ public:
 
     engine::runtime::AudioBuffer generate(const BreezeGenerationRequest & request);
     BreezeSpeechCodes encode_reference(const engine::runtime::AudioBuffer & audio) const;
+    void begin_stream(const BreezeGenerationRequest & request);
+    BreezeStreamEvent next_stream_audio(size_t max_new_frames, int64_t lookahead_margin);
+    void end_stream();
 
 private:
     struct Impl;

--- a/include/engine/models/breeze_tts/session.h
+++ b/include/engine/models/breeze_tts/session.h
@@ -80,7 +80,7 @@ private:
     engine::runtime::AudioBuffer stream_merged_audio_;
     std::chrono::steady_clock::time_point stream_started_at_;
     size_t stream_chunk_index_ = 0;
-    size_t stream_frames_per_event_ = 32;
+    size_t stream_frames_per_event_ = 16;
     int64_t stream_lookahead_margin_ = 12;
     bool stream_chunk_active_ = false;
     size_t stream_event_seq_ = 0;

--- a/include/engine/models/breeze_tts/session.h
+++ b/include/engine/models/breeze_tts/session.h
@@ -9,6 +9,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <chrono>
 #include <memory>
 #include <optional>
 #include <vector>
@@ -67,6 +68,7 @@ private:
         const engine::runtime::TaskRequest & request,
         const std::optional<BreezeSpeechCodes> & reference_codes,
         size_t chunk_index) const;
+    std::optional<engine::runtime::StreamEvent> next_subchunk_event();
 
     engine::runtime::TaskSpec task_;
     std::shared_ptr<const BreezeTTSAssets> assets_;
@@ -77,7 +79,13 @@ private:
     std::vector<engine::runtime::TaskRequest> stream_chunk_requests_;
     std::optional<BreezeSpeechCodes> stream_reference_codes_;
     engine::runtime::AudioBuffer stream_merged_audio_;
+    std::chrono::steady_clock::time_point stream_started_at_;
     size_t stream_chunk_index_ = 0;
+    bool stream_subchunk_ = false;
+    size_t stream_frames_per_event_ = 32;
+    int64_t stream_lookahead_margin_ = 12;
+    bool stream_chunk_active_ = false;
+    size_t stream_event_seq_ = 0;
     bool stream_started_ = false;
 };
 

--- a/include/engine/models/breeze_tts/session.h
+++ b/include/engine/models/breeze_tts/session.h
@@ -68,7 +68,6 @@ private:
         const engine::runtime::TaskRequest & request,
         const std::optional<BreezeSpeechCodes> & reference_codes,
         size_t chunk_index) const;
-    std::optional<engine::runtime::StreamEvent> next_subchunk_event();
 
     engine::runtime::TaskSpec task_;
     std::shared_ptr<const BreezeTTSAssets> assets_;
@@ -81,7 +80,6 @@ private:
     engine::runtime::AudioBuffer stream_merged_audio_;
     std::chrono::steady_clock::time_point stream_started_at_;
     size_t stream_chunk_index_ = 0;
-    bool stream_subchunk_ = false;
     size_t stream_frames_per_event_ = 32;
     int64_t stream_lookahead_margin_ = 12;
     bool stream_chunk_active_ = false;

--- a/include/engine/models/breeze_tts/speech_decoder.h
+++ b/include/engine/models/breeze_tts/speech_decoder.h
@@ -42,12 +42,22 @@ public:
     ~BreezeSpeechDecoderRuntime();
 
     runtime::AudioBuffer decode(const BreezeSpeechCodes & codec_codes) const;
+    void reset_streaming_state() const;
+    runtime::AudioBuffer decode_streaming_step(
+        const BreezeSpeechCodes & codec_codes,
+        int64_t lookahead_margin,
+        bool final) const;
     runtime::AudioBuffer decode_and_trim_reference(
         const BreezeSpeechCodes & reference_codes,
         const BreezeSpeechCodes & generated_codes) const;
     void release_runtime_graphs() const;
 
 private:
+    std::vector<float> decode_window_samples(
+        const std::vector<int32_t> & chunk,
+        int64_t chunk_frames,
+        int64_t context_frames) const;
+
     std::shared_ptr<const BreezeTTSAssets> assets_;
     core::ExecutionContext * execution_context_ = nullptr;
     std::shared_ptr<const BreezeSpeechDecoderWeights> weights_;
@@ -55,6 +65,8 @@ private:
     bool allow_flash_attention_ = true;
     std::unique_ptr<core::ConstantTensorCache> constants_;
     mutable std::unique_ptr<BreezeSpeechDecoderGraph> graph_;
+    struct StreamingState;
+    mutable std::unique_ptr<StreamingState> streaming_state_;
     // Always present to keep this public class layout identical when the private
     // Strix Halo compile definition differs between translation units.
     mutable std::array<std::unique_ptr<BreezeSpeechDecoderGraph>, 2> optimized_graphs_;

--- a/model_specs/breeze_tts.json
+++ b/model_specs/breeze_tts.json
@@ -127,6 +127,29 @@
         "required": false,
         "min": 0,
         "default": 0
+      },
+      {
+        "name": "stream_subchunk",
+        "type": "bool",
+        "description": "Emit multiple streaming audio events per text chunk.",
+        "required": false,
+        "default": false
+      },
+      {
+        "name": "stream_frames_per_event",
+        "type": "int",
+        "description": "Generated codec frames per streaming audio event.",
+        "required": false,
+        "min": 1,
+        "default": 32
+      },
+      {
+        "name": "stream_lookahead_margin",
+        "type": "int",
+        "description": "Trailing codec frames held before emission to reduce streaming boundary artifacts.",
+        "required": false,
+        "min": 0,
+        "default": 12
       }
     ],
     "session": [

--- a/model_specs/breeze_tts.json
+++ b/model_specs/breeze_tts.json
@@ -134,7 +134,7 @@
         "description": "Generated codec frames per streaming audio event.",
         "required": false,
         "min": 1,
-        "default": 32
+        "default": 16
       },
       {
         "name": "stream_lookahead_margin",

--- a/model_specs/breeze_tts.json
+++ b/model_specs/breeze_tts.json
@@ -129,13 +129,6 @@
         "default": 0
       },
       {
-        "name": "stream_subchunk",
-        "type": "bool",
-        "description": "Emit multiple streaming audio events per text chunk.",
-        "required": false,
-        "default": false
-      },
-      {
         "name": "stream_frames_per_event",
         "type": "int",
         "description": "Generated codec frames per streaming audio event.",

--- a/src/models/breeze_tts/generator.cpp
+++ b/src/models/breeze_tts/generator.cpp
@@ -967,6 +967,260 @@ struct BreezeGeneratorRuntime::Impl {
         return frame;
     }
 
+    struct StreamState {
+        BreezeGenerationRequest request;
+        modules::QwenCausalPrefillResult cond;
+        std::optional<modules::QwenCausalPrefillResult> uncond;
+        sampling::HfSamplerScratch scratch;
+        std::mt19937 fallback_rng;
+        sampling::HfSamplingOptions first_options;
+        std::vector<int32_t> first_codebook_history;
+        std::vector<int32_t> codes;
+        int64_t steps_taken = 0;
+        bool done = false;
+        bool use_cfg = false;
+        double ar_total_ms = 0.0;
+        double codec_decode_ms = 0.0;
+        double backbone_cond_prefill_ms = 0.0;
+        double backbone_uncond_prefill_ms = 0.0;
+        double backbone_cond_decode_ms = 0.0;
+        double backbone_uncond_decode_ms = 0.0;
+        uint64_t sample_call_index = 0;
+        uint64_t offset_blocks = 0;
+    };
+
+    std::unique_ptr<StreamState> stream_;
+
+    void begin_stream(const BreezeGenerationRequest & request) {
+        if (stream_ != nullptr) {
+            throw std::runtime_error("BreezeTTS stream is already active");
+        }
+        if (request.text.empty()) {
+            throw std::runtime_error("BreezeTTS requires text");
+        }
+        const auto & config = assets->config;
+        BreezeSpeechCodes reference;
+        if (request.reference_codes.has_value()) {
+            reference = *request.reference_codes;
+        } else if (request.reference_audio.has_value()) {
+            reference = speech_encoder->encode(*request.reference_audio);
+            speech_encoder->release_runtime_graphs();
+        }
+        std::vector<int32_t> reference_codes;
+        int64_t reference_frames = 0;
+        if (!reference.codes.empty()) {
+            if (reference.frames < 0 || reference.code_groups <= 0) {
+                throw std::runtime_error("BreezeTTS speech codes have invalid shape");
+            }
+            if (static_cast<int64_t>(reference.codes.size()) != reference.frames * reference.code_groups) {
+                throw std::runtime_error("BreezeTTS speech code count does not match shape");
+            }
+            reference_codes = reference.codes;
+            reference_frames = static_cast<int64_t>(reference_codes.size()) / config.num_codebooks;
+        }
+
+        BreezePromptBranch cond_branch;
+        BreezePromptBranch uncond_branch;
+        std::vector<float> cond_embeddings;
+        std::vector<float> uncond_embeddings;
+        int64_t cond_steps = 0;
+        int64_t uncond_steps = 0;
+        const bool use_cfg = request.guidance_scale != 1.0F;
+        const double prompt_ms = engine::debug::measure_ms([&] {
+            if (!reference_codes.empty()) {
+                if (request.reference_text.empty()) {
+                    throw std::runtime_error("BreezeTTS clone requires reference_text");
+                }
+                cond_branch = tokenizer.build_clone(request.text, request.instruction, request.reference_text, reference_frames);
+                if (use_cfg) {
+                    uncond_branch = tokenizer.build_clone_negative(request.text, request.reference_text, reference_frames);
+                }
+            } else {
+                cond_branch = tokenizer.build_tts_instruction(request.text, request.instruction);
+                if (use_cfg) {
+                    uncond_branch = tokenizer.build_tts_plain(request.text);
+                }
+            }
+            cond_embeddings = merge_prompt(cond_branch, reference_codes);
+            cond_steps = static_cast<int64_t>(cond_branch.input_ids.size());
+            if (use_cfg) {
+                uncond_embeddings = merge_prompt(uncond_branch, reference_codes);
+                uncond_steps = static_cast<int64_t>(uncond_branch.input_ids.size());
+            }
+        });
+        engine::debug::timing_log_scalar("breeze_tts.generate.prompt_ms", prompt_ms);
+        text_encoder.release_runtime_graphs();
+
+        auto state = std::make_unique<StreamState>();
+        state->request = request;
+        state->use_cfg = use_cfg;
+        state->codes.reserve(static_cast<size_t>(request.max_tokens * config.num_codebooks));
+        state->scratch.reserve_vocab(static_cast<size_t>(config.lm_head_size));
+        state->fallback_rng = std::mt19937(static_cast<uint32_t>(request.seed));
+        state->first_options.do_sample = true;
+        state->first_options.temperature = request.temperature;
+        state->first_options.top_k = request.top_k;
+        state->first_options.top_p = request.top_p;
+        state->first_options.repetition_penalty = kRepetitionPenalty;
+        state->first_options.min_tokens_to_keep = 1;
+        speech_decoder->reset_streaming_state();
+        state->ar_total_ms += engine::debug::measure_ms([&] {
+            state->backbone_cond_prefill_ms = engine::debug::measure_ms([&] {
+                state->cond = backbone_cond->prefill_embeddings(cond_embeddings, cond_steps);
+            });
+            if (use_cfg) {
+                state->uncond.emplace();
+                state->backbone_uncond_prefill_ms = engine::debug::measure_ms([&] {
+                    *state->uncond = backbone_uncond->prefill_embeddings(uncond_embeddings, uncond_steps);
+                });
+            }
+            backbone_cond->start_decode_embeddings(state->cond.state, cond_steps + request.max_tokens);
+            if (use_cfg) {
+                backbone_uncond->start_decode_embeddings(state->uncond->state, uncond_steps + request.max_tokens);
+            }
+        });
+        stream_ = std::move(state);
+    }
+
+    int step_frame_once() {
+        if (stream_ == nullptr) {
+            throw std::runtime_error("BreezeTTS stream has not been started");
+        }
+        auto & state = *stream_;
+        const auto & request = state.request;
+        const auto & config = assets->config;
+        if (state.done || state.steps_taken >= request.max_tokens) {
+            state.done = true;
+            return 2;
+        }
+        ++state.steps_taken;
+        if (state.use_cfg) {
+            if (!state.uncond.has_value() || state.cond.logits.size() != state.uncond->logits.size()) {
+                throw std::runtime_error("BreezeTTS CFG logits shape mismatch");
+            }
+        }
+        std::vector<float> logits;
+        if (state.use_cfg) {
+            logits.resize(state.cond.logits.size());
+            for (size_t i = 0; i < logits.size(); ++i) {
+                logits[i] =
+                    state.uncond->logits[i] + request.guidance_scale * (state.cond.logits[i] - state.uncond->logits[i]);
+            }
+        } else {
+            logits = state.cond.logits;
+        }
+        suppress_reserved(logits, kCodecCodebookSize, config.vocab_size);
+        const int32_t first_token = sample_logits(
+            std::move(logits),
+            state.first_codebook_history,
+            state.first_options,
+            state.scratch,
+            state.fallback_rng,
+            sampling_policy.cuda_fast_path ? &sampling_policy : nullptr,
+            request.seed,
+            state.sample_call_index,
+            state.offset_blocks,
+            "BreezeTTS semantic sampler");
+        if (first_token == config.vocab_size) {
+            state.done = true;
+            return 2;
+        }
+        if (first_token == config.codebook_pad_token_id) {
+            return 1;
+        }
+        const auto frame = generate_frame(
+            state.cond.hidden,
+            state.use_cfg ? state.uncond->hidden : state.cond.hidden,
+            first_token,
+            request,
+            state.scratch,
+            state.fallback_rng,
+            state.sample_call_index,
+            state.offset_blocks);
+        state.first_codebook_history.push_back(first_token);
+        state.codes.insert(state.codes.end(), frame.begin(), frame.end());
+        const auto embedded = frame_embedding(
+            weights->audio_embedding,
+            config.num_codebooks * config.vocab_size,
+            config.hidden_size,
+            config.vocab_size,
+            frame);
+        modules::QwenCausalDecodeStepResult cond_step;
+        state.backbone_cond_decode_ms += engine::debug::measure_ms([&] {
+            cond_step = backbone_cond->decode_embedding(embedded);
+        });
+        state.cond.logits = cond_step.logits;
+        state.cond.hidden = cond_step.hidden;
+        if (state.use_cfg) {
+            modules::QwenCausalDecodeStepResult uncond_step;
+            state.backbone_uncond_decode_ms += engine::debug::measure_ms([&] {
+                uncond_step = backbone_uncond->decode_embedding(embedded);
+            });
+            state.uncond->logits = uncond_step.logits;
+            state.uncond->hidden = uncond_step.hidden;
+        }
+        return 0;
+    }
+
+    BreezeStreamEvent next_stream_audio(size_t max_new_frames, int64_t lookahead_margin) {
+        if (max_new_frames == 0) {
+            throw std::runtime_error("BreezeTTS stream step size must be positive");
+        }
+        if (stream_ == nullptr) {
+            throw std::runtime_error("BreezeTTS stream has not been started");
+        }
+        const auto & config = assets->config;
+        BreezeStreamEvent out;
+        int64_t new_frames = 0;
+        const size_t code_begin = stream_->codes.size();
+        stream_->ar_total_ms += engine::debug::measure_ms([&] {
+            while (new_frames < static_cast<int64_t>(max_new_frames)) {
+                const int status = step_frame_once();
+                if (status == 0) {
+                    ++new_frames;
+                } else if (status == 2) {
+                    out.done = true;
+                    break;
+                }
+            }
+        });
+        BreezeSpeechCodes speech_codes;
+        speech_codes.codes.assign(
+            stream_->codes.begin() + static_cast<std::ptrdiff_t>(code_begin),
+            stream_->codes.end());
+        speech_codes.code_groups = config.num_codebooks;
+        speech_codes.frames = new_frames;
+        if (new_frames * config.num_codebooks != static_cast<int64_t>(speech_codes.codes.size())) {
+            throw std::runtime_error("BreezeTTS stream generated code shape mismatch");
+        }
+        if (stream_->done) {
+            out.done = true;
+        }
+        stream_->codec_decode_ms += engine::debug::measure_ms([&] {
+            out.audio = speech_decoder->decode_streaming_step(speech_codes, lookahead_margin, out.done);
+        });
+        for (float & sample : out.audio.samples) {
+            sample = std::clamp(sample, -1.0F, 1.0F);
+        }
+        return out;
+    }
+
+    void end_stream() {
+        if (stream_ == nullptr) {
+            return;
+        }
+        engine::debug::timing_log_scalar("breeze_tts.ar.total_ms", stream_->ar_total_ms);
+        engine::debug::timing_log_scalar("breeze_tts.ar.backbone_cond_prefill_ms", stream_->backbone_cond_prefill_ms);
+        engine::debug::timing_log_scalar("breeze_tts.ar.backbone_uncond_prefill_ms", stream_->backbone_uncond_prefill_ms);
+        engine::debug::timing_log_scalar("breeze_tts.ar.backbone_cond_decode_ms", stream_->backbone_cond_decode_ms);
+        engine::debug::timing_log_scalar("breeze_tts.ar.backbone_uncond_decode_ms", stream_->backbone_uncond_decode_ms);
+        engine::debug::timing_log_scalar("breeze_tts.speech_decoder.streaming_total_ms", stream_->codec_decode_ms);
+        stream_.reset();
+        backbone_cond->release_runtime_graphs();
+        backbone_uncond->release_runtime_graphs();
+        depth_pair->release_runtime_graphs();
+    }
+
     runtime::AudioBuffer generate(const BreezeGenerationRequest & request) {
         if (request.text.empty()) {
             throw std::runtime_error("BreezeTTS requires text");
@@ -1198,6 +1452,18 @@ engine::runtime::AudioBuffer BreezeGeneratorRuntime::generate(const BreezeGenera
 
 BreezeSpeechCodes BreezeGeneratorRuntime::encode_reference(const engine::runtime::AudioBuffer & audio) const {
     return impl_->speech_encoder->encode(audio);
+}
+
+void BreezeGeneratorRuntime::begin_stream(const BreezeGenerationRequest & request) {
+    impl_->begin_stream(request);
+}
+
+BreezeStreamEvent BreezeGeneratorRuntime::next_stream_audio(size_t max_new_frames, int64_t lookahead_margin) {
+    return impl_->next_stream_audio(max_new_frames, lookahead_margin);
+}
+
+void BreezeGeneratorRuntime::end_stream() {
+    impl_->end_stream();
 }
 
 }  // namespace engine::models::breeze_tts

--- a/src/models/breeze_tts/session.cpp
+++ b/src/models/breeze_tts/session.cpp
@@ -7,12 +7,14 @@
 #include "engine/framework/text/chunking.h"
 #include "engine/models/breeze_tts/generator.h"
 
+#include <algorithm>
 #include <chrono>
 #include <cstring>
 #include <limits>
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <utility>
 
 namespace engine::models::breeze_tts {
@@ -78,6 +80,18 @@ void validate_session_options(
         validation_options.options.erase("breeze_tts.attention");
     }
     runtime::validate_spec_backed_session_options(validation_options, contract, kFamily, kModelName);
+}
+
+void validate_request_options(
+    const std::unordered_map<std::string, std::string> & options,
+    const engine::model_spec::ModelContract & contract) {
+    auto validation_options = options;
+    for (const char * key : {"stream_subchunk", "stream_frames_per_event", "stream_lookahead_margin"}) {
+        if (contract.request_option_keys.find(key) == contract.request_option_keys.end()) {
+            validation_options.erase(key);
+        }
+    }
+    runtime::validate_spec_backed_request_options(validation_options, contract, kModelName);
 }
 
 std::size_t reference_cache_slots_from_options(const runtime::SessionOptions & options) {
@@ -183,7 +197,7 @@ runtime::RunMode BreezeTTSSession::run_mode() const {
 }
 
 void BreezeTTSSession::prepare(const runtime::SessionPreparationRequest & request) {
-    runtime::validate_spec_backed_request_options(request.options, *contract_, kModelName);
+    validate_request_options(request.options, *contract_);
     mark_prepared();
 }
 
@@ -225,7 +239,7 @@ BreezeSpeechCodes BreezeTTSSession::resolve_reference_codes(const runtime::Audio
 
 runtime::TaskResult BreezeTTSSession::run(const runtime::TaskRequest & request) {
     const auto wall_start = std::chrono::steady_clock::now();
-    runtime::validate_spec_backed_request_options(request.options, *contract_, kModelName);
+    validate_request_options(request.options, *contract_);
     require_prepared("BreezeTTS run");
     if (task_.mode != runtime::RunMode::Offline) {
         throw std::runtime_error("BreezeTTS run requires an offline session");
@@ -265,7 +279,7 @@ runtime::StreamingPolicy BreezeTTSSession::streaming_policy() const {
 }
 
 void BreezeTTSSession::start_stream(const runtime::TaskRequest & request) {
-    runtime::validate_spec_backed_request_options(request.options, *contract_, kModelName);
+    validate_request_options(request.options, *contract_);
     require_prepared("BreezeTTS streaming");
     if (task_.mode != runtime::RunMode::Streaming) {
         throw std::runtime_error("BreezeTTS start_stream requires a streaming session");
@@ -287,6 +301,27 @@ void BreezeTTSSession::start_stream(const runtime::TaskRequest & request) {
         request.voice->speaker->audio.has_value()) {
         stream_reference_codes_ = resolve_reference_codes(*request.voice->speaker->audio);
     }
+    stream_subchunk_ = false;
+    if (const auto subchunk = runtime::find_option(request.options, {"stream_subchunk"})) {
+        stream_subchunk_ = runtime::parse_bool_option(*subchunk, "stream_subchunk");
+    }
+    const auto frames_per_event = runtime::parse_i64_option(request.options, {"stream_frames_per_event"})
+        .value_or(static_cast<int64_t>(stream_frames_per_event_));
+    if (frames_per_event <= 0) {
+        throw std::runtime_error("BreezeTTS stream_frames_per_event must be positive");
+    }
+    stream_frames_per_event_ = static_cast<size_t>(frames_per_event);
+    stream_lookahead_margin_ = runtime::parse_i64_option(request.options, {"stream_lookahead_margin"})
+        .value_or(stream_lookahead_margin_);
+    if (stream_lookahead_margin_ < 0) {
+        throw std::runtime_error("BreezeTTS stream_lookahead_margin must be non-negative");
+    }
+    stream_merged_audio_ = runtime::AudioBuffer{24000, 1, {}};
+    stream_started_at_ = std::chrono::steady_clock::now();
+    engine::debug::trace_log_scalar("breeze_tts.streaming.subchunk", stream_subchunk_ ? 1 : 0);
+    engine::debug::trace_log_scalar(
+        "breeze_tts.streaming.frames_per_event", static_cast<int64_t>(stream_frames_per_event_));
+    engine::debug::trace_log_scalar("breeze_tts.streaming.lookahead_margin", stream_lookahead_margin_);
     stream_started_ = true;
 }
 
@@ -296,6 +331,9 @@ std::optional<runtime::StreamEvent> BreezeTTSSession::next_stream_event() {
     }
     if (stream_chunk_index_ >= stream_chunk_requests_.size()) {
         return std::nullopt;
+    }
+    if (stream_subchunk_) {
+        return next_subchunk_event();
     }
     const size_t chunk_index = stream_chunk_index_++;
     auto chunk_audio = generator_->generate(
@@ -310,6 +348,41 @@ std::optional<runtime::StreamEvent> BreezeTTSSession::next_stream_event() {
     return event;
 }
 
+std::optional<runtime::StreamEvent> BreezeTTSSession::next_subchunk_event() {
+    while (true) {
+        if (stream_chunk_index_ >= stream_chunk_requests_.size()) {
+            return std::nullopt;
+        }
+        const size_t chunk_index = stream_chunk_index_;
+        if (!stream_chunk_active_) {
+            generator_->begin_stream(build_generation_request(
+                stream_chunk_requests_[chunk_index],
+                stream_reference_codes_,
+                chunk_index));
+            stream_chunk_active_ = true;
+        }
+
+        auto event_audio = generator_->next_stream_audio(stream_frames_per_event_, stream_lookahead_margin_);
+        if (event_audio.done) {
+            generator_->end_stream();
+            stream_chunk_active_ = false;
+            ++stream_chunk_index_;
+        }
+        if (event_audio.audio.samples.empty()) {
+            continue;
+        }
+        runtime::append_audio_buffer(stream_merged_audio_, event_audio.audio);
+        runtime::StreamEvent event;
+        event.named_audio_outputs.push_back({
+            "chunk_" + std::to_string(chunk_index) + "_part_" + std::to_string(stream_event_seq_++),
+            std::move(event_audio.audio),
+            {},
+        });
+        engine::debug::trace_log_scalar("breeze_tts.streaming.event_index", static_cast<int64_t>(stream_event_seq_));
+        return event;
+    }
+}
+
 void BreezeTTSSession::set_stream_event_sink(runtime::StreamEventCallback sink) {
     (void)sink;
 }
@@ -322,15 +395,24 @@ runtime::TaskResult BreezeTTSSession::finish_stream() {
     }
     runtime::TaskResult result;
     result.audio_output = std::move(stream_merged_audio_);
+    engine::debug::timing_log_scalar("session.wall_ms", engine::debug::elapsed_ms(stream_started_at_));
     reset();
     return result;
 }
 
 void BreezeTTSSession::reset() {
+    if (stream_chunk_active_) {
+        generator_->end_stream();
+        stream_chunk_active_ = false;
+    }
     stream_chunk_requests_.clear();
     stream_reference_codes_.reset();
     stream_merged_audio_ = runtime::AudioBuffer{};
     stream_chunk_index_ = 0;
+    stream_subchunk_ = false;
+    stream_frames_per_event_ = 32;
+    stream_lookahead_margin_ = 12;
+    stream_event_seq_ = 0;
     stream_started_ = false;
 }
 

--- a/src/models/breeze_tts/session.cpp
+++ b/src/models/breeze_tts/session.cpp
@@ -86,7 +86,7 @@ void validate_request_options(
     const std::unordered_map<std::string, std::string> & options,
     const engine::model_spec::ModelContract & contract) {
     auto validation_options = options;
-    for (const char * key : {"stream_subchunk", "stream_frames_per_event", "stream_lookahead_margin"}) {
+    for (const char * key : {"stream_frames_per_event", "stream_lookahead_margin"}) {
         if (contract.request_option_keys.find(key) == contract.request_option_keys.end()) {
             validation_options.erase(key);
         }
@@ -301,10 +301,6 @@ void BreezeTTSSession::start_stream(const runtime::TaskRequest & request) {
         request.voice->speaker->audio.has_value()) {
         stream_reference_codes_ = resolve_reference_codes(*request.voice->speaker->audio);
     }
-    stream_subchunk_ = false;
-    if (const auto subchunk = runtime::find_option(request.options, {"stream_subchunk"})) {
-        stream_subchunk_ = runtime::parse_bool_option(*subchunk, "stream_subchunk");
-    }
     const auto frames_per_event = runtime::parse_i64_option(request.options, {"stream_frames_per_event"})
         .value_or(static_cast<int64_t>(stream_frames_per_event_));
     if (frames_per_event <= 0) {
@@ -318,7 +314,6 @@ void BreezeTTSSession::start_stream(const runtime::TaskRequest & request) {
     }
     stream_merged_audio_ = runtime::AudioBuffer{24000, 1, {}};
     stream_started_at_ = std::chrono::steady_clock::now();
-    engine::debug::trace_log_scalar("breeze_tts.streaming.subchunk", stream_subchunk_ ? 1 : 0);
     engine::debug::trace_log_scalar(
         "breeze_tts.streaming.frames_per_event", static_cast<int64_t>(stream_frames_per_event_));
     engine::debug::trace_log_scalar("breeze_tts.streaming.lookahead_margin", stream_lookahead_margin_);
@@ -332,23 +327,6 @@ std::optional<runtime::StreamEvent> BreezeTTSSession::next_stream_event() {
     if (stream_chunk_index_ >= stream_chunk_requests_.size()) {
         return std::nullopt;
     }
-    if (stream_subchunk_) {
-        return next_subchunk_event();
-    }
-    const size_t chunk_index = stream_chunk_index_++;
-    auto chunk_audio = generator_->generate(
-        build_generation_request(stream_chunk_requests_[chunk_index], stream_reference_codes_, chunk_index));
-    runtime::append_audio_buffer(stream_merged_audio_, chunk_audio);
-    runtime::StreamEvent event;
-    event.named_audio_outputs.push_back({
-        "chunk_" + std::to_string(chunk_index),
-        std::move(chunk_audio),
-        {},
-    });
-    return event;
-}
-
-std::optional<runtime::StreamEvent> BreezeTTSSession::next_subchunk_event() {
     while (true) {
         if (stream_chunk_index_ >= stream_chunk_requests_.size()) {
             return std::nullopt;
@@ -409,7 +387,6 @@ void BreezeTTSSession::reset() {
     stream_reference_codes_.reset();
     stream_merged_audio_ = runtime::AudioBuffer{};
     stream_chunk_index_ = 0;
-    stream_subchunk_ = false;
     stream_frames_per_event_ = 32;
     stream_lookahead_margin_ = 12;
     stream_event_seq_ = 0;

--- a/src/models/breeze_tts/session.cpp
+++ b/src/models/breeze_tts/session.cpp
@@ -387,7 +387,7 @@ void BreezeTTSSession::reset() {
     stream_reference_codes_.reset();
     stream_merged_audio_ = runtime::AudioBuffer{};
     stream_chunk_index_ = 0;
-    stream_frames_per_event_ = 32;
+    stream_frames_per_event_ = 16;
     stream_lookahead_margin_ = 12;
     stream_event_seq_ = 0;
     stream_started_ = false;

--- a/src/models/breeze_tts/session.cpp
+++ b/src/models/breeze_tts/session.cpp
@@ -340,7 +340,14 @@ std::optional<runtime::StreamEvent> BreezeTTSSession::next_stream_event() {
             stream_chunk_active_ = true;
         }
 
-        auto event_audio = generator_->next_stream_audio(stream_frames_per_event_, stream_lookahead_margin_);
+        BreezeStreamEvent event_audio;
+        try {
+            event_audio = generator_->next_stream_audio(stream_frames_per_event_, stream_lookahead_margin_);
+        } catch (...) {
+            generator_->end_stream();
+            stream_chunk_active_ = false;
+            throw;
+        }
         if (event_audio.done) {
             generator_->end_stream();
             stream_chunk_active_ = false;

--- a/src/models/breeze_tts/speech_decoder.cpp
+++ b/src/models/breeze_tts/speech_decoder.cpp
@@ -1079,6 +1079,57 @@ BreezeSpeechDecoderRuntime::BreezeSpeechDecoderRuntime(
 
 BreezeSpeechDecoderRuntime::~BreezeSpeechDecoderRuntime() = default;
 
+std::vector<float> BreezeSpeechDecoderRuntime::decode_window_samples(
+    const std::vector<int32_t> & chunk,
+    int64_t chunk_frames,
+    int64_t context_frames) const {
+    if (chunk_frames <= 0 || context_frames < 0 || context_frames > chunk_frames) {
+        throw std::runtime_error("Breeze speech decoder received invalid chunk shape");
+    }
+    if (static_cast<int64_t>(chunk.size()) != chunk_frames * weights_->config.num_quantizers) {
+        throw std::runtime_error("Breeze speech decoder chunk payload size mismatch");
+    }
+    const int threads = std::max(1, execution_context_->config().threads);
+    auto * graph_slot = &graph_;
+#if defined(ENGINE_HIP_STRIX_HALO_OPTIMIZATIONS)
+    const bool optimized_cache_enabled =
+        kStrixHaloGraphCacheEnabled && execution_context_->backend_type() == core::BackendType::Hip;
+    if (optimized_cache_enabled) {
+        for (size_t index = 0; index < kStrixHaloCachedChunkFrames.size(); ++index) {
+            if (chunk_frames == kStrixHaloCachedChunkFrames[index]) {
+                graph_slot = &optimized_graphs_[index];
+                break;
+            }
+        }
+    }
+#endif
+    auto & graph = *graph_slot;
+    const bool graph_rebuilt =
+        graph == nullptr || !graph->matches(*weights_, chunk_frames, execution_context_->backend(), threads);
+    if (graph_rebuilt) {
+        graph.reset();
+        graph = std::make_unique<BreezeSpeechDecoderGraph>(
+            weights_,
+            chunk_frames,
+            *execution_context_,
+            *constants_,
+            graph_arena_bytes_,
+            allow_flash_attention_);
+    }
+    auto decoded = graph->run(chunk.data(), chunk.size());
+    const int64_t drop = context_frames * kDecodeSamplesPerCode;
+    if (drop > static_cast<int64_t>(decoded.size())) {
+        throw std::runtime_error("Breeze speech decoder chunk context exceeds decoded waveform");
+    }
+    const int64_t valid_samples = chunk_frames * kDecodeSamplesPerCode;
+    if (valid_samples < drop || valid_samples > static_cast<int64_t>(decoded.size())) {
+        throw std::runtime_error("Breeze speech decoder valid sample range exceeds decoded waveform");
+    }
+    return std::vector<float>(
+        decoded.begin() + static_cast<std::ptrdiff_t>(drop),
+        decoded.begin() + static_cast<std::ptrdiff_t>(valid_samples));
+}
+
 runtime::AudioBuffer BreezeSpeechDecoderRuntime::decode(const BreezeSpeechCodes & codec_codes) const {
     const auto total_start = Clock::now();
     if (codec_codes.frames <= 0 || codec_codes.code_groups != weights_->config.num_quantizers) {
@@ -1101,48 +1152,80 @@ runtime::AudioBuffer BreezeSpeechDecoderRuntime::decode(const BreezeSpeechCodes 
             const auto dst = chunk.begin() + static_cast<std::ptrdiff_t>(frame * codec_codes.code_groups);
             std::copy(src, src + codec_codes.code_groups, dst);
         }
-        const int threads = std::max(1, execution_context_->config().threads);
-        auto * graph_slot = &graph_;
-#if defined(ENGINE_HIP_STRIX_HALO_OPTIMIZATIONS)
-        const bool optimized_cache_enabled =
-            kStrixHaloGraphCacheEnabled && execution_context_->backend_type() == core::BackendType::Hip;
-        if (optimized_cache_enabled) {
-            for (size_t index = 0; index < kStrixHaloCachedChunkFrames.size(); ++index) {
-                if (chunk_frames == kStrixHaloCachedChunkFrames[index]) {
-                    graph_slot = &optimized_graphs_[index];
-                    break;
-                }
-            }
-        }
-#endif
-        auto & graph = *graph_slot;
-        const bool graph_rebuilt =
-            graph == nullptr || !graph->matches(*weights_, chunk_frames, execution_context_->backend(), threads);
-        if (graph_rebuilt) {
-            auto replacement = std::make_unique<BreezeSpeechDecoderGraph>(
-                weights_,
-                chunk_frames,
-                *execution_context_,
-                *constants_,
-                graph_arena_bytes_,
-                allow_flash_attention_);
-            graph = std::move(replacement);
-        }
-        auto decoded = graph->run(chunk.data(), chunk.size());
-        const int64_t drop = context * kDecodeSamplesPerCode;
-        if (drop > static_cast<int64_t>(decoded.size())) {
-            throw std::runtime_error("Breeze speech decoder chunk context exceeds decoded waveform");
-        }
-        const int64_t valid_samples = chunk_frames * kDecodeSamplesPerCode;
-        if (valid_samples < drop || valid_samples > static_cast<int64_t>(decoded.size())) {
-            throw std::runtime_error("Breeze speech decoder valid sample range exceeds decoded waveform");
-        }
-        samples.insert(
-            samples.end(),
-            decoded.begin() + static_cast<std::ptrdiff_t>(drop),
-            decoded.begin() + static_cast<std::ptrdiff_t>(valid_samples));
+        auto decoded = decode_window_samples(chunk, chunk_frames, context);
+        samples.insert(samples.end(), decoded.begin(), decoded.end());
     }
     debug::timing_log_scalar("breeze_tts.speech_decoder.total_ms", engine::debug::elapsed_ms(total_start, Clock::now()));
+    return runtime::AudioBuffer{kSampleRate, 1, std::move(samples)};
+}
+
+struct BreezeSpeechDecoderRuntime::StreamingState {
+    std::vector<int32_t> left_context_codes;
+    std::vector<int32_t> pending_codes;
+};
+
+void BreezeSpeechDecoderRuntime::reset_streaming_state() const {
+    streaming_state_ = std::make_unique<StreamingState>();
+}
+
+runtime::AudioBuffer BreezeSpeechDecoderRuntime::decode_streaming_step(
+    const BreezeSpeechCodes & codec_codes,
+    int64_t lookahead_margin,
+    bool final) const {
+    const auto total_start = Clock::now();
+    if (lookahead_margin < 0) {
+        throw std::runtime_error("Breeze speech decoder streaming lookahead must be non-negative");
+    }
+    if (codec_codes.frames < 0 || codec_codes.code_groups != weights_->config.num_quantizers) {
+        throw std::runtime_error("Breeze speech decoder received invalid streaming codec shape");
+    }
+    if (static_cast<int64_t>(codec_codes.codes.size()) != codec_codes.frames * codec_codes.code_groups) {
+        throw std::runtime_error("Breeze speech decoder streaming codec payload size mismatch");
+    }
+    if (!streaming_state_) {
+        reset_streaming_state();
+    }
+    auto & state = *streaming_state_;
+    state.pending_codes.insert(state.pending_codes.end(), codec_codes.codes.begin(), codec_codes.codes.end());
+    const int64_t groups = weights_->config.num_quantizers;
+    int64_t pending_frames = static_cast<int64_t>(state.pending_codes.size()) / groups;
+    int64_t frames_to_emit = final ? pending_frames : pending_frames - lookahead_margin;
+    if (frames_to_emit <= 0) {
+        return runtime::AudioBuffer{kSampleRate, 1, {}};
+    }
+    std::vector<float> samples;
+    while (frames_to_emit > 0) {
+        const int64_t emit_frames = std::min<int64_t>(frames_to_emit, kChunkCodes);
+        const int64_t context_frames = static_cast<int64_t>(state.left_context_codes.size()) / groups;
+        const int64_t chunk_frames = context_frames + emit_frames;
+        std::vector<int32_t> chunk;
+        chunk.reserve(static_cast<size_t>(chunk_frames * groups));
+        chunk.insert(chunk.end(), state.left_context_codes.begin(), state.left_context_codes.end());
+        chunk.insert(
+            chunk.end(),
+            state.pending_codes.begin(),
+            state.pending_codes.begin() + static_cast<std::ptrdiff_t>(emit_frames * groups));
+        auto decoded = decode_window_samples(chunk, chunk_frames, context_frames);
+        samples.insert(samples.end(), decoded.begin(), decoded.end());
+
+        std::vector<int32_t> next_context;
+        const int64_t available_context_frames = context_frames + emit_frames;
+        const int64_t keep_context_frames = std::min<int64_t>(available_context_frames, kLeftContextCodes);
+        next_context.reserve(static_cast<size_t>(keep_context_frames * groups));
+        const int64_t skip_frames = available_context_frames - keep_context_frames;
+        next_context.insert(
+            next_context.end(),
+            chunk.begin() + static_cast<std::ptrdiff_t>(skip_frames * groups),
+            chunk.end());
+        state.left_context_codes = std::move(next_context);
+        state.pending_codes.erase(
+            state.pending_codes.begin(),
+            state.pending_codes.begin() + static_cast<std::ptrdiff_t>(emit_frames * groups));
+        pending_frames -= emit_frames;
+        frames_to_emit -= emit_frames;
+    }
+    engine::debug::trace_log_scalar("breeze_tts.speech_decoder.streaming.pending_frames", pending_frames);
+    engine::debug::timing_log_scalar("breeze_tts.speech_decoder.streaming_ms", engine::debug::elapsed_ms(total_start, Clock::now()));
     return runtime::AudioBuffer{kSampleRate, 1, std::move(samples)};
 }
 


### PR DESCRIPTION
## Summary

This tightens the BreezeTTS streaming implementation around the PocketTTS-style ownership boundary. The session now only drives stream events, while the generator owns AR streaming state and returns decoded audio events to the session. The speech decoder owns the incremental codec decode state with left context and pending frames.

Breeze streaming now uses the incremental codec-frame path by default instead of the old one-output-per-text-chunk path. `stream_frames_per_event` controls event granularity, and `stream_lookahead_margin` controls how many trailing codec frames are held before emission to reduce boundary artifacts.

The offline generation path is unchanged.

## Validation

| Case | Result |
|---|---|
| Build | `audiocpp_cli` and `audiocpp_server` build cleanly |
| Default streaming | Passed, emitted 4 incremental audio events plus merged output without any opt-in subchunk flag |
| Offline A/B voice clone | Passed, artifacts/text match; timing 4594.314 ms vs 4452.668 ms (+3.18%) |
| Offline A/B voice design | Passed, artifacts/text match; timing 3375.125 ms vs 3375.804 ms (-0.02%) |
| Path-test compare summary | 2 cases compared, 0 differences |

## Server TTFT

| `stream_frames_per_event` | Server TTFT | Client first delta | Events | Wall |
|---:|---:|---:|---:|---:|
| 32 | 650.675 ms | 663.389 ms | 4 | 1844.125 ms |
| 16 | 375.147 ms | 375.717 ms | 7 | 1836.698 ms |
| 8 | 377.302 ms | 377.861 ms | 12 | 2062.941 ms |
