### PR TITLE
perf(fish_audio): keep Fast-AR inputs on HIP stream

### DIFF
--- a/src/models/fish_audio/ar.cpp
+++ b/src/models/fish_audio/ar.cpp
@@ -13,6 +13,7 @@
 
 #ifdef ENGINE_HAS_HIP_FISH_FAST_SAMPLER
 #include "hip_fast_sampler.h"
+#include <ggml-cuda.h>
 #endif
 
 #include "engine/framework/core/constant_tensor_cache.h"
@@ -1387,6 +1388,19 @@ private:
 #ifdef ENGINE_HAS_HIP_FISH_FAST_SAMPLER
             if (runtime_->backend_type() == core::BackendType::Hip) {
                 hip_sampler_ = detail::hip_fast_sampler_create(static_cast<int32_t>(config.vocab_size));
+                std::vector<float> embedding_table(static_cast<size_t>(config.vocab_size * config.dim));
+                for (int64_t row = 0; row < config.vocab_size; ++row) {
+                    copy_tensor_row_to_f32(
+                        weights.fast_embedding_host,
+                        row,
+                        config.dim,
+                        embedding_table.data() + static_cast<size_t>(row * config.dim));
+                }
+                detail::hip_fast_sampler_upload_embeddings(
+                    hip_sampler_,
+                    embedding_table.data(),
+                    static_cast<int32_t>(config.vocab_size),
+                    static_cast<int32_t>(config.dim));
             }
 #endif
         }
@@ -1402,6 +1416,46 @@ private:
             }
             if (state_buffer_ != nullptr) {
                 ggml_backend_buffer_free(state_buffer_);
+            }
+        }
+
+        void run_initial_step(const std::vector<float> & input, FishARProfile & profile) {
+            const auto & config = runtime_->assets().config.fast;
+            if (static_cast<int64_t>(input.size()) != config.dim) {
+                throw std::runtime_error("Fish Audio fast AR input size mismatch");
+            }
+            ++profile.fast_runs;
+            auto timing_start = Clock::now();
+#ifdef ENGINE_HAS_HIP_FISH_FAST_SAMPLER
+            if (hip_sampler_ != nullptr) {
+                detail::hip_fast_sampler_prepare_step(
+                    hip_sampler_,
+                    0,
+                    static_cast<int32_t>(config.num_codebooks),
+                    static_cast<int32_t *>(position_->data),
+                    mask_->data,
+                    ggml_backend_cuda_get_stream(runtime_->backend()));
+            } else
+#endif
+            {
+                const int32_t pos = 0;
+                ggml_backend_tensor_set(position_, &pos, 0, sizeof(pos));
+                const auto visible = ggml_fp32_to_fp16(0.0F);
+                std::fill(mask_scratch_.begin(), mask_scratch_.end(), ggml_fp32_to_fp16(-INFINITY));
+                mask_scratch_[0] = visible;
+                ggml_backend_tensor_set(mask_, mask_scratch_.data(), 0, mask_scratch_.size() * sizeof(ggml_fp16_t));
+            }
+            profile.fast_mask_upload_ms += engine::debug::elapsed_ms(timing_start, Clock::now());
+            timing_start = Clock::now();
+            ggml_backend_tensor_set(input_, input.data(), 0, input.size() * sizeof(float));
+            profile.fast_input_upload_ms += engine::debug::elapsed_ms(timing_start, Clock::now());
+            core::set_backend_threads(runtime_->backend(), runtime_->threads());
+            timing_start = Clock::now();
+            const ggml_status status = core::compute_backend_graph(runtime_->backend(), graph_, nullptr, "fish_audio.ar.fast");
+            ggml_backend_synchronize(runtime_->backend());
+            profile.fast_graph_ms += engine::debug::elapsed_ms(timing_start, Clock::now());
+            if (status != GGML_STATUS_SUCCESS) {
+                throw std::runtime_error("Fish Audio fast AR graph compute failed");
             }
         }
 
@@ -1447,35 +1501,31 @@ private:
         }
 
 #ifdef ENGINE_HAS_HIP_FISH_FAST_SAMPLER
