### PR TITLE
perf(mira-tts): accelerate CPU and Vulkan inference

### DIFF
--- a/src/community_models/mira_tts/generator.cpp
+++ b/src/community_models/mira_tts/generator.cpp
@@ -124,11 +124,16 @@ modules::QwenCausalDecoderConfig decoder_config(
         modules::QwenDecoderStaticCacheUpdateMode::DirectSetRows;
     if (backend_type == core::BackendType::Vulkan) {
         // Mira's projections are sensitive to Vulkan's default reduced
-        // precision. Materialize grouped K/V heads for attention as well:
-        // the strided-view path diverges during prompt evaluation.
+        // precision. Prompt evaluation still needs materialized grouped K/V:
+        // the strided-view prefill path diverges. Single-token decoding can
+        // use the cached views without copying the grouped heads each step.
         out.stack.projection_precision = GGML_PREC_F32;
         out.stack.runtime.attention.prefill_mode = modules::QwenDecoderAttentionMode::FlashGrouped;
         out.stack.runtime.attention.static_mode = modules::QwenDecoderAttentionMode::FlashGrouped;
+        const char * view_decode = std::getenv("AUDIOCPP_MIRA_TTS_VULKAN_VIEW_DECODE");
+        if (view_decode == nullptr || view_decode[0] != '0') {
+            out.stack.runtime.attention.static_mode = modules::QwenDecoderAttentionMode::FlashGroupedViewKV;
+        }
     }
     out.logits_size = config.vocab_size;
     out.logits_mode = modules::QwenCausalDecoderLogitsMode::LastStep;
@@ -181,7 +186,9 @@ std::shared_ptr<MiraQwenWeights> load_weights(
     out->store->upload();
     out->lm_head = out->token_embedding;
     const char * sparse_head = std::getenv("AUDIOCPP_MIRA_TTS_SPARSE_HEAD");
-    if (backend_type == core::BackendType::Cpu &&
+    // Vulkan can project the same speech/EOS window as CPU without lowering
+    // precision. Keep the full-head diagnostic available on both backends.
+    if ((backend_type == core::BackendType::Cpu || backend_type == core::BackendType::Vulkan) &&
         !(sparse_head != nullptr && sparse_head[0] == '0')) {
         // Only MiraTTS knows its speech/EOS alphabet. Keep its weight window
         // here, presenting an ordinary, correctly sized head to shared Qwen.

--- a/src/framework/audio/flashsr.cpp
+++ b/src/framework/audio/flashsr.cpp
@@ -397,41 +397,37 @@ inline void conv1d_direct(
     float * out) {
     (void)pad;
     constexpr int C = kFlashSrChannels;
-    constexpr int kMaxTaps = 11;
     const int c = (kernel - 1) / 2;
     #pragma omp parallel for schedule(static)
     for (int64_t p0 = 0; p0 < n; p0 += 256) {
         const int64_t p1 = std::min<int64_t>(p0 + 256, n);
-        for (int64_t p = p0; p < p1; ++p) {
-            int taps[kMaxTaps];
-            int64_t src[kMaxTaps];
-            int ns = 0;
-            for (int k = 0; k < kernel; ++k) {
-                const int64_t s = p + static_cast<int64_t>(dilation) * (k - c);
-                if (s < 0 || s >= n) {
-                    continue;
-                }
-                taps[ns] = k;
-                src[ns] = s;
-                ++ns;
-            }
-            float window[C][kMaxTaps];
+        // Vectorize across independent output positions, retaining the same
+        // input-channel/tap accumulation order for every individual sample.
+        for (int oc = 0; oc < C; ++oc) {
+            float * dst = out + static_cast<size_t>(oc) * n;
+            alignas(64) float acc[256];
+            std::fill_n(acc, p1 - p0, bias != nullptr ? bias[oc] : 0.0f);
             for (int ic = 0; ic < C; ++ic) {
                 const float * row = in + static_cast<size_t>(ic) * n;
-                for (int j = 0; j < ns; ++j) {
-                    window[ic][j] = row[src[j]];
-                }
-            }
-            for (int oc = 0; oc < C; ++oc) {
-                float acc = bias != nullptr ? bias[oc] : 0.0f;
-                for (int ic = 0; ic < C; ++ic) {
-                    const float * wr = w + (static_cast<size_t>(oc) * C + ic) * kernel;
-                    for (int j = 0; j < ns; ++j) {
-                        acc += wr[taps[j]] * window[ic][j];
+                const float * wr = w + (static_cast<size_t>(oc) * C + ic) * kernel;
+                for (int k = 0; k < kernel; ++k) {
+                    const int64_t shift = static_cast<int64_t>(dilation) * (k - c);
+                    const int64_t begin = std::max<int64_t>(p0, -shift);
+                    const int64_t end = std::min<int64_t>(p1, n - shift);
+                    const float weight = wr[k];
+                    if (begin >= end) {
+                        continue;
+                    }
+                    // Local tile + simple pointer walks allow MSVC to vectorize
+                    // without aliasing the input or changing the reduction order.
+                    float * ap = acc + (begin - p0);
+                    const float * xp = row + begin + shift;
+                    for (int64_t i = 0; i < end - begin; ++i) {
+                        ap[i] += weight * xp[i];
                     }
                 }
-                out[static_cast<size_t>(oc) * n + p] = acc;
             }
+            std::copy_n(acc, p1 - p0, dst + p0);
         }
     }
 }
@@ -611,18 +607,29 @@ public:
 
         // conv_post: [C][l] -> [l], kernel 7, zero pad 3, no bias, then tanh.
         #pragma omp parallel for schedule(static)
-        for (int64_t p = 0; p < l; ++p) {
-            float acc = 0.0f;
+        for (int64_t p0 = 0; p0 < l; p0 += 256) {
+            const int64_t p1 = std::min<int64_t>(p0 + 256, l);
+            alignas(64) float acc[256] = {};
             for (int c = 0; c < kFlashSrChannels; ++c) {
                 const float * row = za.data() + static_cast<size_t>(c) * l;
                 for (int k = 0; k < 7; ++k) {
-                    const int64_t idx = p - 3 + k;
-                    if (idx >= 0 && idx < l) {
-                        acc += weights_.conv_post_w[static_cast<size_t>(c) * 7 + k] * row[idx];
+                    const int64_t shift = k - 3;
+                    const int64_t begin = std::max<int64_t>(p0, -shift);
+                    const int64_t end = std::min<int64_t>(p1, l - shift);
+                    const float w = weights_.conv_post_w[static_cast<size_t>(c) * 7 + k];
+                    if (begin >= end) {
+                        continue;
+                    }
+                    float * ap = acc + (begin - p0);
+                    const float * xp = row + begin + shift;
+                    for (int64_t i = 0; i < end - begin; ++i) {
+                        ap[i] += w * xp[i];
                     }
                 }
             }
-            out[static_cast<size_t>(p)] = tanhf(acc);
+            for (int64_t p = p0; p < p1; ++p) {
+                out[static_cast<size_t>(p)] = tanhf(acc[p - p0]);
+            }
         }
         return out;
     }

--- a/tests/mira_tts/CPU_VULKAN_OPTIMIZATION.md
+++ b/tests/mira_tts/CPU_VULKAN_OPTIMIZATION.md
@@ -1,0 +1,232 @@
+# MiraTTS CPU/Vulkan optimization validation
+
+Baseline: `f3bd8255` (upstream main merged into the MiraTTS branch).
+Tested on Windows, September 8, 2026: Ryzen 9 7950X3D, RTX 3090
+(Vulkan device 1), Release/MSVC builds, eight CPU threads.
+
+## Changes
+
+- CPU FlashSR: accumulate convolution taps across contiguous output positions
+  rather than calculating one complete output sample at a time. This exposes
+  independent samples to SIMD while retaining the input-channel/tap accumulation
+  order for each sample, including omission of out-of-range taps. Work is still
+  partitioned into disjoint 256-position blocks. No weight or precision changes.
+- Vulkan MiraTTS: use the existing model-local speech/EOS output-head view on
+  Vulkan as well as CPU. The view shares the original embedding buffer and keeps
+  its existing lifetime. It avoids projecting unused vocabulary rows, not
+  changing the sampling alphabet, weights, or token IDs. The shared Qwen runtime
+  is untouched. The first pass retains the existing Vulkan attention/precision
+  settings; the later decode-only KV-view pass is documented below.
+- `AUDIOCPP_MIRA_TTS_SPARSE_HEAD=0` disables the local head on CPU or Vulkan for
+  diagnostic comparisons. CUDA retains the existing full-head behavior.
+
+## Method
+
+Reference: `assets/resources/b.wav`. Models: local `mira-tts-q8.gguf` and
+`mira-tts-bf16.gguf`. Request parameters/seeds come from
+`offline_requests.json` and `streaming_requests.json`. Offline cases cover cold,
+repeat, changed prompt, long request, and repeat after the long request in one
+session. The offline token budgets cap outputs at 5.12/15.36 seconds; these are
+lifecycle/parity tests, not proof that the complete prompt was spoken.
+
+Timings are per-request wall times, excluding initial model loading. Cold means
+the first request in a prepared session, not total process startup. Runs were
+serial with no competing inference. One before/after sequence per precision is
+reported; these are local measurements, not statistically bounded guarantees.
+
+CPU baseline uses the original FlashSR implementation, candidate uses the new
+loop. Vulkan compares the full head (`AUDIOCPP_MIRA_TTS_SPARSE_HEAD=0`) with the
+local head (`1`). Both Vulkan runs use the same candidate binary, so the only
+runtime difference is the head switch.
+
+Reproduction (change backend, device, precision, and mode as appropriate):
+
+```powershell
+.\build\windows-vulkan-release\bin\mira_tts_warm_bench.exe --model ..\models_v3_test\MiraTTS-GGUF\mira-tts-q8.gguf --backend vulkan --device 1 --threads 8 --voice-ref assets/resources/b.wav --request-file tests/mira_tts/offline_requests.json --run-mode offline --model-spec-override model_specs/mira_tts.json --audio-out-dir ../outputs/candidate --summary-file ../outputs/candidate.json --log-file ../outputs/candidate.log
+python tests/mira_tts/compare_optimization.py --before ../outputs/baseline.json --after ../outputs/candidate.json
+```
+
+## Results
+
+| Backend / weights | Request | Before (s) | After (s) | Time reduction |
+|---|---|---:|---:|---:|
+| CPU Q8 | clone_cold | 8.245 | 7.446 | 9.7% |
+| CPU Q8 | clone_repeat | 8.210 | 7.445 | 9.3% |
+| CPU Q8 | short_second_prompt | 8.211 | 7.407 | 9.8% |
+| CPU Q8 | longform | 26.923 | 24.106 | 10.5% |
+| CPU Q8 | clone_repeat_after_longform | 8.180 | 7.457 | 8.8% |
+| CPU Q8 | stream_cold | 32.852 | 28.893 | 12.0% |
+| CPU Q8 | stream_repeat | 33.243 | 28.826 | 13.3% |
+| CPU BF16 | clone_cold | 8.933 | 8.121 | 9.1% |
+| CPU BF16 | clone_repeat | 8.851 | 8.170 | 7.7% |
+| CPU BF16 | short_second_prompt | 8.832 | 8.488 | 3.9% |
+| CPU BF16 | longform | 28.677 | 26.416 | 7.9% |
+| CPU BF16 | clone_repeat_after_longform | 8.767 | 8.383 | 4.4% |
+| CPU BF16 | stream_cold | 36.138 | 33.739 | 6.6% |
+| CPU BF16 | stream_repeat | 36.528 | 32.801 | 10.2% |
+| Vulkan Q8 | clone_cold | 0.994 | 0.940 | 5.5% |
+| Vulkan Q8 | clone_repeat | 0.881 | 0.815 | 7.5% |
+| Vulkan Q8 | short_second_prompt | 0.930 | 0.829 | 10.8% |
+| Vulkan Q8 | longform | 2.942 | 2.743 | 6.8% |
+| Vulkan Q8 | clone_repeat_after_longform | 0.937 | 0.881 | 6.0% |
+| Vulkan Q8 | stream_cold | 3.747 | 3.444 | 8.1% |
+| Vulkan Q8 | stream_repeat | 3.739 | 3.432 | 8.2% |
+| Vulkan BF16 | clone_cold | 1.015 | 1.065 | -4.9% |
+| Vulkan BF16 | clone_repeat | 0.928 | 0.857 | 7.7% |
+| Vulkan BF16 | short_second_prompt | 0.951 | 0.863 | 9.3% |
+| Vulkan BF16 | longform | 3.173 | 2.898 | 8.7% |
+| Vulkan BF16 | clone_repeat_after_longform | 1.017 | 0.999 | 1.8% |
+| Vulkan BF16 | stream_cold | 3.973 | 3.687 | 7.2% |
+| Vulkan BF16 | stream_repeat | 3.969 | 3.681 | 7.3% |
+
+All 28 paired requests have identical complete WAV bytes (SHA-256), reported
+audio hashes, frame counts, sample formats, durations, and event counts.
+`validate_bench.py` passes for all four backend/precision combinations, including
+repeat-after-long-form and streaming repeat determinism. Every streaming request
+produced four audio events. Cross-backend/precision outputs are not expected to
+be identical; each candidate is compared only to its matching baseline.
+
+The BF16 Vulkan cold-request regression in this sequence illustrates startup
+variability; warm requests and streaming improved. No universal cold-start
+speedup is claimed.
+
+An additional short-prompt Q8 CPU check ("Hello, this is a native Mira
+TTS test.", seed 1234, max_tokens 1024, same reference and eight threads) produced
+6.18 seconds of identical audio: repeated-request wall time 10.222 -> 8.994 s,
+and FlashSR stage time 2.085 -> 1.110 s. This is separate from the capped fixtures
+in the table.
+
+`flashsr_utility_test` passes its two Python-reference fixtures plus eight input
+length cases (1, 7, 85, 86, 255, 256, 257, 1025) checking finite output, 3x length,
+and exact one/eight-thread agreement around convolution block boundaries.
+The six no-model tests for `compare_optimization.py` also pass, including
+rejection of changed WAV bytes despite an unchanged reported hash.
+
+Local artifacts: `../outputs/perf-cpu-{q8,bf16}-{before,after}-{offline,streaming}`
+and `../outputs/perf-vk-{q8,bf16}-{0,1}-{offline,streaming}`, with sibling `.json`
+summaries and `.log` traces. Large WAV/model files are not added to the repository.
+
+## Experiments not adopted
+
+- Raising CPU thread count from 4 to 16 improved elapsed time, but changed the
+  generated hash and duration under otherwise identical sampling parameters.
+  It is not an exact-output optimization; the default thread count is unchanged.
+- CPU graph rebuilding costs only a few milliseconds versus seconds in
+  generation/decoding. Its repeat-determinism safeguard is retained.
+- No lower precision, changed sampling defaults, shortened token budgets, or
+  reduced audio quality settings were introduced.
+
+## Second CPU pass: local accumulator and pointer-based convolution
+
+The local comparison tree (`TEST_22_audio.cpp_qwen_3.8`,
+`src/community_models/miratts/dsp_internal.h`) uses a small stack accumulator
+and pointer-based convolution loops to help MSVC vectorize. This pattern is
+adapted to FlashSR's residual convolutions and final output convolution, rather
+than replacing MiraTTS's generator/decoder wholesale. Each tile is written to
+the output once. The input-channel/tap summation order and final `tanhf` are
+unchanged. Empty tap intersections are rejected before forming input pointers.
+
+The short-prompt Q8 comparison was rerun against a saved first-pass binary on
+the same machine: repeated request 9.005 -> 8.671 s (3.7% less time), FlashSR
+1.115 -> 0.637 s (42.8% less time), identical complete WAV. The generator's
+runtime varied slightly between runs, so stage and total improvements differ.
+
+Additional experiments were rejected and removed:
+
+- Packing only speech/EOS weight rows: same audio, but CPU slowed slightly and
+  Vulkan's warm improvement was only about 1.5%, insufficient to justify an
+  extra copied weight allocation in this pass.
+- Skipping odd/noncontributing upsampling taps with a variable-bound loop:
+  preserved audio but did not improve measured performance.
+- Restricting the eight-thread benchmark process to either 16-logical-CPU
+  group: slower than the unrestricted process. No affinity settings persist,
+  and no affinity/default-thread-count changes are included.
+
+| CPU weights | Request | First pass (s) | Second pass (s) | Time reduction |
+|---|---|---:|---:|---:|
+| Q8 | clone_cold | 7.446 | 7.018 | 5.7% |
+| Q8 | clone_repeat | 7.445 | 7.035 | 5.5% |
+| Q8 | short_second_prompt | 7.407 | 7.082 | 4.4% |
+| Q8 | longform | 24.106 | 22.381 | 7.2% |
+| Q8 | clone_repeat_after_longform | 7.457 | 7.016 | 5.9% |
+| Q8 | stream_cold | 28.893 | 28.053 | 2.9% |
+| Q8 | stream_repeat | 28.826 | 27.965 | 3.0% |
+| BF16 | clone_cold | 8.121 | 7.550 | 7.0% |
+| BF16 | clone_repeat | 8.170 | 7.553 | 7.6% |
+| BF16 | short_second_prompt | 8.488 | 7.644 | 9.9% |
+| BF16 | longform | 26.416 | 23.891 | 9.6% |
+| BF16 | clone_repeat_after_longform | 8.383 | 7.504 | 10.5% |
+| BF16 | stream_cold | 33.739 | 31.376 | 7.0% |
+| BF16 | stream_repeat | 32.801 | 31.435 | 4.2% |
+
+All 14 second-pass sequence outputs are byte-identical to their first-pass
+counterparts; both precisions pass the offline/streaming lifecycle validator.
+The FlashSR reference/boundary tests and comparison-tool unit tests also pass.
+The first-pass sequence timings were collected earlier on the same machine;
+the fresh short-prompt comparison above corroborates the stage-level benefit.
+These are local observations, not multi-trial confidence intervals.
+
+Artifacts: `../outputs/round2-cpu-{q8,bf16}-{offline,streaming}` and their sibling
+JSON/log files. CPU/Vulkan CLI and server targets were rebuilt. There is no
+additional Vulkan algorithm change in this pass; its earlier optimization is
+retained. The alternate source tree was inspected read-only.
+
+## Third pass: Vulkan decode-only KV views
+
+Vulkan now uses `FlashGroupedViewKV` for single-token decoding, avoiding
+materialization of grouped cached heads on each token. Prefill remains
+`FlashGrouped`: the previous strided-prefill precision issue is not bypassed.
+F32 projection precision, sampling, token budgets and CPU execution are unchanged.
+Set `AUDIOCPP_MIRA_TTS_VULKAN_VIEW_DECODE=0` to compare the previous decode path.
+
+RTX 3090, Vulkan device 1, eight host threads, same fixtures as above:
+
+| Weights | Request | Before (s) | After (s) | Time reduction |
+|---|---|---:|---:|---:|
+| Q8 | clone_repeat | 0.816 | 0.792 | 2.9% |
+| Q8 | longform | 2.787 | 2.674 | 4.1% |
+| Q8 | stream_repeat | 3.395 | 3.424 | -0.9% |
+| BF16 | clone_repeat | 0.853 | 0.824 | 3.3% |
+| BF16 | longform | 2.977 | 2.731 | 8.3% |
+| BF16 | stream_repeat | 3.735 | 3.551 | 4.9% |
+
+All 14 paired offline/streaming WAV files are byte-identical, and both lifecycle
+validators pass. Q8 streaming did not improve in this measurement; the change
+does not claim universal speedups. Other Vulkan devices are not validated here.
+
+The initial BF16 offline runs had abnormal first-request times (61–65 seconds)
+in **both** modes. Their cause is unconfirmed. These timings are excluded from
+the table; a fresh paired rerun returned to normal timings. Artifacts are retained
+for inspection rather than treating the anomaly as an optimization gain.
+
+Artifacts: `../outputs/round3-vk-{q8,bf16}-{0,1}-{offline,streaming}`; the BF16
+offline table uses `../outputs/round3-rerun-bf16-{0,1}.json`. The final default
+build is additionally exercised in `../outputs/round3-final-{q8,bf16}.json`.
+Use `compare_optimization.py` with the corresponding before/after JSON paths.
+
+### CPU pool experiment rejected
+
+An opt-in persistent ggml thread pool was tested in an off/on/on/off sequence.
+Repeated short-request timings were 8.747 / 8.551 / 8.748 / 8.632 seconds, with
+identical WAVs. This does not establish a repeatable improvement, so the pool
+code was removed. The current build uses OpenMP, which already reuses OS worker
+threads; allocating a ggml pool per graph is not equivalent to creating new OS
+threads per token. The accepted CPU convolution optimizations remain intact.
+
+## Fourth pass: no additional optimization retained
+
+The following experiments were removed rather than claiming noise as a gain:
+
+- CPU direct-convolution tiles enlarged from 256 to 1024: repeated short Q8
+  request 8.684 -> 8.660 s, cold request 8.699 -> 8.722 s. Inconclusive.
+- CPU activation downsampling tiled across positions with the same tap order:
+  repeated request 8.739 s, slower than the 8.684 s baseline.
+- Channel-major direct interpolation was tried, but initially benchmarked on
+  Vulkan, which uses the GGML upsampler rather than this CPU DSP function.
+  Those measurements do not validate the CPU optimization; it was removed.
+
+The CPU tile and downsampling WAVs match the baseline byte-for-byte; FlashSR
+utility tests pass. Artifacts: `../outputs/round4-cpu-tile-*` and
+`../outputs/round4-cpu-downsample.*`. The Vulkan `round4-interp-*` and
+`round4-tile-*` measurements are retained only as diagnostic artifacts, not
+evidence for a speedup. Previous accepted optimizations remain unchanged.

--- a/tests/mira_tts/LOCAL_HEAD_VALIDATION.md
+++ b/tests/mira_tts/LOCAL_HEAD_VALIDATION.md
@@ -11,8 +11,12 @@ prompt and generated token IDs still use the full embedding vocabulary.
 
 The shared `qwen_causal_decode_runtime.h` and `.cpp` are restored to upstream
 `origin/main` at `a8fccb4`, with no sparse-head field, slicing, or index rebasing.
-GPU backends retain their full output projection. The model-local CPU
+At that revision, GPU backends retained their full output projection. The model-local CPU
 `AUDIOCPP_MIRA_TTS_SPARSE_HEAD=0` diagnostic remains available.
+
+This describes the September 6 validation. The subsequent CPU/Vulkan
+optimization extends the local head to Vulkan as well; CUDA remains unchanged.
+See [CPU/Vulkan optimization validation](CPU_VULKAN_OPTIMIZATION.md).
 
 ## Output preservation
 

--- a/tests/mira_tts/README.md
+++ b/tests/mira_tts/README.md
@@ -111,3 +111,20 @@ frame-count, token-boundary, or sampling mismatch.
 Run deterministic checks before experimenting with unseeded sampling. If a
 repeat hash changes, inspect generated speech-token boundaries, prompt/context
 tokens, and component traces before comparing subjective audio quality.
+
+## Exact-output optimization comparisons
+
+For performance-only changes, run the same fixtures with the same model,
+reference, seed, thread count, device, and request options before and after the
+change. Then compare each offline/streaming summary pair:
+
+```powershell
+python tests/mira_tts/compare_optimization.py --before <baseline.json> --after <candidate.json>
+python -m unittest discover -s tests/mira_tts -p test_compare_optimization.py
+```
+
+The comparison rejects changed request sets, audio hashes, WAV bytes, sample
+metadata, or streaming event counts. It reports timing changes without treating
+a single noisy measurement as a performance failure. Run `validate_bench.py`
+as well to check repeat determinism and streaming lifecycle behavior. Relative
+WAV paths are resolved from the current directory, normally the repository root.

--- a/tests/mira_tts/compare_optimization.py
+++ b/tests/mira_tts/compare_optimization.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Require exact before/after MiraTTS output parity and report request timings.
+
+Run from the repository root so relative audio_out paths in benchmark summaries
+resolve in the same way as they did for mira_tts_warm_bench.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from pathlib import Path
+
+
+def load(path: Path) -> tuple[dict, dict]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    results = {}
+    for item in payload["results"]:
+        key = (item["name"], item["iteration"], item["mode"])
+        if key in results:
+            raise ValueError(f"duplicate request in {path}: {key}")
+        results[key] = item
+    if not results:
+        raise ValueError(f"empty results: {path}")
+    return payload, results
+
+
+def compare(before_path: Path, after_path: Path) -> list[str]:
+    before_meta, before = load(before_path)
+    after_meta, after = load(after_path)
+    for field in ("family", "backend", "model", "mode"):
+        if before_meta[field] != after_meta[field]:
+            raise ValueError(f"different {field}: cannot compare like-for-like runs")
+    if before.keys() != after.keys():
+        raise ValueError("before/after request sets differ")
+    rows = []
+    for key, left in before.items():
+        right = after[key]
+        for field in ("audio_hash", "samples", "sample_rate", "channels",
+                      "audio_seconds", "event_count"):
+            if left[field] != right[field]:
+                raise ValueError(f"{key}: {field} changed")
+        if left["samples"] <= 0:
+            raise ValueError(f"{key}: empty audio")
+        hashes = [hashlib.sha256(Path(item["audio_out"]).read_bytes()).digest()
+                  for item in (left, right)]
+        if hashes[0] != hashes[1]:
+            raise ValueError(f"{key}: WAV bytes differ")
+        old, new = float(left["wall_ms"]), float(right["wall_ms"])
+        if not all(math.isfinite(value) and value > 0 for value in (old, new)):
+            raise ValueError(f"{key}: invalid timing")
+        rows.append(f"| {key[0]} ({key[1]}) | {old / 1000:.3f} | "
+                    f"{new / 1000:.3f} | {(1 - new / old) * 100:.1f}% | identical |")
+    return rows
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--before", required=True, type=Path)
+    parser.add_argument("--after", required=True, type=Path)
+    args = parser.parse_args()
+    # Validate every result before printing a success table.
+    rows = compare(args.before, args.after)
+    print("| Request | Before (s) | After (s) | Time reduction | WAV |")
+    print("|---|---:|---:|---:|---|")
+    print("\n".join(rows))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/mira_tts/test_compare_optimization.py
+++ b/tests/mira_tts/test_compare_optimization.py
@@ -1,0 +1,71 @@
+"""Regression tests for the exact-output optimization gate (no models needed)."""
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+from compare_optimization import compare
+
+
+class ComparisonTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        root = Path(self.temp.name)
+        self.before, self.after = root / "before.json", root / "after.json"
+        self.audio = [root / "before.wav", root / "after.wav"]
+        for path in self.audio:
+            path.write_bytes(b"test audio payload")
+        self.payload = {
+            "family": "mira_tts", "backend": "cpu", "model": "model.gguf",
+            "mode": "offline", "results": [{
+                "name": "repeat", "iteration": 1, "mode": "offline",
+                "audio_hash": "same", "samples": 48000, "sample_rate": 48000,
+                "channels": 1, "audio_seconds": 1.0, "event_count": 0,
+                "wall_ms": 1000, "audio_out": str(self.audio[0]),
+            }],
+        }
+        self.before.write_text(json.dumps(self.payload), encoding="utf-8")
+        self.payload["results"][0]["audio_out"] = str(self.audio[1])
+        self.payload["results"][0]["wall_ms"] = 900
+        self.save_after()
+
+    def save_after(self):
+        self.after.write_text(json.dumps(self.payload), encoding="utf-8")
+
+    def test_identical_output(self):
+        self.assertIn("10.0%", compare(self.before, self.after)[0])
+
+    def test_changed_wav_even_with_same_reported_hash(self):
+        self.audio[1].write_bytes(b"changed audio")
+        with self.assertRaisesRegex(ValueError, "WAV bytes differ"):
+            compare(self.before, self.after)
+
+    def test_different_metadata(self):
+        self.payload["results"][0]["event_count"] = 2
+        self.save_after()
+        with self.assertRaisesRegex(ValueError, "event_count changed"):
+            compare(self.before, self.after)
+
+    def test_wrong_backend(self):
+        self.payload["backend"] = "vulkan"
+        self.save_after()
+        with self.assertRaisesRegex(ValueError, "different backend"):
+            compare(self.before, self.after)
+
+    def test_empty_results(self):
+        self.payload["results"] = []
+        self.save_after()
+        with self.assertRaisesRegex(ValueError, "empty results"):
+            compare(self.before, self.after)
+
+    def test_duplicate_results(self):
+        self.payload["results"].append(self.payload["results"][0])
+        self.save_after()
+        with self.assertRaisesRegex(ValueError, "duplicate request"):
+            compare(self.before, self.after)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittests/test_flashsr_utility.cpp
+++ b/tests/unittests/test_flashsr_utility.cpp
@@ -77,12 +77,40 @@ void run_case(int case_index) {
     require_close(output.samples, expected, 2.0e-4f, 2.0e-5, "case " + std::to_string(case_index));
 }
 
+void run_block_boundary_cases() {
+    // Cover tiny padded inputs and partial/full 256-position blocks both
+    // before and after the 3x upsampling stages. Construct fresh DSP instances
+    // for each thread count because their constructors set the OpenMP policy.
+    for (const size_t n : {1u, 7u, 85u, 86u, 255u, 256u, 257u, 1025u}) {
+        std::vector<float> input(n);
+        for (size_t i = 0; i < n; ++i) {
+            input[i] = 0.1f * std::sin(static_cast<float>(i) * 0.17f);
+        }
+        engine::core::BackendConfig config;
+        config.threads = 1;
+        const auto serial = engine::audio::FlashSrModel::load_from_directory(
+            repo_path("assets/framework/audio_utilities/flashsr"), config);
+        const auto one = serial.super_resolve_mono_16k(input);
+        config.threads = 8;
+        const auto parallel = engine::audio::FlashSrModel::load_from_directory(
+            repo_path("assets/framework/audio_utilities/flashsr"), config);
+        const auto many = parallel.super_resolve_mono_16k(input);
+        require(one.samples.size() == n * 3, "FlashSR boundary output size");
+        require(one.samples == many.samples,
+                "FlashSR thread count changed boundary output at n=" + std::to_string(n));
+        for (const float sample : many.samples) {
+            require(std::isfinite(sample), "FlashSR non-finite boundary output");
+        }
+    }
+}
+
 }  // namespace
 
 int main() {
     try {
         run_case(0);
         run_case(1);
+        run_block_boundary_cases();
         std::cout << "flashsr_utility_test passed\n";
     } catch (const std::exception & ex) {
         std::cerr << "flashsr_utility_test failed: " << ex.what() << "\n";


### PR DESCRIPTION
## Summary

This continues the MiraTTS performance work from #395, focusing on CPU and Vulkan while preserving generated output exactly.

- vectorizes the CPU FlashSR residual and output convolutions across contiguous output positions while preserving each sample's accumulation order
- uses MiraTTS's model-local 8,193-row speech/EOS output head on Vulkan as well as CPU, avoiding projection of the unused full text vocabulary
- keeps Vulkan prefill on the existing materialized grouped-K/V path, but uses grouped cached K/V views for single-token decode to avoid a copy on every generated token
- adds block-boundary FlashSR coverage and a reusable before/after validator that rejects changed WAV bytes, hashes, metadata, request sets, or streaming event counts
- documents rejected experiments so noisy or output-changing results are not presented as optimizations

The shared Qwen runtime is unchanged. CUDA behavior is unchanged. No precision, sampling, token-budget, or output-quality setting is reduced.

## Same-backend results

Windows Release/MSVC, Ryzen 9 7950X3D, RTX 3090 Vulkan device 1, eight CPU threads. Times exclude initial model loading. Each candidate is compared only with the matching backend and precision baseline.

| Backend | Request | Before | After | Improvement |
|---|---|---:|---:|---:|
| CPU Q8 | Cold, 5.12 s audio | 8.245 s | 7.018 s | 14.9% |
| CPU Q8 | Repeated, 5.12 s audio | 8.210 s | 7.035 s | 14.3% |
| CPU Q8 | Second prompt, 5.12 s audio | 8.211 s | 7.082 s | 13.8% |
| CPU Q8 | Long-form, 15.36 s audio | 26.923 s | 22.381 s | 16.9% |
| CPU Q8 | Repeat after long-form | 8.180 s | 7.016 s | 14.2% |
| Vulkan Q8 | Cold, 5.12 s audio | 0.994 s | 0.910 s | 8.5% |
| Vulkan Q8 | Repeated, 5.12 s audio | 0.881 s | 0.789 s | 10.4% |
| Vulkan Q8 | Second prompt, 5.12 s audio | 0.930 s | 0.797 s | 14.3% |
| Vulkan Q8 | Long-form, 15.36 s audio | 2.942 s | 2.652 s | 9.9% |
| Vulkan Q8 | Repeat after long-form | 0.937 s | 0.837 s | 10.7% |

BF16 is covered as well. CPU BF16 offline reductions range from 13.5% to 16.7% across the same five cases. Warm Vulkan BF16 reductions range from 8.4% to 15.4%; Vulkan BF16 cold time is effectively unchanged and is not claimed as a speedup. Full offline and streaming tables are in `tests/mira_tts/CPU_VULKAN_OPTIMIZATION.md`.

## Context against the requested #395 table

The linked #395 comment measured CUDA Q8. The new Vulkan numbers below are therefore context, not a same-backend before/after claim.

| Test | #395 previous CUDA Q8 | #395 optimized CUDA Q8 | This PR Vulkan Q8 | Vulkan vs optimized CUDA |
|---|---:|---:|---:|---:|
| Cold request, 5.12 s audio | 1.707 s | 0.874 s | 0.910 s | 4.1% slower |
| Repeated request, 5.12 s audio | 1.561 s | 0.798 s | 0.789 s | 1.1% faster |
| Second short prompt, 5.12 s audio | 1.566 s | 0.798 s | 0.797 s | effectively equal |
| Long-form, 15.36 s audio | 4.771 s | 2.530 s | 2.652 s | 4.8% slower |
| Repeat after long-form, 5.12 s audio | 1.584 s | 0.835 s | 0.837 s | effectively equal |

This puts Vulkan Q8 within about 5% of the optimized CUDA Q8 results from #395 on this machine, while the purpose of this PR remains the independently measured same-backend gains above.

## Validation

- all 28 first-pass CPU/Vulkan Q8/BF16 offline and streaming comparisons produced identical complete WAV bytes, hashes, frame counts, formats, durations, and event counts
- all 14 second CPU-pass outputs are byte-identical to their matching first-pass outputs
- all 14 Vulkan decode-K/V comparisons are byte-identical to their matching pre-change outputs
- offline/streaming lifecycle validation passes for CPU and Vulkan, Q8 and BF16
- `flashsr_utility_test` passes two Python-reference fixtures and eight boundary sizes: 1, 7, 85, 86, 255, 256, 257, and 1025 samples
- six comparison-tool unit tests pass
- current CPU and Vulkan CLI/server/benchmark targets build successfully after merging current `origin/main`
- loader/catalog synchronization passes (existing safetensors warnings only)

The benchmark document includes commands, artifacts, stage timings, limitations, and experiments that were tested but removed.
