### PR TITLE
Add Niagara ASR model family

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1410,6 +1410,25 @@ audiocpp_add_model(granite5asr
         granite_speech5_ctc
 )
 
+audiocpp_add_model(niagara_asr
+    SOURCES
+        src/community_models/niagara_asr/assets.cpp
+        src/community_models/niagara_asr/encoder.cpp
+        src/community_models/niagara_asr/frontend.cpp
+        src/community_models/niagara_asr/runtime.cpp
+        src/community_models/niagara_asr/session.cpp
+        src/community_models/niagara_asr/weights.cpp
+    INCLUDES
+        engine/community_models/niagara_asr/assets.h
+        engine/community_models/niagara_asr/encoder.h
+        engine/community_models/niagara_asr/frontend.h
+        engine/community_models/niagara_asr/runtime.h
+        engine/community_models/niagara_asr/session.h
+        engine/community_models/niagara_asr/weights.h
+    LOADERS
+        engine::community_models::niagara_asr::make_niagara_asr_loader
+)
+
 audiocpp_add_model(audio8_asr
     SOURCES
         src/community_models/audio8_asr/assets.cpp
@@ -2126,6 +2145,10 @@ if (ENGINE_BUILD_WARMBENCH)
     add_engine_warmbench(miocodec_warm_bench tests/miocodec/miocodec_warm_bench.cpp)
     add_engine_warmbench(mira_tts_warm_bench tests/mira_tts/mira_tts_warm_bench.cpp)
     add_engine_warmbench(muscriptor_warm_bench tests/muscriptor/muscriptor_warm_bench.cpp)
+    add_engine_warmbench(niagara_asr_warm_bench tests/niagara_asr/niagara_asr_warm_bench.cpp)
+    add_engine_warmbench(niagara_asr_native_ffn_probe tests/niagara_asr/niagara_asr_native_ffn_probe.cpp)
+    add_engine_warmbench(niagara_asr_native_state_space_probe tests/niagara_asr/niagara_asr_native_state_space_probe.cpp)
+    add_engine_warmbench(niagara_asr_weight_load_probe tests/niagara_asr/niagara_asr_weight_load_probe.cpp)
     add_engine_warmbench(moss_tts_nano_warm_bench tests/moss_tts_nano/moss_tts_nano_warm_bench.cpp)
     add_engine_warmbench(moss_tts_local_warm_bench tests/moss_tts_local/moss_tts_local_warm_bench.cpp)
     add_engine_warmbench(nemotron_asr_warm_bench tests/nemotron_asr/nemotron_asr_warm_bench.cpp)

--- a/include/engine/community_models/niagara_asr/assets.h
+++ b/include/engine/community_models/niagara_asr/assets.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "engine/framework/assets/tensor_source.h"
+#include "engine/framework/model_spec/package.h"
+#include "engine/framework/tokenizers/sentencepiece.h"
+
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace engine::community_models::niagara_asr {
+
+struct NiagaraFrontendConfig {
+    int64_t sample_rate = 16000;
+    int64_t n_fft = 400;
+    int64_t win_length = 400;
+    int64_t hop_length = 160;
+    int64_t n_mels = 80;
+};
+
+struct NiagaraEncoderConfig {
+    int64_t hidden_size = 0;
+    int64_t intermediate_size = 0;
+    int64_t num_layers = 0;
+    int64_t state_size = 0;
+    int64_t state_channels = 0;
+    int64_t dense_input_features = 0;
+    int64_t subsampling_kernel_height = 4;
+    int64_t subsampling_kernel_width = 3;
+};
+
+struct NiagaraAsrConfig {
+    std::string model_type = "niagara_asr";
+    int64_t vocab_size = 256;
+    int64_t blank_id = 256;
+    NiagaraFrontendConfig frontend;
+    NiagaraEncoderConfig encoder;
+};
+
+struct NiagaraAsrAssets {
+    assets::ResourceBundle resources;
+    std::shared_ptr<const assets::TensorSource> source;
+    NiagaraAsrConfig config;
+    std::vector<tokenizers::SentencePiecePiece> tokenizer_pieces;
+};
+
+std::shared_ptr<const NiagaraAsrAssets> load_niagara_asr_assets(
+    const std::filesystem::path & model_path);
+
+}  // namespace engine::community_models::niagara_asr

--- a/include/engine/community_models/niagara_asr/encoder.h
+++ b/include/engine/community_models/niagara_asr/encoder.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "engine/community_models/niagara_asr/assets.h"
+#include "engine/community_models/niagara_asr/weights.h"
+#include "engine/framework/core/module.h"
+
+namespace engine::community_models::niagara_asr {
+
+core::TensorValue build_niagara_l1_norm(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    const engine::modules::NormWeights & weights,
+    const NiagaraEncoderConfig & config);
+
+core::TensorValue build_niagara_feed_forward(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    const NiagaraFeedForwardWeights & weights,
+    const NiagaraEncoderConfig & config);
+
+core::TensorValue build_niagara_subsampling(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    const NiagaraSubsamplingWeights & weights,
+    const NiagaraEncoderConfig & config);
+
+core::TensorValue build_niagara_self_attention(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    const NiagaraSelfAttentionWeights & weights,
+    const NiagaraEncoderConfig & config);
+
+core::TensorValue build_niagara_state_space(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    const NiagaraStateSpaceWeights & weights,
+    const NiagaraEncoderConfig & config);
+
+core::TensorValue build_niagara_layer(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    const NiagaraLayerWeights & weights,
+    const NiagaraEncoderConfig & config);
+
+core::TensorValue build_niagara_encoder_logits(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    const NiagaraWeights & weights,
+    const NiagaraAsrConfig & config);
+
+}  // namespace engine::community_models::niagara_asr

--- a/include/engine/community_models/niagara_asr/frontend.h
+++ b/include/engine/community_models/niagara_asr/frontend.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "engine/community_models/niagara_asr/assets.h"
+#include "engine/framework/runtime/session.h"
+
+#include <memory>
+#include <vector>
+
+namespace engine::community_models::niagara_asr {
+
+struct NiagaraFeatures {
+    std::vector<float> values;
+    int64_t frames = 0;
+    int64_t feature_dim = 80;
+};
+
+class NiagaraFrontend {
+public:
+    explicit NiagaraFrontend(std::shared_ptr<const NiagaraAsrAssets> assets);
+
+    NiagaraFeatures extract(const runtime::AudioBuffer & audio) const;
+
+private:
+    std::shared_ptr<const NiagaraAsrAssets> assets_;
+    std::vector<float> window_;
+    std::vector<float> mel_filterbank_;
+};
+
+}  // namespace engine::community_models::niagara_asr

--- a/include/engine/community_models/niagara_asr/runtime.h
+++ b/include/engine/community_models/niagara_asr/runtime.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "engine/community_models/niagara_asr/assets.h"
+#include "engine/community_models/niagara_asr/frontend.h"
+#include "engine/framework/assets/tensor_source.h"
+#include "engine/framework/core/execution_context.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace engine::community_models::niagara_asr {
+
+struct NiagaraInferenceResult {
+    std::vector<float> logits;
+    int64_t frames = 0;
+    int64_t vocab_size = 0;
+    double elapsed_ms = 0.0;
+};
+
+class NiagaraRuntime {
+public:
+    NiagaraRuntime(
+        std::shared_ptr<const NiagaraAsrAssets> assets,
+        engine::core::ExecutionContext & execution,
+        engine::assets::TensorStorageType weight_storage_type,
+        size_t graph_arena_bytes,
+        size_t weight_context_bytes);
+    ~NiagaraRuntime();
+
+    NiagaraInferenceResult infer(const NiagaraFeatures & features);
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace engine::community_models::niagara_asr

--- a/include/engine/community_models/niagara_asr/session.h
+++ b/include/engine/community_models/niagara_asr/session.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "engine/community_models/niagara_asr/assets.h"
+#include "engine/community_models/niagara_asr/frontend.h"
+#include "engine/community_models/niagara_asr/runtime.h"
+#include "engine/framework/model_spec/metadata.h"
+#include "engine/framework/runtime/session_base.h"
+
+#include <memory>
+#include <string>
+
+namespace engine::community_models::niagara_asr {
+
+std::shared_ptr<runtime::IVoiceModelLoader> make_niagara_asr_loader();
+
+class NiagaraAsrSession final
+    : public runtime::RuntimeSessionBase
+    , public runtime::IOfflineVoiceTaskSession {
+public:
+    NiagaraAsrSession(
+        runtime::TaskSpec task,
+        runtime::SessionOptions options,
+        std::shared_ptr<const NiagaraAsrAssets> assets,
+        std::shared_ptr<const engine::model_spec::ModelContract> contract);
+    ~NiagaraAsrSession() override;
+
+    std::string family() const override;
+    runtime::VoiceTaskKind task_kind() const override;
+    runtime::RunMode run_mode() const override;
+    void prepare(const runtime::SessionPreparationRequest & request) override;
+    runtime::TaskResult run(const runtime::TaskRequest & request) override;
+
+private:
+    std::string decode(const NiagaraInferenceResult & inference) const;
+
+    runtime::TaskSpec task_;
+    std::shared_ptr<const NiagaraAsrAssets> assets_;
+    std::shared_ptr<const engine::model_spec::ModelContract> contract_;
+    NiagaraFrontend frontend_;
+    NiagaraRuntime runtime_;
+};
+
+}  // namespace engine::community_models::niagara_asr

--- a/include/engine/community_models/niagara_asr/weights.h
+++ b/include/engine/community_models/niagara_asr/weights.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "engine/community_models/niagara_asr/assets.h"
+#include "engine/framework/core/backend_weight_store.h"
+#include "engine/framework/core/execution_context.h"
+#include "engine/framework/modules/conv_modules.h"
+#include "engine/framework/modules/linear_module.h"
+#include "engine/framework/modules/norm_modules.h"
+
+#include <memory>
+#include <vector>
+
+namespace engine::community_models::niagara_asr {
+
+struct NiagaraSubsamplingWeights {
+    engine::modules::BatchNorm2dEvalWeights bn0;
+    engine::modules::BatchNorm2dEvalWeights bn1;
+    engine::modules::Conv2dWeights input_projection;
+    engine::modules::Conv2dWeights conv1;
+    engine::modules::Conv2dWeights conv2;
+    engine::modules::LinearWeights dense;
+};
+
+struct NiagaraSelfAttentionWeights {
+    engine::modules::NormWeights norm;
+    engine::modules::LinearWeights query;
+    engine::modules::LinearWeights key;
+    engine::modules::LinearWeights value;
+    engine::modules::LinearWeights global_attention;
+    engine::modules::LinearWeights out;
+    engine::core::TensorValue relative_position;
+    engine::core::TensorValue u_bias;
+    engine::core::TensorValue v_bias;
+};
+
+struct NiagaraFeedForwardWeights {
+    engine::modules::NormWeights norm;
+    engine::modules::LinearWeights dense1;
+    engine::modules::LinearWeights dense2;
+    engine::core::TensorValue residual_scale;
+};
+
+struct NiagaraStateSpaceWeights {
+    engine::modules::NormWeights norm;
+    engine::modules::LinearWeights dense1;
+    engine::modules::LinearWeights dense2;
+    engine::core::TensorValue conv_kernel;
+};
+
+struct NiagaraLayerWeights {
+    NiagaraFeedForwardWeights ffn;
+    NiagaraSelfAttentionWeights self_attention;
+    NiagaraStateSpaceWeights state_space;
+    NiagaraFeedForwardWeights ffn1;
+    engine::modules::NormWeights out_norm;
+};
+
+struct NiagaraWeights {
+    std::shared_ptr<engine::core::BackendWeightStore> store;
+    NiagaraSubsamplingWeights subsampling;
+    std::vector<NiagaraLayerWeights> layers;
+    engine::modules::LinearWeights ctc;
+};
+
+std::shared_ptr<const NiagaraWeights> load_niagara_weights(
+    const NiagaraAsrAssets & assets,
+    engine::core::ExecutionContext & execution,
+    engine::assets::TensorStorageType storage_type,
+    size_t weight_context_bytes);
+
+}  // namespace engine::community_models::niagara_asr

--- a/model_specs/niagara_asr.json
+++ b/model_specs/niagara_asr.json
@@ -1,0 +1,133 @@
+{
+  "family": "niagara_asr",
+  "schema_version": 1,
+  "display_name": "Niagara ASR",
+  "description": "ABR Niagara English batch ASR state-space models with attention, greedy CTC decoding, and SentencePiece tokenization.",
+  "category": "asr",
+  "status": "supported",
+  "tasks": [
+    "asr"
+  ],
+  "modes": [
+    "offline"
+  ],
+  "languages": [
+    "en"
+  ],
+  "capabilities": {},
+  "dependencies": [],
+  "options": {
+    "request": [
+      {
+        "name": "language",
+        "type": "string",
+        "description": "Recognition language; Niagara batch models are English-only.",
+        "required": false,
+        "default": "en"
+      },
+      {
+        "name": "audio_chunk_mode",
+        "type": "enum",
+        "description": "Audio chunking mode.",
+        "values": [
+          "none"
+        ],
+        "required": false,
+        "default": "none"
+      }
+    ],
+    "session": [
+      {
+        "name": "weight_type",
+        "type": "enum",
+        "description": "Matmul weight storage type.",
+        "preset": "weight_type_full",
+        "required": false,
+        "default": "native"
+      },
+      {
+        "name": "graph_arena_mb",
+        "type": "int",
+        "description": "Inference graph arena size in MiB.",
+        "required": false,
+        "min": 64,
+        "default": 1024
+      },
+      {
+        "name": "weight_context_mb",
+        "type": "int",
+        "description": "Weight descriptor context size in MiB.",
+        "required": false,
+        "min": 16,
+        "default": 256
+      }
+    ],
+    "load": []
+  },
+  "runtime": {
+    "tags": [
+      "gguf",
+      "cpu"
+    ]
+  },
+  "ui": {
+    "recommended_package": "niagara_19m_orig",
+    "tags": [
+      "ASR",
+      "GGUF"
+    ],
+    "docs": [
+      "docs/asr.md",
+      "docs/gguf.md"
+    ],
+    "summary": "ABR Niagara compact English speech recognition."
+  },
+  "package_defaults": {
+    "download": {
+      "kind": "unsupported",
+      "reason": "convert the original ABR Niagara PT2 CPU package with tools/community_models/convert_niagara_asr.py"
+    }
+  },
+  "packages": [
+    {
+      "id": "niagara_19m_orig",
+      "display_name": "Niagara 19M Batch English Original GGUF",
+      "default": true,
+      "format": "gguf",
+      "precision": "orig",
+      "target_directory": "Niagara-19M-Batch-EN-GGUF",
+      "files": [
+        "Niagara-19M-Batch-EN-GGUF/niagara-19m-batch.en.gguf"
+      ],
+      "strip_prefix": "Niagara-19M-Batch-EN-GGUF"
+    },
+    {
+      "id": "niagara_38m_orig",
+      "display_name": "Niagara 38M Batch English Original GGUF",
+      "format": "gguf",
+      "precision": "orig",
+      "target_directory": "Niagara-38M-Batch-EN-GGUF",
+      "files": [
+        "Niagara-38M-Batch-EN-GGUF/niagara-38m-batch.en.gguf"
+      ],
+      "strip_prefix": "Niagara-38M-Batch-EN-GGUF"
+    }
+  ],
+  "sources": [
+    {
+      "format": "gguf",
+      "roots": {
+        "model": ".",
+        "weights": "$gguf"
+      },
+      "files": {
+        "config": "model:config.json",
+        "preprocessor_config": "model:preprocessor_config.json",
+        "tokenizer_spm": "model:sentencepiece.model"
+      },
+      "tensors": {
+        "weights": "weights:"
+      }
+    }
+  ]
+}

--- a/src/community_models/niagara_asr/assets.cpp
+++ b/src/community_models/niagara_asr/assets.cpp
@@ -1,0 +1,178 @@
+#include "engine/community_models/niagara_asr/assets.h"
+
+#include "engine/framework/io/json.h"
+#include "engine/framework/model_spec/package.h"
+
+#include <stdexcept>
+#include <utility>
+
+namespace engine::community_models::niagara_asr {
+namespace json = engine::io::json;
+namespace {
+
+void require_shape(
+    const assets::TensorSource & source,
+    const std::string & name,
+    const std::vector<int64_t> & expected) {
+    const auto metadata = source.require_metadata(name);
+    if (metadata.shape != expected) {
+        throw std::runtime_error("Niagara ASR tensor shape mismatch for " + name);
+    }
+}
+
+std::string lmuformer_prefix(int64_t layer) {
+    if (layer == 0) {
+        return "p__torch_params_encoder_lmuformer_";
+    }
+    return "p__torch_params_encoder_lmuformer_" + std::to_string(layer) + "_";
+}
+
+std::string indexed_layer_name(
+    const std::string & prefix,
+    const std::string & base,
+    int64_t layer,
+    bool omit_zero) {
+    if (layer == 0 && omit_zero) {
+        return prefix + base;
+    }
+    return prefix + base + "_" + std::to_string(layer);
+}
+
+int64_t count_lmuformer_layers(const assets::TensorSource & source) {
+    int64_t layers = source.has_tensor(lmuformer_prefix(0) + "ffn_dense_1_kernel") ? 1 : 0;
+    for (int64_t layer = 1; source.has_tensor(lmuformer_prefix(layer) + "ffn_dense_1_kernel"); ++layer) {
+        ++layers;
+    }
+    return layers;
+}
+
+NiagaraEncoderConfig infer_encoder_config(
+    const assets::TensorSource & source,
+    int64_t vocab_size,
+    int64_t feature_size) {
+    NiagaraEncoderConfig config;
+    const auto dense = source.require_metadata("p__torch_params_encoder_dense_kernel");
+    if (dense.shape.size() != 2) {
+        throw std::runtime_error("Niagara ASR encoder dense kernel must be rank 2");
+    }
+    config.hidden_size = dense.shape[1];
+    if (config.hidden_size <= 0 || dense.shape[0] % config.hidden_size != 0) {
+        throw std::runtime_error("Niagara ASR encoder dense kernel has invalid hidden size");
+    }
+    config.dense_input_features = dense.shape[0] / config.hidden_size;
+    if (feature_size <= 0 || config.dense_input_features <= 0) {
+        throw std::runtime_error("Niagara ASR encoder dense input shape is invalid");
+    }
+
+    config.num_layers = count_lmuformer_layers(source);
+    if (config.num_layers <= 0) {
+        throw std::runtime_error("Niagara ASR is missing LMUFormer layers");
+    }
+
+    const auto ffn = source.require_metadata(lmuformer_prefix(0) + "ffn_dense_1_kernel");
+    if (ffn.shape.size() != 2 || ffn.shape[0] != config.hidden_size) {
+        throw std::runtime_error("Niagara ASR FFN kernel shape does not match hidden size");
+    }
+    config.intermediate_size = ffn.shape[1];
+
+    const auto state = source.require_metadata(lmuformer_prefix(0) + "state_space_state_space_c");
+    if (state.shape.size() != 3 || state.shape[2] != 1) {
+        throw std::runtime_error("Niagara ASR state-space C tensor has unsupported shape");
+    }
+    if (state.shape[0] != config.hidden_size && state.shape[0] != config.hidden_size * 2) {
+        throw std::runtime_error("Niagara ASR state-space channel count must be hidden or 2 * hidden");
+    }
+    config.state_channels = state.shape[0];
+    config.state_size = state.shape[1];
+
+    require_shape(source, "p__torch_params_encoder_dense_bias", {config.hidden_size});
+    require_shape(source, "p__torch_params_encoder_subsampling_mask_aware_conv2d_kernel", {1, 1, 1, 4});
+    require_shape(source, "p__torch_params_encoder_subsampling_mask_aware_conv2d_1_kernel",
+        {4, 3, 4, config.hidden_size});
+    require_shape(source, "p__torch_params_encoder_subsampling_mask_aware_conv2d_2_kernel",
+        {4, 3, config.hidden_size, config.hidden_size});
+    require_shape(source, "p__torch_params_encoder_subsampling_mask_aware_conv2d_1_bias", {config.hidden_size});
+    require_shape(source, "p__torch_params_encoder_subsampling_mask_aware_conv2d_2_bias", {config.hidden_size});
+    require_shape(source, "p__torch_params_shared_dec_bias", {vocab_size + 1});
+    require_shape(source, "p__torch_params_shared_dec_kernel", {config.hidden_size, vocab_size + 1});
+
+    for (int64_t layer = 0; layer < config.num_layers; ++layer) {
+        const auto prefix = lmuformer_prefix(layer);
+        const auto self_attention_dense =
+            indexed_layer_name(prefix, "self_attention_dense", layer + 1, false);
+        const auto global_attention =
+            indexed_layer_name(prefix, "self_attention_global_attention", layer, true);
+        require_shape(source, prefix + "ffn_dense_1_kernel", {config.hidden_size, config.intermediate_size});
+        require_shape(source, prefix + "ffn_dense_1_bias", {config.intermediate_size});
+        require_shape(source, prefix + "ffn_dense_2_kernel", {config.intermediate_size, config.hidden_size});
+        require_shape(source, prefix + "ffn_dense_2_bias", {config.hidden_size});
+        require_shape(source, prefix + "ffn_1_dense_1_kernel", {config.hidden_size, config.intermediate_size});
+        require_shape(source, prefix + "ffn_1_dense_1_bias", {config.intermediate_size});
+        require_shape(source, prefix + "ffn_1_dense_2_kernel", {config.intermediate_size, config.hidden_size});
+        require_shape(source, prefix + "ffn_1_dense_2_bias", {config.hidden_size});
+        require_shape(source, prefix + "self_attention_query_kernel", {config.hidden_size, config.hidden_size});
+        require_shape(source, prefix + "self_attention_key_kernel", {config.hidden_size, config.hidden_size});
+        require_shape(source, prefix + "self_attention_value_kernel", {config.hidden_size, config.hidden_size});
+        require_shape(source, self_attention_dense + "_kernel", {config.hidden_size, config.hidden_size});
+        require_shape(source, global_attention + "_kernel", {config.hidden_size, config.hidden_size});
+        require_shape(source, prefix + "state_space_dense_1_kernel", {config.hidden_size, config.state_channels});
+        require_shape(source, prefix + "state_space_dense_1_bias", {config.state_channels});
+        require_shape(source, prefix + "state_space_dense_2_kernel", {config.hidden_size, config.hidden_size});
+        require_shape(source, prefix + "state_space_dense_2_bias", {config.hidden_size});
+        require_shape(source, prefix + "state_space_state_space_c", {config.state_channels, config.state_size, 1});
+        require_shape(source, prefix + "state_space_state_space_d", {config.state_channels, 1});
+    }
+
+    return config;
+}
+
+NiagaraAsrConfig parse_config(
+    const assets::ResourceBundle & resources,
+    const assets::TensorSource & source) {
+    const auto root = resources.parse_json("config");
+    NiagaraAsrConfig config;
+    config.model_type = json::optional_string(root, "model_type", "niagara_asr");
+    config.vocab_size = json::optional_i64(root, "vocab_size", 256);
+    config.blank_id = config.vocab_size;
+
+    if (resources.has_file("preprocessor_config")) {
+        const auto preproc = resources.parse_json("preprocessor_config");
+        config.frontend.sample_rate = json::optional_i64(preproc, "sampling_rate",
+            json::optional_i64(preproc, "sample_rate", 16000));
+        config.frontend.n_fft = json::optional_i64(preproc, "n_fft", 400);
+        config.frontend.win_length = json::optional_i64(preproc, "win_length", 400);
+        config.frontend.hop_length = json::optional_i64(preproc, "hop_length", 160);
+        config.frontend.n_mels = json::optional_i64(preproc, "feature_size",
+            json::optional_i64(preproc, "num_mel_bins", 80));
+    }
+
+    if (config.frontend.sample_rate != 16000 || config.frontend.n_fft <= 0 ||
+        config.frontend.win_length <= 0 || config.frontend.hop_length <= 0 ||
+        config.frontend.n_mels != 80 || config.vocab_size <= 0) {
+        throw std::runtime_error("Niagara ASR config contains unsupported frontend/model values");
+    }
+    config.encoder = infer_encoder_config(source, config.vocab_size, config.frontend.n_mels);
+    return config;
+}
+
+}  // namespace
+
+std::shared_ptr<const NiagaraAsrAssets> load_niagara_asr_assets(
+    const std::filesystem::path & model_path) {
+    auto resources = engine::model_spec::load_resource_bundle_for_family(model_path, "niagara_asr");
+    auto assets_out = std::make_shared<NiagaraAsrAssets>();
+    assets_out->resources = std::move(resources);
+    assets_out->source = assets_out->resources.open_tensor_source("weights");
+    if (assets_out->source == nullptr) {
+        throw std::runtime_error("Niagara ASR is missing GGUF weights");
+    }
+    assets_out->config = parse_config(assets_out->resources, *assets_out->source);
+    assets_out->tokenizer_pieces =
+        tokenizers::load_sentencepiece_model(assets_out->resources.require_file("tokenizer_spm"));
+    if (static_cast<int64_t>(assets_out->tokenizer_pieces.size()) != assets_out->config.vocab_size) {
+        throw std::runtime_error("Niagara ASR tokenizer size does not match config vocab_size");
+    }
+    return assets_out;
+}
+
+}  // namespace engine::community_models::niagara_asr

--- a/src/community_models/niagara_asr/encoder.cpp
+++ b/src/community_models/niagara_asr/encoder.cpp
@@ -1,0 +1,335 @@
+#include "engine/community_models/niagara_asr/encoder.h"
+
+#include "engine/framework/modules/activation_modules.h"
+#include "engine/framework/modules/conv_modules.h"
+#include "engine/framework/modules/linear_module.h"
+#include "engine/framework/modules/primitive_modules.h"
+#include "engine/framework/modules/structural_modules.h"
+
+#include <array>
+#include <cmath>
+#include <stdexcept>
+
+namespace engine::community_models::niagara_asr {
+namespace {
+
+namespace core = engine::core;
+namespace modules = engine::modules;
+
+constexpr float kL1NormEpsilon = 1.0e-6f;
+constexpr int64_t kNumAttentionHeads = 4;
+constexpr int64_t kRelativePositionCenter = 3000;
+
+core::TensorShape make_last_dim_broadcast_shape(const core::TensorShape & input) {
+    core::TensorShape shape = {};
+    shape.rank = input.rank;
+    for (size_t i = 0; i < shape.rank; ++i) {
+        shape.dims[i] = 1;
+    }
+    shape.dims[shape.rank - 1] = input.last_dim();
+    return shape;
+}
+
+core::TensorShape make_scalar_broadcast_shape(const core::TensorShape & input) {
+    core::TensorShape shape = {};
+    shape.rank = input.rank;
+    for (size_t i = 0; i < shape.rank; ++i) {
+        shape.dims[i] = 1;
+    }
+    return shape;
+}
+
+core::TensorValue contiguous(core::ModuleBuildContext & ctx, const core::TensorValue & input) {
+    return core::wrap_tensor(ggml_cont(ctx.ggml, input.tensor), input.shape, input.type);
+}
+
+core::TensorValue transpose(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    std::array<int, core::kMaxTensorRank> axes,
+    size_t rank) {
+    if (input.shape.rank != rank) {
+        throw std::runtime_error("Niagara transpose rank mismatch");
+    }
+    core::TensorShape output_shape = {};
+    output_shape.rank = rank;
+    std::array<int, core::kMaxTensorRank> ggml_axes = {0, 1, 2, 3};
+    for (size_t out_logical_axis = 0; out_logical_axis < rank; ++out_logical_axis) {
+        const int in_logical_axis = axes[out_logical_axis];
+        output_shape.dims[out_logical_axis] = input.shape.dims[static_cast<size_t>(in_logical_axis)];
+        const int out_ggml_axis = static_cast<int>(rank) - 1 - static_cast<int>(out_logical_axis);
+        const int in_ggml_axis = core::logical_axis_to_ggml_axis(rank, in_logical_axis);
+        ggml_axes[static_cast<size_t>(in_ggml_axis)] = out_ggml_axis;
+    }
+    return core::wrap_tensor(
+        ggml_permute(ctx.ggml, input.tensor, ggml_axes[0], ggml_axes[1], ggml_axes[2], ggml_axes[3]),
+        output_shape,
+        input.type);
+}
+
+core::TensorValue add_last_dim_bias(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    const core::TensorValue & bias) {
+    core::validate_shape(bias, core::TensorShape::from_dims({input.shape.last_dim()}), "bias");
+    const auto bias_view = core::reshape_tensor(ctx, bias, make_last_dim_broadcast_shape(input.shape));
+    const auto repeated = core::wrap_tensor(ggml_repeat(ctx.ggml, bias_view.tensor, input.tensor), input.shape, GGML_TYPE_F32);
+    return core::wrap_tensor(ggml_add(ctx.ggml, input.tensor, repeated.tensor), input.shape, GGML_TYPE_F32);
+}
+
+core::TensorValue add_scaled_residual(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    const core::TensorValue & residual,
+    const core::TensorValue & scale_logits) {
+    core::validate_shape(residual, input.shape, "residual");
+    core::validate_shape(scale_logits, core::TensorShape::from_dims({1}), "scale_logits");
+    const auto scale = core::wrap_tensor(ggml_sigmoid(ctx.ggml, scale_logits.tensor), scale_logits.shape, GGML_TYPE_F32);
+    const auto scale_view = core::reshape_tensor(ctx, scale, make_scalar_broadcast_shape(input.shape));
+    const auto repeated_scale = core::wrap_tensor(ggml_repeat(ctx.ggml, scale_view.tensor, residual.tensor), input.shape, GGML_TYPE_F32);
+    const auto scaled = core::wrap_tensor(ggml_mul(ctx.ggml, residual.tensor, repeated_scale.tensor), input.shape, GGML_TYPE_F32);
+    return core::wrap_tensor(ggml_add(ctx.ggml, input.tensor, scaled.tensor), input.shape, GGML_TYPE_F32);
+}
+
+core::TensorValue reshape_heads(core::ModuleBuildContext & ctx, const core::TensorValue & input) {
+    const int64_t hidden = input.shape.last_dim();
+    if (hidden % kNumAttentionHeads != 0) {
+        throw std::runtime_error("Niagara attention hidden size must divide evenly by heads");
+    }
+    auto x = core::reshape_tensor(
+        ctx,
+        input,
+        core::TensorShape::from_dims({
+            input.shape.dims[0],
+            input.shape.dims[1],
+            kNumAttentionHeads,
+            hidden / kNumAttentionHeads,
+        }));
+    return contiguous(ctx, transpose(ctx, x, {0, 2, 1, 3}, 4));
+}
+
+core::TensorValue relative_shift(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    int64_t frames) {
+    auto x = modules::Pad2dModule({0, 1, 0, 0}).build(ctx, input);
+    x = contiguous(ctx, x);
+    x = core::reshape_tensor(ctx, x, core::TensorShape::from_dims({
+        input.shape.dims[0],
+        input.shape.dims[1],
+        frames * frames * 2,
+    }));
+    auto * padded = ggml_pad_ext(
+        ctx.ggml,
+        x.tensor,
+        0,
+        static_cast<int>(frames - 1),
+        0,
+        0,
+        0,
+        0,
+        0,
+        0);
+    x = core::wrap_tensor(
+        padded,
+        core::TensorShape::from_dims({input.shape.dims[0], input.shape.dims[1], frames * frames * 2 + frames - 1}),
+        GGML_TYPE_F32);
+    x = contiguous(ctx, x);
+    x = core::reshape_tensor(ctx, x, core::TensorShape::from_dims({
+        input.shape.dims[0],
+        input.shape.dims[1],
+        frames + 1,
+        frames * 2 - 1,
+    }));
+    x = modules::SliceModule({2, 0, frames}).build(ctx, x);
+    return modules::SliceModule({3, frames - 1, frames}).build(ctx, x);
+}
+
+core::TensorValue affine_last_dim(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    const modules::NormWeights & weights,
+    int64_t hidden_size) {
+    if (!weights.weight.has_value() || !weights.bias.has_value()) {
+        throw std::runtime_error("Niagara L1 norm requires gamma and beta");
+    }
+    core::validate_shape(*weights.weight, core::TensorShape::from_dims({hidden_size}), "l1norm gamma");
+    core::validate_shape(*weights.bias, core::TensorShape::from_dims({hidden_size}), "l1norm beta");
+
+    const auto weight = core::reshape_tensor(ctx, *weights.weight, make_last_dim_broadcast_shape(input.shape));
+    const auto bias = core::reshape_tensor(ctx, *weights.bias, make_last_dim_broadcast_shape(input.shape));
+    const auto scaled = core::wrap_tensor(ggml_mul(ctx.ggml, input.tensor, weight.tensor), input.shape, GGML_TYPE_F32);
+    return core::wrap_tensor(ggml_add(ctx.ggml, scaled.tensor, bias.tensor), input.shape, GGML_TYPE_F32);
+}
+
+}  // namespace
+
+core::TensorValue build_niagara_l1_norm(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    const modules::NormWeights & weights,
+    const NiagaraEncoderConfig & config) {
+    if (ctx.ggml == nullptr) {
+        throw std::runtime_error("ModuleBuildContext.ggml is null");
+    }
+    core::validate_rank_between(input, 2, core::kMaxTensorRank, "input");
+    core::validate_last_dim(input, config.hidden_size, "input");
+
+    const auto x = core::ensure_backend_addressable_layout(ctx, input);
+    const auto mean = modules::ReduceMeanModule({-1}).build(ctx, x);
+    const auto centered = core::wrap_tensor(ggml_sub(ctx.ggml, x.tensor, mean.tensor), x.shape, GGML_TYPE_F32);
+    const auto abs_centered = core::wrap_tensor(ggml_abs(ctx.ggml, centered.tensor), x.shape, GGML_TYPE_F32);
+    const auto l1_mean = modules::ReduceMeanModule({-1}).build(ctx, abs_centered);
+    const auto denom = core::wrap_tensor(
+        ggml_scale_bias(ctx.ggml, l1_mean.tensor, 1.0f, kL1NormEpsilon),
+        l1_mean.shape,
+        GGML_TYPE_F32);
+    const auto normalized = core::wrap_tensor(ggml_div(ctx.ggml, centered.tensor, denom.tensor), x.shape, GGML_TYPE_F32);
+    ggml_set_output(normalized.tensor);
+    return affine_last_dim(ctx, normalized, weights, config.hidden_size);
+}
+
+core::TensorValue build_niagara_feed_forward(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    const NiagaraFeedForwardWeights & weights,
+    const NiagaraEncoderConfig & config) {
+    auto x = build_niagara_l1_norm(ctx, input, weights.norm, config);
+    x = modules::LinearModule({config.hidden_size, config.intermediate_size, true}).build(ctx, x, weights.dense1);
+    x = modules::SiluModule{}.build(ctx, x);
+    return modules::LinearModule({config.intermediate_size, config.hidden_size, true}).build(ctx, x, weights.dense2);
+}
+
+core::TensorValue build_niagara_subsampling(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    const NiagaraSubsamplingWeights & weights,
+    const NiagaraEncoderConfig & config) {
+    core::validate_shape(input, core::TensorShape::from_dims({input.shape.dims[0], input.shape.dims[1], 80}), "input");
+    auto x = core::reshape_tensor(
+        ctx,
+        input,
+        core::TensorShape::from_dims({input.shape.dims[0], 1, input.shape.dims[1], 80}));
+    x = modules::Conv2dModule({1, 4, 1, 1, 1, 1, 0, 0, 1, 1, false}).build(ctx, x, weights.input_projection);
+    x = modules::Conv2dModule({4, config.hidden_size, 4, 3, 2, 2, 0, 0, 1, 1, true}).build(ctx, x, weights.conv1);
+    x = modules::BatchNorm2dEvalModule({config.hidden_size}).build(ctx, x, weights.bn0);
+    x = modules::SiluModule{}.build(ctx, x);
+    x = modules::Conv2dModule({config.hidden_size, config.hidden_size, 4, 3, 2, 2, 0, 0, 1, 1, true})
+            .build(ctx, x, weights.conv2);
+    x = modules::BatchNorm2dEvalModule({config.hidden_size}).build(ctx, x, weights.bn1);
+    x = modules::SiluModule{}.build(ctx, x);
+    x = contiguous(ctx, transpose(ctx, x, {0, 2, 3, 1}, 4));
+    x = core::reshape_tensor(ctx, x, core::TensorShape::from_dims({
+        input.shape.dims[0],
+        x.shape.dims[1],
+        x.shape.dims[2] * x.shape.dims[3],
+    }));
+    return modules::LinearModule({config.dense_input_features * config.hidden_size, config.hidden_size, true})
+        .build(ctx, x, weights.dense);
+}
+
+core::TensorValue build_niagara_self_attention(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    const NiagaraSelfAttentionWeights & weights,
+    const NiagaraEncoderConfig & config) {
+    const int64_t frames = input.shape.dims[1];
+    const int64_t head_dim = config.hidden_size / kNumAttentionHeads;
+    auto x = build_niagara_l1_norm(ctx, input, weights.norm, config);
+    auto q = modules::LinearModule({config.hidden_size, config.hidden_size, true}).build(ctx, x, weights.query);
+    auto k = modules::LinearModule({config.hidden_size, config.hidden_size, true}).build(ctx, x, weights.key);
+    auto v = modules::LinearModule({config.hidden_size, config.hidden_size, true}).build(ctx, x, weights.value);
+    auto q_content = reshape_heads(ctx, add_last_dim_bias(ctx, q, weights.u_bias));
+    auto q_position = reshape_heads(ctx, add_last_dim_bias(ctx, q, weights.v_bias));
+    k = reshape_heads(ctx, k);
+    v = reshape_heads(ctx, v);
+
+    auto scores = modules::MatMulModule{}.build(ctx, q_content, transpose(ctx, k, {0, 1, 3, 2}, 4));
+
+    const int64_t rel_start = kRelativePositionCenter - frames;
+    auto relative = modules::SliceModule({0, rel_start, frames * 2 - 1}).build(ctx, weights.relative_position);
+    relative = modules::LinearModule({config.hidden_size, config.hidden_size, true}).build(ctx, relative, weights.global_attention);
+    relative = core::reshape_tensor(
+        ctx,
+        relative,
+        core::TensorShape::from_dims({1, frames * 2 - 1, kNumAttentionHeads, head_dim}));
+    relative = contiguous(ctx, transpose(ctx, relative, {0, 2, 3, 1}, 4));
+    auto relative_scores = modules::MatMulModule{}.build(ctx, q_position, relative);
+    relative_scores = relative_shift(ctx, relative_scores, frames);
+    scores = modules::AddModule{}.build(ctx, scores, relative_scores);
+    scores = core::wrap_tensor(
+        ggml_scale(ctx.ggml, core::ensure_backend_addressable_layout(ctx, scores).tensor, 1.0f / std::sqrt(static_cast<float>(head_dim))),
+        scores.shape,
+        GGML_TYPE_F32);
+    auto attn = core::wrap_tensor(ggml_soft_max(ctx.ggml, scores.tensor), scores.shape, GGML_TYPE_F32);
+    auto context = modules::MatMulModule{}.build(ctx, attn, v);
+    context = contiguous(ctx, transpose(ctx, context, {0, 2, 1, 3}, 4));
+    context = core::reshape_tensor(ctx, context, input.shape);
+    return modules::LinearModule({config.hidden_size, config.hidden_size, true}).build(ctx, context, weights.out);
+}
+
+core::TensorValue build_niagara_state_space(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    const NiagaraStateSpaceWeights & weights,
+    const NiagaraEncoderConfig & config) {
+    constexpr int64_t kernel_size = 128;
+    auto x = build_niagara_l1_norm(ctx, input, weights.norm, config);
+    x = modules::LinearModule({config.hidden_size, config.state_channels, true}).build(ctx, x, weights.dense1);
+    x = core::reshape_tensor(
+        ctx,
+        x,
+        core::TensorShape::from_dims({x.shape.dims[0], x.shape.dims[1], 1, config.state_channels}));
+    x = transpose(ctx, x, {0, 3, 1, 2}, 4);
+    x = core::ensure_backend_addressable_layout(ctx, x);
+    x = modules::Pad2dModule({0, 0, kernel_size - 1, 0}).build(ctx, x);
+    x = modules::DepthwiseConv2dModule({config.state_channels, kernel_size, 1, 1, 1, 0, 0, 1, 1, false})
+            .build(ctx, x, {weights.conv_kernel, std::nullopt});
+    x = transpose(ctx, x, {0, 2, 3, 1}, 4);
+    x = core::wrap_tensor(ggml_cont(ctx.ggml, x.tensor), x.shape, x.type);
+    x = core::reshape_tensor(
+        ctx,
+        x,
+        core::TensorShape::from_dims({input.shape.dims[0], input.shape.dims[1], config.state_channels}));
+
+    if (config.state_channels == config.hidden_size * 2) {
+        const int channel_axis = static_cast<int>(x.shape.rank - 1);
+        const auto gate = modules::SliceModule({channel_axis, config.hidden_size, config.hidden_size}).build(ctx, x);
+        const auto value = modules::SliceModule({channel_axis, 0, config.hidden_size}).build(ctx, x);
+        x = core::wrap_tensor(ggml_mul(ctx.ggml, value.tensor, modules::SigmoidModule{}.build(ctx, gate).tensor), value.shape, GGML_TYPE_F32);
+    } else if (config.state_channels == config.hidden_size) {
+        x = modules::SiluModule{}.build(ctx, x);
+    } else {
+        throw std::runtime_error("Niagara state-space channel count must be hidden or 2 * hidden");
+    }
+
+    return modules::LinearModule({config.hidden_size, config.hidden_size, true}).build(ctx, x, weights.dense2);
+}
+
+core::TensorValue build_niagara_layer(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    const NiagaraLayerWeights & weights,
+    const NiagaraEncoderConfig & config) {
+    auto x = add_scaled_residual(ctx, input, build_niagara_feed_forward(ctx, input, weights.ffn, config), weights.ffn.residual_scale);
+    auto attention = build_niagara_self_attention(ctx, x, weights.self_attention, config);
+    x = modules::ResidualAddModule{}.build(ctx, x, attention);
+    auto state = build_niagara_state_space(ctx, x, weights.state_space, config);
+    x = modules::ResidualAddModule{}.build(ctx, x, state);
+    x = add_scaled_residual(ctx, x, build_niagara_feed_forward(ctx, x, weights.ffn1, config), weights.ffn1.residual_scale);
+    return build_niagara_l1_norm(ctx, x, weights.out_norm, config);
+}
+
+core::TensorValue build_niagara_encoder_logits(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    const NiagaraWeights & weights,
+    const NiagaraAsrConfig & config) {
+    auto x = build_niagara_subsampling(ctx, input, weights.subsampling, config.encoder);
+    for (const auto & layer : weights.layers) {
+        x = build_niagara_layer(ctx, x, layer, config.encoder);
+    }
+    return modules::LinearModule({config.encoder.hidden_size, config.vocab_size + 1, true}).build(ctx, x, weights.ctc);
+}
+
+}  // namespace engine::community_models::niagara_asr

--- a/src/community_models/niagara_asr/frontend.cpp
+++ b/src/community_models/niagara_asr/frontend.cpp
@@ -1,0 +1,121 @@
+#include "engine/community_models/niagara_asr/frontend.h"
+
+#include "engine/framework/audio/conversion.h"
+#include "engine/framework/audio/dsp.h"
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+#include <utility>
+
+namespace engine::community_models::niagara_asr {
+namespace {
+
+constexpr double kPi = 3.14159265358979323846264338327950288;
+
+std::vector<float> periodic_hann(int64_t win_length) {
+    std::vector<float> window(static_cast<size_t>(win_length), 0.0f);
+    for (int64_t i = 0; i < win_length; ++i) {
+        window[static_cast<size_t>(i)] = static_cast<float>(
+            0.5 - 0.5 * std::cos(2.0 * kPi * static_cast<double>(i) / static_cast<double>(win_length)));
+    }
+    return window;
+}
+
+double hz_to_mel(double hz) {
+    return 2595.0 * std::log10(1.0 + hz / 700.0);
+}
+
+double mel_to_hz(double mel) {
+    return 700.0 * (std::pow(10.0, mel / 2595.0) - 1.0);
+}
+
+std::vector<float> build_filterbank(int64_t sample_rate, int64_t n_fft, int64_t n_mels) {
+    const int64_t freq_bins = n_fft / 2 + 1;
+    const double f_min = 0.0;
+    const double f_max = static_cast<double>(sample_rate) / 2.0;
+    const double mel_min = hz_to_mel(f_min);
+    const double mel_max = hz_to_mel(f_max);
+
+    std::vector<double> hz_points(static_cast<size_t>(n_mels + 2), 0.0);
+    for (int64_t i = 0; i < n_mels + 2; ++i) {
+        const double mel = mel_min + (mel_max - mel_min) *
+            static_cast<double>(i) / static_cast<double>(n_mels + 1);
+        hz_points[static_cast<size_t>(i)] = mel_to_hz(mel);
+    }
+
+    std::vector<float> filterbank(static_cast<size_t>(n_mels * freq_bins), 0.0f);
+    const double bin_hz = f_max / static_cast<double>(freq_bins - 1);
+    for (int64_t mel = 0; mel < n_mels; ++mel) {
+        const double left = hz_points[static_cast<size_t>(mel)];
+        const double center = hz_points[static_cast<size_t>(mel + 1)];
+        const double right = hz_points[static_cast<size_t>(mel + 2)];
+        for (int64_t bin = 0; bin < freq_bins; ++bin) {
+            const double hz = bin_hz * static_cast<double>(bin);
+            const double up = center > left ? (hz - left) / (center - left) : 0.0;
+            const double down = right > center ? (right - hz) / (right - center) : 0.0;
+            filterbank[static_cast<size_t>(mel * freq_bins + bin)] =
+                static_cast<float>(std::max(0.0, std::min(up, down)));
+        }
+    }
+    return filterbank;
+}
+
+}  // namespace
+
+NiagaraFrontend::NiagaraFrontend(std::shared_ptr<const NiagaraAsrAssets> assets)
+    : assets_(std::move(assets)) {
+    if (assets_ == nullptr) {
+        throw std::runtime_error("Niagara ASR frontend requires assets");
+    }
+    const auto & cfg = assets_->config.frontend;
+    window_ = periodic_hann(cfg.win_length);
+    mel_filterbank_ = build_filterbank(cfg.sample_rate, cfg.n_fft, cfg.n_mels);
+}
+
+NiagaraFeatures NiagaraFrontend::extract(const runtime::AudioBuffer & audio) const {
+    if (audio.sample_rate <= 0 || audio.channels <= 0 || audio.samples.empty()) {
+        throw std::runtime_error("Niagara ASR requires non-empty audio with positive sample rate/channels");
+    }
+    const auto & cfg = assets_->config.frontend;
+    auto waveform = engine::audio::convert_interleaved_audio_to_mono_linear_resampled(
+        audio.samples, audio.sample_rate, audio.channels, static_cast<int>(cfg.sample_rate));
+    if (static_cast<int64_t>(waveform.size()) < cfg.win_length) {
+        waveform.resize(static_cast<size_t>(cfg.win_length), 0.0f);
+    }
+
+    engine::audio::STFTConfig stft_cfg;
+    stft_cfg.n_fft = cfg.n_fft;
+    stft_cfg.win_length = cfg.win_length;
+    stft_cfg.hop_length = cfg.hop_length;
+    stft_cfg.center = false;
+    stft_cfg.pad_mode = engine::audio::STFTPadMode::Constant;
+
+    const auto mag = engine::audio::STFT().compute_magnitude(
+        waveform, window_, 1, static_cast<int64_t>(waveform.size()), stft_cfg);
+    const int64_t freq_bins = cfg.n_fft / 2 + 1;
+    const int64_t raw_frames = mag.shape.size() >= 3
+        ? mag.shape[2]
+        : static_cast<int64_t>(mag.values.size()) / freq_bins;
+    const int64_t padded_frames = ((raw_frames + 3) / 4) * 4;
+
+    NiagaraFeatures out;
+    out.frames = padded_frames;
+    out.feature_dim = cfg.n_mels;
+    out.values.assign(static_cast<size_t>(padded_frames * cfg.n_mels), 1000.0f);
+    for (int64_t t = 0; t < raw_frames; ++t) {
+        for (int64_t m = 0; m < cfg.n_mels; ++m) {
+            double energy = 0.0;
+            for (int64_t f = 0; f < freq_bins; ++f) {
+                const float v = mag.values[static_cast<size_t>(f * raw_frames + t)];
+                energy += static_cast<double>(mel_filterbank_[static_cast<size_t>(m * freq_bins + f)]) *
+                    static_cast<double>(v);
+            }
+            out.values[static_cast<size_t>(t * cfg.n_mels + m)] =
+                std::log(std::max(energy, 1.0e-12));
+        }
+    }
+    return out;
+}
+
+}  // namespace engine::community_models::niagara_asr

--- a/src/community_models/niagara_asr/runtime.cpp
+++ b/src/community_models/niagara_asr/runtime.cpp
@@ -1,0 +1,117 @@
+#include "engine/community_models/niagara_asr/runtime.h"
+
+#include "engine/community_models/niagara_asr/encoder.h"
+#include "engine/community_models/niagara_asr/weights.h"
+#include "engine/framework/core/backend.h"
+
+#include "ggml-alloc.h"
+
+#include <chrono>
+#include <stdexcept>
+#include <utility>
+
+namespace engine::community_models::niagara_asr {
+namespace assets = engine::assets;
+namespace core = engine::core;
+namespace {
+
+using Clock = std::chrono::steady_clock;
+
+const NiagaraAsrAssets & require_runtime_assets(const std::shared_ptr<const NiagaraAsrAssets> & assets) {
+    if (assets == nullptr || assets->source == nullptr) {
+        throw std::runtime_error("Niagara runtime requires assets and tensor source");
+    }
+    return *assets;
+}
+
+}  // namespace
+
+struct NiagaraRuntime::Impl {
+    Impl(
+        std::shared_ptr<const NiagaraAsrAssets> assets,
+        core::ExecutionContext & execution,
+        assets::TensorStorageType weight_storage_type,
+        size_t graph_arena_bytes,
+        size_t weight_context_bytes)
+        : assets(std::move(assets)),
+          execution(&execution),
+          weights(load_niagara_weights(require_runtime_assets(this->assets), execution, weight_storage_type, weight_context_bytes)),
+          graph_arena_bytes(graph_arena_bytes) {}
+
+    std::shared_ptr<const NiagaraAsrAssets> assets;
+    core::ExecutionContext * execution = nullptr;
+    std::shared_ptr<const NiagaraWeights> weights;
+    size_t graph_arena_bytes = 0;
+};
+
+NiagaraRuntime::NiagaraRuntime(
+    std::shared_ptr<const NiagaraAsrAssets> assets,
+    core::ExecutionContext & execution,
+    assets::TensorStorageType weight_storage_type,
+    size_t graph_arena_bytes,
+    size_t weight_context_bytes)
+    : impl_(new Impl(std::move(assets), execution, weight_storage_type, graph_arena_bytes, weight_context_bytes)) {}
+
+NiagaraRuntime::~NiagaraRuntime() = default;
+
+NiagaraInferenceResult NiagaraRuntime::infer(const NiagaraFeatures & features) {
+    if (features.frames <= 0 || features.feature_dim != 80 ||
+        static_cast<int64_t>(features.values.size()) != features.frames * features.feature_dim) {
+        throw std::runtime_error("Niagara runtime received invalid frontend features");
+    }
+
+    const auto started = Clock::now();
+    ggml_init_params params{
+        impl_->graph_arena_bytes,
+        nullptr,
+        true,
+    };
+    ggml_context * ggml_ctx = ggml_init(params);
+    if (ggml_ctx == nullptr) {
+        throw std::runtime_error("failed to allocate Niagara runtime graph context");
+    }
+
+    ggml_gallocr_t gallocr = nullptr;
+    try {
+        core::ModuleBuildContext ctx{ggml_ctx, "niagara_asr.encoder", impl_->execution->backend_type()};
+        auto input = core::make_tensor(
+            ctx,
+            GGML_TYPE_F32,
+            core::TensorShape::from_dims({1, features.frames, features.feature_dim}));
+        auto logits = build_niagara_encoder_logits(ctx, input, *impl_->weights, impl_->assets->config);
+        logits = core::ensure_backend_addressable_layout(ctx, logits);
+        ggml_set_output(logits.tensor);
+
+        ggml_cgraph * graph = ggml_new_graph_custom(ggml_ctx, 65536, false);
+        ggml_build_forward_expand(graph, logits.tensor);
+
+        const auto backend = impl_->execution->backend();
+        gallocr = ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend));
+        if (gallocr == nullptr || !ggml_gallocr_reserve(gallocr, graph) || !ggml_gallocr_alloc_graph(gallocr, graph)) {
+            throw std::runtime_error("failed to allocate Niagara runtime graph");
+        }
+
+        core::write_tensor_f32(input, features.values);
+        const ggml_status status = core::compute_backend_graph(backend, graph, nullptr, "Niagara ASR encoder");
+        if (status != GGML_STATUS_SUCCESS) {
+            throw std::runtime_error("Niagara runtime graph compute failed");
+        }
+
+        NiagaraInferenceResult result;
+        result.frames = logits.shape.dims[1];
+        result.vocab_size = logits.shape.dims[2];
+        result.logits = core::read_tensor_f32(logits.tensor);
+        result.elapsed_ms = std::chrono::duration<double, std::milli>(Clock::now() - started).count();
+        ggml_gallocr_free(gallocr);
+        ggml_free(ggml_ctx);
+        return result;
+    } catch (...) {
+        if (gallocr != nullptr) {
+            ggml_gallocr_free(gallocr);
+        }
+        ggml_free(ggml_ctx);
+        throw;
+    }
+}
+
+}  // namespace engine::community_models::niagara_asr

