### PR TITLE
:bug: fix hip build error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1912,6 +1912,12 @@ if (AUDIOCPP_HIP_STRIX_HALO_OPTIMIZATIONS_ACTIVE)
     target_compile_definitions(engine_runtime PRIVATE ENGINE_HIP_STRIX_HALO_OPTIMIZATIONS=1)
 endif()
 if (ENGINE_ENABLE_HIP)
+    # The Fish HIP sampler is compiled as an external HIP object and linked
+    # into the static runtime. Its HIP host-runtime dependency must therefore
+    # be propagated to executables, especially with dynamic ggml backends.
+    find_package(hip REQUIRED)
+    target_link_libraries(engine_runtime PRIVATE hip::host)
+
     # ggml-hip publicly defines GGML_USE_CUDA for consumers, so engine code
     # needs this marker to tell a real CUDA build apart from a HIP build.
     target_compile_definitions(engine_core PRIVATE ENGINE_GGML_HIP_BACKEND=1)


### PR DESCRIPTION
## Summary

- Link the HIP host runtime with `engine_runtime`.
- Fix linker errors when building the Fish HIP fast sampler with dynamic ggml backends.

## Problem

`hip_fast_sampler.cu` is compiled separately with `hipcc` and linked into the static
`engine_runtime` library as an external object.

When `ENGINE_ENABLE_CPU_ALL_VARIANTS=ON`, ggml HIP backends are built as dynamic modules. In this configuration, ggml-hip's private `hip::host` dependency does not propagate to `audiocpp_cli` and `audiocpp_server`.

This causes undefined references to symbols such as:

- `hipMalloc`
- `hipFree`
- `hipMemcpy`
- `hipLaunchKernel`
- `__hipRegisterFatBinary`

## Fix

Find the HIP package in the top-level CMake scope and explicitly link `hip::host` to `engine_runtime`.

This ensures that executables using the external Fish HIP sampler link against `libamdhip64`.

## Testing

- Configured a HIP build with dynamic CPU variants enabled.
- Verified that the generated executable link command contains `libamdhip64`.