-        detail::HipFastTopKResult run_topk(
-            const std::vector<float> & input,
+        detail::HipFastTopKResult run_topk_code(
+            int32_t code,
             int64_t position,
             int top_k,
             FishARProfile & profile) {
             const auto & config = runtime_->assets().config.fast;
-            if (hip_sampler_ == nullptr || static_cast<int64_t>(input.size()) != config.dim) {
-                throw std::runtime_error("HIP Fish fast AR sampler is unavailable or input size is invalid");
+            if (hip_sampler_ == nullptr || code < 0 || code >= config.vocab_size) {
+                throw std::runtime_error("HIP Fish fast AR embedding gather is unavailable or code is invalid");
             }
             ++profile.fast_runs;
             auto timing_start = Clock::now();
-            const int32_t pos = static_cast<int32_t>(position);
-            ggml_backend_tensor_set(position_, &pos, 0, sizeof(pos));
-            const auto visible = ggml_fp32_to_fp16(0.0F);
-            if (position == 0) {
-                std::fill(mask_scratch_.begin(), mask_scratch_.end(), ggml_fp32_to_fp16(-INFINITY));
-                mask_scratch_[0] = visible;
-                ggml_backend_tensor_set(mask_, mask_scratch_.data(), 0, mask_scratch_.size() * sizeof(ggml_fp16_t));
-            } else {
-                mask_scratch_[static_cast<size_t>(position)] = visible;
-                ggml_backend_tensor_set(
-                    mask_,
-                    &visible,
-                    static_cast<size_t>(position) * sizeof(ggml_fp16_t),
-                    sizeof(ggml_fp16_t));
-            }
+            detail::hip_fast_sampler_prepare_step(
+                hip_sampler_,
+                static_cast<int32_t>(position),
+                static_cast<int32_t>(config.num_codebooks),
+                static_cast<int32_t *>(position_->data),
+                mask_->data,
+                ggml_backend_cuda_get_stream(runtime_->backend()));
             profile.fast_mask_upload_ms += engine::debug::elapsed_ms(timing_start, Clock::now());
             timing_start = Clock::now();
-            ggml_backend_tensor_set(input_, input.data(), 0, input.size() * sizeof(float));
+            detail::hip_fast_sampler_gather_embedding(
+                hip_sampler_,
+                code,
+                static_cast<float *>(input_->data),
+                ggml_backend_cuda_get_stream(runtime_->backend()));
             profile.fast_input_upload_ms += engine::debug::elapsed_ms(timing_start, Clock::now());
             core::set_backend_threads(runtime_->backend(), runtime_->threads());
             timing_start = Clock::now();
@@ -1495,6 +1545,7 @@ private:
             profile.fast_output_read_ms += engine::debug::elapsed_ms(timing_start, Clock::now());
             return result;
         }
+
 #endif
 
     private:
@@ -1595,20 +1646,26 @@ private:
         if (!is_semantic_token(config, main_token)) {
             return frame;
         }
-        const auto fast0_logits = fast_graph_->run(slow_hidden, 0, profile);
+#ifdef ENGINE_HAS_HIP_FISH_FAST_SAMPLER
+        const bool hip_resident_fast_path =
+            runtime_->backend_type() == core::BackendType::Hip &&
+            options.top_k > 0 && options.top_k <= detail::kHipFastSamplerMaxTopK;
+        if (hip_resident_fast_path) {
+            fast_graph_->run_initial_step(slow_hidden, profile);
+        } else
+#endif
+        {
+            (void) fast_graph_->run(slow_hidden, 0, profile);
+        }
         int32_t code = std::clamp<int32_t>(
             main_token - static_cast<int32_t>(config.semantic_start_token_id),
             0,
             static_cast<int32_t>(config.fast.vocab_size - 1));
         frame[1] = code;
         for (int64_t codebook = 1; codebook < config.fast.num_codebooks; ++codebook) {
-            timing_start = Clock::now();
-            const auto embedding = build_fast_embedding(config, weights, code);
-            profile.fast_embedding_ms += engine::debug::elapsed_ms(timing_start, Clock::now());
 #ifdef ENGINE_HAS_HIP_FISH_FAST_SAMPLER
-            if (runtime_->backend_type() == core::BackendType::Hip &&
-                options.top_k > 0 && options.top_k <= detail::kHipFastSamplerMaxTopK) {
-                const auto topk = fast_graph_->run_topk(embedding, codebook, options.top_k, profile);
+            if (hip_resident_fast_path) {
+                const auto topk = fast_graph_->run_topk_code(code, codebook, options.top_k, profile);
                 timing_start = Clock::now();
                 code = sample_from_hip_topk(
                     topk,
@@ -1621,6 +1678,9 @@ private:
             } else
 #endif
             {
+                timing_start = Clock::now();
+                const auto embedding = build_fast_embedding(config, weights, code);
+                profile.fast_embedding_ms += engine::debug::elapsed_ms(timing_start, Clock::now());
                 const auto logits = fast_graph_->run(embedding, codebook, profile);
                 timing_start = Clock::now();
                 code = sample_from_logits(

--- a/src/models/fish_audio/hip_fast_sampler.cu
+++ b/src/models/fish_audio/hip_fast_sampler.cu
@@ -20,6 +20,9 @@ void check_hip(hipError_t status, const char * label) {
 struct Workspace {
     int32_t vocab_size = 0;
     HipFastTopKResult * packed = nullptr;
+    float * embeddings = nullptr;
+    int32_t embedding_rows = 0;
+    int32_t embedding_dim = 0;
 };
 
 __device__ __forceinline__ bool better(float av, int32_t ai, float bv, int32_t bi) {
@@ -112,12 +115,44 @@ __global__ void exact_topk_kernel(
     }
 }
 
+__global__ void prepare_fast_step_kernel(
+    int32_t position,
+    int32_t mask_length,
+    int32_t * device_position,
+    uint16_t * device_mask) {
+    const int32_t tid = static_cast<int32_t>(threadIdx.x);
+    if (tid == 0) {
+        device_position[0] = position;
+    }
+    if (position == 0) {
+        for (int32_t i = tid; i < mask_length; i += static_cast<int32_t>(blockDim.x)) {
+            device_mask[i] = (i == 0) ? static_cast<uint16_t>(0x0000) : static_cast<uint16_t>(0xfc00);
+        }
+    } else if (tid == 0 && position < mask_length) {
+        device_mask[position] = static_cast<uint16_t>(0x0000);
+    }
+}
+
+__global__ void gather_embedding_kernel(
+    const float * table,
+    int32_t dim,
+    int32_t row,
+    float * output) {
+    const int32_t i = static_cast<int32_t>(blockIdx.x * blockDim.x + threadIdx.x);
+    if (i < dim) {
+        output[i] = table[static_cast<size_t>(row) * static_cast<size_t>(dim) + static_cast<size_t>(i)];
+    }
+}
+
 void free_workspace(Workspace * ws) {
     if (ws == nullptr) {
         return;
     }
     if (ws->packed != nullptr) {
         (void) hipFree(ws->packed);
+    }
+    if (ws->embeddings != nullptr) {
+        (void) hipFree(ws->embeddings);
     }
     delete ws;
 }
@@ -174,6 +209,67 @@ void hip_fast_sampler_topk(
     check_hip(
         hipMemcpy(host_result, ws->packed, sizeof(HipFastTopKResult), hipMemcpyDeviceToHost),
         "hipMemcpy Fish sampler result");
+}
+
+void hip_fast_sampler_upload_embeddings(
+    void * workspace,
+    const float * host_embeddings,
+    int32_t rows,
+    int32_t dim) {
+    auto * ws = static_cast<Workspace *>(workspace);
+    if (ws == nullptr || host_embeddings == nullptr || rows <= 0 || dim <= 0) {
+        throw std::invalid_argument("HIP Fish embedding upload received invalid arguments");
+    }
+    if (ws->embeddings != nullptr) {
+        check_hip(hipFree(ws->embeddings), "hipFree old Fish embedding table");
+        ws->embeddings = nullptr;
+    }
+    const size_t bytes = static_cast<size_t>(rows) * static_cast<size_t>(dim) * sizeof(float);
+    check_hip(hipMalloc(&ws->embeddings, bytes), "hipMalloc Fish embedding table");
+    check_hip(hipMemcpy(ws->embeddings, host_embeddings, bytes, hipMemcpyHostToDevice), "hipMemcpy Fish embedding table");
+    ws->embedding_rows = rows;
+    ws->embedding_dim = dim;
+}
+
+void hip_fast_sampler_gather_embedding(
+    void * workspace,
+    int32_t row,
+    float * device_output,
+    void * stream_ptr) {
+    auto * ws = static_cast<Workspace *>(workspace);
+    auto stream = static_cast<hipStream_t>(stream_ptr);
+    if (ws == nullptr || ws->embeddings == nullptr || device_output == nullptr ||
+        row < 0 || row >= ws->embedding_rows || ws->embedding_dim <= 0) {
+        throw std::invalid_argument("HIP Fish embedding gather received invalid arguments");
+    }
+    constexpr int threads = 256;
+    const int blocks = (ws->embedding_dim + threads - 1) / threads;
+    hipLaunchKernelGGL(
+        gather_embedding_kernel,
+        dim3(blocks), dim3(threads), 0, stream,
+        ws->embeddings, ws->embedding_dim, row, device_output);
+    check_hip(hipGetLastError(), "gather_embedding_kernel Fish sampler");
+}
+
+void hip_fast_sampler_prepare_step(
+    void * workspace,
+    int32_t position,
+    int32_t mask_length,
+    int32_t * device_position,
+    void * device_mask,
+    void * stream_ptr) {
+    auto * ws = static_cast<Workspace *>(workspace);
+    auto stream = static_cast<hipStream_t>(stream_ptr);
+    if (ws == nullptr || device_position == nullptr || device_mask == nullptr ||
+        position < 0 || mask_length <= 0 || position >= mask_length) {
+        throw std::invalid_argument("HIP Fish fast step preparation received invalid arguments");
+    }
+    constexpr int threads = 32;
+    hipLaunchKernelGGL(
+        prepare_fast_step_kernel,
+        dim3(1), dim3(threads), 0, stream,
+        position, mask_length, device_position, static_cast<uint16_t *>(device_mask));
+    check_hip(hipGetLastError(), "prepare_fast_step_kernel Fish sampler");
 }
 
 }  // namespace engine::models::fish_audio::detail

--- a/src/models/fish_audio/hip_fast_sampler.h
+++ b/src/models/fish_audio/hip_fast_sampler.h
@@ -22,4 +22,24 @@ void hip_fast_sampler_topk(
     int32_t top_k,
     HipFastTopKResult * host_result);
 
+void hip_fast_sampler_upload_embeddings(
+    void * workspace,
+    const float * host_embeddings,
+    int32_t rows,
+    int32_t dim);
+
+void hip_fast_sampler_gather_embedding(
+    void * workspace,
+    int32_t row,
+    float * device_output,
+    void * stream);
+
+void hip_fast_sampler_prepare_step(
+    void * workspace,
+    int32_t position,
+    int32_t mask_length,
+    int32_t * device_position,
+    void * device_mask,
+    void * stream);
+
 }  // namespace engine::models::fish_audio::detail


### PR DESCRIPTION
## Summary

Follow-up to #386. The HIP Fast-AR top-k path still rebuilds each next-codebook input on the CPU, uploads that embedding back to the GPU, and updates position/mask state through small host-to-device transfers.

This change keeps those recurrent Fast-AR inputs/state updates on the HIP stream:

- uploads the Fast-AR embedding table once into the HIP sampler workspace;
- gathers the selected embedding row directly on the device for subsequent codebooks;
- updates Fast-AR position and attention-mask state with a small HIP kernel on the GGML HIP stream;
- reuses the existing exact HIP top-k sampler after each graph run.

The resident path is only used for the same Linux HIP / supported `top_k` range already handled by the HIP sampler. Other backends and unsupported sampling settings keep the existing path.

## Validation

Tested against current `main` (`16976028a60ea6a70dc8e25ab70fa7a80077ba96`) on:

- Radeon RX 7900 XTX (`gfx1100`)
- ROCm 7.2.1 / HIP
- Fish Audio S2 Pro Q8_0 GGUF

Build:

```bash
bash scripts/build_linux.sh \
  --backend hip \
  --gpu-targets gfx1100 \
  --model-set custom \
  --models fish_audio \
  --target audiocpp_cli
```

For an isolated comparison, three identical requests were run in one loaded process using the same public benchmark sentence and settings as #386. Request 1 was treated as warmup; requests 2-3 are the warm measurements.

| Path | Warm #2 | Warm #3 | Warm mean |
| --- | ---: | ---: | ---: |
| Existing HIP top-k path | 4068.91 ms | 4138.90 ms | 4103.91 ms |
| Resident embedding/state path | 3959.96 ms | 4016.92 ms | 3988.44 ms |

That is about **2.81% lower warm wall time** in this isolated test.

All six WAVs from the OFF/ON comparison were bit-identical:

```text
SHA-256: dfbc6ec75603a05c85d97e5dbf24b75a77dcc2386e5087159cd9d7d673989533
```

## Scope

This PR intentionally does not include chained Fast-AR, Slow-AR changes, BF16/cache fusions, or other experiments from the larger AMD optimization branch.