--- a/src/community_models/niagara_asr/session.cpp
+++ b/src/community_models/niagara_asr/session.cpp
@@ -1,0 +1,182 @@
+#include "engine/community_models/niagara_asr/session.h"
+
+#include "engine/framework/core/backend.h"
+#include "engine/framework/debug/profiler.h"
+#include "engine/framework/io/text.h"
+#include "engine/framework/runtime/host_ops.h"
+#include "engine/framework/runtime/options.h"
+#include "engine/framework/runtime/spec_backed_model.h"
+
+#include <algorithm>
+#include <chrono>
+#include <stdexcept>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace engine::community_models::niagara_asr {
+namespace {
+
+using Clock = std::chrono::steady_clock;
+constexpr size_t kMiB = 1024ULL * 1024ULL;
+constexpr size_t kDefaultGraphArenaBytes = 1024ULL * kMiB;
+constexpr size_t kDefaultWeightContextBytes = 256ULL * kMiB;
+
+const engine::model_spec::ModelContract & require_contract(
+    const std::shared_ptr<const engine::model_spec::ModelContract> & contract) {
+    if (contract == nullptr) {
+        throw std::runtime_error("Niagara ASR session requires a model contract");
+    }
+    return *contract;
+}
+
+runtime::SessionOptions validate_session_setup(
+    const runtime::TaskSpec & task,
+    runtime::SessionOptions options,
+    const engine::model_spec::ModelContract & contract) {
+    if (task.task != runtime::VoiceTaskKind::Asr || task.mode != runtime::RunMode::Offline) {
+        throw std::runtime_error("Niagara ASR only supports offline ASR");
+    }
+    if (options.backend.type != core::BackendType::Cpu) {
+        throw std::runtime_error("Niagara ASR CPU variants require --backend cpu");
+    }
+    for (const char * key : {"weight_type", "graph_arena_mb", "weight_context_mb"}) {
+        if (options.options.find(key) != options.options.end()) {
+            throw std::runtime_error(
+                "Niagara ASR session option " + std::string(key) +
+                " must use the normalized key niagara_asr." + key);
+        }
+    }
+    runtime::validate_spec_backed_session_options(options, contract, "niagara_asr", "Niagara ASR");
+    return options;
+}
+
+std::unordered_map<std::string, std::string> validate_request_options(
+    std::unordered_map<std::string, std::string> options,
+    const engine::model_spec::ModelContract & contract) {
+    runtime::validate_spec_backed_request_options(options, contract, "Niagara ASR");
+    const auto it = options.find("audio_chunk_mode");
+    if (it != options.end() && it->second != "none") {
+        throw std::runtime_error("Niagara ASR supports only audio_chunk_mode=none");
+    }
+    return options;
+}
+
+}  // namespace
+
+NiagaraAsrSession::NiagaraAsrSession(
+    runtime::TaskSpec task,
+    runtime::SessionOptions options,
+    std::shared_ptr<const NiagaraAsrAssets> assets,
+    std::shared_ptr<const engine::model_spec::ModelContract> contract)
+    : RuntimeSessionBase(validate_session_setup(task, std::move(options), require_contract(contract))),
+      task_(std::move(task)),
+      assets_(std::move(assets)),
+      contract_(std::move(contract)),
+      frontend_(assets_),
+      runtime_(
+          assets_,
+          execution_context(),
+          runtime::parse_tensor_storage_option(
+              RuntimeSessionBase::options().options,
+              "niagara_asr.weight_type",
+              engine::assets::TensorStorageType::Native,
+              {engine::assets::TensorStorageType::Native,
+               engine::assets::TensorStorageType::F32,
+               engine::assets::TensorStorageType::F16,
+               engine::assets::TensorStorageType::BF16,
+               engine::assets::TensorStorageType::Q8_0,
+               engine::assets::TensorStorageType::Q4_0,
+               engine::assets::TensorStorageType::Q4_1,
+               engine::assets::TensorStorageType::Q5_0,
+               engine::assets::TensorStorageType::Q5_1,
+               engine::assets::TensorStorageType::Q2_K,
+               engine::assets::TensorStorageType::Q3_K,
+               engine::assets::TensorStorageType::Q4_K,
+               engine::assets::TensorStorageType::Q5_K,
+               engine::assets::TensorStorageType::Q6_K}),
+          runtime::parse_size_mb_option(
+              RuntimeSessionBase::options().options,
+              {"niagara_asr.graph_arena_mb"},
+              kDefaultGraphArenaBytes),
+          runtime::parse_size_mb_option(
+              RuntimeSessionBase::options().options,
+              {"niagara_asr.weight_context_mb"},
+              kDefaultWeightContextBytes)) {
+    if (assets_ == nullptr) {
+        throw std::runtime_error("Niagara ASR session requires assets");
+    }
+}
+
+NiagaraAsrSession::~NiagaraAsrSession() = default;
+
+std::string NiagaraAsrSession::family() const {
+    return "niagara_asr";
+}
+
+runtime::VoiceTaskKind NiagaraAsrSession::task_kind() const {
+    return task_.task;
+}
+
+runtime::RunMode NiagaraAsrSession::run_mode() const {
+    return task_.mode;
+}
+
+void NiagaraAsrSession::prepare(const runtime::SessionPreparationRequest & request) {
+    (void) request;
+    mark_prepared();
+}
+
+std::string NiagaraAsrSession::decode(const NiagaraInferenceResult & inference) const {
+    const auto decoded = runtime::CTCDecoder().compute(
+        inference.logits,
+        1,
+        inference.frames,
+        inference.vocab_size,
+        static_cast<int32_t>(assets_->config.blank_id));
+    std::vector<int32_t> ids;
+    ids.reserve(static_cast<size_t>(inference.frames));
+    for (int32_t id : decoded.values) {
+        if (id != static_cast<int32_t>(assets_->config.blank_id) && id > 0) {
+            ids.push_back(id);
+        }
+    }
+    return engine::io::trim_ascii_whitespace(
+        tokenizers::decode_sentencepiece(assets_->tokenizer_pieces, ids));
+}
+
+runtime::TaskResult NiagaraAsrSession::run(const runtime::TaskRequest & request) {
+    require_prepared("Niagara ASR run()");
+    if (!request.audio_input.has_value()) {
+        throw std::runtime_error("Niagara ASR run() requires audio_input");
+    }
+    (void) validate_request_options(request.options, require_contract(contract_));
+    const auto wall_start = Clock::now();
+    const auto features = frontend_.extract(*request.audio_input);
+    const auto inference = runtime_.infer(features);
+    runtime::TaskResult result;
+    result.text_output = runtime::Transcript{decode(inference), "en"};
+    engine::debug::timing_log_scalar("niagara.frontend_frames", static_cast<double>(features.frames));
+    engine::debug::timing_log_scalar("niagara.model_ms", inference.elapsed_ms);
+    engine::debug::timing_log_scalar("session.wall_ms", engine::debug::elapsed_ms(wall_start));
+    return result;
+}
+
+std::shared_ptr<runtime::IVoiceModelLoader> make_niagara_asr_loader() {
+    runtime::SpecBackedVoiceModelConfig<NiagaraAsrAssets> config;
+    config.family = "niagara_asr";
+    config.load_assets = [](const std::filesystem::path & model_path) {
+        return load_niagara_asr_assets(model_path);
+    };
+    config.create_session =
+        [](const runtime::TaskSpec & task,
+           const runtime::SessionOptions & options,
+           std::shared_ptr<const NiagaraAsrAssets> assets,
+           std::shared_ptr<const engine::model_spec::ModelContract> contract) {
+            return std::make_unique<NiagaraAsrSession>(
+                task, options, std::move(assets), std::move(contract));
+        };
+    return runtime::make_spec_backed_voice_loader(std::move(config));
+}
+
+}  // namespace engine::community_models::niagara_asr

