### PR TITLE
Add VibeVoice ASR Streaming 7B

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -968,6 +968,7 @@ audiocpp_add_model(vibevoice_asr
         engine/models/vibevoice_asr/loader.h
     LOADERS
         engine::models::vibevoice_asr::make_vibevoice_asr_loader
+        engine::models::vibevoice_asr::make_vibevoice_asr_streaming_loader
 )
 
 audiocpp_add_model(voxtral_realtime

--- a/docs/asr.md
+++ b/docs/asr.md
@@ -12,7 +12,8 @@
 | Nemotron ASR | `nemotron_asr` | offline, streaming | [Nemotron ASR](#nemotron-asr) |
 | Parakeet-TDT | `parakeet_tdt` | offline, streaming | [Parakeet-TDT](#parakeet-tdt) |
 | SenseVoice-Small | `sense_asr` | offline, streaming | [SenseVoice-Small](#sensevoice-small) |
-| VibeVoice ASR | `vibevoice_asr` | offline | [VibeVoice ASR](#vibevoice-asr) |
+| VibeVoice ASR | `vibevoice_asr` | offline | [VibeVoice ASR](models/vibevoice_asr.md#vibevoice-asr) |
+| VibeVoice ASR Streaming 7B | `vibevoice_asr_streaming` | offline, streaming | [VibeVoice ASR Streaming 7B](models/vibevoice_asr.md#vibevoice-asr-streaming-7b) |
 | Voxtral Realtime | `voxtral_realtime` | offline, streaming | [Voxtral Realtime](#voxtral-realtime) |
 
 This page covers ASR models. Detailed Qwen3 ASR and forced-alignment notes live in [Qwen3 models](models/qwen3.md).
@@ -327,68 +328,12 @@ chunking, server usage, and validation notes.
 
 ## VibeVoice ASR
 
-VibeVoice ASR is an offline ASR model with greedy, sampling, and beam-search decode paths. It can return transcription text and structured segment/speaker-turn output when the model produces timestamps.
+VibeVoice ASR covers the original offline ASR family and the new Streaming 7B
+family. The streaming family has its own dedicated GGUF repo and supports both
+offline and live streaming transcription.
 
-A fully quantized port of the same model — INT8 activations through the encoder,
-ternary BitNet weights in the decoder — lives under community models as
-`vibeasr`: see [VibeASR](community_models/vibeasr.md). It is not a separate
-model, only a CPU-only alternative numeric pipeline for the same weights.
-
-| Field | Value |
-|---|---|
-| Family | `vibevoice_asr` |
-| Model directory | `models/VibeVoice-ASR` |
-| Task | `asr` |
-| Modes | `offline` |
-| Required tokenizer files | `tokenizer.json`, `tokenizer_config.json`, `vocab.json`, and `merges.txt` in the model directory |
-| Output | Transcription text; optional segments through `--segments-out`; optional speaker turns through `--turns-out` |
-| Streaming | Not supported |
-| Timestamps | Segment and speaker-turn timestamps when produced |
-
-```bash
-audiocpp_cli --task asr --family vibevoice_asr --model models/VibeVoice-ASR-GGUF/vibevoice-asr-q8_0.gguf --backend cuda --audio assets/resources/sample_16k.wav --text-out transcript.txt
-```
-
-VibeVoice-ASR also accepts a standalone audio.cpp-native GGUF. Pass the shard
-index to merge all eight safetensors files while converting:
-
-```powershell
-audiocpp_gguf.exe --input models\VibeVoice-ASR\model.safetensors.index.json --output models\VibeVoice-ASR-Q8_0\model.gguf --type q8_0
-```
-
-Configuration and tokenizer assets are embedded by default, so the output
-directory may contain only `model.gguf`.
-
-Structured output:
-
-```bash
-audiocpp_cli --task asr --family vibevoice_asr --model models/VibeVoice-ASR-GGUF/vibevoice-asr-q8_0.gguf --backend cuda --audio meeting.wav --text "The recording is a meeting conversation." --text-out transcript.txt --segments-out segments.json --turns-out turns.json
-```
-
-With VAD chunking, provide the bundled Silero VAD model:
-
-```bash
-audiocpp_cli --task asr --family vibevoice_asr --model models/VibeVoice-ASR-GGUF/vibevoice-asr-q8_0.gguf --backend cuda --audio assets/resources/sample_16k.wav --audio-chunk-mode vad --session-option vibevoice_asr.vad_model_path=assets/framework/models/silero_vad --text-out transcript.txt
-```
-
-| Option | Values | Default | Meaning |
-|---|---|---:|---|
-| `--audio` | WAV path | required | Speech input. |
-| `--text` | text | empty string | Context prompt for the ASR request. |
-| `--language` | language code | `auto` | ASR language label. |
-| `--max-tokens` | integer | model default | Maximum generated transcript tokens. |
-| `--temperature` | float | model default | Sampling temperature; `0` uses deterministic decoding. |
-| `--top-p` | float | model default | Nucleus sampling probability. |
-| `--top-k` | integer | model default | Top-k sampling limit; `0` disables top-k filtering. |
-| `--num-beams` | integer | `1` | Beam count for deterministic beam search. |
-| `--repetition-penalty` | float | model default | Generation repetition penalty. |
-| `--seed` | integer | random if omitted | Sampling seed. |
-| `--audio-chunk-mode` | `auto`, `fixed`, `vad`, `none` | `auto` | Long-audio chunking mode. `auto` uses fixed chunks. |
-| `--audio-chunk-seconds` | float seconds | `1200` | Fixed audio chunk duration. |
-| `--text-out` | TXT path | not set | Transcript output. The transcript is also printed to stdout. |
-| `--segments-out` | JSON path | not set | Write structured ASR segments when produced. |
-| `--turns-out` | JSON path | not set | Write speaker turns when produced. |
-| `--session-option vibevoice_asr.vad_model_path=<path>` | model directory | `assets/framework/models/silero_vad` | Internal VAD model used by `--audio-chunk-mode vad`. |
+See [VibeVoice ASR models](models/vibevoice_asr.md) for package IDs, conversion
+notes, CLI examples, live server configuration, and request options.
 
 ## Voxtral Realtime
 

--- a/docs/asr.md
+++ b/docs/asr.md
@@ -330,7 +330,8 @@ chunking, server usage, and validation notes.
 
 VibeVoice ASR covers the original offline ASR family and the new Streaming 7B
 family. The streaming family has its own dedicated GGUF repo and supports both
-offline and live streaming transcription.
+offline and live streaming transcription. The Streaming 7B model can emit
+speaker-attributed text, but it does not produce timestamped segments.
 
 See [VibeVoice ASR models](models/vibevoice_asr.md) for package IDs, conversion
 notes, CLI examples, live server configuration, and request options.

--- a/docs/gguf.md
+++ b/docs/gguf.md
@@ -106,6 +106,7 @@ Status labels:
 | `vevo2` | Done | Pass | Pass | Pass (drift) | No (mixed route drift; speech ASR match) |
 | `vibevoice` | Done | Pass | --- | Pass | Pass (drift) |
 | `vibevoice_asr` | Done | Pass | --- | Pass | Pass |
+| `vibevoice_asr_streaming` | Done | --- | --- | Pass | Pass |
 | `voxcpm2` | Done | Pass | Pass | Pass (ASR match, drift) | Pass (ASR match, drift) |
 | `voxtral_realtime` | Done | Pass | --- | Pass | Pass |
 
@@ -115,6 +116,7 @@ Additional lower-bit checks:
 |---|---|---|
 | `meanvc2` | `q4_k` | Pass |
 | `personaplex` | `q4_k` | Pass |
+| `vibevoice_asr_streaming` | `q4_k` | Pass (quick CUDA check; transcript stays usable and matches the BF16 wording class) |
 | `voxtral_realtime` | `q4_k` | Pass (quick CUDA check; transcripts match Q8 except one capitalization-only difference) |
 
 Q8 packaging notes:
@@ -145,6 +147,9 @@ Q8 packaging notes:
 - `voxtral_realtime` also has a tested `q4_k` package. In a quick CUDA path
   check it was smaller and faster than Q8_0, while transcript output matched
   Q8_0 except for one capitalization-only difference.
+- `vibevoice_asr_streaming` also has a tested `q4_k` package. In a quick CUDA
+  check, BF16 and Q4_K produced the same transcript wording on the validation
+  clip; Q8_0 produced the same sentence with minor wording drift.
 
 ## Build The Converter
 

--- a/docs/models/vibevoice_asr.md
+++ b/docs/models/vibevoice_asr.md
@@ -115,6 +115,12 @@ VibeVoice ASR Streaming 7B is the streaming VibeVoice ASR model. It keeps a
 persistent decoder state and can emit speaker-attributed transcript deltas as
 audio arrives. It can also run in offline mode through the same family.
 
+The upstream streaming model emits speaker-attributed text such as
+`Speaker 0: ...`, but it does not emit timestamped segments. In audio.cpp,
+`--turns-out` can expose those speaker/text turns when the model emits speaker
+labels; `--segments-out` is not populated by this streaming model. Use the
+non-streaming `vibevoice_asr` family when timestamped segment output is needed.
+
 The recommended audio.cpp package is the Q8_0 GGUF in the dedicated model repo:
 <https://huggingface.co/audio-cpp/VibeVoice-ASR-Streaming-7B-GGUF>. BF16 and
 Q4_K GGUF variants are also available in the same repo.
@@ -130,7 +136,8 @@ Upstream lists ten supported language codes for this streaming model: `en`,
 | Task | `asr` |
 | Modes | `offline`, `streaming` |
 | Required tokenizer files | Embedded in the standalone GGUF |
-| Output | Transcript text; speaker-attributed text when produced by the model |
+| Output | Transcript text; speaker/text turns when produced by the model |
+| Timestamps | Not produced by the streaming model |
 | Streaming | Live audio chunks over the `/v1/audio/transcriptions/live` endpoint |
 
 Install:
@@ -149,6 +156,7 @@ audiocpp_cli --task asr \
   --threads 8 \
   --audio assets/resources/sample_16k.wav \
   --text-out transcript.txt \
+  --turns-out speaker_turns.json \
   --metrics \
   --log
 ```

--- a/docs/models/vibevoice_asr.md
+++ b/docs/models/vibevoice_asr.md
@@ -121,6 +121,12 @@ The upstream streaming model emits speaker-attributed text such as
 labels; `--segments-out` is not populated by this streaming model. Use the
 non-streaming `vibevoice_asr` family when timestamped segment output is needed.
 
+> [!WARNING]
+> Speaker-turn segmentation can differ from the offline VibeVoice ASR family.
+> In local validation, the streaming 7B model merged adjacent speech into fewer
+> speaker turns than the offline model; the same behavior was reproduced with
+> the official Python streaming reference.
+
 The recommended audio.cpp package is the Q8_0 GGUF in the dedicated model repo:
 <https://huggingface.co/audio-cpp/VibeVoice-ASR-Streaming-7B-GGUF>. BF16 and
 Q4_K GGUF variants are also available in the same repo.

--- a/docs/models/vibevoice_asr.md
+++ b/docs/models/vibevoice_asr.md
@@ -1,0 +1,207 @@
+# VibeVoice ASR Models
+
+audio.cpp supports two VibeVoice ASR families:
+
+| Model | Family | Mode(s) | Recommended package |
+|---|---|---|---|
+| VibeVoice ASR | `vibevoice_asr` | offline | `vibevoice_asr_q8_0` |
+| VibeVoice ASR Streaming 7B | `vibevoice_asr_streaming` | offline, streaming | `vibevoice_asr_streaming_7b_q8_0` |
+
+## VibeVoice ASR
+
+VibeVoice ASR is an offline ASR model with greedy, sampling, and beam-search
+decode paths. It can return transcription text and structured segment or
+speaker-turn output when the model produces timestamps.
+
+A fully quantized port of the same model — INT8 activations through the encoder,
+ternary BitNet weights in the decoder — lives under community models as
+`vibeasr`: see [VibeASR](../community_models/vibeasr.md). It is not a separate
+model, only a CPU-only alternative numeric pipeline for the same weights.
+
+| Field | Value |
+|---|---|
+| Family | `vibevoice_asr` |
+| Model directory | `models/VibeVoice-ASR-GGUF` |
+| Task | `asr` |
+| Modes | `offline` |
+| Required tokenizer files | Embedded in the standalone GGUF |
+| Output | Transcription text; optional segments through `--segments-out`; optional speaker turns through `--turns-out` |
+| Streaming | Not supported |
+| Timestamps | Segment and speaker-turn timestamps when produced |
+
+Install:
+
+```bash
+python3 tools/model_manager_v2.py install vibevoice_asr_q8_0
+```
+
+Offline CLI:
+
+```bash
+audiocpp_cli --task asr \
+  --family vibevoice_asr \
+  --model models/VibeVoice-ASR-GGUF/vibevoice-asr-q8_0.gguf \
+  --backend cuda \
+  --audio assets/resources/sample_16k.wav \
+  --text-out transcript.txt \
+  --metrics \
+  --log
+```
+
+Structured output:
+
+```bash
+audiocpp_cli --task asr \
+  --family vibevoice_asr \
+  --model models/VibeVoice-ASR-GGUF/vibevoice-asr-q8_0.gguf \
+  --backend cuda \
+  --audio meeting.wav \
+  --text "The recording is a meeting conversation." \
+  --text-out transcript.txt \
+  --segments-out segments.json \
+  --turns-out turns.json \
+  --metrics \
+  --log
+```
+
+With VAD chunking, provide the bundled Silero VAD model:
+
+```bash
+audiocpp_cli --task asr \
+  --family vibevoice_asr \
+  --model models/VibeVoice-ASR-GGUF/vibevoice-asr-q8_0.gguf \
+  --backend cuda \
+  --audio assets/resources/sample_16k.wav \
+  --audio-chunk-mode vad \
+  --session-option vibevoice_asr.vad_model_path=assets/framework/models/silero_vad \
+  --text-out transcript.txt \
+  --metrics \
+  --log
+```
+
+Convert from safetensors:
+
+```powershell
+audiocpp_gguf.exe --input models\VibeVoice-ASR\model.safetensors.index.json --output models\VibeVoice-ASR-Q8_0\model.gguf --type q8_0
+```
+
+Configuration and tokenizer assets are embedded by default, so the output
+directory may contain only `model.gguf`.
+
+Options:
+
+| Option | Values | Default | Meaning |
+|---|---|---:|---|
+| `--audio` | WAV path | required | Speech input. |
+| `--text` | text | empty string | Context prompt for the ASR request. |
+| `--language` | language code | `auto` | ASR language label. |
+| `--max-tokens` | integer | model default | Maximum generated transcript tokens. |
+| `--temperature` | float | model default | Sampling temperature; `0` uses deterministic decoding. |
+| `--top-p` | float | model default | Nucleus sampling probability. |
+| `--top-k` | integer | model default | Top-k sampling limit; `0` disables top-k filtering. |
+| `--num-beams` | integer | `1` | Beam count for deterministic beam search. |
+| `--repetition-penalty` | float | model default | Generation repetition penalty. |
+| `--seed` | integer | random if omitted | Sampling seed. |
+| `--audio-chunk-mode` | `auto`, `fixed`, `vad`, `none` | `auto` | Long-audio chunking mode. `auto` uses fixed chunks. |
+| `--audio-chunk-seconds` | float seconds | `1200` | Fixed audio chunk duration. |
+| `--text-out` | TXT path | not set | Transcript output. The transcript is also printed to stdout. |
+| `--segments-out` | JSON path | not set | Write structured ASR segments when produced. |
+| `--turns-out` | JSON path | not set | Write speaker turns when produced. |
+| `--session-option vibevoice_asr.vad_model_path=<path>` | model directory | `assets/framework/models/silero_vad` | Internal VAD model used by `--audio-chunk-mode vad`. |
+
+## VibeVoice ASR Streaming 7B
+
+VibeVoice ASR Streaming 7B is the streaming VibeVoice ASR model. It keeps a
+persistent decoder state and can emit speaker-attributed transcript deltas as
+audio arrives. It can also run in offline mode through the same family.
+
+The recommended audio.cpp package is the Q8_0 GGUF in the dedicated model repo:
+<https://huggingface.co/audio-cpp/VibeVoice-ASR-Streaming-7B-GGUF>. BF16 and
+Q4_K GGUF variants are also available in the same repo.
+
+Upstream lists ten supported language codes for this streaming model: `en`,
+`zh`, `es`, `pt`, `de`, `ja`, `ko`, `fr`, `ru`, and `it`.
+
+| Field | Value |
+|---|---|
+| Family | `vibevoice_asr_streaming` |
+| Model package | `vibevoice_asr_streaming_7b_q8_0` |
+| Model directory | `models/VibeVoice-ASR-Streaming-7B-GGUF` |
+| Task | `asr` |
+| Modes | `offline`, `streaming` |
+| Required tokenizer files | Embedded in the standalone GGUF |
+| Output | Transcript text; speaker-attributed text when produced by the model |
+| Streaming | Live audio chunks over the `/v1/audio/transcriptions/live` endpoint |
+
+Install:
+
+```bash
+python3 tools/model_manager_v2.py install vibevoice_asr_streaming_7b_q8_0
+```
+
+Offline CLI:
+
+```bash
+audiocpp_cli --task asr \
+  --family vibevoice_asr_streaming \
+  --model models/VibeVoice-ASR-Streaming-7B-GGUF/vibevoice-asr-streaming-7b-q8_0.gguf \
+  --backend cuda \
+  --threads 8 \
+  --audio assets/resources/sample_16k.wav \
+  --text-out transcript.txt \
+  --metrics \
+  --log
+```
+
+Server config for live streaming:
+
+```json
+{
+  "host": "127.0.0.1",
+  "port": 8080,
+  "backend": "cuda",
+  "threads": 8,
+  "models": [
+    {
+      "id": "vibevoice-streaming-7b",
+      "family": "vibevoice_asr_streaming",
+      "path": "models/VibeVoice-ASR-Streaming-7B-GGUF/vibevoice-asr-streaming-7b-q8_0.gguf",
+      "task": "asr",
+      "mode": "streaming"
+    }
+  ]
+}
+```
+
+Start the server:
+
+```bash
+audiocpp_server --config server.json --log
+```
+
+Live streaming request with 16 kHz mono signed 16-bit PCM:
+
+```bash
+ffmpeg -hide_banner -loglevel error -i input.wav -f s16le -ac 1 -ar 16000 - \
+  | curl -N -X POST \
+      -H 'Content-Type: application/octet-stream' \
+      -H 'Transfer-Encoding: chunked' \
+      -H 'Expect:' \
+      -T - \
+      'http://127.0.0.1:8080/v1/audio/transcriptions/live?model=vibevoice-streaming-7b&sample_rate=16000&channels=1&sample_format=s16le'
+```
+
+Common request options:
+
+| Option | Values | Default | Meaning |
+|---|---|---:|---|
+| `--language` | language label | `auto` | ASR language label. |
+| `--request-option context=<text>` | text | empty string | Extra context or hotwords injected into the streaming prompt. |
+| `--max-tokens` | integer | `256` | Maximum generated transcript tokens per chunk. |
+| `--temperature` | float | `0` | Sampling temperature; `0` uses deterministic decoding. |
+| `--top-p` | float | `1` | Nucleus sampling probability. |
+| `--top-k` | integer | `0` | Top-k sampling limit; `0` disables top-k filtering. |
+| `--num-beams` | integer | `1` | Beam count for deterministic beam search. |
+| `--repetition-penalty` | float | `1` | Generation repetition penalty. |
+| `--audio-chunk-mode` | `auto`, `fixed`, `vad`, `none` | `auto` | Offline audio chunking mode. |
+| `--audio-chunk-seconds` | float seconds | `1200` | Offline chunk duration for fixed and VAD chunking. |

--- a/include/engine/models/vibevoice_asr/assets.h
+++ b/include/engine/models/vibevoice_asr/assets.h
@@ -87,6 +87,8 @@ struct VibeVoiceAudioProcessorConfig {
 
 struct VibeVoiceProcessorConfig {
     int64_t speech_tok_compress_ratio = 3200;
+    int64_t chunk_frames = 0;
+    int64_t lookahead_frames = 0;
     bool db_normalize = true;
     std::string language_model_pretrained_name = "Qwen/Qwen2.5-1.5B";
     VibeVoiceAudioProcessorConfig audio_processor;
@@ -94,6 +96,7 @@ struct VibeVoiceProcessorConfig {
 
 struct VibeVoiceASRAssets {
     assets::ResourceBundle resources;
+    std::string family = "vibevoice_asr";
     VibeVoiceConfig config;
     VibeVoiceProcessorConfig processor;
     std::shared_ptr<const assets::TensorSource> model_weights;
@@ -104,6 +107,8 @@ struct VibeVoiceASRAssets {
     bool fine_tune_applied = false;
 };
 
-std::shared_ptr<const VibeVoiceASRAssets> load_vibevoice_asr_assets(const std::filesystem::path & model_path);
+std::shared_ptr<const VibeVoiceASRAssets> load_vibevoice_asr_assets(
+    const std::filesystem::path & model_path,
+    const std::string & family = "vibevoice_asr");
 
 }  // namespace engine::models::vibevoice_asr

--- a/include/engine/models/vibevoice_asr/connector.h
+++ b/include/engine/models/vibevoice_asr/connector.h
@@ -80,6 +80,7 @@ public:
         int64_t input_dim) const;
     std::vector<VibeVoiceConnectorOutput> project_semantic_batch(
         const std::vector<VibeVoiceTokenizerLatents> & features) const;
+    void release_cached_graphs() const;
 
 private:
     std::shared_ptr<const VibeVoiceASRAssets> assets_;

--- a/include/engine/models/vibevoice_asr/loader.h
+++ b/include/engine/models/vibevoice_asr/loader.h
@@ -4,6 +4,7 @@
 #include "engine/models/vibevoice_asr/assets.h"
 
 #include <memory>
+#include <string>
 
 namespace engine::models::vibevoice_asr {
 
@@ -26,7 +27,10 @@ private:
     std::shared_ptr<const VibeVoiceASRAssets> assets_;
 };
 
-std::unique_ptr<VibeVoiceASRLoadedModel> load_vibevoice_asr_model(const std::filesystem::path & model_path);
+std::unique_ptr<VibeVoiceASRLoadedModel> load_vibevoice_asr_model(
+    const std::filesystem::path & model_path,
+    const std::string & family = "vibevoice_asr");
 std::shared_ptr<runtime::IVoiceModelLoader> make_vibevoice_asr_loader();
+std::shared_ptr<runtime::IVoiceModelLoader> make_vibevoice_asr_streaming_loader();
 
 }  // namespace engine::models::vibevoice_asr

--- a/include/engine/models/vibevoice_asr/postprocess.h
+++ b/include/engine/models/vibevoice_asr/postprocess.h
@@ -10,6 +10,7 @@ public:
     explicit VibeVoiceASRPostprocessor(const VibeVoiceASRTextTokenizer & tokenizer);
 
     VibeVoiceASRDecoded decode(const VibeVoiceASRGeneratedTokens & tokens) const;
+    std::vector<VibeVoiceASRSegment> decode_speaker_attributed_text(const std::string & text) const;
 
 private:
     const VibeVoiceASRTextTokenizer & tokenizer_;

--- a/include/engine/models/vibevoice_asr/session.h
+++ b/include/engine/models/vibevoice_asr/session.h
@@ -57,6 +57,30 @@ private:
     std::vector<AudioChunkPlan> audio_chunk_plan(const runtime::TaskRequest & request);
     runtime::IOfflineVoiceTaskSession & vad_session();
     runtime::TaskResult run_single(const VibeVoiceASRRequest & request);
+    runtime::TaskResult run_streaming_model(const VibeVoiceASRRequest & request);
+    runtime::StreamEvent process_streaming_model_normalized_chunk(
+        const VibeVoiceASRRequest & request,
+        const runtime::AudioBuffer & audio,
+        int64_t start_sample);
+    void ensure_streaming_decoder_state(const VibeVoiceASRRequest & request);
+    VibeVoiceASRSpeechFeatures encode_streaming_chunk(
+        const runtime::AudioBuffer & audio,
+        const VibeVoiceASRRequest & request);
+    VibeVoiceDecoderResult append_stream_embedding(
+        const std::vector<float> & embedding,
+        VibeVoiceDecoderCachedState & state,
+        int64_t & steps);
+    VibeVoiceDecoderResult append_stream_suffix(
+        const std::vector<float> & embeddings,
+        int64_t steps_to_append,
+        VibeVoiceDecoderCachedState & state,
+        int64_t & steps);
+    std::string generate_streaming_text_chunk(
+        const VibeVoiceASRRequest & request,
+        VibeVoiceDecoderResult next_logits,
+        VibeVoiceDecoderCachedState & state,
+        int64_t & steps);
+    std::vector<AudioChunkPlan> streaming_audio_chunk_plan(const runtime::AudioBuffer & audio) const;
     std::vector<int32_t> generate_tokens(
         const VibeVoiceASRRequest & request,
         const VibeVoiceASRPrompt & prompt,
@@ -93,11 +117,17 @@ private:
     std::filesystem::path vad_model_path_;
     std::unique_ptr<runtime::ILoadedVoiceModel> vad_model_;
     std::unique_ptr<runtime::IOfflineVoiceTaskSession> vad_session_;
+    std::unique_ptr<VibeVoiceDecoderCachedState> streaming_decoder_state_;
+    runtime::AudioBuffer streaming_audio_buffer_;
     runtime::TaskRequest streaming_request_;
     runtime::TaskResult streaming_result_;
     runtime::StreamEventCallback stream_event_sink_;
     bool stream_started_ = false;
     int64_t streaming_chunks_processed_ = 0;
+    int64_t streaming_decoder_steps_ = 0;
+    int64_t streaming_history_steps_ = 0;
+    int64_t streaming_buffer_start_sample_ = 0;
+    uint64_t streaming_rng_offset_ = 0;
 };
 
 }  // namespace engine::models::vibevoice_asr

--- a/include/engine/models/vibevoice_asr/speech_encoder.h
+++ b/include/engine/models/vibevoice_asr/speech_encoder.h
@@ -23,7 +23,10 @@ public:
         assets::TensorStorageType tokenizer_weight_storage_type,
         assets::TensorStorageType connector_weight_storage_type);
 
-    VibeVoiceASRSpeechFeatures encode(const runtime::AudioBuffer & audio, uint64_t seed) const;
+    VibeVoiceASRSpeechFeatures encode(
+        const runtime::AudioBuffer & audio,
+        uint64_t seed,
+        uint64_t rng_offset = 0) const;
 
 private:
     std::shared_ptr<const VibeVoiceASRAssets> assets_;

--- a/include/engine/models/vibevoice_asr/speech_tokenizer.h
+++ b/include/engine/models/vibevoice_asr/speech_tokenizer.h
@@ -135,6 +135,7 @@ public:
     std::vector<runtime::AudioBuffer> decode_acoustic_streaming_batch(
         const std::vector<VibeVoiceTokenizerLatents> & latents,
         std::vector<VibeVoiceTokenizerStreamingState *> states) const;
+    void release_cached_graphs() const;
 
 private:
     std::shared_ptr<const VibeVoiceASRAssets> assets_;

--- a/include/engine/models/vibevoice_asr/text_decoder.h
+++ b/include/engine/models/vibevoice_asr/text_decoder.h
@@ -27,6 +27,7 @@ namespace engine::models::vibevoice_asr {
 
 class VibeVoiceDecoderPrefillGraph;
 class VibeVoiceDecoderCachedStepGraph;
+class VibeVoiceDecoderCachedSuffixGraph;
 class VibeVoiceDecoderEmbeddingGraph;
 
 class VibeVoiceDecoderCachedState final {
@@ -43,8 +44,10 @@ private:
     friend class VibeVoiceDecoderWeightsRuntime;
 
     std::unique_ptr<VibeVoiceDecoderCachedStepGraph> graph_;
+    std::unique_ptr<VibeVoiceDecoderCachedSuffixGraph> suffix_graph_;
     runtime::TransformerKVState pending_state_;
     bool graph_has_state_ = false;
+    bool suffix_graph_has_state_ = false;
 };
 
 struct VibeVoiceDecoderLogits {
@@ -129,6 +132,7 @@ public:
         const std::vector<int32_t> & speech_positions) const;
     VibeVoiceDecoderPrefillOutput prefill_embeddings(const std::vector<float> & embeddings, int64_t steps) const;
     void reset_cached_state(VibeVoiceDecoderCachedState & state, runtime::TransformerKVState prefill_state) const;
+    void prepare_cached_state(VibeVoiceDecoderCachedState & state, int64_t cache_capacity) const;
     runtime::TransformerKVState export_cached_state(VibeVoiceDecoderCachedState & state) const;
     void clone_cached_state(
         const VibeVoiceDecoderCachedState & source,
@@ -136,6 +140,15 @@ public:
         int64_t cache_capacity) const;
     VibeVoiceDecoderResult cached_step(
         const std::vector<float> & embedding,
+        VibeVoiceDecoderCachedState & state,
+        int64_t cache_capacity) const;
+    void append_cached_step(
+        const std::vector<float> & embedding,
+        VibeVoiceDecoderCachedState & state,
+        int64_t cache_capacity) const;
+    VibeVoiceDecoderResult cached_suffix(
+        const std::vector<float> & embeddings,
+        int64_t steps,
         VibeVoiceDecoderCachedState & state,
         int64_t cache_capacity) const;
 

--- a/include/engine/models/vibevoice_asr/text_decoder.h
+++ b/include/engine/models/vibevoice_asr/text_decoder.h
@@ -29,6 +29,7 @@ class VibeVoiceDecoderPrefillGraph;
 class VibeVoiceDecoderCachedStepGraph;
 class VibeVoiceDecoderCachedSuffixGraph;
 class VibeVoiceDecoderEmbeddingGraph;
+class VibeVoiceDecoderKVCache;
 
 class VibeVoiceDecoderCachedState final {
 public:
@@ -45,9 +46,9 @@ private:
 
     std::unique_ptr<VibeVoiceDecoderCachedStepGraph> graph_;
     std::unique_ptr<VibeVoiceDecoderCachedSuffixGraph> suffix_graph_;
+    std::unique_ptr<VibeVoiceDecoderKVCache> cache_;
     runtime::TransformerKVState pending_state_;
-    bool graph_has_state_ = false;
-    bool suffix_graph_has_state_ = false;
+    bool cache_has_state_ = false;
 };
 
 struct VibeVoiceDecoderLogits {

--- a/include/engine/models/vibevoice_asr/tokenizer_text.h
+++ b/include/engine/models/vibevoice_asr/tokenizer_text.h
@@ -17,12 +17,16 @@ public:
     explicit VibeVoiceASRTextTokenizer(std::shared_ptr<const VibeVoiceASRAssets> assets);
 
     VibeVoiceASRPrompt build_prompt(const VibeVoiceASRRequest & request, int64_t speech_tokens) const;
+    std::vector<int32_t> build_streaming_prompt(const std::string & context) const;
     std::vector<int32_t> encode(const std::string & text) const;
     std::string decode(const std::vector<int32_t> & token_ids, bool skip_special_tokens) const;
 
     int32_t eos_id() const noexcept;
     int32_t pad_id() const noexcept;
+    int32_t speech_start_id() const noexcept;
+    int32_t speech_end_id() const noexcept;
     int32_t speech_pad_id() const noexcept;
+    int32_t text_chunk_end_id() const noexcept;
 
 private:
     std::shared_ptr<const VibeVoiceASRAssets> assets_;

--- a/model_specs/vibevoice_asr_streaming.json
+++ b/model_specs/vibevoice_asr_streaming.json
@@ -12,8 +12,16 @@
     "streaming"
   ],
   "languages": [
-    "auto",
-    "51 languages"
+    "en",
+    "zh",
+    "es",
+    "pt",
+    "de",
+    "ja",
+    "ko",
+    "fr",
+    "ru",
+    "it"
   ],
   "capabilities": {
     "asr": [
@@ -123,7 +131,7 @@
     ]
   },
   "ui": {
-    "recommended_package": "vibevoice_asr_streaming_7b_bf16",
+    "recommended_package": "vibevoice_asr_streaming_7b_q8_0",
     "tags": [
       "ASR",
       "Streaming",
@@ -137,23 +145,42 @@
   "package_defaults": {
     "download": {
       "kind": "huggingface_snapshot",
-      "repo": "audio-cpp/audio.cpp-gguf",
+      "repo": "audio-cpp/VibeVoice-ASR-Streaming-7B-GGUF",
       "revision": "main",
       "gated": false
     }
   },
   "packages": [
     {
+      "id": "vibevoice_asr_streaming_7b_q8_0",
+      "display_name": "VibeVoice ASR Streaming 7B Q8_0 GGUF",
+      "default": true,
+      "format": "gguf",
+      "precision": "q8_0",
+      "target_directory": "VibeVoice-ASR-Streaming-7B-GGUF",
+      "files": [
+        "vibevoice-asr-streaming-7b-q8_0.gguf"
+      ]
+    },
+    {
       "id": "vibevoice_asr_streaming_7b_bf16",
       "display_name": "VibeVoice ASR Streaming 7B BF16 GGUF",
-      "default": true,
       "format": "gguf",
       "precision": "bf16",
       "target_directory": "VibeVoice-ASR-Streaming-7B-GGUF",
       "files": [
-        "VibeVoice-ASR-Streaming-7B-GGUF/vibevoice-asr-streaming-7b-bf16.gguf"
-      ],
-      "strip_prefix": "VibeVoice-ASR-Streaming-7B-GGUF"
+        "vibevoice-asr-streaming-7b-bf16.gguf"
+      ]
+    },
+    {
+      "id": "vibevoice_asr_streaming_7b_q4_k",
+      "display_name": "VibeVoice ASR Streaming 7B Q4_K GGUF",
+      "format": "gguf",
+      "precision": "q4_k",
+      "target_directory": "VibeVoice-ASR-Streaming-7B-GGUF",
+      "files": [
+        "vibevoice-asr-streaming-7b-q4_k.gguf"
+      ]
     }
   ],
   "sources": [

--- a/model_specs/vibevoice_asr_streaming.json
+++ b/model_specs/vibevoice_asr_streaming.json
@@ -25,7 +25,6 @@
   ],
   "capabilities": {
     "asr": [
-      "segments",
       "speaker_turns",
       "vad_chunking"
     ]

--- a/model_specs/vibevoice_asr_streaming.json
+++ b/model_specs/vibevoice_asr_streaming.json
@@ -1,0 +1,200 @@
+{
+  "family": "vibevoice_asr_streaming",
+  "display_name": "VibeVoice ASR Streaming 7B",
+  "description": "Microsoft VibeVoice ASR Streaming 7B model for chunked streaming speech-to-text with persistent decoder state.",
+  "category": "asr",
+  "status": "supported",
+  "tasks": [
+    "asr"
+  ],
+  "modes": [
+    "offline",
+    "streaming"
+  ],
+  "languages": [
+    "auto",
+    "51 languages"
+  ],
+  "capabilities": {
+    "asr": [
+      "segments",
+      "speaker_turns",
+      "vad_chunking"
+    ]
+  },
+  "options": {
+    "request": [
+      {
+        "name": "language",
+        "type": "string",
+        "description": "ASR language label.",
+        "required": false,
+        "default": "auto"
+      },
+      {
+        "name": "context",
+        "type": "string",
+        "description": "Extra context or hotwords injected into the streaming prompt.",
+        "required": false,
+        "default": ""
+      },
+      {
+        "name": "max_tokens",
+        "type": "int",
+        "description": "Maximum generated transcript tokens per chunk.",
+        "required": false,
+        "min": 1,
+        "default": 256
+      },
+      {
+        "name": "temperature",
+        "type": "float",
+        "description": "Sampling temperature; 0 uses deterministic decoding.",
+        "required": false,
+        "min": 0,
+        "default": 0
+      },
+      {
+        "name": "top_p",
+        "type": "float",
+        "description": "Nucleus sampling probability.",
+        "required": false,
+        "min": 0.001,
+        "max": 1,
+        "default": 1
+      },
+      {
+        "name": "top_k",
+        "type": "int",
+        "description": "Top-k sampling limit; 0 disables top-k filtering.",
+        "required": false,
+        "min": 0,
+        "default": 0
+      },
+      {
+        "name": "num_beams",
+        "type": "int",
+        "description": "Beam count for deterministic beam search.",
+        "required": false,
+        "min": 1,
+        "default": 1
+      },
+      {
+        "name": "repetition_penalty",
+        "type": "float",
+        "description": "Generation repetition penalty.",
+        "required": false,
+        "min": 0.001,
+        "default": 1
+      },
+      {
+        "name": "seed",
+        "type": "int",
+        "description": "Acoustic latent sampling seed.",
+        "required": false,
+        "default": 42
+      },
+      {
+        "name": "audio_chunk_mode",
+        "type": "enum",
+        "description": "Offline audio chunking mode: auto, fixed, vad, or none.",
+        "values": [
+          "auto",
+          "fixed",
+          "vad",
+          "none"
+        ],
+        "required": false,
+        "default": "auto"
+      },
+      {
+        "name": "audio_chunk_duration_sec",
+        "type": "float",
+        "description": "Audio chunk duration in seconds for fixed and VAD chunking.",
+        "required": false,
+        "min": 0.001,
+        "default": 1200
+      }
+    ]
+  },
+  "runtime": {
+    "tags": [
+      "gguf"
+    ]
+  },
+  "ui": {
+    "recommended_package": "vibevoice_asr_streaming_7b_bf16",
+    "tags": [
+      "ASR",
+      "Streaming",
+      "GGUF"
+    ],
+    "docs": [
+      "docs/asr.md",
+      "docs/gguf.md"
+    ]
+  },
+  "package_defaults": {
+    "download": {
+      "kind": "huggingface_snapshot",
+      "repo": "audio-cpp/audio.cpp-gguf",
+      "revision": "main",
+      "gated": false
+    }
+  },
+  "packages": [
+    {
+      "id": "vibevoice_asr_streaming_7b_bf16",
+      "display_name": "VibeVoice ASR Streaming 7B BF16 GGUF",
+      "default": true,
+      "format": "gguf",
+      "precision": "bf16",
+      "target_directory": "VibeVoice-ASR-Streaming-7B-GGUF",
+      "files": [
+        "VibeVoice-ASR-Streaming-7B-GGUF/vibevoice-asr-streaming-7b-bf16.gguf"
+      ],
+      "strip_prefix": "VibeVoice-ASR-Streaming-7B-GGUF"
+    }
+  ],
+  "sources": [
+    {
+      "format": "gguf",
+      "roots": {
+        "model": ".",
+        "weights": "$gguf"
+      },
+      "files": {
+        "config": "model:config.json",
+        "tokenizer_config": "model:tokenizer_config.json",
+        "tokenizer_json": "model:tokenizer.json",
+        "tokenizer_vocab": "model:vocab.json",
+        "tokenizer_merges": "model:merges.txt"
+      },
+      "optional_files": {
+        "preprocessor_config": "model:preprocessor_config.json"
+      },
+      "tensors": {
+        "model_weights": "weights:"
+      }
+    },
+    {
+      "format": "safetensors",
+      "roots": {
+        "model": "."
+      },
+      "files": {
+        "config": "model:config.json",
+        "tokenizer_config": "model:tokenizer_config.json",
+        "tokenizer_json": "model:tokenizer.json",
+        "tokenizer_vocab": "model:vocab.json",
+        "tokenizer_merges": "model:merges.txt"
+      },
+      "optional_files": {
+        "preprocessor_config": "model:preprocessor_config.json"
+      },
+      "tensors": {
+        "model_weights": "model:model.safetensors.index.json"
+      }
+    }
+  ]
+}

--- a/src/framework/model_spec/options.cpp
+++ b/src/framework/model_spec/options.cpp
@@ -28,6 +28,7 @@ const std::unordered_map<std::string, std::unordered_set<std::string>> & shared_
         {"batch_size", {"int"}},
         {"codec_weight_type", {"enum"}},
         {"connector_weight_type", {"enum"}},
+        {"context", {"string"}},
         {"conv_weight_type", {"enum"}},
         {"cross_fade_duration_sec", {"float"}},
         {"decoder_weight_type", {"enum"}},

--- a/src/models/vibevoice_asr/assets.cpp
+++ b/src/models/vibevoice_asr/assets.cpp
@@ -190,6 +190,8 @@ VibeVoiceProcessorConfig parse_processor_config(const assets::ResourceBundle & r
     VibeVoiceProcessorConfig config;
     config.speech_tok_compress_ratio =
         json::optional_i64(root, "speech_tok_compress_ratio", config.speech_tok_compress_ratio);
+    config.chunk_frames = json::optional_i64(root, "chunk_frames", config.chunk_frames);
+    config.lookahead_frames = json::optional_i64(root, "lookahead_frames", config.lookahead_frames);
     config.db_normalize = json::optional_bool(root, "db_normalize", config.db_normalize);
     config.language_model_pretrained_name =
         json::optional_string(root, "language_model_pretrained_name", config.language_model_pretrained_name);
@@ -204,6 +206,9 @@ VibeVoiceProcessorConfig parse_processor_config(const assets::ResourceBundle & r
     }
     engine::io::require_positive(config.speech_tok_compress_ratio, "processor speech_tok_compress_ratio");
     engine::io::require_positive(config.audio_processor.sample_rate, "processor sampling_rate");
+    if (config.chunk_frames < 0 || config.lookahead_frames < 0) {
+        throw std::runtime_error("VibeVoice processor chunk_frames/lookahead_frames must be non-negative");
+    }
     if (config.language_model_pretrained_name.empty()) {
         throw std::runtime_error("VibeVoice processor language_model_pretrained_name must not be empty");
     }
@@ -253,12 +258,15 @@ void validate_weight_anchors(const VibeVoiceASRAssets & assets) {
 
 }  // namespace
 
-std::shared_ptr<const VibeVoiceASRAssets> load_vibevoice_asr_assets(const std::filesystem::path & model_path) {
+std::shared_ptr<const VibeVoiceASRAssets> load_vibevoice_asr_assets(
+    const std::filesystem::path & model_path,
+    const std::string & family) {
     auto resources = engine::model_spec::load_resource_bundle(
         model_path,
-        engine::model_spec::default_spec_path("vibevoice_asr"));
+        engine::model_spec::default_spec_path(family));
     VibeVoiceASRAssets assets;
     assets.resources = std::move(resources);
+    assets.family = family;
     assets.config = parse_config(assets.resources);
     assets.processor = parse_processor_config(assets.resources);
     assets.model_weights = assets.resources.open_tensor_source("model_weights");

--- a/src/models/vibevoice_asr/connector.cpp
+++ b/src/models/vibevoice_asr/connector.cpp
@@ -1,5 +1,6 @@
 #include "engine/models/vibevoice_asr/connector.h"
 
+#include "engine/framework/core/backend.h"
 #include "engine/framework/core/backend_weight_store.h"
 #include "engine/framework/debug/profiler.h"
 #include "engine/framework/modules/norm_modules.h"
@@ -123,7 +124,7 @@ public:
     }
 
     ~VibeVoiceConnectorGraph() {
-        engine::core::release_backend_graph_resources(runtime_->backend(), graph_);
+        engine::core::release_backend_graph_resources(runtime_->backend(), graph_, true);
         if (gallocr_ != nullptr) {
             ggml_gallocr_free(gallocr_);
         }
@@ -298,6 +299,12 @@ VibeVoiceConnectorWeightsRuntime::~VibeVoiceConnectorWeightsRuntime() {
     if (backend_ != nullptr) {
         ggml_backend_free(backend_);
     }
+}
+
+void VibeVoiceConnectorWeightsRuntime::release_cached_graphs() const {
+    semantic_graph_.reset();
+    acoustic_graph_.reset();
+    core::trim_backend_pools(backend_);
 }
 
 const VibeVoiceASRAssets & VibeVoiceConnectorWeightsRuntime::assets() const noexcept {

--- a/src/models/vibevoice_asr/loader.cpp
+++ b/src/models/vibevoice_asr/loader.cpp
@@ -9,11 +9,17 @@
 namespace engine::models::vibevoice_asr {
 namespace {
 
-runtime::CapabilitySet capabilities(const VibeVoiceASRAssets &) {
+runtime::CapabilitySet capabilities(const VibeVoiceASRAssets & assets) {
     runtime::CapabilitySet out;
-    out.supported_tasks = {
-        {runtime::VoiceTaskKind::Asr, {runtime::RunMode::Offline}},
-    };
+    if (assets.family == "vibevoice_asr_streaming") {
+        out.supported_tasks = {
+            {runtime::VoiceTaskKind::Asr, {runtime::RunMode::Offline, runtime::RunMode::Streaming}},
+        };
+    } else {
+        out.supported_tasks = {
+            {runtime::VoiceTaskKind::Asr, {runtime::RunMode::Offline}},
+        };
+    }
     out.languages = {"auto"};
     out.supports_timestamps = true;
     return out;
@@ -21,7 +27,7 @@ runtime::CapabilitySet capabilities(const VibeVoiceASRAssets &) {
 
 runtime::ModelMetadata metadata(const VibeVoiceASRAssets & assets) {
     runtime::ModelMetadata out;
-    out.family = "vibevoice_asr";
+    out.family = assets.family;
     out.variant = assets.config.model_type.empty() ? "vibevoice-asr" : assets.config.model_type;
     out.description = "VibeVoice-ASR loaded from local assets.";
     return out;
@@ -39,7 +45,7 @@ runtime::ModelCliInterface cli(const VibeVoiceASRAssets &) {
         {"repetition_penalty", "float", "Generation repetition penalty."},
         {"seed", "n", "Acoustic latent sampling seed."},
         {"audio_chunk_mode", "auto|fixed|vad|none", "Audio chunking mode; default auto uses fixed chunks."},
-        {"audio_chunk_seconds", "seconds", "Audio chunk duration; default 1200."},
+        {"audio_chunk_duration_sec", "seconds", "Audio chunk duration; default 1200."},
     };
     out.session_options = {
         {"vibevoice_asr.weight_type", "native|f32|f16|bf16|q8_0", "Tokenizer, connector, and decoder weight storage type."},
@@ -50,21 +56,34 @@ runtime::ModelCliInterface cli(const VibeVoiceASRAssets &) {
         {"vibevoice_asr.connector_weight_context_mb", "mb", "Acoustic and semantic connector weight context arena size."},
         {"vibevoice_asr.decoder_weight_context_mb", "mb", "Text decoder weight context arena size."},
         {"vibevoice_asr.vad_model_path", "path", "Silero VAD model path used by audio_chunk_mode=vad."},
+        {"vibevoice_asr_streaming.weight_type", "native|f32|f16|bf16|q8_0", "Tokenizer, connector, and decoder weight storage type."},
+        {"vibevoice_asr_streaming.tokenizer_weight_type", "native|f32|f16|bf16|q8_0", "Speech tokenizer weight storage type."},
+        {"vibevoice_asr_streaming.connector_weight_type", "native|f32|f16|bf16|q8_0", "Acoustic and semantic connector weight storage type."},
+        {"vibevoice_asr_streaming.decoder_weight_type", "native|f32|f16|bf16|q8_0", "Text decoder weight storage type."},
     };
     return out;
 }
 
 class VibeVoiceASRLoader final : public runtime::IVoiceModelLoader {
 public:
+    explicit VibeVoiceASRLoader(std::string family)
+        : family_(std::move(family)) {}
+
     std::string family() const override {
-        return "vibevoice_asr";
+        return family_;
     }
 
     runtime::CapabilitySet advertised_capabilities() const override {
         runtime::CapabilitySet out;
-        out.supported_tasks = {
-            {runtime::VoiceTaskKind::Asr, {runtime::RunMode::Offline}},
-        };
+        if (family_ == "vibevoice_asr_streaming") {
+            out.supported_tasks = {
+                {runtime::VoiceTaskKind::Asr, {runtime::RunMode::Offline, runtime::RunMode::Streaming}},
+            };
+        } else {
+            out.supported_tasks = {
+                {runtime::VoiceTaskKind::Asr, {runtime::RunMode::Offline}},
+            };
+        }
         out.supports_timestamps = true;
         return out;
     }
@@ -80,7 +99,7 @@ public:
     }
 
     runtime::ModelInspection inspect(const runtime::ModelLoadRequest & request) const override {
-        const auto assets = load_vibevoice_asr_assets(request.model_path);
+        const auto assets = load_vibevoice_asr_assets(request.model_path, family_);
         runtime::ModelInspection inspection;
         inspection.model_root = assets->resources.model_root();
         inspection.metadata = metadata(*assets);
@@ -99,8 +118,11 @@ public:
     }
 
     std::unique_ptr<runtime::ILoadedVoiceModel> load(const runtime::ModelLoadRequest & request) const override {
-        return load_vibevoice_asr_model(request.model_path);
+        return load_vibevoice_asr_model(request.model_path, family_);
     }
+
+private:
+    std::string family_;
 };
 
 }  // namespace
@@ -127,14 +149,16 @@ std::unique_ptr<runtime::IVoiceTaskSession> VibeVoiceASRLoadedModel::create_task
     if (task.task != runtime::VoiceTaskKind::Asr) {
         throw std::runtime_error("VibeVoice-ASR only supports the Asr task");
     }
-    if (task.mode != runtime::RunMode::Offline) {
+    if (metadata_.family != "vibevoice_asr_streaming" && task.mode != runtime::RunMode::Offline) {
         throw std::runtime_error("VibeVoice-ASR streaming sessions are not supported");
     }
     return std::make_unique<VibeVoiceASRSession>(task, options, assets_);
 }
 
-std::unique_ptr<VibeVoiceASRLoadedModel> load_vibevoice_asr_model(const std::filesystem::path & model_path) {
-    auto assets = load_vibevoice_asr_assets(model_path);
+std::unique_ptr<VibeVoiceASRLoadedModel> load_vibevoice_asr_model(
+    const std::filesystem::path & model_path,
+    const std::string & family) {
+    auto assets = load_vibevoice_asr_assets(model_path, family);
     return std::make_unique<VibeVoiceASRLoadedModel>(
         metadata(*assets),
         capabilities(*assets),
@@ -142,7 +166,11 @@ std::unique_ptr<VibeVoiceASRLoadedModel> load_vibevoice_asr_model(const std::fil
 }
 
 std::shared_ptr<runtime::IVoiceModelLoader> make_vibevoice_asr_loader() {
-    return std::make_shared<VibeVoiceASRLoader>();
+    return std::make_shared<VibeVoiceASRLoader>("vibevoice_asr");
+}
+
+std::shared_ptr<runtime::IVoiceModelLoader> make_vibevoice_asr_streaming_loader() {
+    return std::make_shared<VibeVoiceASRLoader>("vibevoice_asr_streaming");
 }
 
 }  // namespace engine::models::vibevoice_asr

--- a/src/models/vibevoice_asr/postprocess.cpp
+++ b/src/models/vibevoice_asr/postprocess.cpp
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <utility>
 
 namespace engine::models::vibevoice_asr {
@@ -74,6 +75,44 @@ double optional_f64_any_key(
     return std::stod(value);
 }
 
+bool speaker_label_at(const std::string & text, size_t pos, size_t * label_end, std::string * speaker_id) {
+    constexpr std::string_view prefix = "Speaker";
+    if (text.compare(pos, prefix.size(), prefix) != 0) {
+        return false;
+    }
+    pos += prefix.size();
+    while (pos < text.size() && std::isspace(static_cast<unsigned char>(text[pos])) != 0) {
+        ++pos;
+    }
+    const size_t id_start = pos;
+    while (pos < text.size() && std::isdigit(static_cast<unsigned char>(text[pos])) != 0) {
+        ++pos;
+    }
+    if (pos == id_start) {
+        return false;
+    }
+    while (pos < text.size() && std::isspace(static_cast<unsigned char>(text[pos])) != 0) {
+        ++pos;
+    }
+    if (pos >= text.size() || text[pos] != ':') {
+        return false;
+    }
+    *label_end = pos + 1;
+    *speaker_id = text.substr(id_start, pos - id_start);
+    return true;
+}
+
+size_t find_speaker_label(const std::string & text, size_t start, size_t * label_end, std::string * speaker_id) {
+    size_t pos = start;
+    while ((pos = text.find("Speaker", pos)) != std::string::npos) {
+        if (speaker_label_at(text, pos, label_end, speaker_id)) {
+            return pos;
+        }
+        ++pos;
+    }
+    return std::string::npos;
+}
+
 }  // namespace
 
 VibeVoiceASRPostprocessor::VibeVoiceASRPostprocessor(const VibeVoiceASRTextTokenizer & tokenizer)
@@ -116,6 +155,31 @@ VibeVoiceASRDecoded VibeVoiceASRPostprocessor::decode(const VibeVoiceASRGenerate
         out.text = trim(out.raw_text);
     }
     return out;
+}
+
+std::vector<VibeVoiceASRSegment> VibeVoiceASRPostprocessor::decode_speaker_attributed_text(
+    const std::string & text) const {
+    std::vector<VibeVoiceASRSegment> segments;
+    size_t label_end = 0;
+    std::string speaker_id;
+    size_t label_pos = find_speaker_label(text, 0, &label_end, &speaker_id);
+    while (label_pos != std::string::npos) {
+        size_t next_label_end = 0;
+        std::string next_speaker_id;
+        const size_t next_label_pos = find_speaker_label(text, label_end, &next_label_end, &next_speaker_id);
+        VibeVoiceASRSegment segment;
+        segment.speaker_id = std::move(speaker_id);
+        segment.text = trim(text.substr(
+            label_end,
+            next_label_pos == std::string::npos ? std::string::npos : next_label_pos - label_end));
+        if (!segment.text.empty()) {
+            segments.push_back(std::move(segment));
+        }
+        label_pos = next_label_pos;
+        label_end = next_label_end;
+        speaker_id = std::move(next_speaker_id);
+    }
+    return segments;
 }
 
 }  // namespace engine::models::vibevoice_asr

--- a/src/models/vibevoice_asr/session.cpp
+++ b/src/models/vibevoice_asr/session.cpp
@@ -33,6 +33,8 @@ constexpr size_t kDefaultTokenizerWeightContextBytes = 512ull * 1024ull * 1024ul
 constexpr size_t kDefaultConnectorWeightContextBytes = 128ull * 1024ull * 1024ull;
 constexpr size_t kDefaultDecoderWeightContextBytes = 4096ull * 1024ull * 1024ull;
 constexpr double kDefaultAudioChunkSeconds = 20.0 * 60.0;
+constexpr int64_t kDefaultStreamingMaxTokensPerChunk = 256;
+constexpr int64_t kStreamingDecoderInitialCacheSteps = 1024;
 
 std::shared_ptr<const VibeVoiceASRAssets> require_assets(std::shared_ptr<const VibeVoiceASRAssets> assets) {
     if (assets == nullptr) {
@@ -43,13 +45,15 @@ std::shared_ptr<const VibeVoiceASRAssets> require_assets(std::shared_ptr<const V
 
 assets::TensorStorageType option_weight_type(
     const runtime::SessionOptions & options,
-    const char * key,
+    std::initializer_list<const char *> keys,
     assets::TensorStorageType fallback) {
-    const auto it = options.options.find(key);
-    if (it == options.options.end()) {
-        return fallback;
+    for (const char * key : keys) {
+        const auto it = options.options.find(key);
+        if (it != options.options.end()) {
+            return assets::parse_tensor_storage_type(it->second);
+        }
     }
-    return assets::parse_tensor_storage_type(it->second);
+    return fallback;
 }
 
 void validate_weight_storage(assets::TensorStorageType storage_type, const char * option_name) {
@@ -75,6 +79,49 @@ int64_t audio_frame_count(const runtime::AudioBuffer & audio) {
         throw std::runtime_error("VibeVoice-ASR audio samples must be divisible by channel count");
     }
     return static_cast<int64_t>(audio.samples.size() / static_cast<size_t>(audio.channels));
+}
+
+bool is_streaming_family(const VibeVoiceASRAssets & assets) {
+    return assets.family == "vibevoice_asr_streaming";
+}
+
+int64_t streaming_decoder_cache_capacity(int64_t max_position_embeddings, int64_t required_steps) {
+    const int64_t requested = std::max<int64_t>(kStreamingDecoderInitialCacheSteps, required_steps);
+    return max_position_embeddings > 0 ? std::min<int64_t>(max_position_embeddings, requested) : requested;
+}
+
+bool is_allowed_session_option(const std::string & key) {
+    const std::vector<std::string> suffixes = {
+        ".weight_type",
+        ".tokenizer_weight_type",
+        ".connector_weight_type",
+        ".decoder_weight_type",
+        ".tokenizer_weight_context_mb",
+        ".connector_weight_context_mb",
+        ".decoder_weight_context_mb",
+        ".vad_model_path",
+    };
+    for (const char * prefix_value : {"vibevoice_asr", "vibevoice_asr_streaming"}) {
+        const std::string prefix(prefix_value);
+        if (key.rfind(prefix + ".", 0) != 0) {
+            continue;
+        }
+        const auto suffix = key.substr(prefix.size());
+        return std::find(suffixes.begin(), suffixes.end(), suffix) != suffixes.end();
+    }
+    return false;
+}
+
+runtime::AudioBuffer pad_audio_tail(runtime::AudioBuffer audio, int64_t target_frames) {
+    if (target_frames <= 0) {
+        throw std::runtime_error("VibeVoice-ASR streaming target chunk size must be positive");
+    }
+    const int64_t frames = audio_frame_count(audio);
+    if (frames >= target_frames) {
+        return audio;
+    }
+    audio.samples.resize(static_cast<size_t>(target_frames * audio.channels), 0.0F);
+    return audio;
 }
 
 size_t common_prefix_size(const std::string & lhs, const std::string & rhs) {
@@ -117,7 +164,11 @@ std::string append_streaming_transcript(
         return "";
     }
     std::string delta;
-    if (!total.text_output->text.empty()) {
+    const bool needs_separator =
+        !total.text_output->text.empty() &&
+        std::isspace(static_cast<unsigned char>(total.text_output->text.back())) == 0 &&
+        std::isspace(static_cast<unsigned char>(chunk.text.front())) == 0;
+    if (needs_separator) {
         total.text_output->text.push_back(' ');
         delta.push_back(' ');
     }
@@ -493,21 +544,21 @@ VibeVoiceASRSession::VibeVoiceASRSession(
     : RuntimeSessionBase(options),
       task_(task),
       assets_(require_assets(std::move(assets))),
-      tokenizer_weight_context_bytes_(runtime::parse_size_mb_option(options.options, {"vibevoice_asr.tokenizer_weight_context_mb"}, kDefaultTokenizerWeightContextBytes)),
-      connector_weight_context_bytes_(runtime::parse_size_mb_option(options.options, {"vibevoice_asr.connector_weight_context_mb"}, kDefaultConnectorWeightContextBytes)),
-      decoder_weight_context_bytes_(runtime::parse_size_mb_option(options.options, {"vibevoice_asr.decoder_weight_context_mb"}, kDefaultDecoderWeightContextBytes)),
+      tokenizer_weight_context_bytes_(runtime::parse_size_mb_option(options.options, {"vibevoice_asr_streaming.tokenizer_weight_context_mb", "vibevoice_asr.tokenizer_weight_context_mb"}, kDefaultTokenizerWeightContextBytes)),
+      connector_weight_context_bytes_(runtime::parse_size_mb_option(options.options, {"vibevoice_asr_streaming.connector_weight_context_mb", "vibevoice_asr.connector_weight_context_mb"}, kDefaultConnectorWeightContextBytes)),
+      decoder_weight_context_bytes_(runtime::parse_size_mb_option(options.options, {"vibevoice_asr_streaming.decoder_weight_context_mb", "vibevoice_asr.decoder_weight_context_mb"}, kDefaultDecoderWeightContextBytes)),
       tokenizer_weight_storage_type_(option_weight_type(
           options,
-          "vibevoice_asr.tokenizer_weight_type",
-          option_weight_type(options, "vibevoice_asr.weight_type", assets::TensorStorageType::Native))),
+          {"vibevoice_asr_streaming.tokenizer_weight_type", "vibevoice_asr.tokenizer_weight_type"},
+          option_weight_type(options, {"vibevoice_asr_streaming.weight_type", "vibevoice_asr.weight_type"}, assets::TensorStorageType::Native))),
       connector_weight_storage_type_(option_weight_type(
           options,
-          "vibevoice_asr.connector_weight_type",
-          option_weight_type(options, "vibevoice_asr.weight_type", assets::TensorStorageType::Native))),
+          {"vibevoice_asr_streaming.connector_weight_type", "vibevoice_asr.connector_weight_type"},
+          option_weight_type(options, {"vibevoice_asr_streaming.weight_type", "vibevoice_asr.weight_type"}, assets::TensorStorageType::Native))),
       decoder_weight_storage_type_(option_weight_type(
           options,
-          "vibevoice_asr.decoder_weight_type",
-          option_weight_type(options, "vibevoice_asr.weight_type", assets::TensorStorageType::Native))),
+          {"vibevoice_asr_streaming.decoder_weight_type", "vibevoice_asr.decoder_weight_type"},
+          option_weight_type(options, {"vibevoice_asr_streaming.weight_type", "vibevoice_asr.weight_type"}, assets::TensorStorageType::Native))),
       greedy_compare_bf16_(
           decoder_weight_storage_type_ == assets::TensorStorageType::Native && options.backend.type == core::BackendType::Cuda),
       sampling_policy_(
@@ -539,24 +590,23 @@ VibeVoiceASRSession::VibeVoiceASRSession(
           128ull * 1024ull * 1024ull,
           decoder_weight_storage_type_),
       postprocessor_(tokenizer_),
-      vad_model_path_(runtime::find_option(options.options, {"vibevoice_asr.vad_model_path"}).value_or(default_vad_model_path().string())) {
-    if (task_.task != runtime::VoiceTaskKind::Asr || task_.mode != runtime::RunMode::Offline) {
+      vad_model_path_(runtime::find_option(options.options, {"vibevoice_asr_streaming.vad_model_path", "vibevoice_asr.vad_model_path"}).value_or(default_vad_model_path().string())) {
+    if (task_.task != runtime::VoiceTaskKind::Asr) {
+        throw std::runtime_error("VibeVoice-ASR only supports the Asr task");
+    }
+    if (!is_streaming_family(*assets_) && task_.mode != runtime::RunMode::Offline) {
         throw std::runtime_error("VibeVoice-ASR streaming sessions are not supported");
+    }
+    if (is_streaming_family(*assets_) && task_.mode != runtime::RunMode::Offline && task_.mode != runtime::RunMode::Streaming) {
+        throw std::runtime_error("VibeVoice-ASR streaming model supports offline and streaming ASR only");
     }
     validate_weight_storage(tokenizer_weight_storage_type_, "vibevoice_asr.tokenizer_weight_type");
     validate_weight_storage(connector_weight_storage_type_, "vibevoice_asr.connector_weight_type");
     validate_weight_storage(decoder_weight_storage_type_, "vibevoice_asr.decoder_weight_type");
     for (const auto & [key, value] : options.options) {
         (void)value;
-        if (key.rfind("vibevoice_asr.", 0) == 0 &&
-            key != "vibevoice_asr.weight_type" &&
-            key != "vibevoice_asr.tokenizer_weight_type" &&
-            key != "vibevoice_asr.connector_weight_type" &&
-            key != "vibevoice_asr.decoder_weight_type" &&
-            key != "vibevoice_asr.tokenizer_weight_context_mb" &&
-            key != "vibevoice_asr.connector_weight_context_mb" &&
-            key != "vibevoice_asr.decoder_weight_context_mb" &&
-            key != "vibevoice_asr.vad_model_path") {
+        if (!is_allowed_session_option(key) &&
+            (key.rfind("vibevoice_asr.", 0) == 0 || key.rfind("vibevoice_asr_streaming.", 0) == 0)) {
             throw std::runtime_error("unknown VibeVoice-ASR session option: " + key);
         }
     }
@@ -566,7 +616,7 @@ VibeVoiceASRSession::VibeVoiceASRSession(
 VibeVoiceASRSession::~VibeVoiceASRSession() = default;
 
 std::string VibeVoiceASRSession::family() const {
-    return "vibevoice_asr";
+    return assets_->family;
 }
 
 runtime::VoiceTaskKind VibeVoiceASRSession::task_kind() const {
@@ -589,6 +639,9 @@ runtime::TaskResult VibeVoiceASRSession::run(const runtime::TaskRequest & reques
     require_prepared("VibeVoice-ASR run()");
     if (task_.mode != runtime::RunMode::Offline) {
         throw std::runtime_error("VibeVoice-ASR offline run called on non-offline session");
+    }
+    if (is_streaming_family(*assets_)) {
+        return run_streaming_model(make_request(request));
     }
     const auto chunks = audio_chunk_plan(request);
     if (chunks.empty()) {
@@ -654,7 +707,7 @@ runtime::StreamingPolicy VibeVoiceASRSession::streaming_policy() const {
     runtime::StreamingPolicy policy;
     policy.input = runtime::StreamingInputKind::AudioChunks;
     policy.output = runtime::StreamingOutputKind::FinalResult;
-    policy.preferred_audio_chunk_samples = assets_->processor.audio_processor.sample_rate;
+    policy.preferred_audio_chunk_seconds = 0.25;
     return policy;
 }
 
@@ -667,8 +720,14 @@ void VibeVoiceASRSession::start_stream(const runtime::TaskRequest & request) {
     streaming_request_ = request;
     streaming_request_.audio_input = std::nullopt;
     streaming_result_ = runtime::TaskResult{};
+    streaming_decoder_state_.reset();
+    streaming_audio_buffer_ = runtime::AudioBuffer{};
     stream_started_ = true;
     streaming_chunks_processed_ = 0;
+    streaming_decoder_steps_ = 0;
+    streaming_history_steps_ = 0;
+    streaming_buffer_start_sample_ = 0;
+    streaming_rng_offset_ = 0;
 }
 
 void VibeVoiceASRSession::set_stream_event_sink(runtime::StreamEventCallback sink) {
@@ -682,8 +741,14 @@ void VibeVoiceASRSession::reset() {
     }
     streaming_request_ = runtime::TaskRequest{};
     streaming_result_ = runtime::TaskResult{};
+    streaming_decoder_state_.reset();
+    streaming_audio_buffer_ = runtime::AudioBuffer{};
     stream_started_ = false;
     streaming_chunks_processed_ = 0;
+    streaming_decoder_steps_ = 0;
+    streaming_history_steps_ = 0;
+    streaming_buffer_start_sample_ = 0;
+    streaming_rng_offset_ = 0;
 }
 
 runtime::StreamEvent VibeVoiceASRSession::process_audio_chunk(const runtime::AudioChunk & chunk) {
@@ -698,6 +763,43 @@ runtime::StreamEvent VibeVoiceASRSession::process_audio_chunk(const runtime::Aud
     audio.sample_rate = chunk.sample_rate;
     audio.channels = chunk.channels;
     audio.samples = chunk.samples;
+
+    if (is_streaming_family(*assets_)) {
+        auto request = streaming_request_;
+        request.audio_input = audio;
+        auto asr_request = make_request(request);
+        const auto normalized = frontend_.normalize(asr_request.audio);
+        if (streaming_audio_buffer_.samples.empty()) {
+            streaming_audio_buffer_.sample_rate = normalized.sample_rate;
+            streaming_audio_buffer_.channels = normalized.channels;
+            streaming_buffer_start_sample_ = chunk.start_sample;
+        } else if (
+            streaming_audio_buffer_.sample_rate != normalized.sample_rate ||
+            streaming_audio_buffer_.channels != normalized.channels) {
+            throw std::runtime_error("VibeVoice-ASR streaming audio format changed between chunks");
+        }
+        streaming_audio_buffer_.samples.insert(
+            streaming_audio_buffer_.samples.end(),
+            normalized.samples.begin(),
+            normalized.samples.end());
+        const int64_t base_samples = assets_->processor.chunk_frames * assets_->processor.speech_tok_compress_ratio;
+        const int64_t lookahead_samples = assets_->processor.lookahead_frames * assets_->processor.speech_tok_compress_ratio;
+        const int64_t target_samples = base_samples + lookahead_samples;
+        if (audio_frame_count(streaming_audio_buffer_) < target_samples) {
+            runtime::StreamEvent event;
+            event.is_final = false;
+            return event;
+        }
+        auto source = engine::audio::slice_audio_buffer(
+            streaming_audio_buffer_,
+            runtime::TimeSpan{0, target_samples});
+        auto event = process_streaming_model_normalized_chunk(asr_request, source, streaming_buffer_start_sample_);
+        streaming_audio_buffer_ = engine::audio::slice_audio_buffer(
+            streaming_audio_buffer_,
+            runtime::TimeSpan{base_samples, audio_frame_count(streaming_audio_buffer_)});
+        streaming_buffer_start_sample_ += base_samples;
+        return event;
+    }
 
     auto request = streaming_request_;
     request.audio_input = std::move(audio);
@@ -753,12 +855,29 @@ runtime::TaskResult VibeVoiceASRSession::finalize() {
     if (!stream_started_) {
         throw std::runtime_error("VibeVoice-ASR finalize requires start_stream");
     }
+    if (is_streaming_family(*assets_) && !streaming_audio_buffer_.samples.empty()) {
+        auto request = streaming_request_;
+        request.audio_input = streaming_audio_buffer_;
+        auto asr_request = make_request(request);
+        asr_request.audio = streaming_audio_buffer_;
+        const int64_t target_samples =
+            (assets_->processor.chunk_frames + assets_->processor.lookahead_frames) *
+            assets_->processor.speech_tok_compress_ratio;
+        auto tail = pad_audio_tail(streaming_audio_buffer_, target_samples);
+        auto event = process_streaming_model_normalized_chunk(asr_request, tail, streaming_buffer_start_sample_);
+        if (stream_event_sink_ != nullptr && event.partial_text.has_value()) {
+            stream_event_sink_(event);
+        }
+        streaming_audio_buffer_ = runtime::AudioBuffer{};
+    }
     if (streaming_chunks_processed_ == 0) {
         throw std::runtime_error("VibeVoice-ASR finalize requires streamed audio");
     }
     if (!streaming_result_.text_output.has_value()) {
         streaming_result_.text_output = runtime::Transcript{};
     }
+    streaming_decoder_state_.reset();
+    streaming_audio_buffer_ = runtime::AudioBuffer{};
     return streaming_result_;
 }
 
@@ -768,10 +887,13 @@ VibeVoiceASRRequest VibeVoiceASRSession::make_request(const runtime::TaskRequest
     }
     VibeVoiceASRRequest out;
     out.audio = *request.audio_input;
-    out.generation.max_new_tokens = 32768;
+    out.generation.max_new_tokens = is_streaming_family(*assets_) ? kDefaultStreamingMaxTokensPerChunk : 32768;
     if (request.text_input.has_value()) {
         out.context = request.text_input->text;
         out.language = request.text_input->language;
+    }
+    if (const auto context = runtime::find_option(request.options, {"context", "context_info"})) {
+        out.context = *context;
     }
     if (const auto language = runtime::find_option(request.options, {"language"})) {
         out.language = *language;
@@ -837,7 +959,7 @@ std::vector<VibeVoiceASRSession::AudioChunkPlan> VibeVoiceASRSession::audio_chun
         const auto seconds = engine::audio::parse_audio_chunk_seconds_override(request.options)
             .value_or(static_cast<float>(kDefaultAudioChunkSeconds));
         if (!(seconds > 0.0F)) {
-            throw std::runtime_error("VibeVoice-ASR audio_chunk_seconds must be positive");
+            throw std::runtime_error("VibeVoice-ASR audio_chunk_duration_sec must be positive");
         }
         const auto options = engine::audio::VadAudioChunkOptions{
             static_cast<int64_t>(std::llround(static_cast<double>(seconds) * static_cast<double>(audio.sample_rate))),
@@ -845,7 +967,7 @@ std::vector<VibeVoiceASRSession::AudioChunkPlan> VibeVoiceASRSession::audio_chun
             static_cast<int64_t>(std::llround(0.25 * static_cast<double>(audio.sample_rate))),
         };
         if (options.max_chunk_samples <= 0) {
-            throw std::runtime_error("VibeVoice-ASR audio_chunk_seconds produced an empty chunk");
+            throw std::runtime_error("VibeVoice-ASR audio_chunk_duration_sec produced an empty chunk");
         }
         const auto spans = engine::audio::plan_vad_audio_chunks(audio, vad_session(), options);
         std::vector<AudioChunkPlan> plan;
@@ -859,12 +981,12 @@ std::vector<VibeVoiceASRSession::AudioChunkPlan> VibeVoiceASRSession::audio_chun
     const auto seconds = engine::audio::parse_audio_chunk_seconds_override(request.options)
         .value_or(static_cast<float>(kDefaultAudioChunkSeconds));
     if (!(seconds > 0.0F)) {
-        throw std::runtime_error("VibeVoice-ASR audio_chunk_seconds must be positive");
+        throw std::runtime_error("VibeVoice-ASR audio_chunk_duration_sec must be positive");
     }
     const int64_t samples = static_cast<int64_t>(
         std::llround(static_cast<double>(seconds) * static_cast<double>(audio.sample_rate)));
     if (samples <= 0) {
-        throw std::runtime_error("VibeVoice-ASR audio_chunk_seconds produced an empty chunk");
+        throw std::runtime_error("VibeVoice-ASR audio_chunk_duration_sec produced an empty chunk");
     }
     const auto chunks = engine::audio::plan_audio_chunks(
         frames,
@@ -903,6 +1025,230 @@ runtime::IOfflineVoiceTaskSession & VibeVoiceASRSession::vad_session() {
         session.release();
     }
     return *vad_session_;
+}
+
+std::vector<VibeVoiceASRSession::AudioChunkPlan> VibeVoiceASRSession::streaming_audio_chunk_plan(
+    const runtime::AudioBuffer & audio) const {
+    const int64_t frames = audio_frame_count(audio);
+    if (assets_->processor.chunk_frames <= 0 || assets_->processor.lookahead_frames < 0) {
+        throw std::runtime_error("VibeVoice-ASR streaming checkpoint requires chunk_frames and lookahead_frames");
+    }
+    const int64_t base_samples = assets_->processor.chunk_frames * assets_->processor.speech_tok_compress_ratio;
+    const int64_t lookahead_samples = assets_->processor.lookahead_frames * assets_->processor.speech_tok_compress_ratio;
+    if (base_samples <= 0) {
+        throw std::runtime_error("VibeVoice-ASR streaming chunk size is invalid");
+    }
+    std::vector<AudioChunkPlan> plan;
+    for (int64_t start = 0; start < frames; start += base_samples) {
+        const int64_t keep_end = std::min(frames, start + base_samples);
+        const int64_t source_end = std::min(frames, start + base_samples + lookahead_samples);
+        plan.push_back(AudioChunkPlan{{start, source_end}, {start, keep_end}});
+    }
+    return plan;
+}
+
+VibeVoiceASRSpeechFeatures VibeVoiceASRSession::encode_streaming_chunk(
+    const runtime::AudioBuffer & audio,
+    const VibeVoiceASRRequest & request) {
+    const uint64_t rng_offset = streaming_rng_offset_;
+    auto speech = speech_encoder_.encode(audio, request.generation.seed, rng_offset);
+    streaming_rng_offset_ += speech.next_rng_index;
+    return speech;
+}
+
+VibeVoiceDecoderResult VibeVoiceASRSession::append_stream_embedding(
+    const std::vector<float> & embedding,
+    VibeVoiceDecoderCachedState & state,
+    int64_t & steps) {
+    const int64_t cache_capacity = streaming_decoder_cache_capacity(
+        assets_->config.decoder.max_position_embeddings,
+        steps + 1);
+    const auto result = text_decoder_.cached_step(embedding, state, cache_capacity);
+    ++steps;
+    return result;
+}
+
+VibeVoiceDecoderResult VibeVoiceASRSession::append_stream_suffix(
+    const std::vector<float> & embeddings,
+    int64_t steps_to_append,
+    VibeVoiceDecoderCachedState & state,
+    int64_t & steps) {
+    if (steps_to_append <= 0) {
+        throw std::runtime_error("VibeVoice-ASR streaming suffix requires positive steps");
+    }
+    const int64_t cache_capacity = streaming_decoder_cache_capacity(
+        assets_->config.decoder.max_position_embeddings,
+        steps + steps_to_append);
+    const auto result = text_decoder_.cached_suffix(embeddings, steps_to_append, state, cache_capacity);
+    steps += steps_to_append;
+    return result;
+}
+
+void VibeVoiceASRSession::ensure_streaming_decoder_state(const VibeVoiceASRRequest & request) {
+    if (streaming_decoder_state_ != nullptr) {
+        return;
+    }
+    if (tokenizer_.text_chunk_end_id() < 0) {
+        throw std::runtime_error("VibeVoice-ASR streaming checkpoint requires <|text_chunk_end|>");
+    }
+    const auto prompt_ids = tokenizer_.build_streaming_prompt(request.context);
+    const auto prompt_embeddings = text_decoder_.embed_tokens(prompt_ids);
+    streaming_history_steps_ = prompt_embeddings.steps;
+    auto prefill = text_decoder_.prefill_embeddings(prompt_embeddings.values, streaming_history_steps_);
+    streaming_decoder_state_ = std::make_unique<VibeVoiceDecoderCachedState>();
+    text_decoder_.reset_cached_state(*streaming_decoder_state_, std::move(prefill.state));
+    text_decoder_.prepare_cached_state(
+        *streaming_decoder_state_,
+        streaming_decoder_cache_capacity(assets_->config.decoder.max_position_embeddings, streaming_history_steps_ + 1));
+    streaming_decoder_steps_ = streaming_history_steps_;
+}
+
+std::string VibeVoiceASRSession::generate_streaming_text_chunk(
+    const VibeVoiceASRRequest & request,
+    VibeVoiceDecoderResult next_logits,
+    VibeVoiceDecoderCachedState & state,
+    int64_t & steps) {
+    std::vector<int32_t> generated;
+    generated.reserve(static_cast<size_t>(std::min<int64_t>(request.generation.max_new_tokens, 256)));
+    std::vector<uint8_t> seen;
+    std::mt19937 rng(static_cast<uint32_t>(request.generation.seed));
+    auto logits = std::move(next_logits.logits.values);
+    for (int64_t step = 0; step < request.generation.max_new_tokens; ++step) {
+        apply_repetition_penalty(
+            logits,
+            {},
+            generated,
+            request.generation.repetition_penalty,
+            seen);
+        const int32_t next = request.generation.temperature > 0.0F
+            ? sample_token(
+                  logits,
+                  request.generation.temperature,
+                  request.generation.top_p,
+                  request.generation.top_k,
+                  request.generation.seed,
+                  static_cast<uint64_t>(step),
+                  sampling_policy_,
+                  rng,
+                  greedy_compare_bf16_)
+            : argmax_token(logits, false);
+        if (next == tokenizer_.text_chunk_end_id() || next == tokenizer_.eos_id()) {
+            break;
+        }
+        generated.push_back(next);
+        const auto embedding = text_decoder_.embed_tokens({next});
+        logits = append_stream_embedding(embedding.values, state, steps).logits.values;
+        ++streaming_history_steps_;
+    }
+    const auto tce_embedding = text_decoder_.embed_tokens({tokenizer_.text_chunk_end_id()});
+    append_stream_embedding(tce_embedding.values, state, steps);
+    ++streaming_history_steps_;
+    static const std::vector<std::string> special_tokens = {
+        "<|text_chunk_end|>",
+        "<|object_ref_start|>",
+        "<|object_ref_end|>",
+        "<|box_start|>",
+        "<|speech_start|>",
+        "<|speech_end|>",
+        "<|speech_pad|>",
+    };
+    std::string text = tokenizer_.decode(generated, true);
+    for (const auto & token : special_tokens) {
+        size_t pos = 0;
+        while ((pos = text.find(token, pos)) != std::string::npos) {
+            text.erase(pos, token.size());
+        }
+    }
+    return text;
+}
+
+runtime::StreamEvent VibeVoiceASRSession::process_streaming_model_normalized_chunk(
+    const VibeVoiceASRRequest & asr_request,
+    const runtime::AudioBuffer & normalized,
+    int64_t start_sample) {
+    ensure_streaming_decoder_state(asr_request);
+    const auto speech = encode_streaming_chunk(normalized, asr_request);
+    const auto & config = assets_->config.decoder;
+    const auto start_embedding = text_decoder_.embed_tokens({tokenizer_.speech_start_id()});
+    const auto end_embedding = text_decoder_.embed_tokens({tokenizer_.speech_end_id()});
+    const int64_t suffix_steps = speech.frames + 2;
+    std::vector<float> suffix(static_cast<size_t>(suffix_steps * config.hidden_size));
+    auto suffix_it = suffix.begin();
+    suffix_it = std::copy(start_embedding.values.begin(), start_embedding.values.end(), suffix_it);
+    for (int64_t frame = 0; frame < speech.frames; ++frame) {
+        const auto begin = speech.values.begin() + frame * config.hidden_size;
+        suffix_it = std::copy(begin, begin + config.hidden_size, suffix_it);
+    }
+    std::copy(end_embedding.values.begin(), end_embedding.values.end(), suffix_it);
+    auto next = append_stream_suffix(
+        suffix,
+        suffix_steps,
+        *streaming_decoder_state_,
+        streaming_decoder_steps_);
+    streaming_history_steps_ += suffix_steps;
+    const std::string text = generate_streaming_text_chunk(
+        asr_request,
+        std::move(next),
+        *streaming_decoder_state_,
+        streaming_decoder_steps_);
+    ++streaming_chunks_processed_;
+
+    runtime::StreamEvent event;
+    const std::string delta = append_streaming_transcript(
+        streaming_result_,
+        runtime::Transcript{text, asr_request.language});
+    if (!delta.empty()) {
+        event.partial_text = runtime::Transcript{delta, asr_request.language};
+    }
+    const int64_t frames = audio_frame_count(normalized);
+    const runtime::TimeSpan streamed_span{start_sample, start_sample + frames};
+    runtime::TaskResult item;
+    item.text_output = runtime::Transcript{text, asr_request.language};
+    engine::audio::append_chunk_speech_metadata(
+        streaming_result_,
+        item,
+        streamed_span,
+        streamed_span,
+        normalized.sample_rate,
+        assets_->processor.audio_processor.sample_rate);
+    event.is_final = false;
+    return event;
+}
+
+runtime::TaskResult VibeVoiceASRSession::run_streaming_model(const VibeVoiceASRRequest & request) {
+    const auto wall_start = Clock::now();
+    const auto frontend_start = Clock::now();
+    const auto audio = frontend_.normalize(request.audio);
+    const auto chunks = streaming_audio_chunk_plan(audio);
+    const int64_t target_samples =
+        (assets_->processor.chunk_frames + assets_->processor.lookahead_frames) *
+        assets_->processor.speech_tok_compress_ratio;
+    streaming_decoder_state_.reset();
+    streaming_audio_buffer_ = runtime::AudioBuffer{};
+    streaming_result_ = runtime::TaskResult{};
+    streaming_decoder_steps_ = 0;
+    streaming_history_steps_ = 0;
+    streaming_buffer_start_sample_ = 0;
+    streaming_rng_offset_ = 0;
+    const auto frontend_end = Clock::now();
+
+    const auto decoder_start = Clock::now();
+    for (const auto & chunk : chunks) {
+        auto chunk_audio = engine::audio::slice_audio_buffer(audio, chunk.source_span);
+        chunk_audio = pad_audio_tail(std::move(chunk_audio), target_samples);
+        auto item_request = request;
+        item_request.audio = chunk_audio;
+        process_streaming_model_normalized_chunk(item_request, chunk_audio, chunk.keep_span.start_sample);
+    }
+    const auto decoder_end = Clock::now();
+    auto result = streaming_result_;
+    streaming_decoder_state_.reset();
+    streaming_audio_buffer_ = runtime::AudioBuffer{};
+    debug::timing_log_scalar("vibevoice_asr_streaming.frontend_ms", engine::debug::elapsed_ms(frontend_start, frontend_end));
+    debug::timing_log_scalar("vibevoice_asr_streaming.decode_ms", engine::debug::elapsed_ms(decoder_start, decoder_end));
+    debug::timing_log_scalar("session.wall_ms", engine::debug::elapsed_ms(wall_start, Clock::now()));
+    debug::trace_log_scalar("vibevoice_asr_streaming.chunks", chunks.size());
+    return result;
 }
 
 runtime::TaskResult VibeVoiceASRSession::run_single(const VibeVoiceASRRequest & request) {

--- a/src/models/vibevoice_asr/session.cpp
+++ b/src/models/vibevoice_asr/session.cpp
@@ -1242,6 +1242,14 @@ runtime::TaskResult VibeVoiceASRSession::run_streaming_model(const VibeVoiceASRR
     }
     const auto decoder_end = Clock::now();
     auto result = streaming_result_;
+    if (result.text_output.has_value()) {
+        for (const auto & segment : postprocessor_.decode_speaker_attributed_text(result.text_output->text)) {
+            runtime::SpeakerTurn turn;
+            turn.speaker_id = segment.speaker_id;
+            turn.text = segment.text;
+            result.speaker_turns.push_back(std::move(turn));
+        }
+    }
     streaming_decoder_state_.reset();
     streaming_audio_buffer_ = runtime::AudioBuffer{};
     debug::timing_log_scalar("vibevoice_asr_streaming.frontend_ms", engine::debug::elapsed_ms(frontend_start, frontend_end));

--- a/src/models/vibevoice_asr/speech_encoder.cpp
+++ b/src/models/vibevoice_asr/speech_encoder.cpp
@@ -91,7 +91,6 @@ VibeVoiceASRSpeechFeatures VibeVoiceASRSpeechEncoder::encode(
     VibeVoiceTokenizerLatents semantic_tokens;
     if (total_frames > segment_samples) {
         VibeVoiceTokenizerStreamingState acoustic_state;
-        VibeVoiceTokenizerStreamingState semantic_state;
         for (int64_t start = 0; start < total_frames; start += segment_samples) {
             runtime::TimeSpan span;
             span.start_sample = start;
@@ -99,11 +98,23 @@ VibeVoiceASRSpeechFeatures VibeVoiceASRSpeechEncoder::encode(
             const auto chunk = audio::slice_audio_buffer(audio, span);
             const bool is_final_chunk = span.end_sample == total_frames;
             append_latents(acoustic_mean, tokenizer_.encode_acoustic_streaming(chunk, acoustic_state, is_final_chunk));
+        }
+        tokenizer_.release_cached_graphs();
+        VibeVoiceTokenizerStreamingState semantic_state;
+        for (int64_t start = 0; start < total_frames; start += segment_samples) {
+            runtime::TimeSpan span;
+            span.start_sample = start;
+            span.end_sample = std::min(total_frames, start + segment_samples);
+            const auto chunk = audio::slice_audio_buffer(audio, span);
+            const bool is_final_chunk = span.end_sample == total_frames;
             append_latents(semantic_tokens, tokenizer_.encode_semantic_streaming(chunk, semantic_state, is_final_chunk));
         }
+        tokenizer_.release_cached_graphs();
     } else {
         acoustic_mean = tokenizer_.encode_acoustic(audio);
+        tokenizer_.release_cached_graphs();
         semantic_tokens = tokenizer_.encode_semantic(audio);
+        tokenizer_.release_cached_graphs();
     }
     if (acoustic_mean.frames != semantic_tokens.frames) {
         const int64_t frames = std::min(acoustic_mean.frames, semantic_tokens.frames);
@@ -123,10 +134,12 @@ VibeVoiceASRSpeechFeatures VibeVoiceASRSpeechEncoder::encode(
         sampled.latents.front().values,
         sampled.latents.front().frames,
         sampled.latents.front().dim);
+    connector_.release_cached_graphs();
     const auto semantic = connector_.project_semantic(
         semantic_tokens.values,
         semantic_tokens.frames,
         semantic_tokens.dim);
+    connector_.release_cached_graphs();
     if (acoustic.frames != semantic.frames || acoustic.hidden_size != semantic.hidden_size) {
         throw std::runtime_error("VibeVoice-ASR acoustic and semantic connector shapes mismatch");
     }

--- a/src/models/vibevoice_asr/speech_encoder.cpp
+++ b/src/models/vibevoice_asr/speech_encoder.cpp
@@ -83,7 +83,8 @@ VibeVoiceASRSpeechEncoder::VibeVoiceASRSpeechEncoder(
 
 VibeVoiceASRSpeechFeatures VibeVoiceASRSpeechEncoder::encode(
     const runtime::AudioBuffer & audio,
-    uint64_t seed) const {
+    uint64_t seed,
+    uint64_t rng_offset) const {
     const int64_t total_frames = audio_frame_count(audio);
     const int64_t segment_samples = static_cast<int64_t>(audio.sample_rate) * kStreamingSegmentSeconds;
     VibeVoiceTokenizerLatents acoustic_mean;
@@ -115,7 +116,7 @@ VibeVoiceASRSpeechFeatures VibeVoiceASRSpeechEncoder::encode(
         {acoustic_mean},
         assets_->config.acoustic_tokenizer.fix_std,
         seed,
-        0,
+        rng_offset,
         sampling::TorchRandnPrecision::BFloat16,
         sampling_policy_ ? &*sampling_policy_ : nullptr);
     const auto acoustic = connector_.project_acoustic(

--- a/src/models/vibevoice_asr/speech_tokenizer.cpp
+++ b/src/models/vibevoice_asr/speech_tokenizer.cpp
@@ -2,6 +2,7 @@
 
 #include "engine/framework/audio/conversion.h"
 #include "engine/framework/audio/resampling.h"
+#include "engine/framework/core/backend.h"
 #include "engine/framework/core/backend_weight_store.h"
 #include "engine/framework/debug/profiler.h"
 #include "engine/framework/modules/activation_modules.h"
@@ -935,7 +936,7 @@ public:
     }
 
     ~VibeVoiceTokenizerEncoderGraph() {
-        engine::core::release_backend_graph_resources(backend_, graph_);
+        engine::core::release_backend_graph_resources(backend_, graph_, true);
         if (gallocr_ != nullptr) {
             ggml_gallocr_free(gallocr_);
         }
@@ -1066,7 +1067,7 @@ public:
     }
 
     ~VibeVoiceTokenizerDecoderGraph() {
-        engine::core::release_backend_graph_resources(backend_, graph_);
+        engine::core::release_backend_graph_resources(backend_, graph_, true);
         if (gallocr_ != nullptr) {
             ggml_gallocr_free(gallocr_);
         }
@@ -1229,7 +1230,7 @@ public:
     }
 
     ~VibeVoiceTokenizerStreamingGraph() {
-        engine::core::release_backend_graph_resources(backend_, graph_);
+        engine::core::release_backend_graph_resources(backend_, graph_, true);
         if (gallocr_ != nullptr) {
             ggml_gallocr_free(gallocr_);
         }
@@ -1776,6 +1777,15 @@ VibeVoiceTokenizerWeightsRuntime::~VibeVoiceTokenizerWeightsRuntime() {
     if (backend_ != nullptr) {
         ggml_backend_free(backend_);
     }
+}
+
+void VibeVoiceTokenizerWeightsRuntime::release_cached_graphs() const {
+    acoustic_streaming_graph_.reset();
+    semantic_streaming_graph_.reset();
+    acoustic_decoder_graph_.reset();
+    semantic_encoder_graph_.reset();
+    acoustic_encoder_graph_.reset();
+    core::trim_backend_pools(backend_);
 }
 
 void VibeVoiceTokenizerStreamingState::reset() {

--- a/src/models/vibevoice_asr/text_decoder.cpp
+++ b/src/models/vibevoice_asr/text_decoder.cpp
@@ -33,8 +33,8 @@ namespace {
 
 namespace binding = modules::binding;
 
-constexpr int64_t kScratchTailCachedAttentionMinSteps = 32768;
-constexpr int64_t kLargeCacheGrowthStep = 2048;
+constexpr int64_t kCacheInitialGraphSteps = 1024;
+constexpr int64_t kCacheGraphGrowthStep = 512;
 
 struct GgmlContextDeleter {
     void operator()(ggml_context * ctx) const noexcept {
@@ -178,47 +178,13 @@ int64_t cache_graph_capacity(int64_t required_capacity, int64_t model_capacity) 
     if (model_capacity > 0 && required_capacity > model_capacity) {
         throw std::runtime_error("VibeVoice decoder cache requirement exceeds model position capacity");
     }
-    int64_t capacity = required_capacity;
-    if (required_capacity < kScratchTailCachedAttentionMinSteps) {
-        capacity = 1;
-        while (capacity < required_capacity) {
-            if (capacity > std::numeric_limits<int64_t>::max() / 2) {
-                throw std::runtime_error("VibeVoice decoder cache capacity overflow");
-            }
-            capacity *= 2;
-        }
-    } else {
-        capacity = ((required_capacity + kLargeCacheGrowthStep - 1) / kLargeCacheGrowthStep) *
-            kLargeCacheGrowthStep;
+    const int64_t requested = std::max<int64_t>(required_capacity, kCacheInitialGraphSteps);
+    if (requested > std::numeric_limits<int64_t>::max() - (kCacheGraphGrowthStep - 1)) {
+        throw std::runtime_error("VibeVoice decoder cache capacity overflow");
     }
+    int64_t capacity = ((requested + kCacheGraphGrowthStep - 1) / kCacheGraphGrowthStep) *
+        kCacheGraphGrowthStep;
     return model_capacity > 0 ? std::min(capacity, model_capacity) : capacity;
-}
-
-void copy_vibevoice_decoder_cache_backend(
-    runtime::TransformerKVCache & target,
-    const runtime::TransformerKVCache & source,
-    size_t layers) {
-    if (target.cache_steps() != source.cache_steps()) {
-        throw std::runtime_error("VibeVoice decoder cache backend copy requires matching cache capacity");
-    }
-    if (source.current_end() != source.valid_steps()) {
-        throw std::runtime_error("VibeVoice decoder cache backend copy requires contiguous source state");
-    }
-    for (size_t layer = 0; layer < layers; ++layer) {
-        const auto & source_key = source.key_tensor(layer);
-        const auto & source_value = source.value_tensor(layer);
-        const auto & target_key = target.key_tensor(layer);
-        const auto & target_value = target.value_tensor(layer);
-        if (source_key.type != target_key.type || source_value.type != target_value.type ||
-            source_key.shape.dims != target_key.shape.dims ||
-            source_value.shape.dims != target_value.shape.dims) {
-            throw std::runtime_error("VibeVoice decoder cache backend copy requires matching tensor layout");
-        }
-        ggml_backend_tensor_copy(source_key.tensor, target_key.tensor);
-        ggml_backend_tensor_copy(source_value.tensor, target_value.tensor);
-    }
-    target.retain_prefix(0);
-    target.advance_after_direct_append(source.valid_steps());
 }
 
 runtime::TransformerKVState empty_decoder_state(size_t layers) {
@@ -636,20 +602,118 @@ private:
     ggml_gallocr_t gallocr_ = nullptr;
 };
 
+class VibeVoiceDecoderKVCache {
+public:
+    VibeVoiceDecoderKVCache(
+        const VibeVoiceDecoderWeightsRuntime & runtime,
+        int64_t cache_steps)
+        : runtime_(&runtime),
+          cache_steps_(cache_steps) {
+        if (cache_steps_ <= 0) {
+            throw std::runtime_error("VibeVoice decoder KV cache requires positive capacity");
+        }
+        const auto & config = runtime_->assets().config.decoder;
+        const int64_t step_elems = config.num_key_value_heads * require_head_dim(config);
+        ggml_init_params params{4ull * 1024ull * 1024ull, nullptr, true};
+        ctx_.reset(ggml_init(params));
+        if (ctx_ == nullptr) {
+            throw std::runtime_error("failed to initialize VibeVoice decoder KV cache context");
+        }
+        core::ModuleBuildContext ctx{ctx_.get(), "vibevoice.decoder.kv_cache"};
+        std::vector<core::TensorValue> keys;
+        std::vector<core::TensorValue> values;
+        keys.reserve(runtime_->weights().layers.size());
+        values.reserve(runtime_->weights().layers.size());
+        for (size_t layer = 0; layer < runtime_->weights().layers.size(); ++layer) {
+            keys.push_back(core::make_tensor(
+                ctx,
+                GGML_TYPE_F16,
+                core::TensorShape::from_dims({1, cache_steps_, config.num_key_value_heads, config.head_dim})));
+            values.push_back(core::make_tensor(
+                ctx,
+                GGML_TYPE_F16,
+                core::TensorShape::from_dims({1, cache_steps_, config.num_key_value_heads, config.head_dim})));
+        }
+        runtime::TransformerKVCacheOptions cache_options;
+        cache_options.allow_f16_storage = true;
+        cache_ = runtime::TransformerKVCache(
+            cache_steps_,
+            step_elems,
+            std::move(keys),
+            std::move(values),
+            cache_options);
+        buffer_ = ggml_backend_alloc_ctx_tensors(ctx_.get(), runtime_->backend());
+        if (buffer_ == nullptr) {
+            throw std::runtime_error("failed to allocate VibeVoice decoder KV cache");
+        }
+    }
+
+    ~VibeVoiceDecoderKVCache() {
+        if (buffer_ != nullptr) {
+            ggml_backend_buffer_free(buffer_);
+        }
+    }
+
+    bool can_run(const VibeVoiceDecoderWeightsRuntime & runtime, int64_t required_steps) const {
+        return runtime_ == &runtime && cache_steps_ >= required_steps;
+    }
+
+    int64_t cache_steps() const noexcept {
+        return cache_.cache_steps();
+    }
+
+    int64_t valid_steps() const noexcept {
+        return cache_.valid_steps();
+    }
+
+    int64_t current_end() const noexcept {
+        return cache_.current_end();
+    }
+
+    void import_state(const runtime::TransformerKVState & state) {
+        cache_.import_state(state);
+    }
+
+    runtime::TransformerKVState export_state() const {
+        return cache_.export_state();
+    }
+
+    void advance_after_direct_append(int64_t steps) {
+        cache_.advance_after_direct_append(steps);
+    }
+
+    const core::TensorValue & key_tensor(size_t layer) const {
+        return cache_.key_tensor(layer);
+    }
+
+    const core::TensorValue & value_tensor(size_t layer) const {
+        return cache_.value_tensor(layer);
+    }
+
+private:
+    const VibeVoiceDecoderWeightsRuntime * runtime_ = nullptr;
+    int64_t cache_steps_ = 0;
+    std::unique_ptr<ggml_context, GgmlContextDeleter> ctx_;
+    runtime::TransformerKVCache cache_;
+    ggml_backend_buffer_t buffer_ = nullptr;
+};
+
 class VibeVoiceDecoderCachedStepGraph {
 public:
     VibeVoiceDecoderCachedStepGraph(
         const VibeVoiceDecoderWeightsRuntime & runtime,
-        int64_t cache_steps,
+        VibeVoiceDecoderKVCache & cache,
         size_t graph_arena_bytes)
         : runtime_(&runtime),
-          cache_steps_(cache_steps) {
+          cache_(&cache),
+          cache_steps_(cache.cache_steps()) {
         if (cache_steps_ <= 0) {
             throw std::runtime_error("VibeVoice decoder cached step graph requires positive cache steps");
         }
+        if (!cache_->can_run(runtime, cache_steps_)) {
+            throw std::runtime_error("VibeVoice decoder cached step graph requires matching KV cache");
+        }
         const auto & config = runtime_->assets().config.decoder;
-        scratch_tail_ = cache_steps_ >= kScratchTailCachedAttentionMinSteps;
-        const int64_t cache_tensor_steps = cache_steps_ + (scratch_tail_ ? 1 : 0);
         ggml_init_params params{graph_arena_bytes, nullptr, true};
         ctx_.reset(ggml_init(params));
         if (ctx_ == nullptr) {
@@ -663,39 +727,43 @@ public:
         auto positions_value = core::wrap_tensor(positions_, core::TensorShape::from_dims({1}), GGML_TYPE_I32);
         cache_slot_ = ggml_new_tensor_1d(ctx_.get(), GGML_TYPE_I32, 1);
         auto cache_slot_value = core::wrap_tensor(cache_slot_, core::TensorShape::from_dims({1}), GGML_TYPE_I32);
-        attention_mask_ = ggml_new_tensor_4d(ctx_.get(), GGML_TYPE_F16, cache_tensor_steps, 1, 1, 1);
+        attention_mask_ = ggml_new_tensor_4d(ctx_.get(), GGML_TYPE_F16, cache_steps_, 1, 1, 1);
         auto attention_mask_value = core::wrap_tensor(
             attention_mask_,
-            core::TensorShape::from_dims({1, 1, 1, cache_tensor_steps}),
+            core::TensorShape::from_dims({1, 1, 1, cache_steps_}),
             GGML_TYPE_F16);
 
         graph_ = ggml_new_graph_custom(ctx_.get(), 65536, false);
         auto & constants = runtime_->constants();
         constants.begin_graph();
         auto decoder_config = make_qwen_decoder_config(config);
-        if (scratch_tail_) {
-            decoder_config.stack.runtime.static_cache.update_mode =
-                modules::QwenDecoderStaticCacheUpdateMode::ScratchTail;
+        auto layer_input = x;
+        const modules::QwenDecoderLayerModule layer_module(
+            modules::qwen_decoder_layer_config_from_stack(decoder_config.stack));
+        for (size_t layer_index = 0; layer_index < runtime_->weights().layers.size(); ++layer_index) {
+            auto layer_out = layer_module.build_with_static_cache_tail(
+                ctx,
+                graph_,
+                layer_input,
+                positions_value,
+                to_qwen_layer_weights(runtime_->weights().layers[layer_index], constants),
+                cache_->key_tensor(layer_index),
+                cache_->value_tensor(layer_index),
+                cache_slot_value,
+                attention_mask_value);
+            layer_input = layer_out.output;
         }
-        auto decoder_out = modules::QwenCausalDecoderModule(decoder_config)
-                               .build_static_cache_tail(
-                                   ctx,
-                                   graph_,
-                                   x,
-                                   positions_value,
-                                   make_qwen_decoder_weights(runtime_->weights(), constants),
-                                   cache_tensor_steps,
-                                   attention_mask_value,
-                                   scratch_tail_
-                                       ? std::optional<core::TensorValue>{}
-                                       : std::optional<core::TensorValue>{cache_slot_value});
-        cache_ = std::move(decoder_out.cache);
-        if (scratch_tail_) {
-            build_scratch_transfer_views(config.num_key_value_heads * require_head_dim(config));
-        }
-        hidden_output_ = ggml_cpy(ctx_.get(), decoder_out.hidden.tensor, ggml_dup_tensor(ctx_.get(), decoder_out.hidden.tensor));
+        auto hidden = modules::RMSNormModule({config.hidden_size, config.rms_norm_eps, true, false})
+                          .build(ctx, layer_input, binding::norm_data(constants, runtime_->weights().norm));
+        auto logits = modules::LinearModule({
+                          config.hidden_size,
+                          config.vocab_size,
+                          false,
+                      })
+                          .build(ctx, hidden, {runtime_->weights().lm_head, std::nullopt});
+        hidden_output_ = ggml_cpy(ctx_.get(), hidden.tensor, ggml_dup_tensor(ctx_.get(), hidden.tensor));
         ggml_set_output(hidden_output_);
-        logits_output_ = decoder_out.logits.tensor;
+        logits_output_ = logits.tensor;
         ggml_set_output(logits_output_);
         ggml_build_forward_expand(graph_, hidden_output_);
         ggml_build_forward_expand(graph_, logits_output_);
@@ -705,7 +773,7 @@ public:
         if (buffer_ == nullptr) {
             throw std::runtime_error("failed to allocate VibeVoice decoder cached step graph");
         }
-        attention_mask_buffer_.assign(static_cast<size_t>(cache_tensor_steps), ggml_fp32_to_fp16(-std::numeric_limits<float>::infinity()));
+        attention_mask_buffer_.assign(static_cast<size_t>(cache_steps_), ggml_fp32_to_fp16(-std::numeric_limits<float>::infinity()));
     }
 
     ~VibeVoiceDecoderCachedStepGraph() {
@@ -717,53 +785,15 @@ public:
     }
 
     bool can_decode(const VibeVoiceDecoderWeightsRuntime & runtime, int64_t required_capacity) const {
-        return runtime_ == &runtime && cache_steps_ >= required_capacity;
+        return runtime_ == &runtime && cache_ != nullptr && cache_->can_run(runtime, required_capacity);
     }
 
     int64_t current_end() const noexcept {
-        return cache_.current_end();
+        return cache_->current_end();
     }
 
     int64_t cache_steps() const noexcept {
-        return cache_.cache_steps();
-    }
-
-    const runtime::TransformerKVCache & cache() const noexcept {
-        return cache_;
-    }
-
-    void copy_state_from_cache(const runtime::TransformerKVCache & source) {
-        copy_vibevoice_decoder_cache_backend(cache_, source, runtime_->weights().layers.size());
-    }
-
-    void import_state(const runtime::TransformerKVState & state) {
-        cache_.import_state(state);
-    }
-
-    runtime::TransformerKVState export_state() const {
-        return cache_.export_state();
-    }
-
-    void clone_state_from(const VibeVoiceDecoderCachedStepGraph & source) {
-        if (runtime_ != source.runtime_) {
-            throw std::runtime_error("VibeVoice decoder cached step clone requires matching runtime");
-        }
-        if (cache_steps_ < source.cache_.valid_steps()) {
-            throw std::runtime_error("VibeVoice decoder cached step clone target capacity is too small");
-        }
-        if (source.cache_.current_end() != source.cache_.valid_steps()) {
-            throw std::runtime_error("VibeVoice decoder cached step clone requires contiguous cache positions");
-        }
-        for (size_t layer = 0; layer < runtime_->weights().layers.size(); ++layer) {
-            ggml_backend_tensor_copy(
-                source.cache_.key_tensor(layer).tensor,
-                cache_.key_tensor(layer).tensor);
-            ggml_backend_tensor_copy(
-                source.cache_.value_tensor(layer).tensor,
-                cache_.value_tensor(layer).tensor);
-        }
-        cache_.retain_prefix(0);
-        cache_.advance_after_direct_append(source.cache_.valid_steps());
+        return cache_->cache_steps();
     }
 
     VibeVoiceDecoderResult run_step(const std::vector<float> & embedding) {
@@ -785,22 +815,20 @@ public:
         if (static_cast<int64_t>(embedding.size()) != config.hidden_size) {
             throw std::runtime_error("VibeVoice decoder cached step embedding size mismatch");
         }
-        if (cache_.valid_steps() >= cache_steps_) {
+        if (cache_->valid_steps() >= cache_steps_) {
             throw std::runtime_error("VibeVoice decoder cached step exceeds cache capacity");
         }
         ggml_backend_tensor_set(input_, embedding.data(), 0, embedding.size() * sizeof(float));
-        const int32_t position = static_cast<int32_t>(cache_.current_end());
+        const int32_t position = static_cast<int32_t>(cache_->current_end());
         ggml_backend_tensor_set(positions_, &position, 0, sizeof(position));
-        const int32_t cache_slot = static_cast<int32_t>(cache_.valid_steps());
-        if (!scratch_tail_) {
-            ggml_backend_tensor_set(cache_slot_, &cache_slot, 0, sizeof(cache_slot));
-        }
+        const int32_t cache_slot = static_cast<int32_t>(cache_->valid_steps());
+        ggml_backend_tensor_set(cache_slot_, &cache_slot, 0, sizeof(cache_slot));
         modules::write_qwen_cached_step_mask(
             attention_mask_,
             attention_mask_buffer_,
             static_cast<int64_t>(attention_mask_buffer_.size()),
-            cache_.valid_steps(),
-            scratch_tail_ ? cache_steps_ : cache_.valid_steps());
+            cache_->valid_steps(),
+            cache_->valid_steps());
 
         core::set_backend_threads(runtime_->backend(), runtime_->threads());
         const ggml_status status = engine::core::compute_backend_graph(runtime_->backend(), graph_);
@@ -808,48 +836,13 @@ public:
         if (status != GGML_STATUS_SUCCESS) {
             throw std::runtime_error("VibeVoice decoder cached step graph compute failed");
         }
-        if (scratch_tail_) {
-            const size_t dst_slot = static_cast<size_t>(cache_.valid_steps());
-            for (size_t layer = 0; layer < scratch_key_sources_.size(); ++layer) {
-                ggml_backend_tensor_copy(scratch_key_sources_[layer], scratch_key_destinations_[dst_slot][layer]);
-                ggml_backend_tensor_copy(scratch_value_sources_[layer], scratch_value_destinations_[dst_slot][layer]);
-            }
-        }
-        cache_.advance_after_direct_append(1);
+        cache_->advance_after_direct_append(1);
     }
 
 private:
-    void build_scratch_transfer_views(int64_t step_elems) {
-        scratch_key_sources_.reserve(runtime_->weights().layers.size());
-        scratch_value_sources_.reserve(runtime_->weights().layers.size());
-        for (size_t layer = 0; layer < runtime_->weights().layers.size(); ++layer) {
-            const size_t scratch_offset = ggml_row_size(cache_.key_tensor(layer).type, cache_steps_ * step_elems);
-            scratch_key_sources_.push_back(
-                ggml_view_1d(ctx_.get(), cache_.key_tensor(layer).tensor, step_elems, scratch_offset));
-            scratch_value_sources_.push_back(
-                ggml_view_1d(ctx_.get(), cache_.value_tensor(layer).tensor, step_elems, scratch_offset));
-        }
-
-        scratch_key_destinations_.assign(static_cast<size_t>(cache_steps_), {});
-        scratch_value_destinations_.assign(static_cast<size_t>(cache_steps_), {});
-        for (int64_t slot = 0; slot < cache_steps_; ++slot) {
-            auto & key_slot = scratch_key_destinations_[static_cast<size_t>(slot)];
-            auto & value_slot = scratch_value_destinations_[static_cast<size_t>(slot)];
-            key_slot.reserve(scratch_key_sources_.size());
-            value_slot.reserve(scratch_value_sources_.size());
-            for (size_t layer = 0; layer < scratch_key_sources_.size(); ++layer) {
-                const size_t byte_offset = ggml_row_size(cache_.key_tensor(layer).type, slot * step_elems);
-                key_slot.push_back(
-                    ggml_view_1d(ctx_.get(), cache_.key_tensor(layer).tensor, step_elems, byte_offset));
-                value_slot.push_back(
-                    ggml_view_1d(ctx_.get(), cache_.value_tensor(layer).tensor, step_elems, byte_offset));
-            }
-        }
-    }
-
     const VibeVoiceDecoderWeightsRuntime * runtime_ = nullptr;
+    VibeVoiceDecoderKVCache * cache_ = nullptr;
     int64_t cache_steps_ = 0;
-    bool scratch_tail_ = false;
     std::unique_ptr<ggml_context, GgmlContextDeleter> ctx_;
     ggml_tensor * input_ = nullptr;
     ggml_tensor * positions_ = nullptr;
@@ -858,11 +851,6 @@ private:
     ggml_tensor * hidden_output_ = nullptr;
     ggml_tensor * logits_output_ = nullptr;
     std::vector<ggml_fp16_t> attention_mask_buffer_;
-    runtime::TransformerKVCache cache_;
-    std::vector<ggml_tensor *> scratch_key_sources_;
-    std::vector<ggml_tensor *> scratch_value_sources_;
-    std::vector<std::vector<ggml_tensor *>> scratch_key_destinations_;
-    std::vector<std::vector<ggml_tensor *>> scratch_value_destinations_;
     ggml_cgraph * graph_ = nullptr;
     ggml_backend_buffer_t buffer_ = nullptr;
 };
@@ -872,16 +860,20 @@ public:
     VibeVoiceDecoderCachedSuffixGraph(
         const VibeVoiceDecoderWeightsRuntime & runtime,
         int64_t suffix_steps,
-        int64_t cache_steps,
+        VibeVoiceDecoderKVCache & cache,
         size_t graph_arena_bytes)
         : runtime_(&runtime),
+          cache_(&cache),
           suffix_steps_(suffix_steps),
-          cache_steps_(cache_steps) {
+          cache_steps_(cache.cache_steps()) {
         if (suffix_steps_ <= 0) {
             throw std::runtime_error("VibeVoice decoder cached suffix graph requires positive suffix steps");
         }
         if (cache_steps_ <= 0) {
             throw std::runtime_error("VibeVoice decoder cached suffix graph requires positive cache steps");
+        }
+        if (!cache_->can_run(runtime, cache_steps_)) {
+            throw std::runtime_error("VibeVoice decoder cached suffix graph requires matching KV cache");
         }
         const auto & config = runtime_->assets().config.decoder;
         ggml_init_params params{graph_arena_bytes, nullptr, true};
@@ -918,29 +910,19 @@ public:
         constants.begin_graph();
         auto decoder_config = make_qwen_decoder_config(config);
         const int64_t step_elems = config.num_key_value_heads * require_head_dim(config);
-        std::vector<core::TensorValue> cache_keys;
-        std::vector<core::TensorValue> cache_values;
-        cache_keys.reserve(runtime_->weights().layers.size());
-        cache_values.reserve(runtime_->weights().layers.size());
         auto layer_input = x;
         const modules::QwenDecoderLayerModule layer_module(
             modules::qwen_decoder_layer_config_from_stack(decoder_config.stack));
-        for (const auto & layer : runtime_->weights().layers) {
-            cache_keys.push_back(core::make_tensor(
-                ctx,
-                decoder_config.static_cache_type,
-                core::TensorShape::from_dims({1, cache_steps_, config.num_key_value_heads, require_head_dim(config)})));
-            cache_values.push_back(core::make_tensor(
-                ctx,
-                decoder_config.static_cache_type,
-                core::TensorShape::from_dims({1, cache_steps_, config.num_key_value_heads, require_head_dim(config)})));
+        for (size_t layer_index = 0; layer_index < runtime_->weights().layers.size(); ++layer_index) {
+            const auto & key_cache = cache_->key_tensor(layer_index);
+            const auto & value_cache = cache_->value_tensor(layer_index);
             auto layer_out = layer_module.build(
                 ctx,
                 layer_input,
                 positions_value,
-                to_qwen_layer_weights(layer, constants),
-                cache_keys.back(),
-                cache_values.back(),
+                to_qwen_layer_weights(runtime_->weights().layers[layer_index], constants),
+                key_cache,
+                value_cache,
                 attention_mask_value);
             layer_input = layer_out.output;
 
@@ -948,11 +930,11 @@ public:
             auto value_rows = core::ensure_backend_addressable_layout(ctx, layer_out.value);
             auto flat_key_cache = core::reshape_tensor(
                 ctx,
-                cache_keys.back(),
+                key_cache,
                 core::TensorShape::from_dims({cache_steps_, step_elems}));
             auto flat_value_cache = core::reshape_tensor(
                 ctx,
-                cache_values.back(),
+                value_cache,
                 core::TensorShape::from_dims({cache_steps_, step_elems}));
             auto flat_key_rows = core::reshape_tensor(
                 ctx,
@@ -979,15 +961,6 @@ public:
                           false,
                       })
                           .build(ctx, hidden, {runtime_->weights().lm_head, std::nullopt});
-        runtime::TransformerKVCacheOptions cache_options;
-        cache_options.allow_f16_storage = decoder_config.static_cache_type == GGML_TYPE_F16;
-        cache_options.allow_bf16_storage = decoder_config.static_cache_type == GGML_TYPE_BF16;
-        cache_ = runtime::TransformerKVCache(
-            cache_steps_,
-            step_elems,
-            std::move(cache_keys),
-            std::move(cache_values),
-            cache_options);
         hidden_output_ = ggml_cpy(ctx_.get(), hidden.tensor, ggml_dup_tensor(ctx_.get(), hidden.tensor));
         ggml_set_output(hidden_output_);
         logits_output_ = logits.tensor;
@@ -1014,31 +987,16 @@ public:
     }
 
     bool can_decode(const VibeVoiceDecoderWeightsRuntime & runtime, int64_t suffix_steps, int64_t required_capacity) const {
-        return runtime_ == &runtime && this->suffix_steps_ == suffix_steps && cache_steps_ >= required_capacity;
+        return runtime_ == &runtime && this->suffix_steps_ == suffix_steps && cache_ != nullptr &&
+            cache_->can_run(runtime, required_capacity);
     }
 
     int64_t current_end() const noexcept {
-        return cache_.current_end();
+        return cache_->current_end();
     }
 
     int64_t cache_steps() const noexcept {
-        return cache_.cache_steps();
-    }
-
-    const runtime::TransformerKVCache & cache() const noexcept {
-        return cache_;
-    }
-
-    void copy_state_from_cache(const runtime::TransformerKVCache & source) {
-        copy_vibevoice_decoder_cache_backend(cache_, source, runtime_->weights().layers.size());
-    }
-
-    void import_state(const runtime::TransformerKVState & state) {
-        cache_.import_state(state);
-    }
-
-    runtime::TransformerKVState export_state() const {
-        return cache_.export_state();
+        return cache_->cache_steps();
     }
 
     VibeVoiceDecoderResult run_suffix(const std::vector<float> & embeddings) {
@@ -1046,13 +1004,13 @@ public:
         if (static_cast<int64_t>(embeddings.size()) != suffix_steps_ * config.hidden_size) {
             throw std::runtime_error("VibeVoice decoder cached suffix embedding size mismatch");
         }
-        if (cache_.valid_steps() + suffix_steps_ > cache_steps_) {
+        if (cache_->valid_steps() + suffix_steps_ > cache_steps_) {
             throw std::runtime_error("VibeVoice decoder cached suffix exceeds cache capacity");
         }
         ggml_backend_tensor_set(input_, embeddings.data(), 0, embeddings.size() * sizeof(float));
         for (int64_t step = 0; step < suffix_steps_; ++step) {
-            position_values_[static_cast<size_t>(step)] = static_cast<int32_t>(cache_.current_end() + step);
-            cache_slot_values_[static_cast<size_t>(step)] = static_cast<int32_t>(cache_.valid_steps() + step);
+            position_values_[static_cast<size_t>(step)] = static_cast<int32_t>(cache_->current_end() + step);
+            cache_slot_values_[static_cast<size_t>(step)] = static_cast<int32_t>(cache_->valid_steps() + step);
         }
         ggml_backend_tensor_set(positions_, position_values_.data(), 0, position_values_.size() * sizeof(int32_t));
         ggml_backend_tensor_set(cache_slot_, cache_slot_values_.data(), 0, cache_slot_values_.size() * sizeof(int32_t));
@@ -1064,7 +1022,7 @@ public:
             const size_t row_offset = static_cast<size_t>(row * attention_key_steps_);
             std::fill_n(
                 attention_mask_buffer_.begin() + static_cast<std::ptrdiff_t>(row_offset),
-                static_cast<size_t>(cache_.valid_steps()),
+                static_cast<size_t>(cache_->valid_steps()),
                 visible);
             std::fill_n(
                 attention_mask_buffer_.begin() + static_cast<std::ptrdiff_t>(row_offset + cache_steps_),
@@ -1083,7 +1041,7 @@ public:
         if (status != GGML_STATUS_SUCCESS) {
             throw std::runtime_error("VibeVoice decoder cached suffix graph compute failed");
         }
-        cache_.advance_after_direct_append(suffix_steps_);
+        cache_->advance_after_direct_append(suffix_steps_);
 
         std::vector<float> logits(static_cast<size_t>(config.vocab_size));
         std::vector<float> hidden(static_cast<size_t>(config.hidden_size));
@@ -1101,6 +1059,7 @@ public:
 
 private:
     const VibeVoiceDecoderWeightsRuntime * runtime_ = nullptr;
+    VibeVoiceDecoderKVCache * cache_ = nullptr;
     int64_t suffix_steps_ = 0;
     int64_t cache_steps_ = 0;
     int64_t attention_key_steps_ = 0;
@@ -1114,7 +1073,6 @@ private:
     std::vector<int32_t> position_values_;
     std::vector<int32_t> cache_slot_values_;
     std::vector<ggml_fp16_t> attention_mask_buffer_;
-    runtime::TransformerKVCache cache_;
     ggml_cgraph * graph_ = nullptr;
     ggml_backend_buffer_t buffer_ = nullptr;
 };
@@ -1264,9 +1222,9 @@ void VibeVoiceDecoderWeightsRuntime::reset_cached_state(
     runtime::TransformerKVState prefill_state) const {
     state.graph_.reset();
     state.suffix_graph_.reset();
+    state.cache_.reset();
     state.pending_state_ = std::move(prefill_state);
-    state.graph_has_state_ = false;
-    state.suffix_graph_has_state_ = false;
+    state.cache_has_state_ = false;
 }
 
 void VibeVoiceDecoderWeightsRuntime::prepare_cached_state(
@@ -1277,37 +1235,33 @@ void VibeVoiceDecoderWeightsRuntime::prepare_cached_state(
         throw std::runtime_error("VibeVoice decoder cached state prepare requires positive cache capacity");
     }
     const int64_t required_capacity = cache_graph_capacity(cache_capacity, config.max_position_embeddings);
-    if (state.suffix_graph_has_state_ && state.suffix_graph_ != nullptr) {
-        state.pending_state_ = state.suffix_graph_->export_state();
-        state.suffix_graph_has_state_ = false;
-    }
-    if (state.graph_ == nullptr || !state.graph_->can_decode(*this, required_capacity)) {
+    if (state.cache_ != nullptr && state.cache_has_state_ && !state.cache_->can_run(*this, required_capacity)) {
+        state.pending_state_ = state.cache_->export_state();
+        state.cache_has_state_ = false;
         state.graph_.reset();
-        const size_t graph_arena_bytes = 1536ull * 1024ull * 1024ull;
-        state.graph_ = std::make_unique<VibeVoiceDecoderCachedStepGraph>(
-            *this,
-            required_capacity,
-            graph_arena_bytes);
+        state.suffix_graph_.reset();
+        state.cache_.reset();
     }
-    if (!state.graph_has_state_) {
+    if (state.cache_ == nullptr || !state.cache_->can_run(*this, required_capacity)) {
+        state.graph_.reset();
+        state.suffix_graph_.reset();
+        state.cache_ = std::make_unique<VibeVoiceDecoderKVCache>(*this, required_capacity);
+    }
+    if (!state.cache_has_state_) {
         if (state.pending_state_.layers.empty() && state.pending_state_.current_end == 0) {
             state.pending_state_ = empty_decoder_state(weights_->layers.size());
         }
-        state.graph_->import_state(state.pending_state_);
+        state.cache_->import_state(state.pending_state_);
         state.pending_state_ = {};
-        state.graph_has_state_ = true;
+        state.cache_has_state_ = true;
     }
 }
 
 runtime::TransformerKVState VibeVoiceDecoderWeightsRuntime::export_cached_state(
     VibeVoiceDecoderCachedState & state) const {
-    if (state.suffix_graph_has_state_ && state.suffix_graph_ != nullptr) {
-        state.pending_state_ = state.suffix_graph_->export_state();
-        state.suffix_graph_has_state_ = false;
-    }
-    if (state.graph_has_state_ && state.graph_ != nullptr) {
-        state.pending_state_ = state.graph_->export_state();
-        state.graph_has_state_ = false;
+    if (state.cache_has_state_ && state.cache_ != nullptr) {
+        state.pending_state_ = state.cache_->export_state();
+        state.cache_has_state_ = false;
     }
     return state.pending_state_;
 }
@@ -1320,23 +1274,21 @@ void VibeVoiceDecoderWeightsRuntime::clone_cached_state(
     if (cache_capacity <= 0) {
         throw std::runtime_error("VibeVoice decoder cached state clone requires positive cache capacity");
     }
-    if (!source.graph_has_state_ || source.graph_ == nullptr) {
+    if (!source.cache_has_state_ || source.cache_ == nullptr) {
         throw std::runtime_error("VibeVoice decoder cached state clone requires live source graph state");
     }
+    const auto source_state = source.cache_->export_state();
     const int64_t required_capacity = cache_graph_capacity(
-        std::max<int64_t>(cache_capacity, source.graph_->current_end() + 1),
+        std::max<int64_t>(cache_capacity, source.cache_->current_end() + 1),
         config.max_position_embeddings);
-    if (target.graph_ == nullptr || !target.graph_->can_decode(*this, required_capacity)) {
+    if (target.cache_ == nullptr || !target.cache_->can_run(*this, required_capacity)) {
         target.graph_.reset();
-        const size_t graph_arena_bytes = 1536ull * 1024ull * 1024ull;
-        target.graph_ = std::make_unique<VibeVoiceDecoderCachedStepGraph>(
-            *this,
-            required_capacity,
-            graph_arena_bytes);
+        target.suffix_graph_.reset();
+        target.cache_ = std::make_unique<VibeVoiceDecoderKVCache>(*this, required_capacity);
     }
-    target.graph_->clone_state_from(*source.graph_);
+    target.cache_->import_state(source_state);
     target.pending_state_ = {};
-    target.graph_has_state_ = true;
+    target.cache_has_state_ = true;
 }
 
 VibeVoiceDecoderResult VibeVoiceDecoderWeightsRuntime::cached_step(
@@ -1350,45 +1302,40 @@ VibeVoiceDecoderResult VibeVoiceDecoderWeightsRuntime::cached_step(
     if (cache_capacity <= 0) {
         throw std::runtime_error("VibeVoice decoder cached step requires positive cache capacity");
     }
-    const int64_t current_end = state.graph_has_state_ && state.graph_ != nullptr
-        ? state.graph_->current_end()
-        : state.suffix_graph_has_state_ && state.suffix_graph_ != nullptr
-            ? state.suffix_graph_->current_end()
-            : state.pending_state_.current_end;
+    const int64_t current_end = state.cache_has_state_ && state.cache_ != nullptr
+        ? state.cache_->current_end()
+        : state.pending_state_.current_end;
     const int64_t required_capacity = cache_graph_capacity(
         std::max<int64_t>(cache_capacity, current_end + 1),
         config.max_position_embeddings);
-    if (state.graph_ != nullptr && state.graph_has_state_ && !state.graph_->can_decode(*this, required_capacity)) {
-        state.pending_state_ = state.graph_->export_state();
-        state.graph_has_state_ = false;
+    if (state.cache_ != nullptr && state.cache_has_state_ && !state.cache_->can_run(*this, required_capacity)) {
+        state.pending_state_ = state.cache_->export_state();
+        state.cache_has_state_ = false;
+        state.graph_.reset();
+        state.suffix_graph_.reset();
+        state.cache_.reset();
     }
+    if (state.cache_ == nullptr || !state.cache_->can_run(*this, required_capacity)) {
+        state.graph_.reset();
+        state.suffix_graph_.reset();
+        state.cache_ = std::make_unique<VibeVoiceDecoderKVCache>(*this, required_capacity);
+    }
+    if (!state.cache_has_state_) {
+        if (state.pending_state_.layers.empty() && state.pending_state_.current_end == 0) {
+            state.pending_state_ = empty_decoder_state(weights_->layers.size());
+        }
+        state.cache_->import_state(state.pending_state_);
+        state.pending_state_ = {};
+        state.cache_has_state_ = true;
+    }
+    state.suffix_graph_.reset();
     if (state.graph_ == nullptr || !state.graph_->can_decode(*this, required_capacity)) {
         state.graph_.reset();
         const size_t graph_arena_bytes = 1536ull * 1024ull * 1024ull;
         state.graph_ = std::make_unique<VibeVoiceDecoderCachedStepGraph>(
             *this,
-            required_capacity,
+            *state.cache_,
             graph_arena_bytes);
-    }
-    if (state.suffix_graph_has_state_ && state.suffix_graph_ != nullptr) {
-        if (state.graph_->cache_steps() == state.suffix_graph_->cache_steps()) {
-            state.graph_->copy_state_from_cache(state.suffix_graph_->cache());
-            state.pending_state_ = {};
-            state.graph_has_state_ = true;
-        } else {
-            state.pending_state_ = state.suffix_graph_->export_state();
-            state.graph_has_state_ = false;
-        }
-        state.suffix_graph_has_state_ = false;
-        state.suffix_graph_.reset();
-    }
-    if (!state.graph_has_state_) {
-        if (state.pending_state_.layers.empty() && state.pending_state_.current_end == 0) {
-            state.pending_state_ = empty_decoder_state(weights_->layers.size());
-        }
-        state.graph_->import_state(state.pending_state_);
-        state.pending_state_ = {};
-        state.graph_has_state_ = true;
     }
     return state.graph_->run_step(embedding);
 }
@@ -1404,45 +1351,40 @@ void VibeVoiceDecoderWeightsRuntime::append_cached_step(
     if (cache_capacity <= 0) {
         throw std::runtime_error("VibeVoice decoder cached append requires positive cache capacity");
     }
-    const int64_t current_end = state.graph_has_state_ && state.graph_ != nullptr
-        ? state.graph_->current_end()
-        : state.suffix_graph_has_state_ && state.suffix_graph_ != nullptr
-            ? state.suffix_graph_->current_end()
-            : state.pending_state_.current_end;
+    const int64_t current_end = state.cache_has_state_ && state.cache_ != nullptr
+        ? state.cache_->current_end()
+        : state.pending_state_.current_end;
     const int64_t required_capacity = cache_graph_capacity(
         std::max<int64_t>(cache_capacity, current_end + 1),
         config.max_position_embeddings);
-    if (state.graph_ != nullptr && state.graph_has_state_ && !state.graph_->can_decode(*this, required_capacity)) {
-        state.pending_state_ = state.graph_->export_state();
-        state.graph_has_state_ = false;
+    if (state.cache_ != nullptr && state.cache_has_state_ && !state.cache_->can_run(*this, required_capacity)) {
+        state.pending_state_ = state.cache_->export_state();
+        state.cache_has_state_ = false;
+        state.graph_.reset();
+        state.suffix_graph_.reset();
+        state.cache_.reset();
     }
+    if (state.cache_ == nullptr || !state.cache_->can_run(*this, required_capacity)) {
+        state.graph_.reset();
+        state.suffix_graph_.reset();
+        state.cache_ = std::make_unique<VibeVoiceDecoderKVCache>(*this, required_capacity);
+    }
+    if (!state.cache_has_state_) {
+        if (state.pending_state_.layers.empty() && state.pending_state_.current_end == 0) {
+            state.pending_state_ = empty_decoder_state(weights_->layers.size());
+        }
+        state.cache_->import_state(state.pending_state_);
+        state.pending_state_ = {};
+        state.cache_has_state_ = true;
+    }
+    state.suffix_graph_.reset();
     if (state.graph_ == nullptr || !state.graph_->can_decode(*this, required_capacity)) {
         state.graph_.reset();
         const size_t graph_arena_bytes = 1536ull * 1024ull * 1024ull;
         state.graph_ = std::make_unique<VibeVoiceDecoderCachedStepGraph>(
             *this,
-            required_capacity,
+            *state.cache_,
             graph_arena_bytes);
-    }
-    if (state.suffix_graph_has_state_ && state.suffix_graph_ != nullptr) {
-        if (state.graph_->cache_steps() == state.suffix_graph_->cache_steps()) {
-            state.graph_->copy_state_from_cache(state.suffix_graph_->cache());
-            state.pending_state_ = {};
-            state.graph_has_state_ = true;
-        } else {
-            state.pending_state_ = state.suffix_graph_->export_state();
-            state.graph_has_state_ = false;
-        }
-        state.suffix_graph_has_state_ = false;
-        state.suffix_graph_.reset();
-    }
-    if (!state.graph_has_state_) {
-        if (state.pending_state_.layers.empty() && state.pending_state_.current_end == 0) {
-            state.pending_state_ = empty_decoder_state(weights_->layers.size());
-        }
-        state.graph_->import_state(state.pending_state_);
-        state.pending_state_ = {};
-        state.graph_has_state_ = true;
     }
     state.graph_->run_step_no_readback(embedding);
 }
@@ -1462,47 +1404,41 @@ VibeVoiceDecoderResult VibeVoiceDecoderWeightsRuntime::cached_suffix(
     if (cache_capacity <= 0) {
         throw std::runtime_error("VibeVoice decoder cached suffix requires positive cache capacity");
     }
-    const int64_t current_end = state.suffix_graph_has_state_ && state.suffix_graph_ != nullptr
-        ? state.suffix_graph_->current_end()
-        : state.graph_has_state_ && state.graph_ != nullptr
-            ? state.graph_->current_end()
-            : state.pending_state_.current_end;
+    const int64_t current_end = state.cache_has_state_ && state.cache_ != nullptr
+        ? state.cache_->current_end()
+        : state.pending_state_.current_end;
     const int64_t required_capacity = cache_graph_capacity(
         std::max<int64_t>(cache_capacity, current_end + steps),
         config.max_position_embeddings);
-    if (state.suffix_graph_ != nullptr && state.suffix_graph_has_state_ &&
-        !state.suffix_graph_->can_decode(*this, steps, required_capacity)) {
-        state.pending_state_ = state.suffix_graph_->export_state();
-        state.suffix_graph_has_state_ = false;
+    if (state.cache_ != nullptr && state.cache_has_state_ && !state.cache_->can_run(*this, required_capacity)) {
+        state.pending_state_ = state.cache_->export_state();
+        state.cache_has_state_ = false;
+        state.graph_.reset();
+        state.suffix_graph_.reset();
+        state.cache_.reset();
     }
+    if (state.cache_ == nullptr || !state.cache_->can_run(*this, required_capacity)) {
+        state.graph_.reset();
+        state.suffix_graph_.reset();
+        state.cache_ = std::make_unique<VibeVoiceDecoderKVCache>(*this, required_capacity);
+    }
+    if (!state.cache_has_state_) {
+        if (state.pending_state_.layers.empty() && state.pending_state_.current_end == 0) {
+            state.pending_state_ = empty_decoder_state(weights_->layers.size());
+        }
+        state.cache_->import_state(state.pending_state_);
+        state.pending_state_ = {};
+        state.cache_has_state_ = true;
+    }
+    state.graph_.reset();
     if (state.suffix_graph_ == nullptr || !state.suffix_graph_->can_decode(*this, steps, required_capacity)) {
         state.suffix_graph_.reset();
         const size_t graph_arena_bytes = 1536ull * 1024ull * 1024ull;
         state.suffix_graph_ = std::make_unique<VibeVoiceDecoderCachedSuffixGraph>(
             *this,
             steps,
-            required_capacity,
+            *state.cache_,
             graph_arena_bytes);
-    }
-    if (state.graph_has_state_ && state.graph_ != nullptr) {
-        if (state.suffix_graph_->cache_steps() == state.graph_->cache_steps()) {
-            state.suffix_graph_->copy_state_from_cache(state.graph_->cache());
-            state.pending_state_ = {};
-            state.suffix_graph_has_state_ = true;
-        } else {
-            state.pending_state_ = state.graph_->export_state();
-            state.suffix_graph_has_state_ = false;
-        }
-        state.graph_has_state_ = false;
-        state.graph_.reset();
-    }
-    if (!state.suffix_graph_has_state_) {
-        if (state.pending_state_.layers.empty() && state.pending_state_.current_end == 0) {
-            state.pending_state_ = empty_decoder_state(weights_->layers.size());
-        }
-        state.suffix_graph_->import_state(state.pending_state_);
-        state.pending_state_ = {};
-        state.suffix_graph_has_state_ = true;
     }
     return state.suffix_graph_->run_suffix(embeddings);
 }

--- a/src/models/vibevoice_asr/text_decoder.cpp
+++ b/src/models/vibevoice_asr/text_decoder.cpp
@@ -722,6 +722,20 @@ public:
     }
 
     VibeVoiceDecoderResult run_step(const std::vector<float> & embedding) {
+        run_step_no_readback(embedding);
+        const auto & config = runtime_->assets().config.decoder;
+        VibeVoiceDecoderResult out;
+        out.logits.vocab_size = config.vocab_size;
+        out.logits.values.resize(static_cast<size_t>(config.vocab_size));
+        out.last_hidden.dims = config.hidden_size;
+        out.last_hidden.values.resize(static_cast<size_t>(config.hidden_size));
+        ggml_backend_tensor_get(logits_output_, out.logits.values.data(), 0, out.logits.values.size() * sizeof(float));
+        ggml_backend_tensor_get(hidden_output_, out.last_hidden.values.data(), 0, out.last_hidden.values.size() * sizeof(float));
+        ggml_backend_synchronize(runtime_->backend());
+        return out;
+    }
+
+    void run_step_no_readback(const std::vector<float> & embedding) {
         const auto & config = runtime_->assets().config.decoder;
         if (static_cast<int64_t>(embedding.size()) != config.hidden_size) {
             throw std::runtime_error("VibeVoice decoder cached step embedding size mismatch");
@@ -749,14 +763,6 @@ public:
         if (status != GGML_STATUS_SUCCESS) {
             throw std::runtime_error("VibeVoice decoder cached step graph compute failed");
         }
-
-        VibeVoiceDecoderResult out;
-        out.logits.vocab_size = config.vocab_size;
-        out.logits.values.resize(static_cast<size_t>(config.vocab_size));
-        out.last_hidden.dims = config.hidden_size;
-        out.last_hidden.values.resize(static_cast<size_t>(config.hidden_size));
-        ggml_backend_tensor_get(logits_output_, out.logits.values.data(), 0, out.logits.values.size() * sizeof(float));
-        ggml_backend_tensor_get(hidden_output_, out.last_hidden.values.data(), 0, out.last_hidden.values.size() * sizeof(float));
         if (scratch_tail_) {
             const size_t dst_slot = static_cast<size_t>(cache_.valid_steps());
             for (size_t layer = 0; layer < scratch_key_sources_.size(); ++layer) {
@@ -765,7 +771,6 @@ public:
             }
         }
         cache_.advance_after_direct_append(1);
-        return out;
     }
 
 private:
@@ -813,6 +818,244 @@ private:
     std::vector<ggml_tensor *> scratch_value_sources_;
     std::vector<std::vector<ggml_tensor *>> scratch_key_destinations_;
     std::vector<std::vector<ggml_tensor *>> scratch_value_destinations_;
+    ggml_cgraph * graph_ = nullptr;
+    ggml_backend_buffer_t buffer_ = nullptr;
+};
+
+class VibeVoiceDecoderCachedSuffixGraph {
+public:
+    VibeVoiceDecoderCachedSuffixGraph(
+        const VibeVoiceDecoderWeightsRuntime & runtime,
+        int64_t suffix_steps,
+        int64_t cache_steps,
+        size_t graph_arena_bytes)
+        : runtime_(&runtime),
+          suffix_steps_(suffix_steps),
+          cache_steps_(cache_steps) {
+        if (suffix_steps_ <= 0) {
+            throw std::runtime_error("VibeVoice decoder cached suffix graph requires positive suffix steps");
+        }
+        if (cache_steps_ <= 0) {
+            throw std::runtime_error("VibeVoice decoder cached suffix graph requires positive cache steps");
+        }
+        const auto & config = runtime_->assets().config.decoder;
+        ggml_init_params params{graph_arena_bytes, nullptr, true};
+        ctx_.reset(ggml_init(params));
+        if (ctx_ == nullptr) {
+            throw std::runtime_error("failed to initialize VibeVoice decoder cached suffix graph context");
+        }
+
+        core::ModuleBuildContext ctx{ctx_.get(), "vibevoice.decoder.cached_suffix"};
+        auto x = core::make_tensor(
+            ctx,
+            GGML_TYPE_F32,
+            core::TensorShape::from_dims({1, suffix_steps_, config.hidden_size}));
+        input_ = x.tensor;
+        positions_ = ggml_new_tensor_1d(ctx_.get(), GGML_TYPE_I32, suffix_steps_);
+        auto positions_value = core::wrap_tensor(
+            positions_,
+            core::TensorShape::from_dims({suffix_steps_}),
+            GGML_TYPE_I32);
+        cache_slot_ = ggml_new_tensor_1d(ctx_.get(), GGML_TYPE_I32, suffix_steps_);
+        auto cache_slot_value = core::wrap_tensor(
+            cache_slot_,
+            core::TensorShape::from_dims({suffix_steps_}),
+            GGML_TYPE_I32);
+        attention_key_steps_ = cache_steps_ + suffix_steps_;
+        attention_mask_ = ggml_new_tensor_4d(ctx_.get(), GGML_TYPE_F16, attention_key_steps_, suffix_steps_, 1, 1);
+        auto attention_mask_value = core::wrap_tensor(
+            attention_mask_,
+            core::TensorShape::from_dims({1, 1, suffix_steps_, attention_key_steps_}),
+            GGML_TYPE_F16);
+
+        graph_ = ggml_new_graph_custom(ctx_.get(), 65536, false);
+        auto & constants = runtime_->constants();
+        constants.begin_graph();
+        auto decoder_config = make_qwen_decoder_config(config);
+        const int64_t step_elems = config.num_key_value_heads * require_head_dim(config);
+        std::vector<core::TensorValue> cache_keys;
+        std::vector<core::TensorValue> cache_values;
+        cache_keys.reserve(runtime_->weights().layers.size());
+        cache_values.reserve(runtime_->weights().layers.size());
+        auto layer_input = x;
+        const modules::QwenDecoderLayerModule layer_module(
+            modules::qwen_decoder_layer_config_from_stack(decoder_config.stack));
+        for (const auto & layer : runtime_->weights().layers) {
+            cache_keys.push_back(core::make_tensor(
+                ctx,
+                GGML_TYPE_F32,
+                core::TensorShape::from_dims({1, cache_steps_, config.num_key_value_heads, require_head_dim(config)})));
+            cache_values.push_back(core::make_tensor(
+                ctx,
+                GGML_TYPE_F32,
+                core::TensorShape::from_dims({1, cache_steps_, config.num_key_value_heads, require_head_dim(config)})));
+            auto layer_out = layer_module.build(
+                ctx,
+                layer_input,
+                positions_value,
+                to_qwen_layer_weights(layer, constants),
+                cache_keys.back(),
+                cache_values.back(),
+                attention_mask_value);
+            layer_input = layer_out.output;
+
+            auto key_rows = core::ensure_backend_addressable_layout(ctx, layer_out.key);
+            auto value_rows = core::ensure_backend_addressable_layout(ctx, layer_out.value);
+            auto flat_key_cache = core::reshape_tensor(
+                ctx,
+                cache_keys.back(),
+                core::TensorShape::from_dims({cache_steps_, step_elems}));
+            auto flat_value_cache = core::reshape_tensor(
+                ctx,
+                cache_values.back(),
+                core::TensorShape::from_dims({cache_steps_, step_elems}));
+            auto flat_key_rows = core::reshape_tensor(
+                ctx,
+                key_rows,
+                core::TensorShape::from_dims({suffix_steps_, step_elems}));
+            auto flat_value_rows = core::reshape_tensor(
+                ctx,
+                value_rows,
+                core::TensorShape::from_dims({suffix_steps_, step_elems}));
+            ggml_build_forward_expand(
+                graph_,
+                ggml_set_rows(ctx.ggml, flat_key_cache.tensor, flat_key_rows.tensor, cache_slot_value.tensor));
+            ggml_build_forward_expand(
+                graph_,
+                ggml_set_rows(ctx.ggml, flat_value_cache.tensor, flat_value_rows.tensor, cache_slot_value.tensor));
+        }
+
+        auto hidden = modules::RMSNormModule({config.hidden_size, config.rms_norm_eps, true, false})
+                          .build(ctx, layer_input, binding::norm_data(constants, runtime_->weights().norm));
+        auto logits = modules::LinearModule({
+                          config.hidden_size,
+                          config.vocab_size,
+                          false,
+                      })
+                          .build(ctx, hidden, {runtime_->weights().lm_head, std::nullopt});
+        cache_ = runtime::TransformerKVCache(
+            cache_steps_,
+            step_elems,
+            std::move(cache_keys),
+            std::move(cache_values));
+        hidden_output_ = ggml_cpy(ctx_.get(), hidden.tensor, ggml_dup_tensor(ctx_.get(), hidden.tensor));
+        ggml_set_output(hidden_output_);
+        logits_output_ = logits.tensor;
+        ggml_set_output(logits_output_);
+        ggml_build_forward_expand(graph_, hidden_output_);
+        ggml_build_forward_expand(graph_, logits_output_);
+        constants.finish_graph();
+        constants.ensure_uploaded();
+        buffer_ = ggml_backend_alloc_ctx_tensors(ctx_.get(), runtime_->backend());
+        if (buffer_ == nullptr) {
+            throw std::runtime_error("failed to allocate VibeVoice decoder cached suffix graph");
+        }
+        position_values_.resize(static_cast<size_t>(suffix_steps_));
+        cache_slot_values_.resize(static_cast<size_t>(suffix_steps_));
+        attention_mask_buffer_.resize(static_cast<size_t>(suffix_steps_ * attention_key_steps_));
+    }
+
+    ~VibeVoiceDecoderCachedSuffixGraph() {
+        engine::core::release_backend_graph_resources(runtime_->backend(), graph_);
+        if (buffer_ != nullptr) {
+            ggml_backend_buffer_free(buffer_);
+        }
+    }
+
+    bool can_decode(const VibeVoiceDecoderWeightsRuntime & runtime, int64_t suffix_steps, int64_t required_capacity) const {
+        return runtime_ == &runtime && suffix_steps_ == suffix_steps && cache_steps_ >= required_capacity;
+    }
+
+    int64_t current_end() const noexcept {
+        return cache_.current_end();
+    }
+
+    void import_state(const runtime::TransformerKVState & state) {
+        cache_.import_state(state);
+    }
+
+    runtime::TransformerKVState export_state() const {
+        return cache_.export_state();
+    }
+
+    VibeVoiceDecoderResult run_suffix(const std::vector<float> & embeddings) {
+        const auto & config = runtime_->assets().config.decoder;
+        if (static_cast<int64_t>(embeddings.size()) != suffix_steps_ * config.hidden_size) {
+            throw std::runtime_error("VibeVoice decoder cached suffix embedding size mismatch");
+        }
+        if (cache_.valid_steps() + suffix_steps_ > cache_steps_) {
+            throw std::runtime_error("VibeVoice decoder cached suffix exceeds cache capacity");
+        }
+        ggml_backend_tensor_set(input_, embeddings.data(), 0, embeddings.size() * sizeof(float));
+        for (int64_t step = 0; step < suffix_steps_; ++step) {
+            position_values_[static_cast<size_t>(step)] = static_cast<int32_t>(cache_.current_end() + step);
+            cache_slot_values_[static_cast<size_t>(step)] = static_cast<int32_t>(cache_.valid_steps() + step);
+        }
+        ggml_backend_tensor_set(positions_, position_values_.data(), 0, position_values_.size() * sizeof(int32_t));
+        ggml_backend_tensor_set(cache_slot_, cache_slot_values_.data(), 0, cache_slot_values_.size() * sizeof(int32_t));
+
+        const auto masked = ggml_fp32_to_fp16(-std::numeric_limits<float>::infinity());
+        const auto visible = ggml_fp32_to_fp16(0.0F);
+        std::fill(attention_mask_buffer_.begin(), attention_mask_buffer_.end(), masked);
+        for (int64_t row = 0; row < suffix_steps_; ++row) {
+            const size_t row_offset = static_cast<size_t>(row * attention_key_steps_);
+            std::fill_n(
+                attention_mask_buffer_.begin() + static_cast<std::ptrdiff_t>(row_offset),
+                static_cast<size_t>(cache_.valid_steps()),
+                visible);
+            std::fill_n(
+                attention_mask_buffer_.begin() + static_cast<std::ptrdiff_t>(row_offset + cache_steps_),
+                static_cast<size_t>(row + 1),
+                visible);
+        }
+        ggml_backend_tensor_set(
+            attention_mask_,
+            attention_mask_buffer_.data(),
+            0,
+            attention_mask_buffer_.size() * sizeof(ggml_fp16_t));
+
+        core::set_backend_threads(runtime_->backend(), runtime_->threads());
+        const ggml_status status = engine::core::compute_backend_graph(runtime_->backend(), graph_);
+        ggml_backend_synchronize(runtime_->backend());
+        if (status != GGML_STATUS_SUCCESS) {
+            throw std::runtime_error("VibeVoice decoder cached suffix graph compute failed");
+        }
+        cache_.advance_after_direct_append(suffix_steps_);
+
+        const size_t logits_per_step = static_cast<size_t>(config.vocab_size);
+        const size_t hidden_per_step = static_cast<size_t>(config.hidden_size);
+        std::vector<float> logits(static_cast<size_t>(suffix_steps_) * logits_per_step);
+        std::vector<float> hidden(static_cast<size_t>(suffix_steps_) * hidden_per_step);
+        ggml_backend_tensor_get(logits_output_, logits.data(), 0, logits.size() * sizeof(float));
+        ggml_backend_tensor_get(hidden_output_, hidden.data(), 0, hidden.size() * sizeof(float));
+        ggml_backend_synchronize(runtime_->backend());
+
+        const size_t last_logits = static_cast<size_t>(suffix_steps_ - 1) * logits_per_step;
+        const size_t last_hidden = static_cast<size_t>(suffix_steps_ - 1) * hidden_per_step;
+        VibeVoiceDecoderResult out;
+        out.logits.vocab_size = config.vocab_size;
+        out.logits.values.assign(logits.begin() + static_cast<std::ptrdiff_t>(last_logits), logits.end());
+        out.last_hidden.dims = config.hidden_size;
+        out.last_hidden.values.assign(hidden.begin() + static_cast<std::ptrdiff_t>(last_hidden), hidden.end());
+        return out;
+    }
+
+private:
+    const VibeVoiceDecoderWeightsRuntime * runtime_ = nullptr;
+    int64_t suffix_steps_ = 0;
+    int64_t cache_steps_ = 0;
+    int64_t attention_key_steps_ = 0;
+    std::unique_ptr<ggml_context, GgmlContextDeleter> ctx_;
+    ggml_tensor * input_ = nullptr;
+    ggml_tensor * positions_ = nullptr;
+    ggml_tensor * cache_slot_ = nullptr;
+    ggml_tensor * attention_mask_ = nullptr;
+    ggml_tensor * hidden_output_ = nullptr;
+    ggml_tensor * logits_output_ = nullptr;
+    std::vector<int32_t> position_values_;
+    std::vector<int32_t> cache_slot_values_;
+    std::vector<ggml_fp16_t> attention_mask_buffer_;
+    runtime::TransformerKVCache cache_;
     ggml_cgraph * graph_ = nullptr;
     ggml_backend_buffer_t buffer_ = nullptr;
 };
@@ -960,12 +1203,49 @@ VibeVoiceDecoderPrefillOutput VibeVoiceDecoderWeightsRuntime::prefill_prompt(
 void VibeVoiceDecoderWeightsRuntime::reset_cached_state(
     VibeVoiceDecoderCachedState & state,
     runtime::TransformerKVState prefill_state) const {
+    state.graph_.reset();
+    state.suffix_graph_.reset();
     state.pending_state_ = std::move(prefill_state);
     state.graph_has_state_ = false;
+    state.suffix_graph_has_state_ = false;
+}
+
+void VibeVoiceDecoderWeightsRuntime::prepare_cached_state(
+    VibeVoiceDecoderCachedState & state,
+    int64_t cache_capacity) const {
+    const auto & config = assets_->config.decoder;
+    if (cache_capacity <= 0) {
+        throw std::runtime_error("VibeVoice decoder cached state prepare requires positive cache capacity");
+    }
+    const int64_t required_capacity = cache_graph_capacity(cache_capacity, config.max_position_embeddings);
+    if (state.suffix_graph_has_state_ && state.suffix_graph_ != nullptr) {
+        state.pending_state_ = state.suffix_graph_->export_state();
+        state.suffix_graph_has_state_ = false;
+    }
+    if (state.graph_ == nullptr || !state.graph_->can_decode(*this, required_capacity)) {
+        state.graph_.reset();
+        const size_t graph_arena_bytes = 1536ull * 1024ull * 1024ull;
+        state.graph_ = std::make_unique<VibeVoiceDecoderCachedStepGraph>(
+            *this,
+            required_capacity,
+            graph_arena_bytes);
+    }
+    if (!state.graph_has_state_) {
+        if (state.pending_state_.layers.empty() && state.pending_state_.current_end == 0) {
+            state.pending_state_ = empty_decoder_state(weights_->layers.size());
+        }
+        state.graph_->import_state(state.pending_state_);
+        state.pending_state_ = {};
+        state.graph_has_state_ = true;
+    }
 }
 
 runtime::TransformerKVState VibeVoiceDecoderWeightsRuntime::export_cached_state(
     VibeVoiceDecoderCachedState & state) const {
+    if (state.suffix_graph_has_state_ && state.suffix_graph_ != nullptr) {
+        state.pending_state_ = state.suffix_graph_->export_state();
+        state.suffix_graph_has_state_ = false;
+    }
     if (state.graph_has_state_ && state.graph_ != nullptr) {
         state.pending_state_ = state.graph_->export_state();
         state.graph_has_state_ = false;
@@ -1013,10 +1293,16 @@ VibeVoiceDecoderResult VibeVoiceDecoderWeightsRuntime::cached_step(
     }
     const int64_t current_end = state.graph_has_state_ && state.graph_ != nullptr
         ? state.graph_->current_end()
-        : state.pending_state_.current_end;
+        : state.suffix_graph_has_state_ && state.suffix_graph_ != nullptr
+            ? state.suffix_graph_->current_end()
+            : state.pending_state_.current_end;
     const int64_t required_capacity = cache_graph_capacity(
         std::max<int64_t>(cache_capacity, current_end + 1),
         config.max_position_embeddings);
+    if (state.suffix_graph_has_state_ && state.suffix_graph_ != nullptr) {
+        state.pending_state_ = state.suffix_graph_->export_state();
+        state.suffix_graph_has_state_ = false;
+    }
     if (state.graph_ != nullptr && state.graph_has_state_ && !state.graph_->can_decode(*this, required_capacity)) {
         state.pending_state_ = state.graph_->export_state();
         state.graph_has_state_ = false;
@@ -1038,6 +1324,104 @@ VibeVoiceDecoderResult VibeVoiceDecoderWeightsRuntime::cached_step(
         state.graph_has_state_ = true;
     }
     return state.graph_->run_step(embedding);
+}
+
+void VibeVoiceDecoderWeightsRuntime::append_cached_step(
+    const std::vector<float> & embedding,
+    VibeVoiceDecoderCachedState & state,
+    int64_t cache_capacity) const {
+    const auto & config = assets_->config.decoder;
+    if (static_cast<int64_t>(embedding.size()) != config.hidden_size) {
+        throw std::runtime_error("VibeVoice decoder cached append embedding payload size mismatch");
+    }
+    if (cache_capacity <= 0) {
+        throw std::runtime_error("VibeVoice decoder cached append requires positive cache capacity");
+    }
+    const int64_t current_end = state.graph_has_state_ && state.graph_ != nullptr
+        ? state.graph_->current_end()
+        : state.suffix_graph_has_state_ && state.suffix_graph_ != nullptr
+            ? state.suffix_graph_->current_end()
+            : state.pending_state_.current_end;
+    const int64_t required_capacity = cache_graph_capacity(
+        std::max<int64_t>(cache_capacity, current_end + 1),
+        config.max_position_embeddings);
+    if (state.suffix_graph_has_state_ && state.suffix_graph_ != nullptr) {
+        state.pending_state_ = state.suffix_graph_->export_state();
+        state.suffix_graph_has_state_ = false;
+    }
+    if (state.graph_ != nullptr && state.graph_has_state_ && !state.graph_->can_decode(*this, required_capacity)) {
+        state.pending_state_ = state.graph_->export_state();
+        state.graph_has_state_ = false;
+    }
+    if (state.graph_ == nullptr || !state.graph_->can_decode(*this, required_capacity)) {
+        state.graph_.reset();
+        const size_t graph_arena_bytes = 1536ull * 1024ull * 1024ull;
+        state.graph_ = std::make_unique<VibeVoiceDecoderCachedStepGraph>(
+            *this,
+            required_capacity,
+            graph_arena_bytes);
+    }
+    if (!state.graph_has_state_) {
+        if (state.pending_state_.layers.empty() && state.pending_state_.current_end == 0) {
+            state.pending_state_ = empty_decoder_state(weights_->layers.size());
+        }
+        state.graph_->import_state(state.pending_state_);
+        state.pending_state_ = {};
+        state.graph_has_state_ = true;
+    }
+    state.graph_->run_step_no_readback(embedding);
+}
+
+VibeVoiceDecoderResult VibeVoiceDecoderWeightsRuntime::cached_suffix(
+    const std::vector<float> & embeddings,
+    int64_t steps,
+    VibeVoiceDecoderCachedState & state,
+    int64_t cache_capacity) const {
+    const auto & config = assets_->config.decoder;
+    if (steps <= 0) {
+        throw std::runtime_error("VibeVoice decoder cached suffix requires positive steps");
+    }
+    if (static_cast<int64_t>(embeddings.size()) != steps * config.hidden_size) {
+        throw std::runtime_error("VibeVoice decoder cached suffix embedding payload size mismatch");
+    }
+    if (cache_capacity <= 0) {
+        throw std::runtime_error("VibeVoice decoder cached suffix requires positive cache capacity");
+    }
+    const int64_t current_end = state.suffix_graph_has_state_ && state.suffix_graph_ != nullptr
+        ? state.suffix_graph_->current_end()
+        : state.graph_has_state_ && state.graph_ != nullptr
+            ? state.graph_->current_end()
+            : state.pending_state_.current_end;
+    const int64_t required_capacity = cache_graph_capacity(
+        std::max<int64_t>(cache_capacity, current_end + steps),
+        config.max_position_embeddings);
+    if (state.graph_has_state_ && state.graph_ != nullptr) {
+        state.pending_state_ = state.graph_->export_state();
+        state.graph_has_state_ = false;
+    }
+    if (state.suffix_graph_ != nullptr && state.suffix_graph_has_state_ &&
+        !state.suffix_graph_->can_decode(*this, steps, required_capacity)) {
+        state.pending_state_ = state.suffix_graph_->export_state();
+        state.suffix_graph_has_state_ = false;
+    }
+    if (state.suffix_graph_ == nullptr || !state.suffix_graph_->can_decode(*this, steps, required_capacity)) {
+        state.suffix_graph_.reset();
+        const size_t graph_arena_bytes = 1536ull * 1024ull * 1024ull;
+        state.suffix_graph_ = std::make_unique<VibeVoiceDecoderCachedSuffixGraph>(
+            *this,
+            steps,
+            required_capacity,
+            graph_arena_bytes);
+    }
+    if (!state.suffix_graph_has_state_) {
+        if (state.pending_state_.layers.empty() && state.pending_state_.current_end == 0) {
+            state.pending_state_ = empty_decoder_state(weights_->layers.size());
+        }
+        state.suffix_graph_->import_state(state.pending_state_);
+        state.pending_state_ = {};
+        state.suffix_graph_has_state_ = true;
+    }
+    return state.suffix_graph_->run_suffix(embeddings);
 }
 
 }  // namespace engine::models::vibevoice_asr

--- a/src/models/vibevoice_asr/text_decoder.cpp
+++ b/src/models/vibevoice_asr/text_decoder.cpp
@@ -1,5 +1,6 @@
 #include "engine/models/vibevoice_asr/text_decoder.h"
 
+#include "engine/framework/core/backend.h"
 #include "engine/framework/core/backend_weight_store.h"
 #include "engine/framework/debug/profiler.h"
 #include "engine/framework/debug/trace.h"
@@ -70,8 +71,10 @@ modules::QwenCausalDecoderConfig make_qwen_decoder_config(const VibeVoiceDecoder
     out.stack.runtime.attention.prefill_mode = modules::QwenDecoderAttentionMode::FlashGroupedViewKV;
     out.stack.runtime.attention.static_mode = modules::QwenDecoderAttentionMode::FlashGroupedViewKV;
     out.stack.runtime.static_cache.update_mode = modules::QwenDecoderStaticCacheUpdateMode::DirectSetRows;
+    out.stack.runtime.static_cache.set_rows_mode = modules::QwenDecoderStaticCacheSetRowsMode::BackendViewOptimized;
     out.logits_size = config.vocab_size;
     out.logits_mode = modules::QwenCausalDecoderLogitsMode::LastStep;
+    out.static_cache_type = GGML_TYPE_F16;
     return out;
 }
 
@@ -191,6 +194,33 @@ int64_t cache_graph_capacity(int64_t required_capacity, int64_t model_capacity) 
     return model_capacity > 0 ? std::min(capacity, model_capacity) : capacity;
 }
 
+void copy_vibevoice_decoder_cache_backend(
+    runtime::TransformerKVCache & target,
+    const runtime::TransformerKVCache & source,
+    size_t layers) {
+    if (target.cache_steps() != source.cache_steps()) {
+        throw std::runtime_error("VibeVoice decoder cache backend copy requires matching cache capacity");
+    }
+    if (source.current_end() != source.valid_steps()) {
+        throw std::runtime_error("VibeVoice decoder cache backend copy requires contiguous source state");
+    }
+    for (size_t layer = 0; layer < layers; ++layer) {
+        const auto & source_key = source.key_tensor(layer);
+        const auto & source_value = source.value_tensor(layer);
+        const auto & target_key = target.key_tensor(layer);
+        const auto & target_value = target.value_tensor(layer);
+        if (source_key.type != target_key.type || source_value.type != target_value.type ||
+            source_key.shape.dims != target_key.shape.dims ||
+            source_value.shape.dims != target_value.shape.dims) {
+            throw std::runtime_error("VibeVoice decoder cache backend copy requires matching tensor layout");
+        }
+        ggml_backend_tensor_copy(source_key.tensor, target_key.tensor);
+        ggml_backend_tensor_copy(source_value.tensor, target_value.tensor);
+    }
+    target.retain_prefix(0);
+    target.advance_after_direct_append(source.valid_steps());
+}
+
 runtime::TransformerKVState empty_decoder_state(size_t layers) {
     runtime::TransformerKVState state;
     state.layers.resize(layers);
@@ -292,10 +322,11 @@ public:
     }
 
     ~VibeVoiceDecoderEmbeddingGraph() {
-        engine::core::release_backend_graph_resources(runtime_->backend(), graph_);
+        engine::core::release_backend_graph_resources(runtime_->backend(), graph_, true);
         if (gallocr_ != nullptr) {
             ggml_gallocr_free(gallocr_);
         }
+        engine::core::trim_backend_pools(runtime_->backend());
     }
 
     bool matches(const VibeVoiceDecoderWeightsRuntime & runtime, int64_t steps) const {
@@ -448,10 +479,11 @@ public:
     }
 
     ~VibeVoiceDecoderPrefillGraph() {
-        engine::core::release_backend_graph_resources(runtime_->backend(), graph_);
+        engine::core::release_backend_graph_resources(runtime_->backend(), graph_, true);
         if (gallocr_ != nullptr) {
             ggml_gallocr_free(gallocr_);
         }
+        engine::core::trim_backend_pools(runtime_->backend());
     }
 
     bool matches(
@@ -677,10 +709,11 @@ public:
     }
 
     ~VibeVoiceDecoderCachedStepGraph() {
-        engine::core::release_backend_graph_resources(runtime_->backend(), graph_);
+        engine::core::release_backend_graph_resources(runtime_->backend(), graph_, true);
         if (buffer_ != nullptr) {
             ggml_backend_buffer_free(buffer_);
         }
+        engine::core::trim_backend_pools(runtime_->backend());
     }
 
     bool can_decode(const VibeVoiceDecoderWeightsRuntime & runtime, int64_t required_capacity) const {
@@ -689,6 +722,18 @@ public:
 
     int64_t current_end() const noexcept {
         return cache_.current_end();
+    }
+
+    int64_t cache_steps() const noexcept {
+        return cache_.cache_steps();
+    }
+
+    const runtime::TransformerKVCache & cache() const noexcept {
+        return cache_;
+    }
+
+    void copy_state_from_cache(const runtime::TransformerKVCache & source) {
+        copy_vibevoice_decoder_cache_backend(cache_, source, runtime_->weights().layers.size());
     }
 
     void import_state(const runtime::TransformerKVState & state) {
@@ -777,8 +822,8 @@ private:
     void build_scratch_transfer_views(int64_t step_elems) {
         scratch_key_sources_.reserve(runtime_->weights().layers.size());
         scratch_value_sources_.reserve(runtime_->weights().layers.size());
-        const size_t scratch_offset = static_cast<size_t>(cache_steps_ * step_elems) * sizeof(float);
         for (size_t layer = 0; layer < runtime_->weights().layers.size(); ++layer) {
+            const size_t scratch_offset = ggml_row_size(cache_.key_tensor(layer).type, cache_steps_ * step_elems);
             scratch_key_sources_.push_back(
                 ggml_view_1d(ctx_.get(), cache_.key_tensor(layer).tensor, step_elems, scratch_offset));
             scratch_value_sources_.push_back(
@@ -788,12 +833,12 @@ private:
         scratch_key_destinations_.assign(static_cast<size_t>(cache_steps_), {});
         scratch_value_destinations_.assign(static_cast<size_t>(cache_steps_), {});
         for (int64_t slot = 0; slot < cache_steps_; ++slot) {
-            const size_t byte_offset = static_cast<size_t>(slot * step_elems) * sizeof(float);
             auto & key_slot = scratch_key_destinations_[static_cast<size_t>(slot)];
             auto & value_slot = scratch_value_destinations_[static_cast<size_t>(slot)];
             key_slot.reserve(scratch_key_sources_.size());
             value_slot.reserve(scratch_value_sources_.size());
             for (size_t layer = 0; layer < scratch_key_sources_.size(); ++layer) {
+                const size_t byte_offset = ggml_row_size(cache_.key_tensor(layer).type, slot * step_elems);
                 key_slot.push_back(
                     ggml_view_1d(ctx_.get(), cache_.key_tensor(layer).tensor, step_elems, byte_offset));
                 value_slot.push_back(
@@ -883,11 +928,11 @@ public:
         for (const auto & layer : runtime_->weights().layers) {
             cache_keys.push_back(core::make_tensor(
                 ctx,
-                GGML_TYPE_F32,
+                decoder_config.static_cache_type,
                 core::TensorShape::from_dims({1, cache_steps_, config.num_key_value_heads, require_head_dim(config)})));
             cache_values.push_back(core::make_tensor(
                 ctx,
-                GGML_TYPE_F32,
+                decoder_config.static_cache_type,
                 core::TensorShape::from_dims({1, cache_steps_, config.num_key_value_heads, require_head_dim(config)})));
             auto layer_out = layer_module.build(
                 ctx,
@@ -925,19 +970,24 @@ public:
                 ggml_set_rows(ctx.ggml, flat_value_cache.tensor, flat_value_rows.tensor, cache_slot_value.tensor));
         }
 
+        auto last_layer_input = modules::SliceModule({1, suffix_steps_ - 1, 1}).build(ctx, layer_input);
         auto hidden = modules::RMSNormModule({config.hidden_size, config.rms_norm_eps, true, false})
-                          .build(ctx, layer_input, binding::norm_data(constants, runtime_->weights().norm));
+                          .build(ctx, last_layer_input, binding::norm_data(constants, runtime_->weights().norm));
         auto logits = modules::LinearModule({
                           config.hidden_size,
                           config.vocab_size,
                           false,
                       })
                           .build(ctx, hidden, {runtime_->weights().lm_head, std::nullopt});
+        runtime::TransformerKVCacheOptions cache_options;
+        cache_options.allow_f16_storage = decoder_config.static_cache_type == GGML_TYPE_F16;
+        cache_options.allow_bf16_storage = decoder_config.static_cache_type == GGML_TYPE_BF16;
         cache_ = runtime::TransformerKVCache(
             cache_steps_,
             step_elems,
             std::move(cache_keys),
-            std::move(cache_values));
+            std::move(cache_values),
+            cache_options);
         hidden_output_ = ggml_cpy(ctx_.get(), hidden.tensor, ggml_dup_tensor(ctx_.get(), hidden.tensor));
         ggml_set_output(hidden_output_);
         logits_output_ = logits.tensor;
@@ -956,18 +1006,31 @@ public:
     }
 
     ~VibeVoiceDecoderCachedSuffixGraph() {
-        engine::core::release_backend_graph_resources(runtime_->backend(), graph_);
+        engine::core::release_backend_graph_resources(runtime_->backend(), graph_, true);
         if (buffer_ != nullptr) {
             ggml_backend_buffer_free(buffer_);
         }
+        engine::core::trim_backend_pools(runtime_->backend());
     }
 
     bool can_decode(const VibeVoiceDecoderWeightsRuntime & runtime, int64_t suffix_steps, int64_t required_capacity) const {
-        return runtime_ == &runtime && suffix_steps_ == suffix_steps && cache_steps_ >= required_capacity;
+        return runtime_ == &runtime && this->suffix_steps_ == suffix_steps && cache_steps_ >= required_capacity;
     }
 
     int64_t current_end() const noexcept {
         return cache_.current_end();
+    }
+
+    int64_t cache_steps() const noexcept {
+        return cache_.cache_steps();
+    }
+
+    const runtime::TransformerKVCache & cache() const noexcept {
+        return cache_;
+    }
+
+    void copy_state_from_cache(const runtime::TransformerKVCache & source) {
+        copy_vibevoice_decoder_cache_backend(cache_, source, runtime_->weights().layers.size());
     }
 
     void import_state(const runtime::TransformerKVState & state) {
@@ -1022,21 +1085,17 @@ public:
         }
         cache_.advance_after_direct_append(suffix_steps_);
 
-        const size_t logits_per_step = static_cast<size_t>(config.vocab_size);
-        const size_t hidden_per_step = static_cast<size_t>(config.hidden_size);
-        std::vector<float> logits(static_cast<size_t>(suffix_steps_) * logits_per_step);
-        std::vector<float> hidden(static_cast<size_t>(suffix_steps_) * hidden_per_step);
+        std::vector<float> logits(static_cast<size_t>(config.vocab_size));
+        std::vector<float> hidden(static_cast<size_t>(config.hidden_size));
         ggml_backend_tensor_get(logits_output_, logits.data(), 0, logits.size() * sizeof(float));
         ggml_backend_tensor_get(hidden_output_, hidden.data(), 0, hidden.size() * sizeof(float));
         ggml_backend_synchronize(runtime_->backend());
 
-        const size_t last_logits = static_cast<size_t>(suffix_steps_ - 1) * logits_per_step;
-        const size_t last_hidden = static_cast<size_t>(suffix_steps_ - 1) * hidden_per_step;
         VibeVoiceDecoderResult out;
         out.logits.vocab_size = config.vocab_size;
-        out.logits.values.assign(logits.begin() + static_cast<std::ptrdiff_t>(last_logits), logits.end());
+        out.logits.values = std::move(logits);
         out.last_hidden.dims = config.hidden_size;
-        out.last_hidden.values.assign(hidden.begin() + static_cast<std::ptrdiff_t>(last_hidden), hidden.end());
+        out.last_hidden.values = std::move(hidden);
         return out;
     }
 
@@ -1299,10 +1358,6 @@ VibeVoiceDecoderResult VibeVoiceDecoderWeightsRuntime::cached_step(
     const int64_t required_capacity = cache_graph_capacity(
         std::max<int64_t>(cache_capacity, current_end + 1),
         config.max_position_embeddings);
-    if (state.suffix_graph_has_state_ && state.suffix_graph_ != nullptr) {
-        state.pending_state_ = state.suffix_graph_->export_state();
-        state.suffix_graph_has_state_ = false;
-    }
     if (state.graph_ != nullptr && state.graph_has_state_ && !state.graph_->can_decode(*this, required_capacity)) {
         state.pending_state_ = state.graph_->export_state();
         state.graph_has_state_ = false;
@@ -1314,6 +1369,18 @@ VibeVoiceDecoderResult VibeVoiceDecoderWeightsRuntime::cached_step(
             *this,
             required_capacity,
             graph_arena_bytes);
+    }
+    if (state.suffix_graph_has_state_ && state.suffix_graph_ != nullptr) {
+        if (state.graph_->cache_steps() == state.suffix_graph_->cache_steps()) {
+            state.graph_->copy_state_from_cache(state.suffix_graph_->cache());
+            state.pending_state_ = {};
+            state.graph_has_state_ = true;
+        } else {
+            state.pending_state_ = state.suffix_graph_->export_state();
+            state.graph_has_state_ = false;
+        }
+        state.suffix_graph_has_state_ = false;
+        state.suffix_graph_.reset();
     }
     if (!state.graph_has_state_) {
         if (state.pending_state_.layers.empty() && state.pending_state_.current_end == 0) {
@@ -1345,10 +1412,6 @@ void VibeVoiceDecoderWeightsRuntime::append_cached_step(
     const int64_t required_capacity = cache_graph_capacity(
         std::max<int64_t>(cache_capacity, current_end + 1),
         config.max_position_embeddings);
-    if (state.suffix_graph_has_state_ && state.suffix_graph_ != nullptr) {
-        state.pending_state_ = state.suffix_graph_->export_state();
-        state.suffix_graph_has_state_ = false;
-    }
     if (state.graph_ != nullptr && state.graph_has_state_ && !state.graph_->can_decode(*this, required_capacity)) {
         state.pending_state_ = state.graph_->export_state();
         state.graph_has_state_ = false;
@@ -1360,6 +1423,18 @@ void VibeVoiceDecoderWeightsRuntime::append_cached_step(
             *this,
             required_capacity,
             graph_arena_bytes);
+    }
+    if (state.suffix_graph_has_state_ && state.suffix_graph_ != nullptr) {
+        if (state.graph_->cache_steps() == state.suffix_graph_->cache_steps()) {
+            state.graph_->copy_state_from_cache(state.suffix_graph_->cache());
+            state.pending_state_ = {};
+            state.graph_has_state_ = true;
+        } else {
+            state.pending_state_ = state.suffix_graph_->export_state();
+            state.graph_has_state_ = false;
+        }
+        state.suffix_graph_has_state_ = false;
+        state.suffix_graph_.reset();
     }
     if (!state.graph_has_state_) {
         if (state.pending_state_.layers.empty() && state.pending_state_.current_end == 0) {
@@ -1395,10 +1470,6 @@ VibeVoiceDecoderResult VibeVoiceDecoderWeightsRuntime::cached_suffix(
     const int64_t required_capacity = cache_graph_capacity(
         std::max<int64_t>(cache_capacity, current_end + steps),
         config.max_position_embeddings);
-    if (state.graph_has_state_ && state.graph_ != nullptr) {
-        state.pending_state_ = state.graph_->export_state();
-        state.graph_has_state_ = false;
-    }
     if (state.suffix_graph_ != nullptr && state.suffix_graph_has_state_ &&
         !state.suffix_graph_->can_decode(*this, steps, required_capacity)) {
         state.pending_state_ = state.suffix_graph_->export_state();
@@ -1412,6 +1483,18 @@ VibeVoiceDecoderResult VibeVoiceDecoderWeightsRuntime::cached_suffix(
             steps,
             required_capacity,
             graph_arena_bytes);
+    }
+    if (state.graph_has_state_ && state.graph_ != nullptr) {
+        if (state.suffix_graph_->cache_steps() == state.graph_->cache_steps()) {
+            state.suffix_graph_->copy_state_from_cache(state.graph_->cache());
+            state.pending_state_ = {};
+            state.suffix_graph_has_state_ = true;
+        } else {
+            state.pending_state_ = state.graph_->export_state();
+            state.suffix_graph_has_state_ = false;
+        }
+        state.graph_has_state_ = false;
+        state.graph_.reset();
     }
     if (!state.suffix_graph_has_state_) {
         if (state.pending_state_.layers.empty() && state.pending_state_.current_end == 0) {

--- a/src/models/vibevoice_asr/tokenizer_text.cpp
+++ b/src/models/vibevoice_asr/tokenizer_text.cpp
@@ -28,6 +28,11 @@ int32_t require_token_id(const engine::tokenizers::LlamaBpeTokenizer & tokenizer
     return *id;
 }
 
+int32_t optional_token_id(const engine::tokenizers::LlamaBpeTokenizer & tokenizer, const char * token) {
+    const auto id = tokenizer.find_token_id(token);
+    return id.value_or(-1);
+}
+
 std::string format_seconds(double seconds) {
     std::ostringstream stream;
     stream << std::fixed << std::setprecision(2) << seconds;
@@ -56,6 +61,7 @@ struct VibeVoiceASRTextTokenizer::Impl {
           speech_start(require_token_id(tokenizer, "<|object_ref_start|>")),
           speech_end(require_token_id(tokenizer, "<|object_ref_end|>")),
           speech_pad(require_token_id(tokenizer, "<|box_start|>")),
+          text_chunk_end(optional_token_id(tokenizer, "<|text_chunk_end|>")),
           eos(require_token_id(tokenizer, "<|endoftext|>")),
           pad(require_token_id(tokenizer, "<|image_pad|>")) {}
 
@@ -63,6 +69,7 @@ struct VibeVoiceASRTextTokenizer::Impl {
     int32_t speech_start = 0;
     int32_t speech_end = 0;
     int32_t speech_pad = 0;
+    int32_t text_chunk_end = 0;
     int32_t eos = 0;
     int32_t pad = 0;
 };
@@ -121,6 +128,18 @@ VibeVoiceASRPrompt VibeVoiceASRTextTokenizer::build_prompt(
     return prompt;
 }
 
+std::vector<int32_t> VibeVoiceASRTextTokenizer::build_streaming_prompt(const std::string & context) const {
+    const std::string keys = "speaker, content";
+    std::string prompt =
+        "You are a helpful assistant that transcribes audio input into text output. "
+        "Please transcribe the following audios streamingly with these keys: " + keys;
+    if (!context.empty()) {
+        prompt += " and extra info: " + context;
+    }
+    prompt.push_back('\n');
+    return impl_->tokenizer.encode(prompt);
+}
+
 std::string VibeVoiceASRTextTokenizer::decode(
     const std::vector<int32_t> & token_ids,
     bool skip_special_tokens) const {
@@ -135,8 +154,20 @@ int32_t VibeVoiceASRTextTokenizer::pad_id() const noexcept {
     return impl_->pad;
 }
 
+int32_t VibeVoiceASRTextTokenizer::speech_start_id() const noexcept {
+    return impl_->speech_start;
+}
+
+int32_t VibeVoiceASRTextTokenizer::speech_end_id() const noexcept {
+    return impl_->speech_end;
+}
+
 int32_t VibeVoiceASRTextTokenizer::speech_pad_id() const noexcept {
     return impl_->speech_pad;
+}
+
+int32_t VibeVoiceASRTextTokenizer::text_chunk_end_id() const noexcept {
+    return impl_->text_chunk_end;
 }
 
 }  // namespace engine::models::vibevoice_asr


### PR DESCRIPTION
Draft PR for early review and conflict tracking.

This adds the VibeVoice ASR Streaming 7B runtime path and GGUF packaging/spec/docs updates. The branch is opened as draft first so review can happen before spending more time on conflict resolution and final validation.

Current validation includes basic CUDA ASR runs for the streaming 7B GGUFs. Speaker-attributed output is still being checked against the official Python baseline before this is marked ready.