### PR TITLE
Add Niagara ASR model family

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1410,6 +1410,25 @@ audiocpp_add_model(granite5asr
         granite_speech5_ctc
 )
 
+audiocpp_add_model(niagara_asr
+    SOURCES
+        src/models/niagara_asr/assets.cpp
+        src/models/niagara_asr/encoder.cpp
+        src/models/niagara_asr/frontend.cpp
+        src/models/niagara_asr/runtime.cpp
+        src/models/niagara_asr/session.cpp
+        src/models/niagara_asr/weights.cpp
+    INCLUDES
+        engine/models/niagara_asr/assets.h
+        engine/models/niagara_asr/encoder.h
+        engine/models/niagara_asr/frontend.h
+        engine/models/niagara_asr/runtime.h
+        engine/models/niagara_asr/session.h
+        engine/models/niagara_asr/weights.h
+    LOADERS
+        engine::models::niagara_asr::make_niagara_asr_loader
+)
+
 audiocpp_add_model(audio8_asr
     SOURCES
         src/community_models/audio8_asr/assets.cpp
@@ -2126,6 +2145,7 @@ if (ENGINE_BUILD_WARMBENCH)
     add_engine_warmbench(miocodec_warm_bench tests/miocodec/miocodec_warm_bench.cpp)
     add_engine_warmbench(mira_tts_warm_bench tests/mira_tts/mira_tts_warm_bench.cpp)
     add_engine_warmbench(muscriptor_warm_bench tests/muscriptor/muscriptor_warm_bench.cpp)
+    add_engine_warmbench(niagara_asr_warm_bench tests/niagara_asr/niagara_asr_warm_bench.cpp)
     add_engine_warmbench(moss_tts_nano_warm_bench tests/moss_tts_nano/moss_tts_nano_warm_bench.cpp)
     add_engine_warmbench(moss_tts_local_warm_bench tests/moss_tts_local/moss_tts_local_warm_bench.cpp)
     add_engine_warmbench(nemotron_asr_warm_bench tests/nemotron_asr/nemotron_asr_warm_bench.cpp)
@@ -2282,6 +2302,10 @@ if (ENGINE_BUILD_TESTS OR ENGINE_BUILD_EXTENDED_TESTS OR ENGINE_BUILD_MODEL_TEST
 
         add_engine_unittest(encoder_module_test tests/unittests/test_encoder_modules.cpp)
         add_test(NAME encoder_module_test COMMAND encoder_module_test)
+
+        add_engine_unittest(transpose_module_test tests/unittests/test_transpose_module.cpp)
+        target_include_directories(transpose_module_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests/unittests)
+        add_test(NAME transpose_module_test COMMAND transpose_module_test)
 
         add_engine_unittest(gguf_tensor_source_test tests/unittests/test_gguf_tensor_source.cpp)
         target_include_directories(gguf_tensor_source_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests/unittests)

--- a/include/engine/framework/modules/weight_binding.h
+++ b/include/engine/framework/modules/weight_binding.h
@@ -359,6 +359,16 @@ LinearWeights linear_from_source(
 }
 
 template <typename Store>
+LinearWeights linear_from_transposed_named_source(
+    Store & store,
+    const assets::TensorSource & source,
+    const std::string & weight_name,
+    const std::optional<std::string> & bias_name,
+    assets::TensorStorageType storage_type,
+    int64_t in_features,
+    int64_t out_features);
+
+template <typename Store>
 LinearWeights hf_conv1d_linear_from_source(
     Store & store,
     const assets::TensorSource & source,
@@ -367,7 +377,26 @@ LinearWeights hf_conv1d_linear_from_source(
     int64_t in_features,
     int64_t out_features,
     bool use_bias) {
-    const auto source_weight = source.require_f32(prefix + ".weight", {in_features, out_features});
+    return linear_from_transposed_named_source(
+        store,
+        source,
+        prefix + ".weight",
+        use_bias ? std::optional<std::string>{prefix + ".bias"} : std::nullopt,
+        storage_type,
+        in_features,
+        out_features);
+}
+
+template <typename Store>
+LinearWeights linear_from_transposed_named_source(
+    Store & store,
+    const assets::TensorSource & source,
+    const std::string & weight_name,
+    const std::optional<std::string> & bias_name,
+    assets::TensorStorageType storage_type,
+    int64_t in_features,
+    int64_t out_features) {
+    const auto source_weight = source.require_f32(weight_name, {in_features, out_features});
     std::vector<float> transposed(static_cast<std::size_t>(out_features * in_features));
     for (int64_t in = 0; in < in_features; ++in) {
         for (int64_t out = 0; out < out_features; ++out) {
@@ -380,8 +409,8 @@ LinearWeights hf_conv1d_linear_from_source(
         core::TensorShape::from_dims({out_features, in_features}),
         storage_type,
         std::move(transposed));
-    if (use_bias) {
-        weights.bias = store.load_f32_tensor(source, prefix + ".bias", {out_features});
+    if (bias_name.has_value()) {
+        weights.bias = store.load_f32_tensor(source, *bias_name, {out_features});
     }
     return weights;
 }

--- a/include/engine/models/niagara_asr/assets.h
+++ b/include/engine/models/niagara_asr/assets.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "engine/framework/assets/tensor_source.h"
+#include "engine/framework/model_spec/package.h"
+#include "engine/framework/tokenizers/sentencepiece.h"
+
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace engine::models::niagara_asr {
+
+struct NiagaraFrontendConfig {
+    int64_t sample_rate = 16000;
+    int64_t n_fft = 400;
+    int64_t win_length = 400;
+    int64_t hop_length = 160;
+    int64_t n_mels = 80;
+};
+
+struct NiagaraEncoderConfig {
+    int64_t hidden_size = 0;
+    int64_t intermediate_size = 0;
+    int64_t num_layers = 0;
+    int64_t state_size = 0;
+    int64_t state_channels = 0;
+    int64_t dense_input_features = 0;
+    int64_t subsampling_kernel_height = 4;
+    int64_t subsampling_kernel_width = 3;
+};
+
+struct NiagaraAsrConfig {
+    std::string model_type = "niagara_asr";
+    int64_t vocab_size = 256;
+    int64_t blank_id = 256;
+    NiagaraFrontendConfig frontend;
+    NiagaraEncoderConfig encoder;
+};
+
+struct NiagaraAsrAssets {
+    assets::ResourceBundle resources;
+    std::shared_ptr<const assets::TensorSource> source;
+    NiagaraAsrConfig config;
+    std::vector<tokenizers::SentencePiecePiece> tokenizer_pieces;
+};
+
+std::shared_ptr<const NiagaraAsrAssets> load_niagara_asr_assets(
+    const std::filesystem::path & model_path);
+
+}  // namespace engine::models::niagara_asr

--- a/include/engine/models/niagara_asr/encoder.h
+++ b/include/engine/models/niagara_asr/encoder.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "engine/models/niagara_asr/assets.h"
+#include "engine/models/niagara_asr/weights.h"
+#include "engine/framework/core/module.h"
+
+namespace engine::models::niagara_asr {
+
+core::TensorValue build_niagara_l1_norm(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    const engine::modules::NormWeights & weights,
+    const NiagaraEncoderConfig & config);
+
+core::TensorValue build_niagara_feed_forward(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    const NiagaraFeedForwardWeights & weights,
+    const NiagaraEncoderConfig & config);
+
+core::TensorValue build_niagara_subsampling(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    const NiagaraSubsamplingWeights & weights,
+    const NiagaraEncoderConfig & config);
+
+core::TensorValue build_niagara_self_attention(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    const NiagaraSelfAttentionWeights & weights,
+    const NiagaraEncoderConfig & config);
+
+core::TensorValue build_niagara_state_space(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    const NiagaraStateSpaceWeights & weights,
+    const NiagaraEncoderConfig & config);
+
+core::TensorValue build_niagara_layer(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    const NiagaraLayerWeights & weights,
+    const NiagaraEncoderConfig & config);
+
+core::TensorValue build_niagara_encoder_logits(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    const NiagaraWeights & weights,
+    const NiagaraAsrConfig & config);
+
+}  // namespace engine::models::niagara_asr

--- a/include/engine/models/niagara_asr/frontend.h
+++ b/include/engine/models/niagara_asr/frontend.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "engine/models/niagara_asr/assets.h"
+#include "engine/framework/audio/dsp.h"
+#include "engine/framework/runtime/session.h"
+
+#include <memory>
+#include <vector>
+
+namespace engine::models::niagara_asr {
+
+struct NiagaraFeatures {
+    std::vector<float> values;
+    int64_t frames = 0;
+    int64_t feature_dim = 80;
+};
+
+class NiagaraFrontend {
+public:
+    explicit NiagaraFrontend(std::shared_ptr<const NiagaraAsrAssets> assets);
+
+    NiagaraFeatures extract(const runtime::AudioBuffer & audio) const;
+
+private:
+    std::shared_ptr<const NiagaraAsrAssets> assets_;
+    std::vector<float> window_;
+    engine::audio::AudioTensor mel_filterbank_;
+};
+
+}  // namespace engine::models::niagara_asr

--- a/include/engine/models/niagara_asr/runtime.h
+++ b/include/engine/models/niagara_asr/runtime.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "engine/models/niagara_asr/assets.h"
+#include "engine/models/niagara_asr/frontend.h"
+#include "engine/framework/assets/tensor_source.h"
+#include "engine/framework/core/execution_context.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace engine::models::niagara_asr {
+
+struct NiagaraInferenceResult {
+    std::vector<float> logits;
+    int64_t frames = 0;
+    int64_t vocab_size = 0;
+    double elapsed_ms = 0.0;
+};
+
+class NiagaraRuntime {
+public:
+    NiagaraRuntime(
+        std::shared_ptr<const NiagaraAsrAssets> assets,
+        engine::core::ExecutionContext & execution,
+        engine::assets::TensorStorageType weight_storage_type,
+        size_t graph_arena_bytes,
+        size_t weight_context_bytes);
+    ~NiagaraRuntime();
+
+    NiagaraInferenceResult infer(const NiagaraFeatures & features);
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace engine::models::niagara_asr

--- a/include/engine/models/niagara_asr/session.h
+++ b/include/engine/models/niagara_asr/session.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "engine/models/niagara_asr/assets.h"
+#include "engine/models/niagara_asr/frontend.h"
+#include "engine/models/niagara_asr/runtime.h"
+#include "engine/framework/model_spec/metadata.h"
+#include "engine/framework/runtime/session_base.h"
+
+#include <memory>
+#include <string>
+
+namespace engine::models::niagara_asr {
+
+std::shared_ptr<runtime::IVoiceModelLoader> make_niagara_asr_loader();
+
+class NiagaraAsrSession final
+    : public runtime::RuntimeSessionBase
+    , public runtime::IOfflineVoiceTaskSession {
+public:
+    NiagaraAsrSession(
+        runtime::TaskSpec task,
+        runtime::SessionOptions options,
+        std::shared_ptr<const NiagaraAsrAssets> assets,
+        std::shared_ptr<const engine::model_spec::ModelContract> contract);
+    ~NiagaraAsrSession() override;
+
+    std::string family() const override;
+    runtime::VoiceTaskKind task_kind() const override;
+    runtime::RunMode run_mode() const override;
+    void prepare(const runtime::SessionPreparationRequest & request) override;
+    runtime::TaskResult run(const runtime::TaskRequest & request) override;
+
+private:
+    std::string decode(const NiagaraInferenceResult & inference) const;
+
+    runtime::TaskSpec task_;
+    std::shared_ptr<const NiagaraAsrAssets> assets_;
+    std::shared_ptr<const engine::model_spec::ModelContract> contract_;
+    NiagaraFrontend frontend_;
+    NiagaraRuntime runtime_;
+};
+
+}  // namespace engine::models::niagara_asr

--- a/include/engine/models/niagara_asr/weights.h
+++ b/include/engine/models/niagara_asr/weights.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "engine/models/niagara_asr/assets.h"
+#include "engine/framework/core/backend_weight_store.h"
+#include "engine/framework/core/execution_context.h"
+#include "engine/framework/modules/conv_modules.h"
+#include "engine/framework/modules/linear_module.h"
+#include "engine/framework/modules/norm_modules.h"
+
+#include <memory>
+#include <vector>
+
+namespace engine::models::niagara_asr {
+
+struct NiagaraSubsamplingWeights {
+    engine::modules::BatchNorm2dEvalWeights bn0;
+    engine::modules::BatchNorm2dEvalWeights bn1;
+    engine::modules::Conv2dWeights input_projection;
+    engine::modules::Conv2dWeights conv1;
+    engine::modules::Conv2dWeights conv2;
+    engine::modules::LinearWeights dense;
+};
+
+struct NiagaraSelfAttentionWeights {
+    engine::modules::NormWeights norm;
+    engine::modules::LinearWeights query;
+    engine::modules::LinearWeights key;
+    engine::modules::LinearWeights value;
+    engine::modules::LinearWeights global_attention;
+    engine::modules::LinearWeights out;
+    engine::core::TensorValue relative_position;
+    engine::core::TensorValue u_bias;
+    engine::core::TensorValue v_bias;
+};
+
+struct NiagaraFeedForwardWeights {
+    engine::modules::NormWeights norm;
+    engine::modules::LinearWeights dense1;
+    engine::modules::LinearWeights dense2;
+    engine::core::TensorValue residual_scale;
+};
+
+struct NiagaraStateSpaceWeights {
+    engine::modules::NormWeights norm;
+    engine::modules::LinearWeights dense1;
+    engine::modules::LinearWeights dense2;
+    engine::core::TensorValue conv_kernel;
+};
+
+struct NiagaraLayerWeights {
+    NiagaraFeedForwardWeights ffn;
+    NiagaraSelfAttentionWeights self_attention;
+    NiagaraStateSpaceWeights state_space;
+    NiagaraFeedForwardWeights ffn1;
+    engine::modules::NormWeights out_norm;
+};
+
+struct NiagaraWeights {
+    std::shared_ptr<engine::core::BackendWeightStore> store;
+    NiagaraSubsamplingWeights subsampling;
+    std::vector<NiagaraLayerWeights> layers;
+    engine::modules::LinearWeights ctc;
+};
+
+std::shared_ptr<const NiagaraWeights> load_niagara_weights(
+    const NiagaraAsrAssets & assets,
+    engine::core::ExecutionContext & execution,
+    engine::assets::TensorStorageType storage_type,
+    size_t weight_context_bytes);
+
+}  // namespace engine::models::niagara_asr

--- a/model_specs/niagara_asr.json
+++ b/model_specs/niagara_asr.json
@@ -1,0 +1,133 @@
+{
+  "family": "niagara_asr",
+  "schema_version": 1,
+  "display_name": "Niagara ASR",
+  "description": "ABR Niagara English batch ASR state-space models with attention, greedy CTC decoding, and SentencePiece tokenization.",
+  "category": "asr",
+  "status": "supported",
+  "tasks": [
+    "asr"
+  ],
+  "modes": [
+    "offline"
+  ],
+  "languages": [
+    "en"
+  ],
+  "capabilities": {},
+  "dependencies": [],
+  "options": {
+    "request": [
+      {
+        "name": "language",
+        "type": "string",
+        "description": "Recognition language; Niagara batch models are English-only.",
+        "required": false,
+        "default": "en"
+      },
+      {
+        "name": "audio_chunk_mode",
+        "type": "enum",
+        "description": "Audio chunking mode.",
+        "values": [
+          "none"
+        ],
+        "required": false,
+        "default": "none"
+      }
+    ],
+    "session": [
+      {
+        "name": "weight_type",
+        "type": "enum",
+        "description": "Matmul weight storage type.",
+        "preset": "weight_type_full",
+        "required": false,
+        "default": "native"
+      },
+      {
+        "name": "graph_arena_mb",
+        "type": "int",
+        "description": "Inference graph arena size in MiB.",
+        "required": false,
+        "min": 64,
+        "default": 1024
+      },
+      {
+        "name": "weight_context_mb",
+        "type": "int",
+        "description": "Weight descriptor context size in MiB.",
+        "required": false,
+        "min": 16,
+        "default": 256
+      }
+    ],
+    "load": []
+  },
+  "runtime": {
+    "tags": [
+      "gguf",
+      "cpu"
+    ]
+  },
+  "ui": {
+    "recommended_package": "niagara_19m_orig",
+    "tags": [
+      "ASR",
+      "GGUF"
+    ],
+    "docs": [
+      "docs/asr.md",
+      "docs/gguf.md"
+    ],
+    "summary": "ABR Niagara compact English speech recognition."
+  },
+  "package_defaults": {
+    "download": {
+      "kind": "unsupported",
+      "reason": "convert the original ABR Niagara PT2 CPU package with tests/niagara_asr/convert_niagara_asr.py"
+    }
+  },
+  "packages": [
+    {
+      "id": "niagara_19m_orig",
+      "display_name": "Niagara 19M Batch English Original GGUF",
+      "default": true,
+      "format": "gguf",
+      "precision": "orig",
+      "target_directory": "Niagara-19M-Batch-EN-GGUF",
+      "files": [
+        "Niagara-19M-Batch-EN-GGUF/niagara-19m-batch.en.gguf"
+      ],
+      "strip_prefix": "Niagara-19M-Batch-EN-GGUF"
+    },
+    {
+      "id": "niagara_38m_orig",
+      "display_name": "Niagara 38M Batch English Original GGUF",
+      "format": "gguf",
+      "precision": "orig",
+      "target_directory": "Niagara-38M-Batch-EN-GGUF",
+      "files": [
+        "Niagara-38M-Batch-EN-GGUF/niagara-38m-batch.en.gguf"
+      ],
+      "strip_prefix": "Niagara-38M-Batch-EN-GGUF"
+    }
+  ],
+  "sources": [
+    {
+      "format": "gguf",
+      "roots": {
+        "model": ".",
+        "weights": "$gguf"
+      },
+      "files": {
+        "config": "model:config.json",
+        "preprocessor_config": "model:preprocessor_config.json",
+        "tokenizer_spm": "model:sentencepiece.model"
+      },
+      "tensors": {
+        "weights": "weights:"
+      }
+    }
+  ]
+}

--- a/src/framework/modules/structural_modules.cpp
+++ b/src/framework/modules/structural_modules.cpp
@@ -259,7 +259,8 @@ core::TensorValue TransposeModule::build(core::ModuleBuildContext & ctx, const c
     for (size_t out_logical_axis = 0; out_logical_axis < input.shape.rank; ++out_logical_axis) {
         const int in_logical_axis = config_.axes[out_logical_axis];
         const int out_ggml_axis = static_cast<int>(input.shape.rank) - 1 - static_cast<int>(out_logical_axis);
-        ggml_axes[out_ggml_axis] = core::logical_axis_to_ggml_axis(input.shape.rank, in_logical_axis);
+        const int in_ggml_axis = core::logical_axis_to_ggml_axis(input.shape.rank, in_logical_axis);
+        ggml_axes[static_cast<size_t>(in_ggml_axis)] = out_ggml_axis;
     }
 
     return core::wrap_tensor(

--- a/src/models/niagara_asr/assets.cpp
+++ b/src/models/niagara_asr/assets.cpp
@@ -1,0 +1,168 @@
+#include "engine/models/niagara_asr/assets.h"
+
+#include "engine/framework/io/json.h"
+#include "engine/framework/model_spec/package.h"
+
+#include <stdexcept>
+#include <utility>
+
+namespace engine::models::niagara_asr {
+namespace json = engine::io::json;
+namespace {
+
+std::string lmuformer_prefix(int64_t layer) {
+    if (layer == 0) {
+        return "p__torch_params_encoder_lmuformer_";
+    }
+    return "p__torch_params_encoder_lmuformer_" + std::to_string(layer) + "_";
+}
+
+std::string indexed_layer_name(
+    const std::string & prefix,
+    const std::string & base,
+    int64_t layer,
+    bool omit_zero) {
+    if (layer == 0 && omit_zero) {
+        return prefix + base;
+    }
+    return prefix + base + "_" + std::to_string(layer);
+}
+
+int64_t count_lmuformer_layers(const assets::TensorSource & source) {
+    int64_t layers = source.has_tensor(lmuformer_prefix(0) + "ffn_dense_1_kernel") ? 1 : 0;
+    for (int64_t layer = 1; source.has_tensor(lmuformer_prefix(layer) + "ffn_dense_1_kernel"); ++layer) {
+        ++layers;
+    }
+    return layers;
+}
+
+NiagaraEncoderConfig infer_encoder_config(
+    const assets::TensorSource & source,
+    int64_t vocab_size,
+    int64_t feature_size) {
+    NiagaraEncoderConfig config;
+    const auto dense = source.require_metadata("p__torch_params_encoder_dense_kernel");
+    if (dense.shape.size() != 2) {
+        throw std::runtime_error("Niagara ASR encoder dense kernel must be rank 2");
+    }
+    config.hidden_size = dense.shape[1];
+    if (config.hidden_size <= 0 || dense.shape[0] % config.hidden_size != 0) {
+        throw std::runtime_error("Niagara ASR encoder dense kernel has invalid hidden size");
+    }
+    config.dense_input_features = dense.shape[0] / config.hidden_size;
+    if (feature_size <= 0 || config.dense_input_features <= 0) {
+        throw std::runtime_error("Niagara ASR encoder dense input shape is invalid");
+    }
+
+    config.num_layers = count_lmuformer_layers(source);
+    if (config.num_layers <= 0) {
+        throw std::runtime_error("Niagara ASR is missing LMUFormer layers");
+    }
+
+    const auto ffn = source.require_metadata(lmuformer_prefix(0) + "ffn_dense_1_kernel");
+    if (ffn.shape.size() != 2 || ffn.shape[0] != config.hidden_size) {
+        throw std::runtime_error("Niagara ASR FFN kernel shape does not match hidden size");
+    }
+    config.intermediate_size = ffn.shape[1];
+
+    const auto state = source.require_metadata(lmuformer_prefix(0) + "state_space_state_space_c");
+    if (state.shape.size() != 3 || state.shape[2] != 1) {
+        throw std::runtime_error("Niagara ASR state-space C tensor has unsupported shape");
+    }
+    if (state.shape[0] != config.hidden_size && state.shape[0] != config.hidden_size * 2) {
+        throw std::runtime_error("Niagara ASR state-space channel count must be hidden or 2 * hidden");
+    }
+    config.state_channels = state.shape[0];
+    config.state_size = state.shape[1];
+
+    assets::require_tensor_shape(source, "p__torch_params_encoder_dense_bias", {config.hidden_size});
+    assets::require_tensor_shape(source, "p__torch_params_encoder_subsampling_mask_aware_conv2d_kernel", {1, 1, 1, 4});
+    assets::require_tensor_shape(source, "p__torch_params_encoder_subsampling_mask_aware_conv2d_1_kernel",
+        {4, 3, 4, config.hidden_size});
+    assets::require_tensor_shape(source, "p__torch_params_encoder_subsampling_mask_aware_conv2d_2_kernel",
+        {4, 3, config.hidden_size, config.hidden_size});
+    assets::require_tensor_shape(source, "p__torch_params_encoder_subsampling_mask_aware_conv2d_1_bias", {config.hidden_size});
+    assets::require_tensor_shape(source, "p__torch_params_encoder_subsampling_mask_aware_conv2d_2_bias", {config.hidden_size});
+    assets::require_tensor_shape(source, "p__torch_params_shared_dec_bias", {vocab_size + 1});
+    assets::require_tensor_shape(source, "p__torch_params_shared_dec_kernel", {config.hidden_size, vocab_size + 1});
+
+    for (int64_t layer = 0; layer < config.num_layers; ++layer) {
+        const auto prefix = lmuformer_prefix(layer);
+        const auto self_attention_dense =
+            indexed_layer_name(prefix, "self_attention_dense", layer + 1, false);
+        const auto global_attention =
+            indexed_layer_name(prefix, "self_attention_global_attention", layer, true);
+        assets::require_tensor_shape(source, prefix + "ffn_dense_1_kernel", {config.hidden_size, config.intermediate_size});
+        assets::require_tensor_shape(source, prefix + "ffn_dense_1_bias", {config.intermediate_size});
+        assets::require_tensor_shape(source, prefix + "ffn_dense_2_kernel", {config.intermediate_size, config.hidden_size});
+        assets::require_tensor_shape(source, prefix + "ffn_dense_2_bias", {config.hidden_size});
+        assets::require_tensor_shape(source, prefix + "ffn_1_dense_1_kernel", {config.hidden_size, config.intermediate_size});
+        assets::require_tensor_shape(source, prefix + "ffn_1_dense_1_bias", {config.intermediate_size});
+        assets::require_tensor_shape(source, prefix + "ffn_1_dense_2_kernel", {config.intermediate_size, config.hidden_size});
+        assets::require_tensor_shape(source, prefix + "ffn_1_dense_2_bias", {config.hidden_size});
+        assets::require_tensor_shape(source, prefix + "self_attention_query_kernel", {config.hidden_size, config.hidden_size});
+        assets::require_tensor_shape(source, prefix + "self_attention_key_kernel", {config.hidden_size, config.hidden_size});
+        assets::require_tensor_shape(source, prefix + "self_attention_value_kernel", {config.hidden_size, config.hidden_size});
+        assets::require_tensor_shape(source, self_attention_dense + "_kernel", {config.hidden_size, config.hidden_size});
+        assets::require_tensor_shape(source, global_attention + "_kernel", {config.hidden_size, config.hidden_size});
+        assets::require_tensor_shape(source, prefix + "state_space_dense_1_kernel", {config.hidden_size, config.state_channels});
+        assets::require_tensor_shape(source, prefix + "state_space_dense_1_bias", {config.state_channels});
+        assets::require_tensor_shape(source, prefix + "state_space_dense_2_kernel", {config.hidden_size, config.hidden_size});
+        assets::require_tensor_shape(source, prefix + "state_space_dense_2_bias", {config.hidden_size});
+        assets::require_tensor_shape(source, prefix + "state_space_state_space_c", {config.state_channels, config.state_size, 1});
+        assets::require_tensor_shape(source, prefix + "state_space_state_space_d", {config.state_channels, 1});
+    }
+
+    return config;
+}
+
+NiagaraAsrConfig parse_config(
+    const assets::ResourceBundle & resources,
+    const assets::TensorSource & source) {
+    const auto root = resources.parse_json("config");
+    NiagaraAsrConfig config;
+    config.model_type = json::optional_string(root, "model_type", "niagara_asr");
+    config.vocab_size = json::optional_i64(root, "vocab_size", 256);
+    config.blank_id = config.vocab_size;
+
+    if (resources.has_file("preprocessor_config")) {
+        const auto preproc = resources.parse_json("preprocessor_config");
+        config.frontend.sample_rate = json::optional_i64(preproc, "sampling_rate",
+            json::optional_i64(preproc, "sample_rate", 16000));
+        config.frontend.n_fft = json::optional_i64(preproc, "n_fft", 400);
+        config.frontend.win_length = json::optional_i64(preproc, "win_length", 400);
+        config.frontend.hop_length = json::optional_i64(preproc, "hop_length", 160);
+        config.frontend.n_mels = json::optional_i64(preproc, "feature_size",
+            json::optional_i64(preproc, "num_mel_bins", 80));
+    }
+
+    if (config.frontend.sample_rate != 16000 || config.frontend.n_fft <= 0 ||
+        config.frontend.win_length <= 0 || config.frontend.hop_length <= 0 ||
+        config.frontend.n_mels != 80 || config.vocab_size <= 0) {
+        throw std::runtime_error("Niagara ASR config contains unsupported frontend/model values");
+    }
+    config.encoder = infer_encoder_config(source, config.vocab_size, config.frontend.n_mels);
+    return config;
+}
+
+}  // namespace
+
+std::shared_ptr<const NiagaraAsrAssets> load_niagara_asr_assets(
+    const std::filesystem::path & model_path) {
+    auto resources = engine::model_spec::load_resource_bundle_for_family(model_path, "niagara_asr");
+    auto assets_out = std::make_shared<NiagaraAsrAssets>();
+    assets_out->resources = std::move(resources);
+    assets_out->source = assets_out->resources.open_tensor_source("weights");
+    if (assets_out->source == nullptr) {
+        throw std::runtime_error("Niagara ASR is missing GGUF weights");
+    }
+    assets_out->config = parse_config(assets_out->resources, *assets_out->source);
+    assets_out->tokenizer_pieces =
+        tokenizers::load_sentencepiece_model(assets_out->resources.require_file("tokenizer_spm"));
+    if (static_cast<int64_t>(assets_out->tokenizer_pieces.size()) != assets_out->config.vocab_size) {
+        throw std::runtime_error("Niagara ASR tokenizer size does not match config vocab_size");
+    }
+    return assets_out;
+}
+
+}  // namespace engine::models::niagara_asr

--- a/src/models/niagara_asr/encoder.cpp
+++ b/src/models/niagara_asr/encoder.cpp
@@ -1,0 +1,312 @@
+#include "engine/models/niagara_asr/encoder.h"
+
+#include "engine/framework/modules/activation_modules.h"
+#include "engine/framework/modules/conv_modules.h"
+#include "engine/framework/modules/linear_module.h"
+#include "engine/framework/modules/primitive_modules.h"
+#include "engine/framework/modules/structural_modules.h"
+
+#include <cmath>
+#include <stdexcept>
+
+namespace engine::models::niagara_asr {
+namespace {
+
+namespace core = engine::core;
+namespace modules = engine::modules;
+
+constexpr float kL1NormEpsilon = 1.0e-6f;
+constexpr int64_t kNumAttentionHeads = 4;
+constexpr int64_t kRelativePositionCenter = 3000;
+
+core::TensorShape make_last_dim_broadcast_shape(const core::TensorShape & input) {
+    core::TensorShape shape = {};
+    shape.rank = input.rank;
+    for (size_t i = 0; i < shape.rank; ++i) {
+        shape.dims[i] = 1;
+    }
+    shape.dims[shape.rank - 1] = input.last_dim();
+    return shape;
+}
+
+core::TensorShape make_scalar_broadcast_shape(const core::TensorShape & input) {
+    core::TensorShape shape = {};
+    shape.rank = input.rank;
+    for (size_t i = 0; i < shape.rank; ++i) {
+        shape.dims[i] = 1;
+    }
+    return shape;
+}
+
+core::TensorValue add_last_dim_bias(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    const core::TensorValue & bias) {
+    core::validate_shape(bias, core::TensorShape::from_dims({input.shape.last_dim()}), "bias");
+    const auto bias_view = core::reshape_tensor(ctx, bias, make_last_dim_broadcast_shape(input.shape));
+    const auto repeated = modules::RepeatModule({input.shape}).build(ctx, bias_view);
+    return modules::AddModule{}.build(ctx, input, repeated);
+}
+
+core::TensorValue add_scaled_residual(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    const core::TensorValue & residual,
+    const core::TensorValue & scale_logits) {
+    core::validate_shape(residual, input.shape, "residual");
+    core::validate_shape(scale_logits, core::TensorShape::from_dims({1}), "scale_logits");
+    const auto scale = modules::SigmoidModule{}.build(ctx, scale_logits);
+    const auto scale_view = core::reshape_tensor(ctx, scale, make_scalar_broadcast_shape(input.shape));
+    const auto repeated_scale = modules::RepeatModule({input.shape}).build(ctx, scale_view);
+    const auto scaled = modules::MulModule{}.build(ctx, residual, repeated_scale);
+    return modules::AddModule{}.build(ctx, input, scaled);
+}
+
+core::TensorValue reshape_heads(core::ModuleBuildContext & ctx, const core::TensorValue & input) {
+    const int64_t hidden = input.shape.last_dim();
+    if (hidden % kNumAttentionHeads != 0) {
+        throw std::runtime_error("Niagara attention hidden size must divide evenly by heads");
+    }
+    auto x = core::reshape_tensor(
+        ctx,
+        input,
+        core::TensorShape::from_dims({
+            input.shape.dims[0],
+            input.shape.dims[1],
+            kNumAttentionHeads,
+            hidden / kNumAttentionHeads,
+        }));
+    x = modules::TransposeModule({{0, 2, 1, 3}, 4}).build(ctx, x);
+    return core::ensure_backend_addressable_layout(ctx, x);
+}
+
+core::TensorValue relative_shift(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    int64_t frames) {
+    auto x = modules::Pad2dModule({0, 1, 0, 0}).build(ctx, input);
+    x = core::ensure_backend_addressable_layout(ctx, x);
+    x = core::reshape_tensor(ctx, x, core::TensorShape::from_dims({
+        input.shape.dims[0],
+        input.shape.dims[1],
+        frames * frames * 2,
+    }));
+    auto * padded = ggml_pad_ext(
+        ctx.ggml,
+        x.tensor,
+        0,
+        static_cast<int>(frames - 1),
+        0,
+        0,
+        0,
+        0,
+        0,
+        0);
+    x = core::wrap_tensor(
+        padded,
+        core::TensorShape::from_dims({input.shape.dims[0], input.shape.dims[1], frames * frames * 2 + frames - 1}),
+        GGML_TYPE_F32);
+    x = core::ensure_backend_addressable_layout(ctx, x);
+    x = core::reshape_tensor(ctx, x, core::TensorShape::from_dims({
+        input.shape.dims[0],
+        input.shape.dims[1],
+        frames + 1,
+        frames * 2 - 1,
+    }));
+    x = modules::SliceModule({2, 0, frames}).build(ctx, x);
+    return modules::SliceModule({3, frames - 1, frames}).build(ctx, x);
+}
+
+core::TensorValue affine_last_dim(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    const modules::NormWeights & weights,
+    int64_t hidden_size) {
+    if (!weights.weight.has_value() || !weights.bias.has_value()) {
+        throw std::runtime_error("Niagara L1 norm requires gamma and beta");
+    }
+    core::validate_shape(*weights.weight, core::TensorShape::from_dims({hidden_size}), "l1norm gamma");
+    core::validate_shape(*weights.bias, core::TensorShape::from_dims({hidden_size}), "l1norm beta");
+
+    const auto weight = core::reshape_tensor(ctx, *weights.weight, make_last_dim_broadcast_shape(input.shape));
+    const auto bias = core::reshape_tensor(ctx, *weights.bias, make_last_dim_broadcast_shape(input.shape));
+    const auto repeated_weight = modules::RepeatModule({input.shape}).build(ctx, weight);
+    const auto repeated_bias = modules::RepeatModule({input.shape}).build(ctx, bias);
+    const auto scaled = modules::MulModule{}.build(ctx, input, repeated_weight);
+    return modules::AddModule{}.build(ctx, scaled, repeated_bias);
+}
+
+}  // namespace
+
+core::TensorValue build_niagara_l1_norm(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    const modules::NormWeights & weights,
+    const NiagaraEncoderConfig & config) {
+    if (ctx.ggml == nullptr) {
+        throw std::runtime_error("ModuleBuildContext.ggml is null");
+    }
+    core::validate_rank_between(input, 2, core::kMaxTensorRank, "input");
+    core::validate_last_dim(input, config.hidden_size, "input");
+
+    const auto x = core::ensure_backend_addressable_layout(ctx, input);
+    const auto mean = modules::ReduceMeanModule({-1}).build(ctx, x);
+    const auto centered = core::wrap_tensor(ggml_sub(ctx.ggml, x.tensor, mean.tensor), x.shape, GGML_TYPE_F32);
+    const auto abs_centered = core::wrap_tensor(ggml_abs(ctx.ggml, centered.tensor), x.shape, GGML_TYPE_F32);
+    const auto l1_mean = modules::ReduceMeanModule({-1}).build(ctx, abs_centered);
+    const auto denom = core::wrap_tensor(
+        ggml_scale_bias(ctx.ggml, l1_mean.tensor, 1.0f, kL1NormEpsilon),
+        l1_mean.shape,
+        GGML_TYPE_F32);
+    const auto normalized = core::wrap_tensor(ggml_div(ctx.ggml, centered.tensor, denom.tensor), x.shape, GGML_TYPE_F32);
+    ggml_set_output(normalized.tensor);
+    return affine_last_dim(ctx, normalized, weights, config.hidden_size);
+}
+
+core::TensorValue build_niagara_feed_forward(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    const NiagaraFeedForwardWeights & weights,
+    const NiagaraEncoderConfig & config) {
+    auto x = build_niagara_l1_norm(ctx, input, weights.norm, config);
+    x = modules::LinearModule({config.hidden_size, config.intermediate_size, true}).build(ctx, x, weights.dense1);
+    x = modules::SiluModule{}.build(ctx, x);
+    return modules::LinearModule({config.intermediate_size, config.hidden_size, true}).build(ctx, x, weights.dense2);
+}
+
+core::TensorValue build_niagara_subsampling(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    const NiagaraSubsamplingWeights & weights,
+    const NiagaraEncoderConfig & config) {
+    core::validate_shape(input, core::TensorShape::from_dims({input.shape.dims[0], input.shape.dims[1], 80}), "input");
+    auto x = core::reshape_tensor(
+        ctx,
+        input,
+        core::TensorShape::from_dims({input.shape.dims[0], 1, input.shape.dims[1], 80}));
+    x = modules::Conv2dModule({1, 4, 1, 1, 1, 1, 0, 0, 1, 1, false}).build(ctx, x, weights.input_projection);
+    x = modules::Conv2dModule({4, config.hidden_size, 4, 3, 2, 2, 0, 0, 1, 1, true}).build(ctx, x, weights.conv1);
+    x = modules::BatchNorm2dEvalModule({config.hidden_size}).build(ctx, x, weights.bn0);
+    x = modules::SiluModule{}.build(ctx, x);
+    x = modules::Conv2dModule({config.hidden_size, config.hidden_size, 4, 3, 2, 2, 0, 0, 1, 1, true})
+            .build(ctx, x, weights.conv2);
+    x = modules::BatchNorm2dEvalModule({config.hidden_size}).build(ctx, x, weights.bn1);
+    x = modules::SiluModule{}.build(ctx, x);
+    x = modules::TransposeModule({{0, 2, 3, 1}, 4}).build(ctx, x);
+    x = core::ensure_backend_addressable_layout(ctx, x);
+    x = core::reshape_tensor(ctx, x, core::TensorShape::from_dims({
+        input.shape.dims[0],
+        x.shape.dims[1],
+        x.shape.dims[2] * x.shape.dims[3],
+    }));
+    return modules::LinearModule({config.dense_input_features * config.hidden_size, config.hidden_size, true})
+        .build(ctx, x, weights.dense);
+}
+
+core::TensorValue build_niagara_self_attention(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    const NiagaraSelfAttentionWeights & weights,
+    const NiagaraEncoderConfig & config) {
+    const int64_t frames = input.shape.dims[1];
+    const int64_t head_dim = config.hidden_size / kNumAttentionHeads;
+    auto x = build_niagara_l1_norm(ctx, input, weights.norm, config);
+    auto q = modules::LinearModule({config.hidden_size, config.hidden_size, true}).build(ctx, x, weights.query);
+    auto k = modules::LinearModule({config.hidden_size, config.hidden_size, true}).build(ctx, x, weights.key);
+    auto v = modules::LinearModule({config.hidden_size, config.hidden_size, true}).build(ctx, x, weights.value);
+    auto q_content = reshape_heads(ctx, add_last_dim_bias(ctx, q, weights.u_bias));
+    auto q_position = reshape_heads(ctx, add_last_dim_bias(ctx, q, weights.v_bias));
+    k = reshape_heads(ctx, k);
+    v = reshape_heads(ctx, v);
+
+    auto scores = modules::MatMulModule{}.build(ctx, q_content, modules::TransposeModule({{0, 1, 3, 2}, 4}).build(ctx, k));
+
+    const int64_t rel_start = kRelativePositionCenter - frames;
+    auto relative = modules::SliceModule({0, rel_start, frames * 2 - 1}).build(ctx, weights.relative_position);
+    relative = modules::LinearModule({config.hidden_size, config.hidden_size, true}).build(ctx, relative, weights.global_attention);
+    relative = core::reshape_tensor(
+        ctx,
+        relative,
+        core::TensorShape::from_dims({1, frames * 2 - 1, kNumAttentionHeads, head_dim}));
+    relative = modules::TransposeModule({{0, 2, 3, 1}, 4}).build(ctx, relative);
+    relative = core::ensure_backend_addressable_layout(ctx, relative);
+    auto relative_scores = modules::MatMulModule{}.build(ctx, q_position, relative);
+    relative_scores = relative_shift(ctx, relative_scores, frames);
+    scores = modules::AddModule{}.build(ctx, scores, relative_scores);
+    scores = core::wrap_tensor(
+        ggml_scale(ctx.ggml, core::ensure_backend_addressable_layout(ctx, scores).tensor, 1.0f / std::sqrt(static_cast<float>(head_dim))),
+        scores.shape,
+        GGML_TYPE_F32);
+    auto attn = core::wrap_tensor(ggml_soft_max(ctx.ggml, scores.tensor), scores.shape, GGML_TYPE_F32);
+    auto context = modules::MatMulModule{}.build(ctx, attn, v);
+    context = modules::TransposeModule({{0, 2, 1, 3}, 4}).build(ctx, context);
+    context = core::ensure_backend_addressable_layout(ctx, context);
+    context = core::reshape_tensor(ctx, context, input.shape);
+    return modules::LinearModule({config.hidden_size, config.hidden_size, true}).build(ctx, context, weights.out);
+}
+
+core::TensorValue build_niagara_state_space(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    const NiagaraStateSpaceWeights & weights,
+    const NiagaraEncoderConfig & config) {
+    constexpr int64_t kernel_size = 128;
+    auto x = build_niagara_l1_norm(ctx, input, weights.norm, config);
+    x = modules::LinearModule({config.hidden_size, config.state_channels, true}).build(ctx, x, weights.dense1);
+    x = core::reshape_tensor(
+        ctx,
+        x,
+        core::TensorShape::from_dims({x.shape.dims[0], x.shape.dims[1], 1, config.state_channels}));
+    x = modules::TransposeModule({{0, 3, 1, 2}, 4}).build(ctx, x);
+    x = core::ensure_backend_addressable_layout(ctx, x);
+    x = modules::Pad2dModule({0, 0, kernel_size - 1, 0}).build(ctx, x);
+    x = modules::DepthwiseConv2dModule({config.state_channels, kernel_size, 1, 1, 1, 0, 0, 1, 1, false})
+            .build(ctx, x, {weights.conv_kernel, std::nullopt});
+    x = modules::TransposeModule({{0, 2, 3, 1}, 4}).build(ctx, x);
+    x = core::ensure_backend_addressable_layout(ctx, x);
+    x = core::reshape_tensor(
+        ctx,
+        x,
+        core::TensorShape::from_dims({input.shape.dims[0], input.shape.dims[1], config.state_channels}));
+
+    if (config.state_channels == config.hidden_size * 2) {
+        const int channel_axis = static_cast<int>(x.shape.rank - 1);
+        const auto gate = modules::SliceModule({channel_axis, config.hidden_size, config.hidden_size}).build(ctx, x);
+        const auto value = modules::SliceModule({channel_axis, 0, config.hidden_size}).build(ctx, x);
+        x = modules::MulModule{}.build(ctx, value, modules::SigmoidModule{}.build(ctx, gate));
+    } else if (config.state_channels == config.hidden_size) {
+        x = modules::SiluModule{}.build(ctx, x);
+    } else {
+        throw std::runtime_error("Niagara state-space channel count must be hidden or 2 * hidden");
+    }
+
+    return modules::LinearModule({config.hidden_size, config.hidden_size, true}).build(ctx, x, weights.dense2);
+}
+
+core::TensorValue build_niagara_layer(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    const NiagaraLayerWeights & weights,
+    const NiagaraEncoderConfig & config) {
+    auto x = add_scaled_residual(ctx, input, build_niagara_feed_forward(ctx, input, weights.ffn, config), weights.ffn.residual_scale);
+    auto attention = build_niagara_self_attention(ctx, x, weights.self_attention, config);
+    x = modules::ResidualAddModule{}.build(ctx, x, attention);
+    auto state = build_niagara_state_space(ctx, x, weights.state_space, config);
+    x = modules::ResidualAddModule{}.build(ctx, x, state);
+    x = add_scaled_residual(ctx, x, build_niagara_feed_forward(ctx, x, weights.ffn1, config), weights.ffn1.residual_scale);
+    return build_niagara_l1_norm(ctx, x, weights.out_norm, config);
+}
+
+core::TensorValue build_niagara_encoder_logits(
+    core::ModuleBuildContext & ctx,
+    const core::TensorValue & input,
+    const NiagaraWeights & weights,
+    const NiagaraAsrConfig & config) {
+    auto x = build_niagara_subsampling(ctx, input, weights.subsampling, config.encoder);
+    for (const auto & layer : weights.layers) {
+        x = build_niagara_layer(ctx, x, layer, config.encoder);
+    }
+    return modules::LinearModule({config.encoder.hidden_size, config.vocab_size + 1, true}).build(ctx, x, weights.ctc);
+}
+
+}  // namespace engine::models::niagara_asr

--- a/src/models/niagara_asr/frontend.cpp
+++ b/src/models/niagara_asr/frontend.cpp
@@ -1,0 +1,80 @@
+#include "engine/models/niagara_asr/frontend.h"
+
+#include "engine/framework/audio/conversion.h"
+#include "engine/framework/audio/dsp.h"
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+#include <utility>
+
+namespace engine::models::niagara_asr {
+
+NiagaraFrontend::NiagaraFrontend(std::shared_ptr<const NiagaraAsrAssets> assets)
+    : assets_(std::move(assets)) {
+    if (assets_ == nullptr) {
+        throw std::runtime_error("Niagara ASR frontend requires assets");
+    }
+    const auto & cfg = assets_->config.frontend;
+    engine::audio::STFTConfig stft_cfg;
+    stft_cfg.win_length = cfg.win_length;
+    stft_cfg.family = engine::audio::STFTFamily::Kokoro;
+    window_ = engine::audio::get_cached_stft_window(stft_cfg);
+    mel_filterbank_ = engine::audio::MelFilterbank().build(
+        engine::audio::MelFilterbankConfig{
+            cfg.sample_rate,
+            cfg.n_fft,
+            cfg.n_mels,
+            0.0f,
+            static_cast<float>(cfg.sample_rate) / 2.0f,
+            false,
+        });
+}
+
+NiagaraFeatures NiagaraFrontend::extract(const runtime::AudioBuffer & audio) const {
+    if (audio.sample_rate <= 0 || audio.channels <= 0 || audio.samples.empty()) {
+        throw std::runtime_error("Niagara ASR requires non-empty audio with positive sample rate/channels");
+    }
+    const auto & cfg = assets_->config.frontend;
+    auto waveform = engine::audio::convert_interleaved_audio_to_mono_linear_resampled(
+        audio.samples, audio.sample_rate, audio.channels, static_cast<int>(cfg.sample_rate));
+    if (static_cast<int64_t>(waveform.size()) < cfg.win_length) {
+        waveform.resize(static_cast<size_t>(cfg.win_length), 0.0f);
+    }
+
+    engine::audio::STFTConfig stft_cfg;
+    stft_cfg.n_fft = cfg.n_fft;
+    stft_cfg.win_length = cfg.win_length;
+    stft_cfg.hop_length = cfg.hop_length;
+    stft_cfg.center = false;
+    stft_cfg.pad_mode = engine::audio::STFTPadMode::Constant;
+    stft_cfg.family = engine::audio::STFTFamily::Kokoro;
+
+    const auto mag = engine::audio::STFT().compute_magnitude(
+        waveform, window_, 1, static_cast<int64_t>(waveform.size()), stft_cfg);
+    const int64_t freq_bins = cfg.n_fft / 2 + 1;
+    const int64_t raw_frames = mag.shape.size() >= 3
+        ? mag.shape[2]
+        : static_cast<int64_t>(mag.values.size()) / freq_bins;
+    const int64_t padded_frames = ((raw_frames + 3) / 4) * 4;
+
+    NiagaraFeatures out;
+    out.frames = padded_frames;
+    out.feature_dim = cfg.n_mels;
+    out.values.assign(static_cast<size_t>(padded_frames * cfg.n_mels), 1000.0f);
+    const auto mel = engine::audio::MelFilterbank().compute_custom(
+        mag.values,
+        1,
+        freq_bins,
+        raw_frames,
+        mel_filterbank_);
+    for (int64_t t = 0; t < raw_frames; ++t) {
+        for (int64_t m = 0; m < cfg.n_mels; ++m) {
+            out.values[static_cast<size_t>(t * cfg.n_mels + m)] =
+                std::log(std::max(static_cast<double>(mel.values[static_cast<size_t>(m * raw_frames + t)]), 1.0e-12));
+        }
+    }
+    return out;
+}
+
+}  // namespace engine::models::niagara_asr

--- a/src/models/niagara_asr/runtime.cpp
+++ b/src/models/niagara_asr/runtime.cpp
@@ -1,0 +1,117 @@
+#include "engine/models/niagara_asr/runtime.h"
+
+#include "engine/models/niagara_asr/encoder.h"
+#include "engine/models/niagara_asr/weights.h"
+#include "engine/framework/core/backend.h"
+
+#include "ggml-alloc.h"
+
+#include <chrono>
+#include <stdexcept>
+#include <utility>
+
+namespace engine::models::niagara_asr {
+namespace assets = engine::assets;
+namespace core = engine::core;
+namespace {
+
+using Clock = std::chrono::steady_clock;
+
+const NiagaraAsrAssets & require_runtime_assets(const std::shared_ptr<const NiagaraAsrAssets> & assets) {
+    if (assets == nullptr || assets->source == nullptr) {
+        throw std::runtime_error("Niagara runtime requires assets and tensor source");
+    }
+    return *assets;
+}
+
+}  // namespace
+
+struct NiagaraRuntime::Impl {
+    Impl(
+        std::shared_ptr<const NiagaraAsrAssets> assets,
+        core::ExecutionContext & execution,
+        assets::TensorStorageType weight_storage_type,
+        size_t graph_arena_bytes,
+        size_t weight_context_bytes)
+        : assets(std::move(assets)),
+          execution(&execution),
+          weights(load_niagara_weights(require_runtime_assets(this->assets), execution, weight_storage_type, weight_context_bytes)),
+          graph_arena_bytes(graph_arena_bytes) {}
+
+    std::shared_ptr<const NiagaraAsrAssets> assets;
+    core::ExecutionContext * execution = nullptr;
+    std::shared_ptr<const NiagaraWeights> weights;
+    size_t graph_arena_bytes = 0;
+};
+
+NiagaraRuntime::NiagaraRuntime(
+    std::shared_ptr<const NiagaraAsrAssets> assets,
+    core::ExecutionContext & execution,
+    assets::TensorStorageType weight_storage_type,
+    size_t graph_arena_bytes,
+    size_t weight_context_bytes)
+    : impl_(new Impl(std::move(assets), execution, weight_storage_type, graph_arena_bytes, weight_context_bytes)) {}
+
+NiagaraRuntime::~NiagaraRuntime() = default;
+
+NiagaraInferenceResult NiagaraRuntime::infer(const NiagaraFeatures & features) {
+    if (features.frames <= 0 || features.feature_dim != 80 ||
+        static_cast<int64_t>(features.values.size()) != features.frames * features.feature_dim) {
+        throw std::runtime_error("Niagara runtime received invalid frontend features");
+    }
+
+    const auto started = Clock::now();
+    ggml_init_params params{
+        impl_->graph_arena_bytes,
+        nullptr,
+        true,
+    };
+    ggml_context * ggml_ctx = ggml_init(params);
+    if (ggml_ctx == nullptr) {
+        throw std::runtime_error("failed to allocate Niagara runtime graph context");
+    }
+
+    ggml_gallocr_t gallocr = nullptr;
+    try {
+        core::ModuleBuildContext ctx{ggml_ctx, "niagara_asr.encoder", impl_->execution->backend_type()};
+        auto input = core::make_tensor(
+            ctx,
+            GGML_TYPE_F32,
+            core::TensorShape::from_dims({1, features.frames, features.feature_dim}));
+        auto logits = build_niagara_encoder_logits(ctx, input, *impl_->weights, impl_->assets->config);
+        logits = core::ensure_backend_addressable_layout(ctx, logits);
+        ggml_set_output(logits.tensor);
+
+        ggml_cgraph * graph = ggml_new_graph_custom(ggml_ctx, 65536, false);
+        ggml_build_forward_expand(graph, logits.tensor);
+
+        const auto backend = impl_->execution->backend();
+        gallocr = ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend));
+        if (gallocr == nullptr || !ggml_gallocr_reserve(gallocr, graph) || !ggml_gallocr_alloc_graph(gallocr, graph)) {
+            throw std::runtime_error("failed to allocate Niagara runtime graph");
+        }
+
+        core::write_tensor_f32(input, features.values);
+        const ggml_status status = core::compute_backend_graph(backend, graph, nullptr, "Niagara ASR encoder");
+        if (status != GGML_STATUS_SUCCESS) {
+            throw std::runtime_error("Niagara runtime graph compute failed");
+        }
+
+        NiagaraInferenceResult result;
+        result.frames = logits.shape.dims[1];
+        result.vocab_size = logits.shape.dims[2];
+        result.logits = core::read_tensor_f32(logits.tensor);
+        result.elapsed_ms = std::chrono::duration<double, std::milli>(Clock::now() - started).count();
+        ggml_gallocr_free(gallocr);
+        ggml_free(ggml_ctx);
+        return result;
+    } catch (...) {
+        if (gallocr != nullptr) {
+            ggml_gallocr_free(gallocr);
+        }
+        ggml_free(ggml_ctx);
+        throw;
+    }
+}
+
+}  // namespace engine::models::niagara_asr

--- a/src/models/niagara_asr/session.cpp
+++ b/src/models/niagara_asr/session.cpp
@@ -1,0 +1,182 @@
+#include "engine/models/niagara_asr/session.h"
+
+#include "engine/framework/core/backend.h"
+#include "engine/framework/debug/profiler.h"
+#include "engine/framework/io/text.h"
+#include "engine/framework/runtime/host_ops.h"
+#include "engine/framework/runtime/options.h"
+#include "engine/framework/runtime/spec_backed_model.h"
+
+#include <algorithm>
+#include <chrono>
+#include <stdexcept>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace engine::models::niagara_asr {
+namespace {
+
+using Clock = std::chrono::steady_clock;
+constexpr size_t kMiB = 1024ULL * 1024ULL;
+constexpr size_t kDefaultGraphArenaBytes = 1024ULL * kMiB;
+constexpr size_t kDefaultWeightContextBytes = 256ULL * kMiB;
+
+const engine::model_spec::ModelContract & require_contract(
+    const std::shared_ptr<const engine::model_spec::ModelContract> & contract) {
+    if (contract == nullptr) {
+        throw std::runtime_error("Niagara ASR session requires a model contract");
+    }
+    return *contract;
+}
+
+runtime::SessionOptions validate_session_setup(
+    const runtime::TaskSpec & task,
+    runtime::SessionOptions options,
+    const engine::model_spec::ModelContract & contract) {
+    if (task.task != runtime::VoiceTaskKind::Asr || task.mode != runtime::RunMode::Offline) {
+        throw std::runtime_error("Niagara ASR only supports offline ASR");
+    }
+    if (options.backend.type != core::BackendType::Cpu) {
+        throw std::runtime_error("Niagara ASR CPU variants require --backend cpu");
+    }
+    for (const char * key : {"weight_type", "graph_arena_mb", "weight_context_mb"}) {
+        if (options.options.find(key) != options.options.end()) {
+            throw std::runtime_error(
+                "Niagara ASR session option " + std::string(key) +
+                " must use the normalized key niagara_asr." + key);
+        }
+    }
+    runtime::validate_spec_backed_session_options(options, contract, "niagara_asr", "Niagara ASR");
+    return options;
+}
+
+std::unordered_map<std::string, std::string> validate_request_options(
+    std::unordered_map<std::string, std::string> options,
+    const engine::model_spec::ModelContract & contract) {
+    runtime::validate_spec_backed_request_options(options, contract, "Niagara ASR");
+    const auto it = options.find("audio_chunk_mode");
+    if (it != options.end() && it->second != "none") {
+        throw std::runtime_error("Niagara ASR supports only audio_chunk_mode=none");
+    }
+    return options;
+}
+
+}  // namespace
+
+NiagaraAsrSession::NiagaraAsrSession(
+    runtime::TaskSpec task,
+    runtime::SessionOptions options,
+    std::shared_ptr<const NiagaraAsrAssets> assets,
+    std::shared_ptr<const engine::model_spec::ModelContract> contract)
+    : RuntimeSessionBase(validate_session_setup(task, std::move(options), require_contract(contract))),
+      task_(std::move(task)),
+      assets_(std::move(assets)),
+      contract_(std::move(contract)),
+      frontend_(assets_),
+      runtime_(
+          assets_,
+          execution_context(),
+          runtime::parse_tensor_storage_option(
+              RuntimeSessionBase::options().options,
+              "niagara_asr.weight_type",
+              engine::assets::TensorStorageType::Native,
+              {engine::assets::TensorStorageType::Native,
+               engine::assets::TensorStorageType::F32,
+               engine::assets::TensorStorageType::F16,
+               engine::assets::TensorStorageType::BF16,
+               engine::assets::TensorStorageType::Q8_0,
+               engine::assets::TensorStorageType::Q4_0,
+               engine::assets::TensorStorageType::Q4_1,
+               engine::assets::TensorStorageType::Q5_0,
+               engine::assets::TensorStorageType::Q5_1,
+               engine::assets::TensorStorageType::Q2_K,
+               engine::assets::TensorStorageType::Q3_K,
+               engine::assets::TensorStorageType::Q4_K,
+               engine::assets::TensorStorageType::Q5_K,
+               engine::assets::TensorStorageType::Q6_K}),
+          runtime::parse_size_mb_option(
+              RuntimeSessionBase::options().options,
+              {"niagara_asr.graph_arena_mb"},
+              kDefaultGraphArenaBytes),
+          runtime::parse_size_mb_option(
+              RuntimeSessionBase::options().options,
+              {"niagara_asr.weight_context_mb"},
+              kDefaultWeightContextBytes)) {
+    if (assets_ == nullptr) {
+        throw std::runtime_error("Niagara ASR session requires assets");
+    }
+}
+
+NiagaraAsrSession::~NiagaraAsrSession() = default;
+
+std::string NiagaraAsrSession::family() const {
+    return "niagara_asr";
+}
+
+runtime::VoiceTaskKind NiagaraAsrSession::task_kind() const {
+    return task_.task;
+}
+
+runtime::RunMode NiagaraAsrSession::run_mode() const {
+    return task_.mode;
+}
+
+void NiagaraAsrSession::prepare(const runtime::SessionPreparationRequest & request) {
+    (void) request;
+    mark_prepared();
+}
+
+std::string NiagaraAsrSession::decode(const NiagaraInferenceResult & inference) const {
+    const auto decoded = runtime::CTCDecoder().compute(
+        inference.logits,
+        1,
+        inference.frames,
+        inference.vocab_size,
+        static_cast<int32_t>(assets_->config.blank_id));
+    std::vector<int32_t> ids;
+    ids.reserve(static_cast<size_t>(inference.frames));
+    for (int32_t id : decoded.values) {
+        if (id != static_cast<int32_t>(assets_->config.blank_id) && id > 0) {
+            ids.push_back(id);
+        }
+    }
+    return engine::io::trim_ascii_whitespace(
+        tokenizers::decode_sentencepiece(assets_->tokenizer_pieces, ids));
+}
+
+runtime::TaskResult NiagaraAsrSession::run(const runtime::TaskRequest & request) {
+    require_prepared("Niagara ASR run()");
+    if (!request.audio_input.has_value()) {
+        throw std::runtime_error("Niagara ASR run() requires audio_input");
+    }
+    (void) validate_request_options(request.options, require_contract(contract_));
+    const auto wall_start = Clock::now();
+    const auto features = frontend_.extract(*request.audio_input);
+    const auto inference = runtime_.infer(features);
+    runtime::TaskResult result;
+    result.text_output = runtime::Transcript{decode(inference), "en"};
+    engine::debug::timing_log_scalar("niagara.frontend_frames", static_cast<double>(features.frames));
+    engine::debug::timing_log_scalar("niagara.model_ms", inference.elapsed_ms);
+    engine::debug::timing_log_scalar("session.wall_ms", engine::debug::elapsed_ms(wall_start));
+    return result;
+}
+
+std::shared_ptr<runtime::IVoiceModelLoader> make_niagara_asr_loader() {
+    runtime::SpecBackedVoiceModelConfig<NiagaraAsrAssets> config;
+    config.family = "niagara_asr";
+    config.load_assets = [](const std::filesystem::path & model_path) {
+        return load_niagara_asr_assets(model_path);
+    };
+    config.create_session =
+        [](const runtime::TaskSpec & task,
+           const runtime::SessionOptions & options,
+           std::shared_ptr<const NiagaraAsrAssets> assets,
+           std::shared_ptr<const engine::model_spec::ModelContract> contract) {
+            return std::make_unique<NiagaraAsrSession>(
+                task, options, std::move(assets), std::move(contract));
+        };
+    return runtime::make_spec_backed_voice_loader(std::move(config));
+}
+
+}  // namespace engine::models::niagara_asr

--- a/src/models/niagara_asr/weights.cpp
+++ b/src/models/niagara_asr/weights.cpp
@@ -1,0 +1,387 @@
+#include "engine/models/niagara_asr/weights.h"
+
+#include "engine/framework/assets/tensor_source.h"
+#include "engine/framework/modules/weight_binding.h"
+
+#include <cmath>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace engine::models::niagara_asr {
+namespace {
+
+namespace assets = engine::assets;
+namespace core = engine::core;
+namespace modules = engine::modules;
+namespace binding = engine::modules::binding;
+
+constexpr float kBatchNormEpsilon = 1.0e-5f;
+
+std::string lmuformer_prefix(int64_t layer) {
+    if (layer == 0) {
+        return "p__torch_params_encoder_lmuformer_";
+    }
+    return "p__torch_params_encoder_lmuformer_" + std::to_string(layer) + "_";
+}
+
+std::string state_space_basis_name(int64_t layer) {
+    return "c_lifted_tensor_" + std::to_string(44 + 40 * layer);
+}
+
+std::string relative_position_name(int64_t layer) {
+    return "c_lifted_tensor_" + std::to_string(34 + 40 * layer);
+}
+
+std::string indexed_layer_name(
+    const std::string & prefix,
+    const std::string & base,
+    int64_t layer,
+    bool omit_zero) {
+    if (layer == 0 && omit_zero) {
+        return prefix + base;
+    }
+    return prefix + base + "_" + std::to_string(layer);
+}
+
+std::vector<float> build_state_space_conv_kernel(
+    const assets::TensorSource & source,
+    const std::string & prefix,
+    int64_t layer,
+    const NiagaraEncoderConfig & config) {
+    constexpr int64_t kernel_size = 128;
+    const auto basis = source.require_f32(
+        state_space_basis_name(layer),
+        {1, kernel_size, config.state_size});
+    const auto c = source.require_f32(
+        prefix + "state_space_state_space_c",
+        {config.state_channels, config.state_size, 1});
+    std::vector<float> kernel(static_cast<size_t>(config.state_channels * kernel_size), 0.0f);
+    for (int64_t channel = 0; channel < config.state_channels; ++channel) {
+        for (int64_t k = 0; k < kernel_size; ++k) {
+            double sum = 0.0;
+            const int64_t source_k = kernel_size - 1 - k;
+            for (int64_t s = 0; s < config.state_size; ++s) {
+                sum += static_cast<double>(basis[static_cast<size_t>(source_k * config.state_size + s)]) *
+                    static_cast<double>(c[static_cast<size_t>(channel * config.state_size + s)]);
+            }
+            kernel[static_cast<size_t>(channel * kernel_size + k)] = static_cast<float>(sum);
+        }
+    }
+    return kernel;
+}
+
+modules::Conv2dWeights load_conv2d_hwio(
+    core::BackendWeightStore & store,
+    const assets::TensorSource & source,
+    const std::string & prefix,
+    int64_t kernel_height,
+    int64_t kernel_width,
+    int64_t in_channels,
+    int64_t out_channels,
+    assets::TensorStorageType storage_type,
+    bool has_bias = true) {
+    const auto raw = source.require_f32(prefix + "_kernel", {kernel_height, kernel_width, in_channels, out_channels});
+    std::vector<float> converted(static_cast<size_t>(out_channels * in_channels * kernel_height * kernel_width), 0.0f);
+    for (int64_t out = 0; out < out_channels; ++out) {
+        for (int64_t in = 0; in < in_channels; ++in) {
+            for (int64_t kh = 0; kh < kernel_height; ++kh) {
+                for (int64_t kw = 0; kw < kernel_width; ++kw) {
+                    converted[static_cast<size_t>(((out * in_channels + in) * kernel_height + kh) * kernel_width + kw)] =
+                        raw[static_cast<size_t>(((kh * kernel_width + kw) * in_channels + in) * out_channels + out)];
+                }
+            }
+        }
+    }
+    return {
+        store.make_from_f32(
+            core::TensorShape::from_dims({out_channels, in_channels, kernel_height, kernel_width}),
+            storage_type,
+            std::move(converted)),
+        has_bias ? std::optional<core::TensorValue>(store.load_f32_tensor(source, prefix + "_bias", {out_channels}))
+                 : std::nullopt,
+    };
+}
+
+modules::BatchNorm2dEvalWeights load_batch_norm(
+    core::BackendWeightStore & store,
+    const assets::TensorSource & source,
+    const std::string & prefix,
+    int64_t channels) {
+    const auto gamma = source.require_f32(prefix + "_gamma", {channels});
+    const auto beta = source.require_f32(prefix + "_beta", {channels});
+    const auto mean = source.require_f32(prefix + "_moving_mean", {channels});
+    const auto variance = source.require_f32(prefix + "_moving_variance", {channels});
+    std::vector<float> scale(static_cast<size_t>(channels), 0.0f);
+    std::vector<float> bias(static_cast<size_t>(channels), 0.0f);
+    for (int64_t channel = 0; channel < channels; ++channel) {
+        const float folded_scale =
+            gamma[static_cast<size_t>(channel)] / std::sqrt(variance[static_cast<size_t>(channel)] + kBatchNormEpsilon);
+        scale[static_cast<size_t>(channel)] = folded_scale;
+        bias[static_cast<size_t>(channel)] = beta[static_cast<size_t>(channel)] - mean[static_cast<size_t>(channel)] * folded_scale;
+    }
+    return {
+        store.make_from_f32(core::TensorShape::from_dims({channels}), assets::TensorStorageType::F32, std::move(scale)),
+        store.make_from_f32(core::TensorShape::from_dims({channels}), assets::TensorStorageType::F32, std::move(bias)),
+    };
+}
+
+NiagaraFeedForwardWeights load_feed_forward(
+    core::BackendWeightStore & store,
+    const assets::TensorSource & source,
+    const std::string & prefix,
+    const std::string & residual_scale_name,
+    int64_t hidden_size,
+    int64_t intermediate_size,
+    assets::TensorStorageType storage_type) {
+    const auto norm = prefix + "l1norm";
+    return {
+        binding::norm_from_named_source(
+            store,
+            source,
+            norm + "_gamma",
+            std::optional<std::string>{norm + "_beta"}),
+        binding::linear_from_transposed_named_source(
+            store,
+            source,
+            prefix + "dense_1_kernel",
+            std::optional<std::string>{prefix + "dense_1_bias"},
+            storage_type,
+            hidden_size,
+            intermediate_size),
+        binding::linear_from_transposed_named_source(
+            store,
+            source,
+            prefix + "dense_2_kernel",
+            std::optional<std::string>{prefix + "dense_2_bias"},
+            storage_type,
+            intermediate_size,
+            hidden_size),
+        store.load_f32_tensor(source, residual_scale_name, {1}),
+    };
+}
+
+NiagaraSelfAttentionWeights load_self_attention(
+    core::BackendWeightStore & store,
+    const assets::TensorSource & source,
+    const std::string & prefix,
+    int64_t layer,
+    int64_t hidden_size,
+    assets::TensorStorageType storage_type) {
+    const auto norm = indexed_layer_name(prefix, "self_attention_l1_layer_normalization", layer * 2, true);
+    const auto global_attention = indexed_layer_name(prefix, "self_attention_global_attention", layer, true);
+    const auto out = indexed_layer_name(prefix, "self_attention_dense", layer + 1, false);
+    return {
+        binding::norm_from_named_source(
+            store,
+            source,
+            norm + "_gamma",
+            std::optional<std::string>{norm + "_beta"}),
+        binding::linear_from_transposed_named_source(
+            store,
+            source,
+            prefix + "self_attention_query_kernel",
+            std::optional<std::string>{prefix + "self_attention_query_bias"},
+            storage_type,
+            hidden_size,
+            hidden_size),
+        binding::linear_from_transposed_named_source(
+            store,
+            source,
+            prefix + "self_attention_key_kernel",
+            std::optional<std::string>{prefix + "self_attention_key_bias"},
+            storage_type,
+            hidden_size,
+            hidden_size),
+        binding::linear_from_transposed_named_source(
+            store,
+            source,
+            prefix + "self_attention_value_kernel",
+            std::optional<std::string>{prefix + "self_attention_value_bias"},
+            storage_type,
+            hidden_size,
+            hidden_size),
+        binding::linear_from_transposed_named_source(
+            store,
+            source,
+            global_attention + "_kernel",
+            std::optional<std::string>{global_attention + "_bias"},
+            storage_type,
+            hidden_size,
+            hidden_size),
+        binding::linear_from_transposed_named_source(
+            store,
+            source,
+            out + "_kernel",
+            std::optional<std::string>{out + "_bias"},
+            storage_type,
+            hidden_size,
+            hidden_size),
+        store.load_tensor(
+            source,
+            relative_position_name(layer),
+            assets::TensorStorageType::F32,
+            {5999, hidden_size}),
+        store.load_f32_tensor(source, prefix + "self_attention_u_bias_bias", {hidden_size}),
+        store.load_f32_tensor(source, prefix + "self_attention_v_bias_bias", {hidden_size}),
+    };
+}
+
+NiagaraStateSpaceWeights load_state_space(
+    core::BackendWeightStore & store,
+    const assets::TensorSource & source,
+    const std::string & prefix,
+    int64_t layer,
+    const NiagaraEncoderConfig & config,
+    assets::TensorStorageType storage_type) {
+    constexpr int64_t kernel_size = 128;
+    const auto norm = prefix + "state_space_l1norm";
+    return {
+        binding::norm_from_named_source(
+            store,
+            source,
+            norm + "_gamma",
+            std::optional<std::string>{norm + "_beta"}),
+        binding::linear_from_transposed_named_source(
+            store,
+            source,
+            prefix + "state_space_dense_1_kernel",
+            std::optional<std::string>{prefix + "state_space_dense_1_bias"},
+            storage_type,
+            config.hidden_size,
+            config.state_channels),
+        binding::linear_from_transposed_named_source(
+            store,
+            source,
+            prefix + "state_space_dense_2_kernel",
+            std::optional<std::string>{prefix + "state_space_dense_2_bias"},
+            storage_type,
+            config.hidden_size,
+            config.hidden_size),
+        store.make_from_f32(
+            core::TensorShape::from_dims({config.state_channels, 1, kernel_size, 1}),
+            assets::TensorStorageType::F32,
+            build_state_space_conv_kernel(source, prefix, layer, config)),
+    };
+}
+
+NiagaraLayerWeights load_layer(
+    core::BackendWeightStore & store,
+    const assets::TensorSource & source,
+    int64_t layer,
+    const NiagaraEncoderConfig & config,
+    assets::TensorStorageType storage_type) {
+    const auto prefix = lmuformer_prefix(layer);
+    const auto out_norm = indexed_layer_name(prefix, "l1_layer_normalization", layer * 2 + 1, false);
+    return {
+        load_feed_forward(
+            store,
+            source,
+            prefix + "ffn_",
+            "c_lifted_tensor_" + std::to_string(23 + 40 * layer),
+            config.hidden_size,
+            config.intermediate_size,
+            storage_type),
+        load_self_attention(store, source, prefix, layer, config.hidden_size, storage_type),
+        load_state_space(store, source, prefix, layer, config, storage_type),
+        load_feed_forward(
+            store,
+            source,
+            prefix + "ffn_1_",
+            "c_lifted_tensor_" + std::to_string(54 + 40 * layer),
+            config.hidden_size,
+            config.intermediate_size,
+            storage_type),
+        binding::norm_from_named_source(
+            store,
+            source,
+            out_norm + "_gamma",
+            std::optional<std::string>{out_norm + "_beta"}),
+    };
+}
+
+NiagaraSubsamplingWeights load_subsampling(
+    core::BackendWeightStore & store,
+    const assets::TensorSource & source,
+    const NiagaraEncoderConfig & config,
+    assets::TensorStorageType storage_type) {
+    const int64_t hidden = config.hidden_size;
+    return {
+        load_batch_norm(store, source, "p__torch_params_encoder_subsampling_batch_normalization", hidden),
+        load_batch_norm(store, source, "p__torch_params_encoder_subsampling_batch_normalization_1", hidden),
+        load_conv2d_hwio(
+            store,
+            source,
+            "p__torch_params_encoder_subsampling_mask_aware_conv2d",
+            1,
+            1,
+            1,
+            4,
+            storage_type,
+            false),
+        load_conv2d_hwio(
+            store,
+            source,
+            "p__torch_params_encoder_subsampling_mask_aware_conv2d_1",
+            config.subsampling_kernel_height,
+            config.subsampling_kernel_width,
+            4,
+            hidden,
+            storage_type),
+        load_conv2d_hwio(
+            store,
+            source,
+            "p__torch_params_encoder_subsampling_mask_aware_conv2d_2",
+            config.subsampling_kernel_height,
+            config.subsampling_kernel_width,
+            hidden,
+            hidden,
+            storage_type),
+        binding::linear_from_transposed_named_source(
+            store,
+            source,
+            "p__torch_params_encoder_dense_kernel",
+            std::optional<std::string>{"p__torch_params_encoder_dense_bias"},
+            storage_type,
+            config.dense_input_features * hidden,
+            hidden),
+    };
+}
+
+}  // namespace
+
+std::shared_ptr<const NiagaraWeights> load_niagara_weights(
+    const NiagaraAsrAssets & assets,
+    core::ExecutionContext & execution,
+    assets::TensorStorageType storage_type,
+    size_t weight_context_bytes) {
+    if (assets.source == nullptr) {
+        throw std::runtime_error("Niagara ASR weights require a tensor source");
+    }
+    auto out = std::make_shared<NiagaraWeights>();
+    out->store = std::make_shared<core::BackendWeightStore>(
+        execution.backend(),
+        execution.backend_type(),
+        "niagara_asr.weights",
+        weight_context_bytes);
+    const auto & source = *assets.source;
+    const auto & config = assets.config.encoder;
+    out->subsampling = load_subsampling(*out->store, source, config, storage_type);
+    out->layers.reserve(static_cast<size_t>(config.num_layers));
+    for (int64_t layer = 0; layer < config.num_layers; ++layer) {
+        out->layers.push_back(load_layer(*out->store, source, layer, config, storage_type));
+    }
+    out->ctc = binding::linear_from_transposed_named_source(
+        *out->store,
+        source,
+        "p__torch_params_shared_dec_kernel",
+        std::optional<std::string>{"p__torch_params_shared_dec_bias"},
+        storage_type,
+        config.hidden_size,
+        assets.config.vocab_size + 1);
+    out->store->upload();
+    return out;
+}
+
+}  // namespace engine::models::niagara_asr

--- a/tests/niagara_asr/convert_niagara_asr.py
+++ b/tests/niagara_asr/convert_niagara_asr.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Convert ABR Niagara batch ASR PT2 CPU packages to audio.cpp GGUF.
+
+The upstream Niagara repositories publish Torch 2.11 PT2 archives with raw
+numbered tensor payloads and a serialized graph description. This converter
+stages those tensors under the graph input names, then delegates GGUF writing,
+quantization, sidecar embedding, and model-spec embedding to audiocpp_gguf.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SPEC = REPO_ROOT / "model_specs" / "niagara_asr.json"
+REPOS = {
+    "19m": {
+        "repo": "abr-ai/niagara-19m-batch.en",
+        "base": "niagara-19m-batch.en",
+        "tokenizer": "sentencepiece_256.model",
+        "output": "Niagara-19M-Batch-EN-GGUF/niagara-19m-batch.en.gguf",
+    },
+    "38m": {
+        "repo": "abr-ai/niagara-38m-batch.en",
+        "base": "niagara-38m-batch.en",
+        "tokenizer": "sentencepiece_1024.model",
+        "output": "Niagara-38M-Batch-EN-GGUF/niagara-38m-batch.en.gguf",
+    },
+}
+
+def tensor_shape(meta: dict[str, Any]) -> list[int]:
+    return [int(item["as_int"]) for item in meta.get("sizes", [])]
+
+
+def load_raw_tensor(archive: zipfile.ZipFile, path: str, dtype_id: int, shape: list[int]) -> Any:
+    import torch
+
+    torch_dtype = {
+        4: torch.int32,
+        5: torch.int64,
+        7: torch.float32,
+    }
+    try:
+        dtype = torch_dtype[dtype_id]
+    except KeyError as error:
+        raise RuntimeError(f"unsupported Niagara PT2 tensor dtype id: {dtype_id}") from error
+    data = archive.read(path)
+    tensor = torch.frombuffer(bytearray(data), dtype=dtype).clone()
+    return tensor.reshape(shape)
+
+
+def download_if_missing(model_dir: Path, variant: str) -> None:
+    from huggingface_hub import hf_hub_download
+
+    spec = REPOS[variant]
+    required = [
+        f"{spec['base']}-cpu.pt2",
+        "config.json",
+        "preprocessor_config.json",
+        "tokenizer_config.json",
+        spec["tokenizer"],
+    ]
+    missing = [name for name in required if not (model_dir / name).exists()]
+    if not missing:
+        return
+    for name in missing:
+        print(f"downloading {spec['repo']}:{name}", flush=True)
+        hf_hub_download(spec["repo"], name, local_dir=model_dir)
+
+
+def stage_from_pt2(model_dir: Path, variant: str, staging: Path) -> Path:
+    from safetensors.torch import save_file
+
+    spec = REPOS[variant]
+    pt2 = model_dir / f"{spec['base']}-cpu.pt2"
+    if not pt2.exists():
+        raise FileNotFoundError(f"missing Niagara CPU PT2 package: {pt2}")
+
+    with zipfile.ZipFile(pt2) as archive:
+        base = archive.namelist()[0].split("/")[0]
+        graph = json.loads(archive.read(f"{base}/models/model.json"))
+        constants = json.loads(archive.read(f"{base}/data/constants/model_constants_config.json"))["config"]
+        input_specs = graph["graph_module"]["signature"]["input_specs"]
+        tensor_values = graph["graph_module"]["graph"]["tensor_values"]
+
+        tensors: dict[str, Any] = {}
+        parameter_specs = [item["parameter"] for item in input_specs if "parameter" in item]
+        for index, parameter in enumerate(parameter_specs):
+            name = parameter["arg"]["name"]
+            meta = tensor_values[name]
+            tensors[name] = load_raw_tensor(
+                archive,
+                f"{base}/data/weights/weight_{index}",
+                int(meta["dtype"]),
+                tensor_shape(meta),
+            )
+
+        for item in input_specs:
+            if "tensor_constant" not in item:
+                continue
+            constant = item["tensor_constant"]
+            name = constant["arg"]["name"]
+            info = constants[constant["tensor_constant_name"]]
+            meta = info["tensor_meta"]
+            tensors[name] = load_raw_tensor(
+                archive,
+                f"{base}/data/constants/{info['path_name']}",
+                int(meta["dtype"]),
+                tensor_shape(meta),
+            )
+
+    staging.mkdir(parents=True, exist_ok=True)
+    weights = staging / "niagara_asr.safetensors"
+    save_file(tensors, weights)
+    shutil.copyfile(model_dir / "config.json", staging / "config.json")
+    shutil.copyfile(model_dir / "preprocessor_config.json", staging / "preprocessor_config.json")
+    shutil.copyfile(model_dir / "tokenizer_config.json", staging / "tokenizer_config.json")
+    shutil.copyfile(model_dir / spec["tokenizer"], staging / "sentencepiece.model")
+    return weights
+
+
+def run_converter(converter: Path, staged_weights: Path, staging: Path, output: Path, quant_type: str, overwrite: bool) -> None:
+    command = [
+        str(converter),
+        "--input",
+        str(staged_weights),
+        "--root",
+        str(staging),
+        "--family",
+        "niagara_asr",
+        "--model-spec",
+        str(SPEC),
+        "--type",
+        quant_type,
+        "--output",
+        str(output),
+    ]
+    if overwrite:
+        command.append("--overwrite")
+    print("+", " ".join(command), flush=True)
+    subprocess.run(command, check=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--variant", choices=sorted(REPOS), required=True)
+    parser.add_argument("--model-dir", type=Path, help="directory containing the Niagara HF files")
+    parser.add_argument("--converter", type=Path, required=True, help="path to audiocpp_gguf")
+    parser.add_argument("--output", type=Path, help="output GGUF path")
+    parser.add_argument("--type", default="orig", choices=["orig", "f16", "bf16", "q8_0", "q4_k", "q5_k", "q6_k"])
+    parser.add_argument("--overwrite", action="store_true")
+    parser.add_argument("--keep-staging", type=Path, help="keep staged safetensors and sidecars in this directory")
+    parser.add_argument("--no-download", action="store_true", help="require all HF files to already exist locally")
+    args = parser.parse_args()
+
+    spec = REPOS[args.variant]
+    model_dir = args.model_dir or (Path("models") / spec["base"])
+    if not args.no_download:
+        download_if_missing(model_dir, args.variant)
+    output = args.output or Path(spec["output"])
+
+    if args.keep_staging is not None:
+        staging = args.keep_staging
+        staged_weights = stage_from_pt2(model_dir, args.variant, staging)
+        run_converter(args.converter, staged_weights, staging, output, args.type, args.overwrite)
+        return
+
+    with tempfile.TemporaryDirectory(prefix=f"niagara-{args.variant}-") as tmp:
+        staging = Path(tmp)
+        staged_weights = stage_from_pt2(model_dir, args.variant, staging)
+        run_converter(args.converter, staged_weights, staging, output, args.type, args.overwrite)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as error:
+        print(f"error: {error}", file=sys.stderr)
+        raise

--- a/tests/niagara_asr/niagara_asr_warm_bench.cpp
+++ b/tests/niagara_asr/niagara_asr_warm_bench.cpp
@@ -1,0 +1,15 @@
+#include "../core/audio_task_warm_bench.h"
+
+int main(int argc, char ** argv) {
+    try {
+        engine::tools::AudioTaskBenchConfig config;
+        config.family = "niagara_asr";
+        config.default_model = "models/Niagara-19M-Batch-EN-GGUF";
+        config.task = engine::runtime::VoiceTaskKind::Asr;
+        config.output_kind = engine::tools::AudioTaskOutputKind::Asr;
+        return engine::tools::run_audio_task_warm_bench(argc, argv, config);
+    } catch (const std::exception & ex) {
+        std::cerr << "niagara_asr_warm_bench failed: " << ex.what() << "\n";
+        return 1;
+    }
+}

--- a/tests/niagara_asr/niagara_asr_warm_bench_cases.json
+++ b/tests/niagara_asr/niagara_asr_warm_bench_cases.json
@@ -1,0 +1,17 @@
+{
+  "warmup": {
+    "audio": "assets/asr_validation/librispeech/librispeech_test_clean_6930-75918-0000.wav"
+  },
+  "requests": [
+    {
+      "id": "librispeech_clean_short",
+      "audio": "assets/asr_validation/librispeech/librispeech_test_clean_6930-75918-0000.wav",
+      "expected_text": "concord returned to its place amidst the tents"
+    },
+    {
+      "id": "librispeech_clean_long",
+      "audio": "assets/asr_validation/librispeech/librispeech_test_clean_6930-75918-0001.wav",
+      "expected_text": "the english forwarded to the french baskets of flowers of which they had made a plentiful provision to greet the arrival of the young princess the french in return invited the english to a supper which was to be given the next day"
+    }
+  ]
+}

--- a/tests/unittests/test_transpose_module.cpp
+++ b/tests/unittests/test_transpose_module.cpp
@@ -1,0 +1,121 @@
+#include "engine/framework/core/backend.h"
+#include "engine/framework/core/module.h"
+#include "engine/framework/modules/structural_modules.h"
+#include "test_assert.h"
+
+#include <ggml-backend.h>
+#include <ggml.h>
+
+#include <cstddef>
+#include <exception>
+#include <iostream>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+
+std::vector<float> make_input_values(int64_t batch, int64_t time, int64_t freq, int64_t channels) {
+    std::vector<float> values(static_cast<size_t>(batch * time * freq * channels), 0.0F);
+    for (int64_t b = 0; b < batch; ++b) {
+        for (int64_t t = 0; t < time; ++t) {
+            for (int64_t f = 0; f < freq; ++f) {
+                for (int64_t c = 0; c < channels; ++c) {
+                    const auto index = static_cast<size_t>(((b * time + t) * freq + f) * channels + c);
+                    values[index] = static_cast<float>(1000 * b + 100 * t + 10 * f + c);
+                }
+            }
+        }
+    }
+    return values;
+}
+
+std::vector<float> expected_transpose_0231(const std::vector<float> & input, int64_t batch, int64_t time, int64_t freq, int64_t channels) {
+    std::vector<float> expected(static_cast<size_t>(batch * freq * channels * time), 0.0F);
+    for (int64_t b = 0; b < batch; ++b) {
+        for (int64_t f = 0; f < freq; ++f) {
+            for (int64_t c = 0; c < channels; ++c) {
+                for (int64_t t = 0; t < time; ++t) {
+                    const auto input_index = static_cast<size_t>(((b * time + t) * freq + f) * channels + c);
+                    const auto output_index = static_cast<size_t>(((b * freq + f) * channels + c) * time + t);
+                    expected[output_index] = input[input_index];
+                }
+            }
+        }
+    }
+    return expected;
+}
+
+void test_non_self_inverse_transpose_matches_logical_axes() {
+    constexpr int64_t batch = 2;
+    constexpr int64_t time = 3;
+    constexpr int64_t freq = 4;
+    constexpr int64_t channels = 5;
+
+    auto * backend = engine::core::init_backend({engine::core::BackendType::Cpu, 0, 1});
+    engine::test::require(backend != nullptr, "failed to initialize CPU backend");
+
+    ggml_init_params params{};
+    params.mem_size = 4 * 1024 * 1024;
+    params.mem_buffer = nullptr;
+    params.no_alloc = true;
+    ggml_context * ggml_ctx = ggml_init(params);
+    if (ggml_ctx == nullptr) {
+        ggml_backend_free(backend);
+        throw std::runtime_error("failed to initialize ggml context");
+    }
+
+    try {
+        engine::core::ModuleBuildContext ctx{ggml_ctx, "transpose_module_test", engine::core::BackendType::Cpu};
+        auto input = engine::core::make_tensor(
+            ctx,
+            GGML_TYPE_F32,
+            engine::core::TensorShape::from_dims({batch, time, freq, channels}));
+
+        auto transposed = engine::modules::TransposeModule({{0, 2, 3, 1}, 4}).build(ctx, input);
+        engine::test::require_eq(transposed.shape.rank, static_cast<size_t>(4), "transpose rank");
+        engine::test::require_eq(transposed.shape.dims[0], batch, "transpose dim 0");
+        engine::test::require_eq(transposed.shape.dims[1], freq, "transpose dim 1");
+        engine::test::require_eq(transposed.shape.dims[2], channels, "transpose dim 2");
+        engine::test::require_eq(transposed.shape.dims[3], time, "transpose dim 3");
+
+        auto output = engine::core::ensure_backend_addressable_layout(ctx, transposed);
+        ggml_cgraph * graph = ggml_new_graph_custom(ggml_ctx, 64, false);
+        ggml_build_forward_expand(graph, output.tensor);
+
+        auto * buffer = ggml_backend_alloc_ctx_tensors(ggml_ctx, backend);
+        engine::test::require(buffer != nullptr, "failed to allocate transpose test tensors");
+
+        const auto input_values = make_input_values(batch, time, freq, channels);
+        engine::core::write_tensor_f32(input, input_values);
+        const auto status = engine::core::compute_backend_graph(backend, graph, nullptr, "TransposeModule non-self-inverse test");
+        engine::test::require(status == GGML_STATUS_SUCCESS, "transpose compute failed");
+
+        const auto actual = engine::core::read_tensor_f32(output.tensor);
+        const auto expected = expected_transpose_0231(input_values, batch, time, freq, channels);
+        engine::test::require_eq(actual.size(), expected.size(), "transpose output value count");
+        for (size_t i = 0; i < expected.size(); ++i) {
+            engine::test::require_close(actual[i], expected[i], 0.0F, "transpose value " + std::to_string(i));
+        }
+
+        ggml_backend_buffer_free(buffer);
+        ggml_free(ggml_ctx);
+        ggml_backend_free(backend);
+    } catch (...) {
+        ggml_free(ggml_ctx);
+        ggml_backend_free(backend);
+        throw;
+    }
+}
+
+}  // namespace
+
+int main() {
+    try {
+        test_non_self_inverse_transpose_matches_logical_axes();
+        std::cout << "transpose_module_test passed\n";
+        return 0;
+    } catch (const std::exception & ex) {
+        std::cerr << "transpose_module_test failed: " << ex.what() << "\n";
+        return 1;
+    }
+}

--- a/tests/warmbench.py
+++ b/tests/warmbench.py
@@ -309,6 +309,16 @@ FAMILY_CONFIG: dict[str, dict[str, Any]] = {
         "case_catalog": "tests/nemotron_asr/nemotron_asr_warm_bench_cases.json",
         "default_requests_per_session": 1,
     },
+    "niagara_asr": {
+        "kind": "asr",
+        "modes": ["offline"],
+        "cpp_bin": "build/debug/bin/niagara_asr_warm_bench",
+        "python_script": "tests/niagara_asr/niagara_asr_python_warm_bench.py",
+        "model": "models/Niagara-19M-Batch-EN-GGUF",
+        "python_model": "models/niagara-19m-batch.en",
+        "case_catalog": "tests/niagara_asr/niagara_asr_warm_bench_cases.json",
+        "default_requests_per_session": 2,
+    },
     "muscriptor": {
         "kind": "asr",
         "modes": ["offline"],
@@ -3909,6 +3919,8 @@ def build_catalog_asr_commands(
             "--keep-language-tags-sequence",
             csv_bools(request_cases, "keep_language_tags", bool(warmup_case.get("keep_language_tags", False))),
         ])
+    elif family == "niagara_asr":
+        pass
     elif family == "muscriptor":
         common.extend([
             "--instruments",
@@ -5549,7 +5561,7 @@ def run_scenario(
                 "transcripts": getattr(args, f"{family}_request_transcripts"),
                 "expected_words": [item.get("expected_words", []) for item in request_cases],
             }
-        elif family in {"higgs_audio_stt", "hviske_asr", "nemotron_asr", "muscriptor", "vibevoice_asr", "voxtral_realtime"}:
+        elif family in {"higgs_audio_stt", "hviske_asr", "nemotron_asr", "niagara_asr", "muscriptor", "vibevoice_asr", "voxtral_realtime"}:
             if len(args.case_names) > 1:
                 raise RuntimeError(f"{family} warmbench accepts at most one --case-name")
             case_name = args.case_names[0] if args.case_names else str(config.get("default_case_name", ""))

--- a/tools/audiocpp_cli/audiocpp_cli_path_cases.json
+++ b/tools/audiocpp_cli/audiocpp_cli_path_cases.json
@@ -2470,6 +2470,33 @@
       ]
     },
     {
+      "id": "niagara_asr_paths",
+      "coverage": "Niagara ASR offline CPU CTC decode on short and longer Librispeech inputs with session reuse",
+      "family": "niagara_asr",
+      "model": "models/Niagara-19M-Batch-EN-GGUF",
+      "task": "asr",
+      "mode": "offline",
+      "outputs": [
+        "text"
+      ],
+      "requests": [
+        {
+          "id": "librispeech_clean_short",
+          "audio": "assets/asr_validation/librispeech/librispeech_test_clean_6930-75918-0000.wav",
+          "options": {
+            "audio_chunk_mode": "none"
+          }
+        },
+        {
+          "id": "librispeech_clean_long",
+          "audio": "assets/asr_validation/librispeech/librispeech_test_clean_6930-75918-0001.wav",
+          "options": {
+            "audio_chunk_mode": "none"
+          }
+        }
+      ]
+    },
+    {
       "id": "higgs_audio_stt_paths",
       "coverage": "Higgs Audio STT default prompt, custom prompt, enable_thinking on/off, max-token variation, and session reuse paths",
       "family": "higgs_audio_stt",


### PR DESCRIPTION
Adds Niagara ASR support for the 19M and 38M batch English variants.

Includes the model implementation under `models`, GGUF conversion/test tooling under `tests/niagara_asr`, and focused validation coverage.