--- a/src/community_models/niagara_asr/weights.cpp
+++ b/src/community_models/niagara_asr/weights.cpp
@@ -1,0 +1,365 @@
+#include "engine/community_models/niagara_asr/weights.h"
+
+#include "engine/framework/assets/tensor_source.h"
+
+#include <cmath>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace engine::community_models::niagara_asr {
+namespace {
+
+namespace assets = engine::assets;
+namespace core = engine::core;
+namespace modules = engine::modules;
+
+constexpr float kBatchNormEpsilon = 1.0e-5f;
+
+std::string lmuformer_prefix(int64_t layer) {
+    if (layer == 0) {
+        return "p__torch_params_encoder_lmuformer_";
+    }
+    return "p__torch_params_encoder_lmuformer_" + std::to_string(layer) + "_";
+}
+
+std::string state_space_basis_name(int64_t layer) {
+    return "c_lifted_tensor_" + std::to_string(44 + 40 * layer);
+}
+
+std::string relative_position_name(int64_t layer) {
+    return "c_lifted_tensor_" + std::to_string(34 + 40 * layer);
+}
+
+std::string indexed_layer_name(
+    const std::string & prefix,
+    const std::string & base,
+    int64_t layer,
+    bool omit_zero) {
+    if (layer == 0 && omit_zero) {
+        return prefix + base;
+    }
+    return prefix + base + "_" + std::to_string(layer);
+}
+
+std::vector<float> build_state_space_conv_kernel(
+    const assets::TensorSource & source,
+    const std::string & prefix,
+    int64_t layer,
+    const NiagaraEncoderConfig & config) {
+    constexpr int64_t kernel_size = 128;
+    const auto basis = source.require_f32(
+        state_space_basis_name(layer),
+        {1, kernel_size, config.state_size});
+    const auto c = source.require_f32(
+        prefix + "state_space_state_space_c",
+        {config.state_channels, config.state_size, 1});
+    std::vector<float> kernel(static_cast<size_t>(config.state_channels * kernel_size), 0.0f);
+    for (int64_t channel = 0; channel < config.state_channels; ++channel) {
+        for (int64_t k = 0; k < kernel_size; ++k) {
+            double sum = 0.0;
+            const int64_t source_k = kernel_size - 1 - k;
+            for (int64_t s = 0; s < config.state_size; ++s) {
+                sum += static_cast<double>(basis[static_cast<size_t>(source_k * config.state_size + s)]) *
+                    static_cast<double>(c[static_cast<size_t>(channel * config.state_size + s)]);
+            }
+            kernel[static_cast<size_t>(channel * kernel_size + k)] = static_cast<float>(sum);
+        }
+    }
+    return kernel;
+}
+
+modules::LinearWeights load_keras_dense(
+    core::BackendWeightStore & store,
+    const assets::TensorSource & source,
+    const std::string & prefix,
+    int64_t in_features,
+    int64_t out_features,
+    assets::TensorStorageType storage_type) {
+    const auto raw = source.require_f32(prefix + "_kernel", {in_features, out_features});
+    std::vector<float> transposed(static_cast<size_t>(in_features * out_features), 0.0f);
+    for (int64_t in = 0; in < in_features; ++in) {
+        for (int64_t out = 0; out < out_features; ++out) {
+            transposed[static_cast<size_t>(out * in_features + in)] =
+                raw[static_cast<size_t>(in * out_features + out)];
+        }
+    }
+    return {
+        store.make_from_f32(
+            core::TensorShape::from_dims({out_features, in_features}),
+            storage_type,
+            std::move(transposed)),
+        store.load_f32_tensor(source, prefix + "_bias", {out_features}),
+    };
+}
+
+modules::Conv2dWeights load_conv2d_hwio(
+    core::BackendWeightStore & store,
+    const assets::TensorSource & source,
+    const std::string & prefix,
+    int64_t kernel_height,
+    int64_t kernel_width,
+    int64_t in_channels,
+    int64_t out_channels,
+    assets::TensorStorageType storage_type,
+    bool has_bias = true) {
+    const auto raw = source.require_f32(prefix + "_kernel", {kernel_height, kernel_width, in_channels, out_channels});
+    std::vector<float> converted(static_cast<size_t>(out_channels * in_channels * kernel_height * kernel_width), 0.0f);
+    for (int64_t out = 0; out < out_channels; ++out) {
+        for (int64_t in = 0; in < in_channels; ++in) {
+            for (int64_t kh = 0; kh < kernel_height; ++kh) {
+                for (int64_t kw = 0; kw < kernel_width; ++kw) {
+                    converted[static_cast<size_t>(((out * in_channels + in) * kernel_height + kh) * kernel_width + kw)] =
+                        raw[static_cast<size_t>(((kh * kernel_width + kw) * in_channels + in) * out_channels + out)];
+                }
+            }
+        }
+    }
+    return {
+        store.make_from_f32(
+            core::TensorShape::from_dims({out_channels, in_channels, kernel_height, kernel_width}),
+            storage_type,
+            std::move(converted)),
+        has_bias ? std::optional<core::TensorValue>(store.load_f32_tensor(source, prefix + "_bias", {out_channels}))
+                 : std::nullopt,
+    };
+}
+
+modules::NormWeights load_l1_norm(
+    core::BackendWeightStore & store,
+    const assets::TensorSource & source,
+    const std::string & prefix,
+    int64_t hidden_size) {
+    return {
+        store.load_f32_tensor(source, prefix + "_gamma", {hidden_size}),
+        store.load_f32_tensor(source, prefix + "_beta", {hidden_size}),
+    };
+}
+
+modules::BatchNorm2dEvalWeights load_batch_norm(
+    core::BackendWeightStore & store,
+    const assets::TensorSource & source,
+    const std::string & prefix,
+    int64_t channels) {
+    const auto gamma = source.require_f32(prefix + "_gamma", {channels});
+    const auto beta = source.require_f32(prefix + "_beta", {channels});
+    const auto mean = source.require_f32(prefix + "_moving_mean", {channels});
+    const auto variance = source.require_f32(prefix + "_moving_variance", {channels});
+    std::vector<float> scale(static_cast<size_t>(channels), 0.0f);
+    std::vector<float> bias(static_cast<size_t>(channels), 0.0f);
+    for (int64_t c = 0; c < channels; ++c) {
+        const float folded_scale =
+            gamma[static_cast<size_t>(c)] / std::sqrt(variance[static_cast<size_t>(c)] + kBatchNormEpsilon);
+        scale[static_cast<size_t>(c)] = folded_scale;
+        bias[static_cast<size_t>(c)] = beta[static_cast<size_t>(c)] - mean[static_cast<size_t>(c)] * folded_scale;
+    }
+    return {
+        store.make_from_f32(core::TensorShape::from_dims({channels}), assets::TensorStorageType::F32, std::move(scale)),
+        store.make_from_f32(core::TensorShape::from_dims({channels}), assets::TensorStorageType::F32, std::move(bias)),
+    };
+}
+
+NiagaraFeedForwardWeights load_feed_forward(
+    core::BackendWeightStore & store,
+    const assets::TensorSource & source,
+    const std::string & prefix,
+    const std::string & residual_scale_name,
+    int64_t hidden_size,
+    int64_t intermediate_size,
+    assets::TensorStorageType storage_type) {
+    return {
+        load_l1_norm(store, source, prefix + "l1norm", hidden_size),
+        load_keras_dense(store, source, prefix + "dense_1", hidden_size, intermediate_size, storage_type),
+        load_keras_dense(store, source, prefix + "dense_2", intermediate_size, hidden_size, storage_type),
+        store.load_f32_tensor(source, residual_scale_name, {1}),
+    };
+}
+
+NiagaraSelfAttentionWeights load_self_attention(
+    core::BackendWeightStore & store,
+    const assets::TensorSource & source,
+    const std::string & prefix,
+    int64_t layer,
+    int64_t hidden_size,
+    assets::TensorStorageType storage_type) {
+    return {
+        load_l1_norm(
+            store,
+            source,
+            indexed_layer_name(prefix, "self_attention_l1_layer_normalization", layer * 2, true),
+            hidden_size),
+        load_keras_dense(store, source, prefix + "self_attention_query", hidden_size, hidden_size, storage_type),
+        load_keras_dense(store, source, prefix + "self_attention_key", hidden_size, hidden_size, storage_type),
+        load_keras_dense(store, source, prefix + "self_attention_value", hidden_size, hidden_size, storage_type),
+        load_keras_dense(
+            store,
+            source,
+            indexed_layer_name(prefix, "self_attention_global_attention", layer, true),
+            hidden_size,
+            hidden_size,
+            storage_type),
+        load_keras_dense(
+            store,
+            source,
+            indexed_layer_name(prefix, "self_attention_dense", layer + 1, false),
+            hidden_size,
+            hidden_size,
+            storage_type),
+        store.load_tensor(
+            source,
+            relative_position_name(layer),
+            assets::TensorStorageType::F32,
+            {5999, hidden_size}),
+        store.load_f32_tensor(source, prefix + "self_attention_u_bias_bias", {hidden_size}),
+        store.load_f32_tensor(source, prefix + "self_attention_v_bias_bias", {hidden_size}),
+    };
+}
+
+NiagaraStateSpaceWeights load_state_space(
+    core::BackendWeightStore & store,
+    const assets::TensorSource & source,
+    const std::string & prefix,
+    int64_t layer,
+    const NiagaraEncoderConfig & config,
+    assets::TensorStorageType storage_type) {
+    constexpr int64_t kernel_size = 128;
+    return {
+        load_l1_norm(store, source, prefix + "state_space_l1norm", config.hidden_size),
+        load_keras_dense(
+            store,
+            source,
+            prefix + "state_space_dense_1",
+            config.hidden_size,
+            config.state_channels,
+            storage_type),
+        load_keras_dense(
+            store,
+            source,
+            prefix + "state_space_dense_2",
+            config.hidden_size,
+            config.hidden_size,
+            storage_type),
+        store.make_from_f32(
+            core::TensorShape::from_dims({config.state_channels, 1, kernel_size, 1}),
+            assets::TensorStorageType::F32,
+            build_state_space_conv_kernel(source, prefix, layer, config)),
+    };
+}
+
+NiagaraLayerWeights load_layer(
+    core::BackendWeightStore & store,
+    const assets::TensorSource & source,
+    int64_t layer,
+    const NiagaraEncoderConfig & config,
+    assets::TensorStorageType storage_type) {
+    const auto prefix = lmuformer_prefix(layer);
+    return {
+        load_feed_forward(
+            store,
+            source,
+            prefix + "ffn_",
+            "c_lifted_tensor_" + std::to_string(23 + 40 * layer),
+            config.hidden_size,
+            config.intermediate_size,
+            storage_type),
+        load_self_attention(store, source, prefix, layer, config.hidden_size, storage_type),
+        load_state_space(store, source, prefix, layer, config, storage_type),
+        load_feed_forward(
+            store,
+            source,
+            prefix + "ffn_1_",
+            "c_lifted_tensor_" + std::to_string(54 + 40 * layer),
+            config.hidden_size,
+            config.intermediate_size,
+            storage_type),
+        load_l1_norm(
+            store,
+            source,
+            indexed_layer_name(prefix, "l1_layer_normalization", layer * 2 + 1, false),
+            config.hidden_size),
+    };
+}
+
+NiagaraSubsamplingWeights load_subsampling(
+    core::BackendWeightStore & store,
+    const assets::TensorSource & source,
+    const NiagaraEncoderConfig & config,
+    assets::TensorStorageType storage_type) {
+    const int64_t hidden = config.hidden_size;
+    return {
+        load_batch_norm(store, source, "p__torch_params_encoder_subsampling_batch_normalization", hidden),
+        load_batch_norm(store, source, "p__torch_params_encoder_subsampling_batch_normalization_1", hidden),
+        load_conv2d_hwio(
+            store,
+            source,
+            "p__torch_params_encoder_subsampling_mask_aware_conv2d",
+            1,
+            1,
+            1,
+            4,
+            storage_type,
+            false),
+        load_conv2d_hwio(
+            store,
+            source,
+            "p__torch_params_encoder_subsampling_mask_aware_conv2d_1",
+            config.subsampling_kernel_height,
+            config.subsampling_kernel_width,
+            4,
+            hidden,
+            storage_type),
+        load_conv2d_hwio(
+            store,
+            source,
+            "p__torch_params_encoder_subsampling_mask_aware_conv2d_2",
+            config.subsampling_kernel_height,
+            config.subsampling_kernel_width,
+            hidden,
+            hidden,
+            storage_type),
+        load_keras_dense(
+            store,
+            source,
+            "p__torch_params_encoder_dense",
+            config.dense_input_features * hidden,
+            hidden,
+            storage_type),
+    };
+}
+
+}  // namespace
+
+std::shared_ptr<const NiagaraWeights> load_niagara_weights(
+    const NiagaraAsrAssets & assets,
+    core::ExecutionContext & execution,
+    assets::TensorStorageType storage_type,
+    size_t weight_context_bytes) {
+    if (assets.source == nullptr) {
+        throw std::runtime_error("Niagara ASR weights require a tensor source");
+    }
+    auto out = std::make_shared<NiagaraWeights>();
+    out->store = std::make_shared<core::BackendWeightStore>(
+        execution.backend(),
+        execution.backend_type(),
+        "niagara_asr.weights",
+        weight_context_bytes);
+    const auto & source = *assets.source;
+    const auto & config = assets.config.encoder;
+    out->subsampling = load_subsampling(*out->store, source, config, storage_type);
+    out->layers.reserve(static_cast<size_t>(config.num_layers));
+    for (int64_t layer = 0; layer < config.num_layers; ++layer) {
+        out->layers.push_back(load_layer(*out->store, source, layer, config, storage_type));
+    }
+    out->ctc = load_keras_dense(
+        *out->store,
+        source,
+        "p__torch_params_shared_dec",
+        config.hidden_size,
+        assets.config.vocab_size + 1,
+        storage_type);
+    out->store->upload();
+    return out;
+}
+
+}  // namespace engine::community_models::niagara_asr

