### PR TITLE
fix(warmbench): voxtral_realtime branch reads an undefined `mode`, so every run raises NameError

### DIFF
--- a/tests/warmbench.py
+++ b/tests/warmbench.py
@@ -3947,7 +3947,7 @@ def build_catalog_asr_commands(
     elif family == "voxtral_realtime":
         common.extend([
             "--streaming",
-            "true" if mode == "streaming" else "false",
+            "true" if bool(warmup_case.get("streaming", False)) else "false",
             "--do-sample",
             "true" if bool(warmup_case.get("do_sample", False)) else "false",
             "--do-sample-sequence",


### PR DESCRIPTION
## Bug

`tests/warmbench.py:3950`, inside `build_catalog_asr_commands()`:

```python
    elif family == "voxtral_realtime":
        common.extend([
            "--streaming",
            "true" if mode == "streaming" else "false",
```

`mode` is not a parameter of `build_catalog_asr_commands()`, not a local, and not a module-level name. It exists only inside *other* functions (`warmbench.py:1077`, `:5007`, `:5065`), so it is never in scope here.

`voxtral_realtime` is one of the families routed through this builder (`warmbench.py:5552`), and the caller has no `mode` in scope either. The result is that **every** `voxtral_realtime` warmbench run raises before a single command is assembled:

```
NameError: name 'mode' is not defined
```

## Fix

Every other value in that branch is read from `warmup_case`, and the identical `"--streaming"` pair in the `nemotron_asr` branch 50 lines above (`warmbench.py:3903-3904`) already does exactly that:

```python
            "--streaming",
            "true" if bool(warmup_case.get("streaming", False)) else "false",
```

So this uses the same source. `tests/voxtral_realtime/voxtral_realtime_warm_bench_cases.json` carries no `streaming` key today, so the default preserves the pre-existing intent (non-streaming) while making the flag settable per case, the same way `nemotron_asr` allows it.

Note `voxtral_realtime_python_warm_bench.py` declares `--streaming` as a single value (`:188`) with no `--streaming-sequence`, so no sequence flag is added here.

## Verification

`build_catalog_asr_commands` was extracted with `ast` and replayed with stubbed helpers (`catalog_case_audio`, `catalog_asr_model_path`, `csv_values`, `csv_bools`) so no model or audio file is needed:

**Before**
```
  no streaming key   -> NameError: name 'mode' is not defined
  streaming: true    -> NameError: name 'mode' is not defined
```

**After**
```
  no streaming key   -> OK, --streaming false
  streaming: true    -> OK, --streaming true
```

One line changed, no behaviour change for any other family.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
