### PR TITLE
Fix Windows CUDA build when PATH has a stray quote

### DIFF
--- a/scripts/build_windows.ps1
+++ b/scripts/build_windows.ps1
@@ -197,12 +197,25 @@ function Add-MsvcEnvironment {
         [Parameter(Mandatory = $true)][string]$SdkTool
     )
 
+    # A stray double quote in PATH (some installers write one) is fatal here:
+    # nvcc re-runs vcvars64.bat for every .cu file, and on that nested run
+    # vcvarsall restores PATH from the __VSCMD_PREINIT_PATH copy taken below.
+    # The unbalanced quote breaks cmd's parser, the script exits 255, and nvcc
+    # reports "Could not set up the environment for Microsoft Visual Studio".
+    # Strip quotes from PATH going in, and from both PATH copies coming back.
+    $env:PATH = $env:PATH -replace '"', ''
+
     $vcvars = Join-Path $VsInstall "VC\Auxiliary\Build\vcvars64.bat"
     if (Test-Path $vcvars) {
         $cmd = "`"$vcvars`" >nul && set"
         foreach ($line in (& cmd.exe /d /s /c $cmd)) {
             if ($line -match "^([^=]+)=(.*)$") {
-                [Environment]::SetEnvironmentVariable($Matches[1], $Matches[2], "Process")
+                $name = $Matches[1]
+                $value = $Matches[2]
+                if ($name -eq "PATH" -or $name -eq "__VSCMD_PREINIT_PATH") {
+                    $value = $value -replace '"', ''
+                }
+                [Environment]::SetEnvironmentVariable($name, $value, "Process")
             }
         }
     }


### PR DESCRIPTION
## Problem

On Windows, every CUDA object failed to build:

```
nvcc fatal : Could not set up the environment for Microsoft Visual Studio
using '...\VC\Auxiliary\Build\vcvars64.bat'
```

## Cause

`build_windows.ps1` runs `vcvars64.bat` and imports the result into the process. That import includes `__VSCMD_PREINIT_PATH`, a copy of PATH.

`nvcc` then runs `vcvars64.bat` again for every `.cu` file. On that second run, vcvarsall restores PATH from `__VSCMD_PREINIT_PATH`. If PATH contains an unbalanced double quote, cmd cannot parse it, vcvarsall exits 255, and nvcc reports the error above.

A bad PATH entry is easy to get. A recent PowerToys update added this one:

```
C:\Program Files\PowerToys\DSCModules"
```

Note this only breaks when vcvars runs twice. Calling `nvcc` from a plain shell works fine, which makes it confusing to track down.

## Fix

Strip double quotes from PATH before calling vcvars, and from `PATH` and `__VSCMD_PREINIT_PATH` when importing the result.

## Testing

Reproduced the failure, then built `audiocpp_server` with the patch in a shell that still had the bad PATH. All CUDA objects compiled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)