--- a/tests/niagara_asr/niagara_asr_native_ffn_probe.cpp
+++ b/tests/niagara_asr/niagara_asr_native_ffn_probe.cpp
@@ -1,0 +1,277 @@
+#include "engine/community_models/niagara_asr/assets.h"
+#include "engine/community_models/niagara_asr/encoder.h"
+#include "engine/community_models/niagara_asr/weights.h"
+#include "engine/framework/core/backend.h"
+#include "engine/framework/core/execution_context.h"
+#include "engine/framework/modules/activation_modules.h"
+#include "engine/framework/modules/linear_module.h"
+
+#include "ggml-alloc.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <exception>
+#include <filesystem>
+#include <iostream>
+#include <numeric>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+struct Args {
+    std::filesystem::path model;
+    int threads = 8;
+    int frames = 8;
+    int warmup = 1;
+    int iterations = 3;
+};
+
+Args parse_args(int argc, char ** argv) {
+    Args args;
+    for (int i = 1; i < argc; ++i) {
+        const std::string key = argv[i];
+        auto require_value = [&](const char * name) -> std::string {
+            if (i + 1 >= argc) {
+                throw std::runtime_error(std::string(name) + " requires a value");
+            }
+            return argv[++i];
+        };
+        if (key == "--model") {
+            args.model = require_value("--model");
+        } else if (key == "--threads") {
+            args.threads = std::stoi(require_value("--threads"));
+        } else if (key == "--frames") {
+            args.frames = std::stoi(require_value("--frames"));
+        } else if (key == "--warmup") {
+            args.warmup = std::stoi(require_value("--warmup"));
+        } else if (key == "--iterations") {
+            args.iterations = std::stoi(require_value("--iterations"));
+        } else {
+            throw std::runtime_error("unknown argument: " + key);
+        }
+    }
+    if (args.model.empty()) {
+        throw std::runtime_error("--model is required");
+    }
+    if (args.frames <= 0 || args.threads <= 0 || args.warmup < 0 || args.iterations <= 0) {
+        throw std::runtime_error("invalid numeric argument");
+    }
+    return args;
+}
+
+struct GgmlContextDeleter {
+    void operator()(ggml_context * ctx) const noexcept {
+        if (ctx != nullptr) {
+            ggml_free(ctx);
+        }
+    }
+};
+
+struct GgmlGallocrDeleter {
+    void operator()(ggml_gallocr * gallocr) const noexcept {
+        if (gallocr != nullptr) {
+            ggml_gallocr_free(gallocr);
+        }
+    }
+};
+
+std::vector<float> make_input(int64_t elements) {
+    std::vector<float> values(static_cast<size_t>(elements), 0.0f);
+    for (int64_t i = 0; i < elements; ++i) {
+        values[static_cast<size_t>(i)] = std::sin(static_cast<float>(i) * 0.013f);
+    }
+    return values;
+}
+
+std::vector<float> compute_reference_l1(
+    const engine::community_models::niagara_asr::NiagaraAsrAssets & assets,
+    const std::vector<float> & input,
+    int64_t frames) {
+    if (assets.source == nullptr) {
+        throw std::runtime_error("native FFN probe requires GGUF tensor source");
+    }
+    const auto & source = *assets.source;
+    const auto & config = assets.config.encoder;
+    const int64_t hidden = config.hidden_size;
+    const std::string prefix = "p__torch_params_encoder_lmuformer_ffn_";
+    const auto gamma = source.require_f32(prefix + "l1norm_gamma", {hidden});
+    const auto beta = source.require_f32(prefix + "l1norm_beta", {hidden});
+
+    std::vector<float> output(static_cast<size_t>(frames * hidden), 0.0f);
+    for (int64_t frame = 0; frame < frames; ++frame) {
+        const float * row = input.data() + frame * hidden;
+        float mean = std::accumulate(row, row + hidden, 0.0f) / static_cast<float>(hidden);
+        float mean_abs = 0.0f;
+        for (int64_t h = 0; h < hidden; ++h) {
+            mean_abs += std::abs(row[h] - mean);
+        }
+        const float inv_den = 1.0f / (mean_abs / static_cast<float>(hidden) + 1.0e-6f);
+        float * out_row = output.data() + frame * hidden;
+        for (int64_t h = 0; h < hidden; ++h) {
+            out_row[h] =
+                ((row[h] - mean) * inv_den) * gamma[static_cast<size_t>(h)] + beta[static_cast<size_t>(h)];
+        }
+    }
+    return output;
+}
+
+std::vector<float> compute_reference_ffn(
+    const engine::community_models::niagara_asr::NiagaraAsrAssets & assets,
+    const std::vector<float> & input,
+    int64_t frames) {
+    if (assets.source == nullptr) {
+        throw std::runtime_error("native FFN probe requires GGUF tensor source");
+    }
+    const auto & source = *assets.source;
+    const auto & config = assets.config.encoder;
+    const int64_t hidden = config.hidden_size;
+    const int64_t intermediate = config.intermediate_size;
+    const std::string prefix = "p__torch_params_encoder_lmuformer_ffn_";
+    const auto dense1_kernel = source.require_f32(prefix + "dense_1_kernel", {hidden, intermediate});
+    const auto dense1_bias = source.require_f32(prefix + "dense_1_bias", {intermediate});
+    const auto dense2_kernel = source.require_f32(prefix + "dense_2_kernel", {intermediate, hidden});
+    const auto dense2_bias = source.require_f32(prefix + "dense_2_bias", {hidden});
+
+    const auto norm = compute_reference_l1(assets, input, frames);
+    std::vector<float> activation(static_cast<size_t>(intermediate), 0.0f);
+    std::vector<float> output(static_cast<size_t>(frames * hidden), 0.0f);
+    for (int64_t frame = 0; frame < frames; ++frame) {
+        const float * norm_row = norm.data() + frame * hidden;
+        for (int64_t out = 0; out < intermediate; ++out) {
+            float value = dense1_bias[static_cast<size_t>(out)];
+            for (int64_t in = 0; in < hidden; ++in) {
+                value += norm_row[in] *
+                    dense1_kernel[static_cast<size_t>(in * intermediate + out)];
+            }
+            activation[static_cast<size_t>(out)] = value / (1.0f + std::exp(-value));
+        }
+
+        float * out_row = output.data() + frame * hidden;
+        for (int64_t out = 0; out < hidden; ++out) {
+            float value = dense2_bias[static_cast<size_t>(out)];
+            for (int64_t in = 0; in < intermediate; ++in) {
+                value += activation[static_cast<size_t>(in)] *
+                    dense2_kernel[static_cast<size_t>(in * hidden + out)];
+            }
+            out_row[out] = value;
+        }
+    }
+    return output;
+}
+
+}  // namespace
+
+int main(int argc, char ** argv) {
+    try {
+        const auto args = parse_args(argc, argv);
+        auto assets = engine::community_models::niagara_asr::load_niagara_asr_assets(args.model);
+        engine::core::ExecutionContext execution({engine::core::BackendType::Cpu, 0, args.threads});
+        const auto weights = engine::community_models::niagara_asr::load_niagara_weights(
+            *assets,
+            execution,
+            engine::assets::TensorStorageType::F32,
+            512ull * 1024ull * 1024ull);
+
+        ggml_init_params params{64ull * 1024ull * 1024ull, nullptr, true};
+        std::unique_ptr<ggml_context, GgmlContextDeleter> graph_ctx(ggml_init(params));
+        if (graph_ctx == nullptr) {
+            throw std::runtime_error("failed to create Niagara native FFN probe graph context");
+        }
+
+        const auto & config = assets->config.encoder;
+        engine::core::ModuleBuildContext build_ctx{graph_ctx.get(), "niagara_asr.native_ffn_probe", execution.backend_type()};
+        auto input = engine::core::make_tensor(
+            build_ctx,
+            GGML_TYPE_F32,
+            engine::core::TensorShape::from_dims({1, args.frames, config.hidden_size}));
+        ggml_set_input(input.tensor);
+        auto l1 = engine::community_models::niagara_asr::build_niagara_l1_norm(
+            build_ctx,
+            input,
+            weights->layers.front().ffn.norm,
+            config);
+        ggml_set_output(l1.tensor);
+        auto hidden = engine::modules::LinearModule({config.hidden_size, config.intermediate_size, true})
+                          .build(build_ctx, l1, weights->layers.front().ffn.dense1);
+        hidden = engine::modules::SiluModule{}.build(build_ctx, hidden);
+        auto output = engine::modules::LinearModule({config.intermediate_size, config.hidden_size, true})
+                          .build(build_ctx, hidden, weights->layers.front().ffn.dense2);
+        ggml_set_output(output.tensor);
+
+        ggml_cgraph * graph = ggml_new_graph_custom(graph_ctx.get(), 4096, false);
+        ggml_build_forward_expand(graph, output.tensor);
+        std::unique_ptr<ggml_gallocr, GgmlGallocrDeleter> gallocr(
+            ggml_gallocr_new(ggml_backend_get_default_buffer_type(execution.backend())));
+        if (gallocr == nullptr ||
+            !ggml_gallocr_reserve(gallocr.get(), graph) ||
+            !ggml_gallocr_alloc_graph(gallocr.get(), graph)) {
+            throw std::runtime_error("failed to allocate Niagara native FFN probe graph tensors");
+        }
+
+        const auto input_values = make_input(input.shape.num_elements());
+        engine::core::write_tensor_f32(input, input_values);
+
+        for (int i = 0; i < args.warmup; ++i) {
+            const auto status = engine::core::compute_backend_graph(execution.backend(), graph, nullptr, "Niagara native FFN probe");
+            if (status != GGML_STATUS_SUCCESS) {
+                throw std::runtime_error("native FFN probe warmup failed");
+            }
+        }
+        const auto start = std::chrono::steady_clock::now();
+        for (int i = 0; i < std::max(1, args.iterations); ++i) {
+            const auto status = engine::core::compute_backend_graph(execution.backend(), graph, nullptr, "Niagara native FFN probe");
+            if (status != GGML_STATUS_SUCCESS) {
+                throw std::runtime_error("native FFN probe compute failed");
+            }
+        }
+        const auto end = std::chrono::steady_clock::now();
+        const double average_ms =
+            std::chrono::duration<double, std::milli>(end - start).count() / std::max(1, args.iterations);
+        const auto values = engine::core::read_tensor_f32(output.tensor);
+        const auto l1_values = engine::core::read_tensor_f32(l1.tensor);
+        if (values.empty()) {
+            throw std::runtime_error("native FFN probe produced empty output");
+        }
+        const auto l1_reference = compute_reference_l1(*assets, input_values, args.frames);
+        const auto reference = compute_reference_ffn(*assets, input_values, args.frames);
+        if (reference.size() != values.size()) {
+            throw std::runtime_error("native FFN probe reference shape mismatch");
+        }
+        double l1_sum_sq = 0.0;
+        float l1_max_abs_diff = 0.0f;
+        for (size_t i = 0; i < l1_values.size(); ++i) {
+            const float diff = std::abs(l1_values[i] - l1_reference[i]);
+            l1_max_abs_diff = std::max(l1_max_abs_diff, diff);
+            l1_sum_sq += static_cast<double>(diff) * static_cast<double>(diff);
+        }
+        const double l1_rmse = std::sqrt(l1_sum_sq / static_cast<double>(l1_values.size()));
+        double sum_sq = 0.0;
+        float max_abs_diff = 0.0f;
+        for (size_t i = 0; i < values.size(); ++i) {
+            const float diff = std::abs(values[i] - reference[i]);
+            max_abs_diff = std::max(max_abs_diff, diff);
+            sum_sq += static_cast<double>(diff) * static_cast<double>(diff);
+        }
+        const double rmse = std::sqrt(sum_sq / static_cast<double>(values.size()));
+        std::cout << "family=niagara_asr\n";
+        std::cout << "frames=" << args.frames << "\n";
+        std::cout << "hidden_size=" << config.hidden_size << "\n";
+        std::cout << "output_values=" << values.size() << "\n";
+        std::cout << "average_ms=" << average_ms << "\n";
+        std::cout << "l1_max_abs_diff=" << l1_max_abs_diff << "\n";
+        std::cout << "l1_rmse=" << l1_rmse << "\n";
+        std::cout << "max_abs_diff=" << max_abs_diff << "\n";
+        std::cout << "rmse=" << rmse << "\n";
+        if (max_abs_diff > 1.0e-2f) {
+            throw std::runtime_error("native FFN probe exceeded reference tolerance");
+        }
+        return 0;
+    } catch (const std::exception & ex) {
+        std::cerr << "niagara_asr_native_ffn_probe failed: " << ex.what() << "\n";
+        return 1;
+    }
+}

