### PR TITLE
refactor: build Fish HIP fast sampler as a proper HIP CMake target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -999,33 +999,6 @@ audiocpp_add_model(fish_audio
         engine::models::fish_audio::make_fish_audio_loader
 )
 
-# Fish Fast-AR emits a 4096-entry logits tensor for each acoustic codebook.
-# On Linux HIP, use a small device-side exact top-k helper so only the compact
-# sampling candidates cross back to the host. Other backends stay unchanged.
-if (ENGINE_ENABLE_HIP AND UNIX AND NOT APPLE)
-    find_program(AUDIOCPP_HIPCC hipcc REQUIRED)
-    set(AUDIOCPP_FISH_HIP_FAST_SAMPLER_OBJ "${CMAKE_CURRENT_BINARY_DIR}/fish_hip_fast_sampler.o")
-    set(AUDIOCPP_FISH_HIP_TARGETS ${CMAKE_HIP_ARCHITECTURES})
-    if (NOT AUDIOCPP_FISH_HIP_TARGETS)
-        set(AUDIOCPP_FISH_HIP_TARGETS ${GPU_TARGETS})
-    endif()
-    set(AUDIOCPP_FISH_HIP_ARCH_FLAGS)
-    foreach(AUDIOCPP_FISH_HIP_ARCH IN LISTS AUDIOCPP_FISH_HIP_TARGETS)
-        list(APPEND AUDIOCPP_FISH_HIP_ARCH_FLAGS "--offload-arch=${AUDIOCPP_FISH_HIP_ARCH}")
-    endforeach()
-    add_custom_command(
-        OUTPUT ${AUDIOCPP_FISH_HIP_FAST_SAMPLER_OBJ}
-        COMMAND ${AUDIOCPP_HIPCC} -O3 -fPIC ${AUDIOCPP_FISH_HIP_ARCH_FLAGS} -std=c++17
-            -c ${CMAKE_CURRENT_SOURCE_DIR}/src/models/fish_audio/hip_fast_sampler.cu
-            -o ${AUDIOCPP_FISH_HIP_FAST_SAMPLER_OBJ}
-        DEPENDS
-            ${CMAKE_CURRENT_SOURCE_DIR}/src/models/fish_audio/hip_fast_sampler.cu
-            ${CMAKE_CURRENT_SOURCE_DIR}/src/models/fish_audio/hip_fast_sampler.h
-        VERBATIM)
-    set_source_files_properties(${AUDIOCPP_FISH_HIP_FAST_SAMPLER_OBJ} PROPERTIES GENERATED TRUE EXTERNAL_OBJECT TRUE)
-    target_compile_definitions(engine_model_fish_audio PRIVATE ENGINE_HAS_HIP_FISH_FAST_SAMPLER=1)
-endif()
-
 audiocpp_add_model(audio8_tts
     SOURCES
         src/community_models/audio8_tts/ar.cpp
@@ -1841,9 +1814,6 @@ set(AUDIOCPP_RUNTIME_OBJECTS
 foreach(model_name IN LISTS AUDIOCPP_LINKED_MODELS)
     list(APPEND AUDIOCPP_RUNTIME_OBJECTS $<TARGET_OBJECTS:engine_model_${model_name}>)
 endforeach()
-if (ENGINE_ENABLE_HIP AND UNIX AND NOT APPLE AND "fish_audio" IN_LIST AUDIOCPP_LINKED_MODELS)
-    list(APPEND AUDIOCPP_RUNTIME_OBJECTS ${AUDIOCPP_FISH_HIP_FAST_SAMPLER_OBJ})
-endif()
 
 message(STATUS "audio.cpp model composite: ${AUDIOCPP_MODEL_SET} selected [${AUDIOCPP_ENABLED_MODELS}] linked [${AUDIOCPP_LINKED_MODELS}]")
 add_library(engine_runtime STATIC
@@ -1912,16 +1882,21 @@ if (AUDIOCPP_HIP_STRIX_HALO_OPTIMIZATIONS_ACTIVE)
     target_compile_definitions(engine_runtime PRIVATE ENGINE_HIP_STRIX_HALO_OPTIMIZATIONS=1)
 endif()
 if (ENGINE_ENABLE_HIP)
-    # The Fish HIP sampler is compiled as an external HIP object and linked
-    # into the static runtime. Its HIP host-runtime dependency must therefore
-    # be propagated to executables, especially with dynamic ggml backends.
-    find_package(hip REQUIRED)
-    target_link_libraries(engine_runtime PRIVATE hip::host)
-
     # ggml-hip publicly defines GGML_USE_CUDA for consumers, so engine code
     # needs this marker to tell a real CUDA build apart from a HIP build.
     target_compile_definitions(engine_core PRIVATE ENGINE_GGML_HIP_BACKEND=1)
 endif()
+
+# Fish Fast-AR emits a 4096-entry logits tensor for each acoustic codebook.
+# On Linux HIP, a small device-side exact top-k helper keeps only the compact
+# sampling candidates crossing back to the host. Built as a proper HIP target
+# so CMake tracks its HIP runtime dependency; other backends stay unchanged.
+if (ENGINE_ENABLE_HIP AND UNIX AND NOT APPLE)
+    add_subdirectory(src/models/fish_audio)
+    target_link_libraries(engine_runtime PRIVATE engine_fish_audio_hip_sampler)
+    target_compile_definitions(engine_model_fish_audio PRIVATE ENGINE_HAS_HIP_FISH_FAST_SAMPLER=1)
+endif()
+
 if (ENGINE_ENABLE_OPENMP)
     target_link_libraries(engine_runtime PRIVATE OpenMP::OpenMP_CXX)
     if (MSVC)

--- a/src/models/fish_audio/CMakeLists.txt
+++ b/src/models/fish_audio/CMakeLists.txt
@@ -1,0 +1,41 @@
+# Scoped 3.21 minimum: enable_language(HIP) requires CMake 3.21 while the
+# top-level minimum stays at 3.20 (same pattern as ggml-hip).
+cmake_minimum_required(VERSION 3.21)
+
+# ROCm discovery (mirrors external/ggml/src/ggml-hip/CMakeLists.txt).
+if (NOT EXISTS $ENV{ROCM_PATH})
+    if (NOT EXISTS /opt/rocm)
+        set(ROCM_PATH /usr)
+    else()
+        set(ROCM_PATH /opt/rocm)
+    endif()
+else()
+    set(ROCM_PATH $ENV{ROCM_PATH})
+endif()
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH} "${ROCM_PATH}/lib64/cmake")
+
+# Seed HIP architectures before enable_language, same precedence as ggml-hip.
+if (NOT CMAKE_HIP_ARCHITECTURES)
+    if (GPU_TARGETS)
+        set(CMAKE_HIP_ARCHITECTURES ${GPU_TARGETS})
+    elseif (AMDGPU_TARGETS)
+        set(CMAKE_HIP_ARCHITECTURES ${AMDGPU_TARGETS})
+    endif()
+endif()
+
+enable_language(HIP)
+find_package(hip REQUIRED)
+
+# CMake maps .cu to CUDA by default; mark it HIP explicitly like ggml-hip does.
+set_source_files_properties(hip_fast_sampler.cu PROPERTIES LANGUAGE HIP)
+add_library(engine_fish_audio_hip_sampler STATIC hip_fast_sampler.cu)
+set_target_properties(engine_fish_audio_hip_sampler PROPERTIES
+    POSITION_INDEPENDENT_CODE ON
+    HIP_STANDARD 17
+    HIP_STANDARD_REQUIRED ON)
+# The AMDGPU backend can emit illegal DPP instructions for GFX10+ at -O0
+# (https://github.com/ROCm/ROCm/issues/5826), same workaround as ggml-hip.
+target_compile_options(engine_fish_audio_hip_sampler PRIVATE $<$<COMPILE_LANGUAGE:HIP>:-O2>)
+# PUBLIC: this is a static library, so consumers of engine_runtime must link
+# libamdhip64 for the kernel's HIP runtime calls.
+target_link_libraries(engine_fish_audio_hip_sampler PUBLIC hip::host)


### PR DESCRIPTION
Follow-up to #486. Now that the issue has surfaced, let's fix the root cause instead of the symptom.

**Background**

 Fish Audio fast sampler is a small HIP kernel that does exact top-k on the device, so only the compact candidates cross back to the host instead of the full 4096-entry logits on every codebook step.

The kernel itself is fine; the problem is how it is wired in. For readers not familiar with the HIP backend code, the current integration couples the model to HIP in two ways:

1. **Build system:** thecu` is compiled by a hand-rolled `hipcc` custom command and injected into the static `engine_runtime` as an external object. CMake cannot see it, so its HIP runtime dependency (`hip::host`) is invisible — that is exactly what broke with dynamic ggml backends and required #486.
2. **Source code:** `ar.cpp` calls the sampler's HIP entry points directly and passes `logits_->data` as a raw device pointer, relying on ggml-hip's internal memory layout rather than any public ggml contract.

**What this PR does**

This PR addresses (1) only: the sampler becomes a first-class HIP-language CMake (scoped `cmake_minimum_required(3.21)` for `enable_language(HIP)`, mirroring ggml-hip) that PUBLIC-links `hip::host`. The dependency now propagates through `engine_runtime` to executables in both static and `ENGINE_CPU_ALL_VARIANTS=ON` builds, so the #486 workaround is removed. As a bonus, the previously dead `CMAKE_HIP_ARCHITECTURES` path now actually takes effect.

No functional change: the kernel, `ar.cpp`, and non-HIP builds are untouched. Windows HIP still skips the sampler (CMake does not support the HIP language on Windows).

Addressing (2) — decoupling the model code from raw HIP calls, e.g. by moving top-k into the ggml graph so all backends benefit — is deliberately left for a separate discussion.

**Testing** (Linux + ROCm 7.14, gfx115 / Strix Halo)

- Static-backend and `ENGINE_ENABLE_CPU_ALL_VARIANTS=ON` builds both link `libamdhip64.so.7`; sampler symbols present in executables
- Sampler compiles as HIP language with `--offload-arch=gfx1` via both `GPU_TARGETS` and `CMAKE_HIP_ARCHITECTURES`
- `-DAUDIOCPP_MODEL_SET=core` (fish_audio excluded) configures and builds
- fish_audio TTS smoke tests pass on HIP (static + dynamic backends) and CPU


AI usage: Kimi K3