--- a/tests/niagara_asr/niagara_asr_native_state_space_probe.cpp
+++ b/tests/niagara_asr/niagara_asr_native_state_space_probe.cpp
@@ -1,0 +1,327 @@
+#include "engine/community_models/niagara_asr/assets.h"
+#include "engine/community_models/niagara_asr/encoder.h"
+#include "engine/community_models/niagara_asr/weights.h"
+#include "engine/framework/core/backend.h"
+#include "engine/framework/core/execution_context.h"
+
+#include "ggml-alloc.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <exception>
+#include <filesystem>
+#include <iostream>
+#include <memory>
+#include <numeric>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr int64_t kStateKernelSize = 128;
+
+struct Args {
+    std::filesystem::path model;
+    int threads = 8;
+    int frames = 8;
+    int warmup = 1;
+    int iterations = 3;
+};
+
+Args parse_args(int argc, char ** argv) {
+    Args args;
+    for (int i = 1; i < argc; ++i) {
+        const std::string key = argv[i];
+        auto require_value = [&](const char * name) -> std::string {
+            if (i + 1 >= argc) {
+                throw std::runtime_error(std::string(name) + " requires a value");
+            }
+            return argv[++i];
+        };
+        if (key == "--model") {
+            args.model = require_value("--model");
+        } else if (key == "--threads") {
+            args.threads = std::stoi(require_value("--threads"));
+        } else if (key == "--frames") {
+            args.frames = std::stoi(require_value("--frames"));
+        } else if (key == "--warmup") {
+            args.warmup = std::stoi(require_value("--warmup"));
+        } else if (key == "--iterations") {
+            args.iterations = std::stoi(require_value("--iterations"));
+        } else {
+            throw std::runtime_error("unknown argument: " + key);
+        }
+    }
+    if (args.model.empty()) {
+        throw std::runtime_error("--model is required");
+    }
+    if (args.frames <= 0 || args.threads <= 0 || args.warmup < 0 || args.iterations <= 0) {
+        throw std::runtime_error("invalid numeric argument");
+    }
+    return args;
+}
+
+struct GgmlContextDeleter {
+    void operator()(ggml_context * ctx) const noexcept {
+        if (ctx != nullptr) {
+            ggml_free(ctx);
+        }
+    }
+};
+
+struct GgmlGallocrDeleter {
+    void operator()(ggml_gallocr * gallocr) const noexcept {
+        if (gallocr != nullptr) {
+            ggml_gallocr_free(gallocr);
+        }
+    }
+};
+
+std::string lmuformer_prefix(int64_t layer) {
+    if (layer == 0) {
+        return "p__torch_params_encoder_lmuformer_";
+    }
+    return "p__torch_params_encoder_lmuformer_" + std::to_string(layer) + "_";
+}
+
+std::string state_space_basis_name(int64_t layer) {
+    return "c_lifted_tensor_" + std::to_string(44 + 40 * layer);
+}
+
+std::vector<float> make_input(int64_t elements) {
+    std::vector<float> values(static_cast<size_t>(elements), 0.0f);
+    for (int64_t i = 0; i < elements; ++i) {
+        values[static_cast<size_t>(i)] = std::sin(static_cast<float>(i) * 0.013f);
+    }
+    return values;
+}
+
+std::vector<float> dense(
+    const std::vector<float> & input,
+    int64_t rows,
+    int64_t in_features,
+    int64_t out_features,
+    const std::vector<float> & kernel,
+    const std::vector<float> & bias) {
+    std::vector<float> output(static_cast<size_t>(rows * out_features), 0.0f);
+    for (int64_t row = 0; row < rows; ++row) {
+        for (int64_t out = 0; out < out_features; ++out) {
+            float value = bias[static_cast<size_t>(out)];
+            for (int64_t in = 0; in < in_features; ++in) {
+                value += input[static_cast<size_t>(row * in_features + in)] *
+                    kernel[static_cast<size_t>(in * out_features + out)];
+            }
+            output[static_cast<size_t>(row * out_features + out)] = value;
+        }
+    }
+    return output;
+}
+
+std::vector<float> l1_norm(
+    const engine::community_models::niagara_asr::NiagaraAsrAssets & assets,
+    const std::string & prefix,
+    const std::vector<float> & input,
+    int64_t frames) {
+    const auto & source = *assets.source;
+    const auto hidden = assets.config.encoder.hidden_size;
+    const auto gamma = source.require_f32(prefix + "l1norm_gamma", {hidden});
+    const auto beta = source.require_f32(prefix + "l1norm_beta", {hidden});
+    std::vector<float> output(static_cast<size_t>(frames * hidden), 0.0f);
+    for (int64_t frame = 0; frame < frames; ++frame) {
+        const float * row = input.data() + frame * hidden;
+        const float mean = std::accumulate(row, row + hidden, 0.0f) / static_cast<float>(hidden);
+        float mean_abs = 0.0f;
+        for (int64_t h = 0; h < hidden; ++h) {
+            mean_abs += std::abs(row[h] - mean);
+        }
+        const float inv_den = 1.0f / (mean_abs / static_cast<float>(hidden) + 1.0e-6f);
+        for (int64_t h = 0; h < hidden; ++h) {
+            output[static_cast<size_t>(frame * hidden + h)] =
+                ((row[h] - mean) * inv_den) * gamma[static_cast<size_t>(h)] + beta[static_cast<size_t>(h)];
+        }
+    }
+    return output;
+}
+
+std::vector<float> state_conv_kernel(
+    const engine::community_models::niagara_asr::NiagaraAsrAssets & assets,
+    int64_t layer) {
+    const auto & source = *assets.source;
+    const auto & config = assets.config.encoder;
+    const auto prefix = lmuformer_prefix(layer);
+    const auto basis = source.require_f32(
+        state_space_basis_name(layer),
+        {1, kStateKernelSize, config.state_size});
+    const auto c = source.require_f32(
+        prefix + "state_space_state_space_c",
+        {config.state_channels, config.state_size, 1});
+    std::vector<float> kernel(static_cast<size_t>(config.state_channels * kStateKernelSize), 0.0f);
+    for (int64_t channel = 0; channel < config.state_channels; ++channel) {
+        for (int64_t k = 0; k < kStateKernelSize; ++k) {
+            double sum = 0.0;
+            const int64_t source_k = kStateKernelSize - 1 - k;
+            for (int64_t s = 0; s < config.state_size; ++s) {
+                sum += static_cast<double>(basis[static_cast<size_t>(source_k * config.state_size + s)]) *
+                    static_cast<double>(c[static_cast<size_t>(channel * config.state_size + s)]);
+            }
+            kernel[static_cast<size_t>(channel * kStateKernelSize + k)] = static_cast<float>(sum);
+        }
+    }
+    return kernel;
+}
+
+std::vector<float> compute_reference_state_space(
+    const engine::community_models::niagara_asr::NiagaraAsrAssets & assets,
+    const std::vector<float> & input,
+    int64_t frames) {
+    const auto & source = *assets.source;
+    const auto & config = assets.config.encoder;
+    const auto prefix = lmuformer_prefix(0);
+    auto x = l1_norm(assets, prefix + "state_space_", input, frames);
+    x = dense(
+        x,
+        frames,
+        config.hidden_size,
+        config.state_channels,
+        source.require_f32(prefix + "state_space_dense_1_kernel", {config.hidden_size, config.state_channels}),
+        source.require_f32(prefix + "state_space_dense_1_bias", {config.state_channels}));
+
+    const auto kernel = state_conv_kernel(assets, 0);
+    std::vector<float> conv(static_cast<size_t>(frames * config.state_channels), 0.0f);
+    for (int64_t frame = 0; frame < frames; ++frame) {
+        for (int64_t channel = 0; channel < config.state_channels; ++channel) {
+            double sum = 0.0;
+            for (int64_t k = 0; k < kStateKernelSize; ++k) {
+                const int64_t source_frame = frame + k - (kStateKernelSize - 1);
+                if (source_frame >= 0) {
+                    sum += static_cast<double>(x[static_cast<size_t>(source_frame * config.state_channels + channel)]) *
+                        static_cast<double>(kernel[static_cast<size_t>(channel * kStateKernelSize + k)]);
+                }
+            }
+            conv[static_cast<size_t>(frame * config.state_channels + channel)] = static_cast<float>(sum);
+        }
+    }
+
+    if (config.state_channels == config.hidden_size * 2) {
+        std::vector<float> gated(static_cast<size_t>(frames * config.hidden_size), 0.0f);
+        for (int64_t i = 0; i < frames * config.hidden_size; ++i) {
+            const int64_t frame = i / config.hidden_size;
+            const int64_t channel = i % config.hidden_size;
+            const float value = conv[static_cast<size_t>(frame * config.state_channels + channel)];
+            const float gate = conv[static_cast<size_t>(frame * config.state_channels + config.hidden_size + channel)];
+            gated[static_cast<size_t>(i)] = value / (1.0f + std::exp(-gate));
+        }
+        x = std::move(gated);
+    } else if (config.state_channels == config.hidden_size) {
+        for (float & value : conv) {
+            value = value / (1.0f + std::exp(-value));
+        }
+        x = std::move(conv);
+    } else {
+        throw std::runtime_error("unsupported Niagara state-space channel count");
+    }
+
+    return dense(
+        x,
+        frames,
+        config.hidden_size,
+        config.hidden_size,
+        source.require_f32(prefix + "state_space_dense_2_kernel", {config.hidden_size, config.hidden_size}),
+        source.require_f32(prefix + "state_space_dense_2_bias", {config.hidden_size}));
+}
+
+}  // namespace
+
+int main(int argc, char ** argv) {
+    try {
+        const auto args = parse_args(argc, argv);
+        auto assets = engine::community_models::niagara_asr::load_niagara_asr_assets(args.model);
+        engine::core::ExecutionContext execution({engine::core::BackendType::Cpu, 0, args.threads});
+        const auto weights = engine::community_models::niagara_asr::load_niagara_weights(
+            *assets,
+            execution,
+            engine::assets::TensorStorageType::F32,
+            512ull * 1024ull * 1024ull);
+
+        ggml_init_params params{96ull * 1024ull * 1024ull, nullptr, true};
+        std::unique_ptr<ggml_context, GgmlContextDeleter> graph_ctx(ggml_init(params));
+        if (graph_ctx == nullptr) {
+            throw std::runtime_error("failed to create Niagara native state-space probe graph context");
+        }
+
+        const auto & config = assets->config.encoder;
+        engine::core::ModuleBuildContext build_ctx{graph_ctx.get(), "niagara_asr.native_state_space_probe", execution.backend_type()};
+        auto input = engine::core::make_tensor(
+            build_ctx,
+            GGML_TYPE_F32,
+            engine::core::TensorShape::from_dims({1, args.frames, config.hidden_size}));
+        ggml_set_input(input.tensor);
+        auto output = engine::community_models::niagara_asr::build_niagara_state_space(
+            build_ctx,
+            input,
+            weights->layers.front().state_space,
+            config);
+        ggml_set_output(output.tensor);
+
+        ggml_cgraph * graph = ggml_new_graph_custom(graph_ctx.get(), 8192, false);
+        ggml_build_forward_expand(graph, output.tensor);
+        std::unique_ptr<ggml_gallocr, GgmlGallocrDeleter> gallocr(
+            ggml_gallocr_new(ggml_backend_get_default_buffer_type(execution.backend())));
+        if (gallocr == nullptr ||
+            !ggml_gallocr_reserve(gallocr.get(), graph) ||
+            !ggml_gallocr_alloc_graph(gallocr.get(), graph)) {
+            throw std::runtime_error("failed to allocate Niagara native state-space probe graph tensors");
+        }
+
+        const auto input_values = make_input(input.shape.num_elements());
+        engine::core::write_tensor_f32(input, input_values);
+        for (int i = 0; i < args.warmup; ++i) {
+            const auto status = engine::core::compute_backend_graph(execution.backend(), graph, nullptr, "Niagara native state-space probe");
+            if (status != GGML_STATUS_SUCCESS) {
+                throw std::runtime_error("native state-space probe warmup failed");
+            }
+        }
+        const auto start = std::chrono::steady_clock::now();
+        for (int i = 0; i < std::max(1, args.iterations); ++i) {
+            const auto status = engine::core::compute_backend_graph(execution.backend(), graph, nullptr, "Niagara native state-space probe");
+            if (status != GGML_STATUS_SUCCESS) {
+                throw std::runtime_error("native state-space probe compute failed");
+            }
+        }
+        const auto end = std::chrono::steady_clock::now();
+        const double average_ms =
+            std::chrono::duration<double, std::milli>(end - start).count() / std::max(1, args.iterations);
+
+        const auto values = engine::core::read_tensor_f32(output.tensor);
+        const auto reference = compute_reference_state_space(*assets, input_values, args.frames);
+        if (reference.size() != values.size()) {
+            throw std::runtime_error("native state-space probe reference shape mismatch");
+        }
+        double sum_sq = 0.0;
+        float max_abs_diff = 0.0f;
+        for (size_t i = 0; i < values.size(); ++i) {
+            const float diff = std::abs(values[i] - reference[i]);
+            max_abs_diff = std::max(max_abs_diff, diff);
+            sum_sq += static_cast<double>(diff) * static_cast<double>(diff);
+        }
+        const double rmse = std::sqrt(sum_sq / static_cast<double>(values.size()));
+
+        std::cout << "family=niagara_asr\n";
+        std::cout << "frames=" << args.frames << "\n";
+        std::cout << "hidden_size=" << config.hidden_size << "\n";
+        std::cout << "state_channels=" << config.state_channels << "\n";
+        std::cout << "output_values=" << values.size() << "\n";
+        std::cout << "average_ms=" << average_ms << "\n";
+        std::cout << "max_abs_diff=" << max_abs_diff << "\n";
+        std::cout << "rmse=" << rmse << "\n";
+        if (max_abs_diff > 1.0e-2f) {
+            throw std::runtime_error("native state-space probe exceeded reference tolerance");
+        }
+        return 0;
+    } catch (const std::exception & ex) {
+        std::cerr << "niagara_asr_native_state_space_probe failed: " << ex.what() << "\n";
+        return 1;
+    }
+}

--- a/tests/niagara_asr/niagara_asr_python_warm_bench.py
+++ b/tests/niagara_asr/niagara_asr_python_warm_bench.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""Reference PT2 warmbench for ABR Niagara batch ASR."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+import zipfile
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import sentencepiece as spm
+import soundfile as sf
+import torch
+import torch.nn.functional as F
+from transformers.audio_utils import mel_filter_bank
+
+
+DTYPE_MAP = {
+    4: torch.int32,
+    5: torch.int64,
+    7: torch.float32,
+    12: torch.bool,
+}
+
+
+def split_csv(value: str) -> list[str]:
+    return [item for item in value.split(",") if item]
+
+
+def model_files(model: Path) -> tuple[Path, Path]:
+    if model.is_file() and model.suffix == ".pt2":
+        root = model.parent
+        config = json.loads((root / "config.json").read_text(encoding="utf-8"))
+        return model, root / str(config["tokenizer_file"])
+    config = json.loads((model / "config.json").read_text(encoding="utf-8"))
+    pt2 = model / f"{config['exported_model_file']}-cpu.pt2"
+    return pt2, model / str(config["tokenizer_file"])
+
+
+def load_raw_tensor(archive: zipfile.ZipFile, path: str, dtype_id: int, shape: list[int]) -> torch.Tensor:
+    dtype = DTYPE_MAP[dtype_id]
+    data = archive.read(path)
+    return torch.frombuffer(bytearray(data), dtype=dtype).clone().reshape(shape)
+
+
+def tensor_shape(meta: dict[str, Any]) -> list[int]:
+    return [int(item["as_int"]) for item in meta.get("sizes", [])]
+
+
+def load_graph_inputs(pt2: Path, input_tensor: torch.Tensor) -> tuple[dict[str, Any], dict[str, torch.Tensor]]:
+    with zipfile.ZipFile(pt2) as archive:
+        base = archive.namelist()[0].split("/")[0]
+        model = json.loads(archive.read(f"{base}/models/model.json"))
+        constants = json.loads(archive.read(f"{base}/data/constants/model_constants_config.json"))["config"]
+        input_specs = model["graph_module"]["signature"]["input_specs"]
+        tensor_values = model["graph_module"]["graph"]["tensor_values"]
+
+        values: dict[str, torch.Tensor] = {}
+        parameters = [item["parameter"] for item in input_specs if "parameter" in item]
+        for index, parameter in enumerate(parameters):
+            name = parameter["arg"]["name"]
+            meta = tensor_values[name]
+            values[name] = load_raw_tensor(
+                archive,
+                f"{base}/data/weights/weight_{index}",
+                int(meta["dtype"]),
+                tensor_shape(meta),
+            )
+
+        for item in input_specs:
+            if "tensor_constant" in item:
+                constant = item["tensor_constant"]
+                name = constant["arg"]["name"]
+                info = constants[constant["tensor_constant_name"]]
+                meta = info["tensor_meta"]
+                values[name] = load_raw_tensor(
+                    archive,
+                    f"{base}/data/constants/{info['path_name']}",
+                    int(meta["dtype"]),
+                    tensor_shape(meta),
+                )
+            elif "user_input" in item:
+                values[item["user_input"]["arg"]["as_tensor"]["name"]] = input_tensor
+    return model, values
+
+
+def arg_value(arg: dict[str, Any], values: dict[str, torch.Tensor], symbols: dict[str, int]) -> Any:
+    if "as_tensor" in arg:
+        return values[arg["as_tensor"]["name"]]
+    if "as_tensors" in arg:
+        return [values[item["name"]] for item in arg["as_tensors"]]
+    if "as_int" in arg:
+        return int(arg["as_int"])
+    if "as_ints" in arg:
+        return [int(item) for item in arg["as_ints"]]
+    if "as_float" in arg:
+        return float(arg["as_float"])
+    if "as_bool" in arg:
+        return bool(arg["as_bool"])
+    if "as_none" in arg:
+        return None
+    if "as_string" in arg:
+        return str(arg["as_string"])
+    if "as_scalar_type" in arg:
+        return DTYPE_MAP[int(arg["as_scalar_type"])]
+    if "as_sym_int" in arg:
+        sym = arg["as_sym_int"]
+        if "as_int" in sym:
+            return int(sym["as_int"])
+        return symbols[sym["as_name"]]
+    if "as_name" in arg:
+        return symbols[arg["as_name"]]
+    if "as_sym_ints" in arg:
+        return [arg_value(item, values, symbols) for item in arg["as_sym_ints"]]
+    if "as_device" in arg or "as_layout" in arg or "as_memory_format" in arg:
+        return None
+    raise RuntimeError(f"unsupported Niagara reference arg: {arg}")
+
+
+def node_args(node: dict[str, Any], values: dict[str, torch.Tensor], symbols: dict[str, int]) -> tuple[list[Any], dict[str, Any]]:
+    positional: list[Any] = []
+    keyword: dict[str, Any] = {}
+    for item in node.get("inputs", []):
+        value = arg_value(item["arg"], values, symbols)
+        if item.get("kind") == 1:
+            positional.append(value)
+        elif value is not None and item["name"] not in {"device", "layout", "memory_format"}:
+            keyword[item["name"]] = value
+    return positional, keyword
+
+
+def set_output(node: dict[str, Any], result: Any, values: dict[str, torch.Tensor], symbols: dict[str, int]) -> None:
+    output = node["outputs"][0]
+    if "as_tensor" in output:
+        values[output["as_tensor"]["name"]] = result
+    elif "as_tensors" in output:
+        for spec, tensor in zip(output["as_tensors"], result):
+            values[spec["name"]] = tensor
+    elif "as_sym_int" in output:
+        symbols[output["as_sym_int"]["as_name"]] = int(result)
+    else:
+        raise RuntimeError(f"unsupported Niagara reference output: {output}")
+
+
+def replay(pt2: Path, input_tensor: torch.Tensor) -> torch.Tensor:
+    model, values = load_graph_inputs(pt2, input_tensor)
+    symbols: dict[str, int] = {}
+    with torch.no_grad():
+        for node in model["graph_module"]["graph"]["nodes"]:
+            target = node["target"]
+            positional, keyword = node_args(node, values, symbols)
+            if target == "torch.ops.aten._assert_tensor_metadata.default":
+                continue
+            if target.startswith("torch.ops.aten.to."):
+                dtype = next((arg_value(item["arg"], values, symbols) for item in node["inputs"] if "as_scalar_type" in item["arg"]), None)
+                result = positional[0].to(dtype=dtype) if dtype else positional[0]
+            elif target == "torch.ops.aten.sym_size.int":
+                result = positional[0].shape[positional[1]]
+            elif target == "torch.ops.aten.lift_fresh_copy.default":
+                result = positional[0].clone()
+            elif target == "torch.ops.aten.not_equal.Tensor":
+                result = torch.not_equal(positional[0], positional[1])
+            elif target == "torch.ops.aten.all.dim":
+                result = torch.all(positional[0], dim=positional[1], keepdim=positional[2])
+            elif target == "torch.ops.aten.squeeze.dim":
+                result = torch.squeeze(positional[0], dim=positional[1])
+            elif target == "torch.ops.aten.unsqueeze.default":
+                result = torch.unsqueeze(positional[0], dim=positional[1])
+            elif target == "torch.ops.aten.logical_not.default":
+                result = torch.logical_not(positional[0])
+            elif target == "torch.ops.aten.permute.default":
+                result = positional[0].permute(positional[1])
+            elif target == "torch.ops.aten.max_pool2d.default":
+                result = F.max_pool2d(*positional, **keyword)
+            elif target == "torch.ops.aten.reshape.default":
+                result = torch.reshape(positional[0], tuple(positional[1]))
+            elif target == "torch.ops.aten.conv2d.default":
+                result = F.conv2d(*positional, **keyword)
+            elif target == "torch.ops.aten.matmul.default":
+                result = torch.matmul(positional[0], positional[1])
+            elif target in {"torch.ops.aten.add.Tensor", "torch.ops.aten.add_.Tensor"}:
+                result = positional[0] + positional[1]
+            elif target in {"torch.ops.aten.sub.Tensor", "torch.ops.aten.sub_.Tensor", "torch.ops.aten.subtract.Tensor"}:
+                result = positional[0] - positional[1]
+            elif target == "torch.ops.aten.abs.default":
+                result = torch.abs(positional[0])
+            elif target == "torch.ops.aten.mean.dim":
+                result = torch.mean(positional[0], dim=positional[1], keepdim=positional[2])
+            elif target == "torch.ops.aten.div.Tensor":
+                result = positional[0] / positional[1]
+            elif target in {"torch.ops.aten.multiply.Tensor", "torch.ops.aten.mul.Tensor", "torch.ops.aten.mul_.Tensor"}:
+                result = positional[0] * positional[1]
+            elif target == "torch.ops.aten.logical_or.default":
+                result = torch.logical_or(positional[0], positional[1])
+            elif target == "torch.ops.aten.einsum.default":
+                result = torch.einsum(positional[0], positional[1])
+            elif target == "torch.ops.aten.sigmoid.default":
+                result = torch.sigmoid(positional[0])
+            elif target == "torch.ops.aten.pad.default":
+                result = F.pad(positional[0], positional[1])
+            elif target == "torch.ops.aten.__and__.Tensor":
+                result = positional[0] & positional[1]
+            elif target == "torch.ops.aten.silu.default":
+                result = F.silu(positional[0])
+            elif target == "torch.ops.aten.sqrt.default":
+                result = torch.sqrt(positional[0])
+            elif target == "torch.ops.aten.softmax.int":
+                result = F.softmax(positional[0], dim=positional[1])
+            elif target == "torch.ops.aten.flip.default":
+                result = torch.flip(positional[0], positional[1])
+            elif target == "torch.ops.aten.split.Tensor":
+                result = torch.split(positional[0], positional[1], dim=positional[2])
+            elif target == "torch.ops.aten.contiguous.default":
+                result = positional[0].contiguous()
+            elif target == "torch.ops.aten.rsqrt_.default":
+                result = torch.rsqrt(positional[0])
+            elif target == "torch.ops.aten.select.int":
+                result = torch.select(positional[0], positional[1], positional[2])
+            elif target == "torch.ops.aten.slice.Tensor":
+                tensor = positional[0]
+                slices = [slice(None)] * tensor.ndim
+                end = positional[3] if len(positional) > 3 else None
+                if isinstance(end, int) and end > 10**15:
+                    end = None
+                slices[positional[1]] = slice(positional[2] if len(positional) > 2 else None, end, positional[4] if len(positional) > 4 else 1)
+                result = tensor[tuple(slices)]
+            elif target == "_operator.sub":
+                result = positional[0] - positional[1]
+            elif target == "_operator.add":
+                result = positional[0] + positional[1]
+            elif target == "_operator.mul":
+                result = positional[0] * positional[1]
+            else:
+                raise NotImplementedError(target)
+            set_output(node, result, values, symbols)
+    out_name = model["graph_module"]["signature"]["output_specs"][0]["user_output"]["arg"]["as_tensor"]["name"]
+    return values[out_name]
+
+
+def features(wav: np.ndarray, sample_rate: int) -> tuple[torch.Tensor, int]:
+    if wav.ndim > 1:
+        wav = wav.mean(axis=1)
+    signal = torch.from_numpy(wav.astype("float32"))[None, :]
+    win = round(sample_rate * 25 / 1000)
+    hop = round(sample_rate * 10 / 1000)
+    if signal.shape[1] < win:
+        signal = F.pad(signal, (0, win - signal.shape[1]))
+    spec = torch.stft(
+        signal,
+        n_fft=win,
+        hop_length=hop,
+        win_length=win,
+        window=torch.hann_window(win),
+        center=False,
+        return_complex=True,
+    ).abs()
+    mel = torch.from_numpy(mel_filter_bank(
+        num_frequency_bins=win // 2 + 1,
+        num_mel_filters=80,
+        min_frequency=0,
+        max_frequency=8000,
+        sampling_rate=sample_rate,
+    ).astype("float32"))
+    result = torch.matmul(spec.transpose(1, 2), mel)
+    result = torch.log(torch.clamp(result, min=1e-12))
+    pad = (-result.shape[1]) % 4
+    if pad:
+        result = F.pad(result, (0, 0, 0, pad), value=1000.0)
+    valid_frames = (len(wav) - win) // hop + 1 if len(wav) >= win else 1
+    return result, valid_frames
+
+
+def decode(logits: torch.Tensor, tokenizer: spm.SentencePieceProcessor, valid_input_frames: int) -> str:
+    output_frames = valid_input_frames
+    for _ in range(2):
+        output_frames = max(0, (output_frames - 4) // 2 + 1)
+    pred = logits[:, :output_frames, :].argmax(dim=-1)[0].tolist()
+    pieces: list[int] = []
+    previous: int | None = None
+    blank = tokenizer.GetPieceSize()
+    for item in pred:
+        if item == previous:
+            continue
+        previous = item
+        if item != blank and item > 0:
+            pieces.append(int(item))
+    return str(tokenizer.Decode(pieces)).strip()
+
+
+def transcribe(pt2: Path, tokenizer: spm.SentencePieceProcessor, audio_path: Path) -> str:
+    wav, sample_rate = sf.read(audio_path)
+    if sample_rate != 16000:
+        raise RuntimeError(f"Niagara reference expects 16 kHz WAV input, got {sample_rate}: {audio_path}")
+    input_features, valid_frames = features(wav, sample_rate)
+    logits = replay(pt2, input_features)
+    return decode(logits, tokenizer, valid_frames)
+
+
+def step_json(index: int, audio_path: Path, text: str, wall_ms: float) -> dict[str, Any]:
+    return {
+        "request_index": index,
+        "audio": str(audio_path),
+        "text_output": text,
+        "word_timestamps": [],
+        "metrics": {"wall_ms": wall_ms},
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", type=Path, default=Path("models/niagara-19m-batch.en"))
+    parser.add_argument("--audio", type=Path, default=Path("resources/sample_16k.wav"))
+    parser.add_argument("--warmup-audio", type=Path)
+    parser.add_argument("--audio-sequence", default="")
+    parser.add_argument("--backend", default="cpu")
+    parser.add_argument("--device", default="0")
+    parser.add_argument("--threads", default="8")
+    parser.add_argument("--warmup", type=int, default=1)
+    parser.add_argument("--iterations", type=int, default=1)
+    parser.add_argument("--timing-file", type=Path, default=Path("/tmp/niagara_asr_python_warm_bench_timing.log"))
+    args = parser.parse_args()
+
+    if args.backend != "cpu":
+        raise RuntimeError("Niagara PT2 reference warmbench supports only CPU")
+
+    pt2, tokenizer_path = model_files(args.model)
+    tokenizer = spm.SentencePieceProcessor()
+    tokenizer.Load(str(tokenizer_path))
+
+    warmup_audio = args.warmup_audio or args.audio
+    for _ in range(args.warmup):
+        transcribe(pt2, tokenizer, warmup_audio)
+
+    request_paths = [Path(item) for item in split_csv(args.audio_sequence)] or [args.audio]
+    steps: list[dict[str, Any]] = []
+    timing_lines: list[str] = []
+    for index, audio_path in enumerate(request_paths):
+        last_text = ""
+        total_ms = 0.0
+        for _ in range(max(1, args.iterations)):
+            started = time.time()
+            last_text = transcribe(pt2, tokenizer, audio_path)
+            total_ms += (time.time() - started) * 1000.0
+        wall_ms = total_ms / max(1, args.iterations)
+        print(f"average[{index}]")
+        print(f"niagara_asr.python_wall_ms={wall_ms}")
+        steps.append(step_json(index, audio_path, last_text, wall_ms))
+        timing_lines.append(f"niagara_asr.request{index}.python_wall_ms {wall_ms:.6f}")
+
+    if args.timing_file.parent:
+        args.timing_file.parent.mkdir(parents=True, exist_ok=True)
+    args.timing_file.write_text("\n".join(timing_lines) + "\n", encoding="utf-8")
+    print("summary_json=" + json.dumps({
+        "family": "niagara_asr",
+        "backend": args.backend,
+        "sequence_steps": steps,
+    }, separators=(",", ":")))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/niagara_asr/niagara_asr_warm_bench.cpp
+++ b/tests/niagara_asr/niagara_asr_warm_bench.cpp
@@ -1,0 +1,15 @@
+#include "../core/audio_task_warm_bench.h"
+
+int main(int argc, char ** argv) {
+    try {
+        engine::tools::AudioTaskBenchConfig config;
+        config.family = "niagara_asr";
+        config.default_model = "models/Niagara-19M-Batch-EN-GGUF";
+        config.task = engine::runtime::VoiceTaskKind::Asr;
+        config.output_kind = engine::tools::AudioTaskOutputKind::Asr;
+        return engine::tools::run_audio_task_warm_bench(argc, argv, config);
+    } catch (const std::exception & ex) {
+        std::cerr << "niagara_asr_warm_bench failed: " << ex.what() << "\n";
+        return 1;
+    }
+}

--- a/tests/niagara_asr/niagara_asr_warm_bench_cases.json
+++ b/tests/niagara_asr/niagara_asr_warm_bench_cases.json
@@ -1,0 +1,17 @@
+{
+  "warmup": {
+    "audio": "assets/asr_validation/librispeech/librispeech_test_clean_6930-75918-0000.wav"
+  },
+  "requests": [
+    {
+      "id": "librispeech_clean_short",
+      "audio": "assets/asr_validation/librispeech/librispeech_test_clean_6930-75918-0000.wav",
+      "expected_text": "concord returned to its place amidst the tents"
+    },
+    {
+      "id": "librispeech_clean_long",
+      "audio": "assets/asr_validation/librispeech/librispeech_test_clean_6930-75918-0001.wav",
+      "expected_text": "the english forwarded to the french baskets of flowers of which they had made a plentiful provision to greet the arrival of the young princess the french in return invited the english to a supper which was to be given the next day"
+    }
+  ]
+}

--- a/tests/niagara_asr/niagara_asr_weight_load_probe.cpp
+++ b/tests/niagara_asr/niagara_asr_weight_load_probe.cpp
@@ -1,0 +1,69 @@
+#include "engine/community_models/niagara_asr/assets.h"
+#include "engine/community_models/niagara_asr/weights.h"
+#include "engine/framework/core/backend.h"
+#include "engine/framework/core/execution_context.h"
+
+#include <exception>
+#include <filesystem>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+struct Args {
+    std::filesystem::path model;
+    int threads = 8;
+};
+
+Args parse_args(int argc, char ** argv) {
+    Args args;
+    for (int i = 1; i < argc; ++i) {
+        const std::string key = argv[i];
+        auto require_value = [&](const char * name) -> std::string {
+            if (i + 1 >= argc) {
+                throw std::runtime_error(std::string(name) + " requires a value");
+            }
+            return argv[++i];
+        };
+        if (key == "--model") {
+            args.model = require_value("--model");
+        } else if (key == "--threads") {
+            args.threads = std::stoi(require_value("--threads"));
+        } else {
+            throw std::runtime_error("unknown argument: " + key);
+        }
+    }
+    if (args.model.empty()) {
+        throw std::runtime_error("--model is required");
+    }
+    return args;
+}
+
+}  // namespace
+
+int main(int argc, char ** argv) {
+    try {
+        const auto args = parse_args(argc, argv);
+        auto assets = engine::community_models::niagara_asr::load_niagara_asr_assets(args.model);
+        engine::core::ExecutionContext execution({engine::core::BackendType::Cpu, 0, args.threads});
+        const auto weights = engine::community_models::niagara_asr::load_niagara_weights(
+            *assets,
+            execution,
+            engine::assets::TensorStorageType::F32,
+            512ull * 1024ull * 1024ull);
+        const auto & encoder = assets->config.encoder;
+        std::cout << "family=niagara_asr\n";
+        std::cout << "hidden_size=" << encoder.hidden_size << "\n";
+        std::cout << "intermediate_size=" << encoder.intermediate_size << "\n";
+        std::cout << "state_channels=" << encoder.state_channels << "\n";
+        std::cout << "state_size=" << encoder.state_size << "\n";
+        std::cout << "num_layers=" << encoder.num_layers << "\n";
+        std::cout << "vocab_size=" << assets->config.vocab_size << "\n";
+        std::cout << "loaded_layers=" << weights->layers.size() << "\n";
+        return 0;
+    } catch (const std::exception & ex) {
+        std::cerr << "niagara_asr_weight_load_probe failed: " << ex.what() << "\n";
+        return 1;
+    }
+}

--- a/tests/warmbench.py
+++ b/tests/warmbench.py
@@ -309,6 +309,16 @@ FAMILY_CONFIG: dict[str, dict[str, Any]] = {
         "case_catalog": "tests/nemotron_asr/nemotron_asr_warm_bench_cases.json",
         "default_requests_per_session": 1,
     },
+    "niagara_asr": {
+        "kind": "asr",
+        "modes": ["offline"],
+        "cpp_bin": "build/debug/bin/niagara_asr_warm_bench",
+        "python_script": "tests/niagara_asr/niagara_asr_python_warm_bench.py",
+        "model": "models/Niagara-19M-Batch-EN-GGUF",
+        "python_model": "models/niagara-19m-batch.en",
+        "case_catalog": "tests/niagara_asr/niagara_asr_warm_bench_cases.json",
+        "default_requests_per_session": 2,
+    },
     "muscriptor": {
         "kind": "asr",
         "modes": ["offline"],
@@ -3909,6 +3919,8 @@ def build_catalog_asr_commands(
             "--keep-language-tags-sequence",
             csv_bools(request_cases, "keep_language_tags", bool(warmup_case.get("keep_language_tags", False))),
         ])
+    elif family == "niagara_asr":
+        pass
     elif family == "muscriptor":
         common.extend([
             "--instruments",
@@ -5549,7 +5561,7 @@ def run_scenario(
                 "transcripts": getattr(args, f"{family}_request_transcripts"),
                 "expected_words": [item.get("expected_words", []) for item in request_cases],
             }
-        elif family in {"higgs_audio_stt", "hviske_asr", "nemotron_asr", "muscriptor", "vibevoice_asr", "voxtral_realtime"}:
+        elif family in {"higgs_audio_stt", "hviske_asr", "nemotron_asr", "niagara_asr", "muscriptor", "vibevoice_asr", "voxtral_realtime"}:
             if len(args.case_names) > 1:
                 raise RuntimeError(f"{family} warmbench accepts at most one --case-name")
             case_name = args.case_names[0] if args.case_names else str(config.get("default_case_name", ""))

--- a/tools/audiocpp_cli/audiocpp_cli_path_cases.json
+++ b/tools/audiocpp_cli/audiocpp_cli_path_cases.json
@@ -2470,6 +2470,33 @@
       ]
     },
     {
+      "id": "niagara_asr_paths",
+      "coverage": "Niagara ASR offline CPU CTC decode on short and longer Librispeech inputs with session reuse",
+      "family": "niagara_asr",
+      "model": "models/Niagara-19M-Batch-EN-GGUF",
+      "task": "asr",
+      "mode": "offline",
+      "outputs": [
+        "text"
+      ],
+      "requests": [
+        {
+          "id": "librispeech_clean_short",
+          "audio": "assets/asr_validation/librispeech/librispeech_test_clean_6930-75918-0000.wav",
+          "options": {
+            "audio_chunk_mode": "none"
+          }
+        },
+        {
+          "id": "librispeech_clean_long",
+          "audio": "assets/asr_validation/librispeech/librispeech_test_clean_6930-75918-0001.wav",
+          "options": {
+            "audio_chunk_mode": "none"
+          }
+        }
+      ]
+    },
+    {
       "id": "higgs_audio_stt_paths",
       "coverage": "Higgs Audio STT default prompt, custom prompt, enable_thinking on/off, max-token variation, and session reuse paths",
       "family": "higgs_audio_stt",

--- a/tools/community_models/convert_niagara_asr.py
+++ b/tools/community_models/convert_niagara_asr.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Convert ABR Niagara batch ASR PT2 CPU packages to audio.cpp GGUF.
+
+The upstream Niagara repositories publish Torch 2.11 PT2 archives with raw
+numbered tensor payloads and a serialized graph description. This converter
+stages those tensors under the graph input names, then delegates GGUF writing,
+quantization, sidecar embedding, and model-spec embedding to audiocpp_gguf.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+from typing import Any
+
+import torch
+from huggingface_hub import hf_hub_download
+from safetensors.torch import save_file
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SPEC = REPO_ROOT / "model_specs" / "niagara_asr.json"
+REPOS = {
+    "19m": {
+        "repo": "abr-ai/niagara-19m-batch.en",
+        "base": "niagara-19m-batch.en",
+        "tokenizer": "sentencepiece_256.model",
+        "output": "Niagara-19M-Batch-EN-GGUF/niagara-19m-batch.en.gguf",
+    },
+    "38m": {
+        "repo": "abr-ai/niagara-38m-batch.en",
+        "base": "niagara-38m-batch.en",
+        "tokenizer": "sentencepiece_1024.model",
+        "output": "Niagara-38M-Batch-EN-GGUF/niagara-38m-batch.en.gguf",
+    },
+}
+TORCH_DTYPE = {
+    4: torch.int32,
+    5: torch.int64,
+    7: torch.float32,
+}
+
+
+def tensor_shape(meta: dict[str, Any]) -> list[int]:
+    return [int(item["as_int"]) for item in meta.get("sizes", [])]
+
+
+def load_raw_tensor(archive: zipfile.ZipFile, path: str, dtype_id: int, shape: list[int]) -> torch.Tensor:
+    try:
+        dtype = TORCH_DTYPE[dtype_id]
+    except KeyError as error:
+        raise RuntimeError(f"unsupported Niagara PT2 tensor dtype id: {dtype_id}") from error
+    data = archive.read(path)
+    tensor = torch.frombuffer(bytearray(data), dtype=dtype).clone()
+    return tensor.reshape(shape)
+
+
+def download_if_missing(model_dir: Path, variant: str) -> None:
+    spec = REPOS[variant]
+    required = [
+        f"{spec['base']}-cpu.pt2",
+        "config.json",
+        "preprocessor_config.json",
+        "tokenizer_config.json",
+        spec["tokenizer"],
+    ]
+    missing = [name for name in required if not (model_dir / name).exists()]
+    if not missing:
+        return
+    for name in missing:
+        print(f"downloading {spec['repo']}:{name}", flush=True)
+        hf_hub_download(spec["repo"], name, local_dir=model_dir)
+
+
+def stage_from_pt2(model_dir: Path, variant: str, staging: Path) -> Path:
+    spec = REPOS[variant]
+    pt2 = model_dir / f"{spec['base']}-cpu.pt2"
+    if not pt2.exists():
+        raise FileNotFoundError(f"missing Niagara CPU PT2 package: {pt2}")
+
+    with zipfile.ZipFile(pt2) as archive:
+        base = archive.namelist()[0].split("/")[0]
+        graph = json.loads(archive.read(f"{base}/models/model.json"))
+        constants = json.loads(archive.read(f"{base}/data/constants/model_constants_config.json"))["config"]
+        input_specs = graph["graph_module"]["signature"]["input_specs"]
+        tensor_values = graph["graph_module"]["graph"]["tensor_values"]
+
+        tensors: dict[str, torch.Tensor] = {}
+        parameter_specs = [item["parameter"] for item in input_specs if "parameter" in item]
+        for index, parameter in enumerate(parameter_specs):
+            name = parameter["arg"]["name"]
+            meta = tensor_values[name]
+            tensors[name] = load_raw_tensor(
+                archive,
+                f"{base}/data/weights/weight_{index}",
+                int(meta["dtype"]),
+                tensor_shape(meta),
+            )
+
+        for item in input_specs:
+            if "tensor_constant" not in item:
+                continue
+            constant = item["tensor_constant"]
+            name = constant["arg"]["name"]
+            info = constants[constant["tensor_constant_name"]]
+            meta = info["tensor_meta"]
+            tensors[name] = load_raw_tensor(
+                archive,
+                f"{base}/data/constants/{info['path_name']}",
+                int(meta["dtype"]),
+                tensor_shape(meta),
+            )
+
+    staging.mkdir(parents=True, exist_ok=True)
+    weights = staging / "niagara_asr.safetensors"
+    save_file(tensors, weights)
+    shutil.copyfile(model_dir / "config.json", staging / "config.json")
+    shutil.copyfile(model_dir / "preprocessor_config.json", staging / "preprocessor_config.json")
+    shutil.copyfile(model_dir / "tokenizer_config.json", staging / "tokenizer_config.json")
+    shutil.copyfile(model_dir / spec["tokenizer"], staging / "sentencepiece.model")
+    return weights
+
+
+def run_converter(converter: Path, staged_weights: Path, staging: Path, output: Path, quant_type: str, overwrite: bool) -> None:
+    command = [
+        str(converter),
+        "--input",
+        str(staged_weights),
+        "--root",
+        str(staging),
+        "--family",
+        "niagara_asr",
+        "--model-spec",
+        str(SPEC),
+        "--type",
+        quant_type,
+        "--output",
+        str(output),
+    ]
+    if overwrite:
+        command.append("--overwrite")
+    print("+", " ".join(command), flush=True)
+    subprocess.run(command, check=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--variant", choices=sorted(REPOS), required=True)
+    parser.add_argument("--model-dir", type=Path, help="directory containing the Niagara HF files")
+    parser.add_argument("--converter", type=Path, required=True, help="path to audiocpp_gguf")
+    parser.add_argument("--output", type=Path, help="output GGUF path")
+    parser.add_argument("--type", default="orig", choices=["orig", "f16", "bf16", "q8_0", "q4_k", "q5_k", "q6_k"])
+    parser.add_argument("--overwrite", action="store_true")
+    parser.add_argument("--keep-staging", type=Path, help="keep staged safetensors and sidecars in this directory")
+    parser.add_argument("--no-download", action="store_true", help="require all HF files to already exist locally")
+    args = parser.parse_args()
+
+    spec = REPOS[args.variant]
+    model_dir = args.model_dir or (Path("models") / spec["base"])
+    if not args.no_download:
+        download_if_missing(model_dir, args.variant)
+    output = args.output or Path(spec["output"])
+
+    if args.keep_staging is not None:
+        staging = args.keep_staging
+        staged_weights = stage_from_pt2(model_dir, args.variant, staging)
+        run_converter(args.converter, staged_weights, staging, output, args.type, args.overwrite)
+        return
+
+    with tempfile.TemporaryDirectory(prefix=f"niagara-{args.variant}-") as tmp:
+        staging = Path(tmp)
+        staged_weights = stage_from_pt2(model_dir, args.variant, staging)
+        run_converter(args.converter, staged_weights, staging, output, args.type, args.overwrite)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as error:
+        print(f"error: {error}", file=sys.stderr)
+        raise


### PR DESCRIPTION
Adds the Niagara ASR family for ABR Niagara 19M/38M batch English ASR GGUFs.

Includes the model spec, converter, runtime/frontend/encoder integration, CLI path coverage, and warmbench/probe coverage.

Validated locally:
- `audiocpp_cli` build with `AUDIOCPP_MODELS=niagara_asr`
- Niagara ASR weight-load, FFN, and state-space probes
- `niagara_asr_paths` on regenerated 19M GGUF
