### PR TITLE
Rename Moonshine STT to ASR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1251,17 +1251,17 @@ audiocpp_add_model(nemotron_asr
         engine::models::nemotron_asr::make_nemotron_asr_loader
 )
 
-audiocpp_add_model(moonshine_stt
+audiocpp_add_model(moonshine_asr
     SOURCES
-        src/models/moonshine_stt/assets.cpp
-        src/models/moonshine_stt/runtime.cpp
-        src/models/moonshine_stt/session.cpp
-        src/models/moonshine_stt/weights.cpp
+        src/models/moonshine_asr/assets.cpp
+        src/models/moonshine_asr/runtime.cpp
+        src/models/moonshine_asr/session.cpp
+        src/models/moonshine_asr/weights.cpp
     INCLUDES
-        engine/models/moonshine_stt/session.h
-        engine/models/moonshine_stt/runtime.h
+        engine/models/moonshine_asr/session.h
+        engine/models/moonshine_asr/runtime.h
     LOADERS
-        engine::models::moonshine_stt::make_moonshine_stt_loader
+        engine::models::moonshine_asr::make_moonshine_asr_loader
 )
 
 audiocpp_add_model(qwen3_tts

--- a/include/engine/models/moonshine_asr/assets.h
+++ b/include/engine/models/moonshine_asr/assets.h
@@ -9,7 +9,7 @@
 #include <string>
 #include <vector>
 
-namespace engine::models::moonshine_stt {
+namespace engine::models::moonshine_asr {
 
 struct MoonshineSlidingWindow {
     int64_t past = 16;
@@ -74,10 +74,10 @@ struct MoonshineAssets {
     std::vector<MoonshineToken> tokens;
 };
 
-std::shared_ptr<const MoonshineAssets> load_moonshine_stt_assets(const std::filesystem::path & model_path);
+std::shared_ptr<const MoonshineAssets> load_moonshine_asr_assets(const std::filesystem::path & model_path);
 
 std::string decode_moonshine_tokens(
     const MoonshineAssets & assets,
     const std::vector<int32_t> & token_ids);
 
-}  // namespace engine::models::moonshine_stt
+}  // namespace engine::models::moonshine_asr

--- a/include/engine/models/moonshine_asr/runtime.h
+++ b/include/engine/models/moonshine_asr/runtime.h
@@ -13,7 +13,7 @@ namespace engine::core {
 class ExecutionContext;
 }
 
-namespace engine::models::moonshine_stt {
+namespace engine::models::moonshine_asr {
 
 struct MoonshineAssets;
 struct MoonshineConfig;
@@ -34,7 +34,7 @@ MoonshineRuntimeConfig make_moonshine_runtime_config(
     engine::core::BackendType backend_type,
     const std::unordered_map<std::string, std::string> & options);
 
-runtime::TaskResult transcribe_moonshine_stt(
+runtime::TaskResult transcribe_moonshine_asr(
     const MoonshineAssets & assets,
     const MoonshineWeights & weights,
     const engine::core::ExecutionContext & execution_context,
@@ -42,4 +42,4 @@ runtime::TaskResult transcribe_moonshine_stt(
     const std::unordered_map<std::string, std::string> & options,
     const MoonshineRuntimeConfig & config);
 
-}  // namespace engine::models::moonshine_stt
+}  // namespace engine::models::moonshine_asr

--- a/include/engine/models/moonshine_asr/session.h
+++ b/include/engine/models/moonshine_asr/session.h
@@ -3,17 +3,17 @@
 #include "engine/framework/model_spec/metadata.h"
 #include "engine/framework/runtime/model.h"
 #include "engine/framework/runtime/session_base.h"
-#include "engine/models/moonshine_stt/runtime.h"
+#include "engine/models/moonshine_asr/runtime.h"
 
 #include <memory>
 #include <string>
 
-namespace engine::models::moonshine_stt {
+namespace engine::models::moonshine_asr {
 
 struct MoonshineAssets;
 struct MoonshineWeights;
 
-std::shared_ptr<runtime::IVoiceModelLoader> make_moonshine_stt_loader();
+std::shared_ptr<runtime::IVoiceModelLoader> make_moonshine_asr_loader();
 
 class MoonshineSTTSession final
     : public runtime::RuntimeSessionBase
@@ -52,4 +52,4 @@ private:
     bool stream_started_ = false;
 };
 
-}  // namespace engine::models::moonshine_stt
+}  // namespace engine::models::moonshine_asr

--- a/include/engine/models/moonshine_asr/weights.h
+++ b/include/engine/models/moonshine_asr/weights.h
@@ -6,13 +6,13 @@
 #include "engine/framework/modules/conv_modules.h"
 #include "engine/framework/modules/linear_module.h"
 #include "engine/framework/modules/norm_modules.h"
-#include "engine/models/moonshine_stt/assets.h"
+#include "engine/models/moonshine_asr/assets.h"
 
 #include <memory>
 #include <optional>
 #include <vector>
 
-namespace engine::models::moonshine_stt {
+namespace engine::models::moonshine_asr {
 
 struct MoonshineFrontendWeights {
     float log_k = 0.0F;
@@ -59,7 +59,7 @@ struct MoonshineWeights {
     MoonshineDecoderWeights decoder;
 };
 
-std::shared_ptr<const MoonshineWeights> load_moonshine_stt_weights(
+std::shared_ptr<const MoonshineWeights> load_moonshine_asr_weights(
     const MoonshineAssets & assets,
     ggml_backend_t backend,
     engine::core::BackendType backend_type,
@@ -68,4 +68,4 @@ std::shared_ptr<const MoonshineWeights> load_moonshine_stt_weights(
     engine::assets::TensorStorageType conv_storage_type,
     size_t weight_context_bytes);
 
-}  // namespace engine::models::moonshine_stt
+}  // namespace engine::models::moonshine_asr

--- a/model_specs/moonshine_asr.json
+++ b/model_specs/moonshine_asr.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
-  "family": "moonshine_stt",
-  "display_name": "Moonshine Streaming STT",
+  "family": "moonshine_asr",
+  "display_name": "Moonshine Streaming ASR",
   "description": "Moonshine tiny/small/medium streaming English speech recognition models.",
   "category": "asr",
   "status": "experimental",

--- a/src/models/moonshine_asr/assets.cpp
+++ b/src/models/moonshine_asr/assets.cpp
@@ -1,4 +1,4 @@
-#include "engine/models/moonshine_stt/assets.h"
+#include "engine/models/moonshine_asr/assets.h"
 
 #include "engine/framework/io/json.h"
 #include "engine/framework/model_spec/package.h"
@@ -10,7 +10,7 @@
 #include <string>
 #include <utility>
 
-namespace engine::models::moonshine_stt {
+namespace engine::models::moonshine_asr {
 namespace json = engine::io::json;
 namespace {
 
@@ -33,7 +33,7 @@ MoonshineConfig parse_config(const assets::ResourceBundle & resources) {
     config.variant = json::optional_string(root, "_name_or_path", config.model_type);
     config.max_tokens_per_second = json::optional_f32(root, "max_tokens_per_second", config.max_tokens_per_second);
     if (config.model_type != "moonshine_streaming") {
-        throw std::runtime_error("Moonshine STT unsupported model_type: " + config.model_type);
+        throw std::runtime_error("Moonshine ASR unsupported model_type: " + config.model_type);
     }
 
     const auto & enc = root.require("encoder_config");
@@ -78,13 +78,13 @@ MoonshineConfig parse_config(const assets::ResourceBundle & resources) {
         static_cast<int64_t>(std::floor(static_cast<double>(config.decoder.head_dim) *
                                         static_cast<double>(config.decoder.partial_rotary_factor)));
     if (config.encoder.hidden_act != "gelu") {
-        throw std::runtime_error("Moonshine STT unsupported encoder hidden_act: " + config.encoder.hidden_act);
+        throw std::runtime_error("Moonshine ASR unsupported encoder hidden_act: " + config.encoder.hidden_act);
     }
     if (config.decoder.hidden_act != "silu") {
-        throw std::runtime_error("Moonshine STT unsupported decoder hidden_act: " + config.decoder.hidden_act);
+        throw std::runtime_error("Moonshine ASR unsupported decoder hidden_act: " + config.decoder.hidden_act);
     }
     if (config.encoder.sliding_windows.size() != static_cast<size_t>(config.encoder.layers)) {
-        throw std::runtime_error("Moonshine STT sliding window count must match encoder layers");
+        throw std::runtime_error("Moonshine ASR sliding window count must match encoder layers");
     }
     return config;
 }
@@ -152,14 +152,14 @@ std::string replace_metaspace(std::string text) {
 
 }  // namespace
 
-std::shared_ptr<const MoonshineAssets> load_moonshine_stt_assets(const std::filesystem::path & model_path) {
+std::shared_ptr<const MoonshineAssets> load_moonshine_asr_assets(const std::filesystem::path & model_path) {
     MoonshineAssets assets;
-    assets.resources = engine::model_spec::load_resource_bundle_for_family(model_path, "moonshine_stt");
+    assets.resources = engine::model_spec::load_resource_bundle_for_family(model_path, "moonshine_asr");
     assets.config = parse_config(assets.resources);
     assets.source = assets.resources.open_tensor_source("weights");
     assets.tokens = load_tokens(assets.resources.require_file("tokenizer_json"));
     if (assets.tokens.size() < static_cast<size_t>(assets.config.decoder.vocab_size)) {
-        throw std::runtime_error("Moonshine STT tokenizer vocab is smaller than model vocab");
+        throw std::runtime_error("Moonshine ASR tokenizer vocab is smaller than model vocab");
     }
     assets::require_tensor_shape(
         *assets.source,
@@ -198,4 +198,4 @@ std::string decode_moonshine_tokens(
     return text;
 }
 
-}  // namespace engine::models::moonshine_stt
+}  // namespace engine::models::moonshine_asr

--- a/src/models/moonshine_asr/runtime.cpp
+++ b/src/models/moonshine_asr/runtime.cpp
@@ -1,4 +1,4 @@
-#include "engine/models/moonshine_stt/runtime.h"
+#include "engine/models/moonshine_asr/runtime.h"
 
 #include "engine/framework/audio/conversion.h"
 #include "engine/framework/core/backend.h"
@@ -20,8 +20,8 @@
 #include "engine/framework/runtime/kv_cache.h"
 #include "engine/framework/runtime/options.h"
 #include "engine/framework/sampling/hf_sampler.h"
-#include "engine/models/moonshine_stt/assets.h"
-#include "engine/models/moonshine_stt/weights.h"
+#include "engine/models/moonshine_asr/assets.h"
+#include "engine/models/moonshine_asr/weights.h"
 
 #include <ggml-alloc.h>
 #include <ggml-backend.h>
@@ -41,7 +41,7 @@
 #include <utility>
 #include <vector>
 
-namespace engine::models::moonshine_stt {
+namespace engine::models::moonshine_asr {
 namespace {
 
 using Clock = std::chrono::steady_clock;
@@ -51,7 +51,7 @@ constexpr size_t kDefaultGraphArenaBytes = 512ull * 1024ull * 1024ull;
 
 engine::modules::GeluApproximation parse_encoder_gelu_approximation(
     const std::unordered_map<std::string, std::string> & options) {
-    const auto value = runtime::find_option(options, {"moonshine_stt.encoder_gelu"});
+    const auto value = runtime::find_option(options, {"moonshine_asr.encoder_gelu"});
     if (!value.has_value() || *value == "quick") {
         return engine::modules::GeluApproximation::Quick;
     }
@@ -61,7 +61,7 @@ engine::modules::GeluApproximation parse_encoder_gelu_approximation(
     if (*value == "tanh") {
         return engine::modules::GeluApproximation::Tanh;
     }
-    throw std::runtime_error("moonshine_stt.encoder_gelu must be erf, exact, tanh, or quick");
+    throw std::runtime_error("moonshine_asr.encoder_gelu must be erf, exact, tanh, or quick");
 }
 
 struct GgmlContextDeleter {
@@ -482,7 +482,7 @@ public:
         if (ctx_ == nullptr) {
             throw std::runtime_error("failed to initialize Moonshine encoder graph context");
         }
-        engine::core::ModuleBuildContext ctx{ctx_.get(), "moonshine_stt.encoder", execution_context.backend_type()};
+        engine::core::ModuleBuildContext ctx{ctx_.get(), "moonshine_asr.encoder", execution_context.backend_type()};
         input_ = engine::core::make_tensor(
             ctx,
             GGML_TYPE_F32,
@@ -593,9 +593,9 @@ public:
         for (const auto & mask : masks_) {
             engine::core::write_tensor_f16(mask.tensor, mask.values);
         }
-        debug::trace_log_scalar("moonshine_stt.encoder_attention_masks", static_cast<int64_t>(masks_.size()));
-        debug::trace_log_scalar("moonshine_stt.encoder_blas_scheduler", use_scheduler_);
-        debug::timing_log_scalar("moonshine_stt.encoder_graph_build_ms", engine::debug::elapsed_ms(build_start));
+        debug::trace_log_scalar("moonshine_asr.encoder_attention_masks", static_cast<int64_t>(masks_.size()));
+        debug::trace_log_scalar("moonshine_asr.encoder_blas_scheduler", use_scheduler_);
+        debug::timing_log_scalar("moonshine_asr.encoder_graph_build_ms", engine::debug::elapsed_ms(build_start));
     }
 
     ~EncoderGraph() {
@@ -618,7 +618,7 @@ public:
         engine::core::write_tensor_f32(input_, frames);
         const ggml_status status = use_scheduler_
             ? ggml_backend_sched_graph_compute(sched_.get(), graph_)
-            : engine::core::compute_graph(execution_context, graph_, plan_, "moonshine_stt.encoder");
+            : engine::core::compute_graph(execution_context, graph_, plan_, "moonshine_asr.encoder");
         if (status != GGML_STATUS_SUCCESS) {
             throw std::runtime_error("Moonshine encoder graph compute failed");
         }
@@ -627,7 +627,7 @@ public:
         } else {
             ggml_backend_synchronize(backend_);
         }
-        debug::timing_log_scalar("moonshine_stt.encoder_compute_ms", engine::debug::elapsed_ms(compute_start));
+        debug::timing_log_scalar("moonshine_asr.encoder_compute_ms", engine::debug::elapsed_ms(compute_start));
         return engine::core::read_tensor_f32(output_);
     }
 
@@ -736,12 +736,12 @@ public:
         }
         const auto start = Clock::now();
         ggml_backend_tensor_set(memory_, memory.data(), 0, memory.size() * sizeof(float));
-        if (engine::core::compute_graph(execution_context, cross_graph_, cross_plan_, "moonshine_stt.decoder.cross_kv") != GGML_STATUS_SUCCESS) {
+        if (engine::core::compute_graph(execution_context, cross_graph_, cross_plan_, "moonshine_asr.decoder.cross_kv") != GGML_STATUS_SUCCESS) {
             throw std::runtime_error("Moonshine decoder cross-KV graph compute failed");
         }
         ggml_backend_synchronize(backend_);
         reset_state();
-        debug::timing_log_scalar("moonshine_stt.decode_cross_kv_ms", engine::debug::elapsed_ms(start));
+        debug::timing_log_scalar("moonshine_asr.decode_cross_kv_ms", engine::debug::elapsed_ms(start));
     }
 
     std::vector<float> run_step(
@@ -764,7 +764,7 @@ public:
         step_upload_ms_ += engine::debug::elapsed_ms(upload_start);
 
         const auto compute_start = Clock::now();
-        if (engine::core::compute_graph(execution_context, step_graph_, step_plan_, "moonshine_stt.decoder.step") != GGML_STATUS_SUCCESS) {
+        if (engine::core::compute_graph(execution_context, step_graph_, step_plan_, "moonshine_asr.decoder.step") != GGML_STATUS_SUCCESS) {
             throw std::runtime_error("Moonshine decoder step graph compute failed");
         }
         ggml_backend_synchronize(backend_);
@@ -783,10 +783,10 @@ public:
     }
 
     void log_step_timings() const {
-        debug::timing_log_scalar("moonshine_stt.decode_step_count", step_count_);
-        debug::timing_log_scalar("moonshine_stt.decode_step_upload_ms", step_upload_ms_);
-        debug::timing_log_scalar("moonshine_stt.decode_step_compute_ms", step_compute_ms_);
-        debug::timing_log_scalar("moonshine_stt.decode_step_read_ms", step_read_ms_);
+        debug::timing_log_scalar("moonshine_asr.decode_step_count", step_count_);
+        debug::timing_log_scalar("moonshine_asr.decode_step_upload_ms", step_upload_ms_);
+        debug::timing_log_scalar("moonshine_asr.decode_step_compute_ms", step_compute_ms_);
+        debug::timing_log_scalar("moonshine_asr.decode_step_read_ms", step_read_ms_);
     }
 
 private:
@@ -797,7 +797,7 @@ private:
         size_t /*graph_arena_bytes*/) {
         const auto & config = assets.config.decoder;
         memory_hidden_ = config.hidden_size;
-        engine::core::ModuleBuildContext ctx{cross_ctx_.get(), "moonshine_stt.decoder.cross_kv", execution_context.backend_type()};
+        engine::core::ModuleBuildContext ctx{cross_ctx_.get(), "moonshine_asr.decoder.cross_kv", execution_context.backend_type()};
         auto memory = engine::core::wrap_tensor(
             memory_,
             engine::core::TensorShape::from_dims({1, memory_frames_, config.hidden_size}),
@@ -835,7 +835,7 @@ private:
         std::vector<engine::core::TensorValue> self_keys,
         std::vector<engine::core::TensorValue> self_values) {
         const auto & config = assets.config.decoder;
-        engine::core::ModuleBuildContext ctx{step_ctx_.get(), "moonshine_stt.decoder.step", execution_context.backend_type()};
+        engine::core::ModuleBuildContext ctx{step_ctx_.get(), "moonshine_asr.decoder.step", execution_context.backend_type()};
         auto ids = engine::core::wrap_tensor(token_id_, engine::core::TensorShape::from_dims({1}), GGML_TYPE_I32);
         auto positions = engine::core::wrap_tensor(position_, engine::core::TensorShape::from_dims({1}), GGML_TYPE_I32);
         auto cache_slot = engine::core::wrap_tensor(cache_slot_, engine::core::TensorShape::from_dims({1}), GGML_TYPE_I32);
@@ -971,9 +971,9 @@ MoonshineRuntimeConfig make_moonshine_runtime_config(
     const std::unordered_map<std::string, std::string> & options) {
     MoonshineRuntimeConfig runtime_config;
     runtime_config.weight_context_bytes =
-        runtime::parse_size_mb_option(options, {"moonshine_stt.weight_context_mb"}, kDefaultWeightContextBytes);
+        runtime::parse_size_mb_option(options, {"moonshine_asr.weight_context_mb"}, kDefaultWeightContextBytes);
     runtime_config.graph_arena_bytes =
-        runtime::parse_size_mb_option(options, {"moonshine_stt.graph_arena_mb"}, kDefaultGraphArenaBytes);
+        runtime::parse_size_mb_option(options, {"moonshine_asr.graph_arena_mb"}, kDefaultGraphArenaBytes);
     runtime_config.encoder_gelu = parse_encoder_gelu_approximation(options);
     const auto default_matmul_storage =
         backend_type == engine::core::BackendType::Cpu &&
@@ -984,7 +984,7 @@ MoonshineRuntimeConfig make_moonshine_runtime_config(
         : engine::assets::TensorStorageType::Native;
     runtime_config.encoder_weight_storage_type = runtime::parse_tensor_storage_option(
         options,
-        "moonshine_stt.weight_type",
+        "moonshine_asr.weight_type",
         default_matmul_storage,
         {
             engine::assets::TensorStorageType::Native,
@@ -993,8 +993,8 @@ MoonshineRuntimeConfig make_moonshine_runtime_config(
         });
     runtime_config.decoder_weight_storage_type = runtime::parse_tensor_storage_option(
         options,
-        "moonshine_stt.decoder_weight_type",
-        "moonshine_stt.weight_type",
+        "moonshine_asr.decoder_weight_type",
+        "moonshine_asr.weight_type",
         engine::assets::TensorStorageType::Native,
         {
             engine::assets::TensorStorageType::Native,
@@ -1003,20 +1003,20 @@ MoonshineRuntimeConfig make_moonshine_runtime_config(
         });
     runtime_config.conv_weight_storage_type = runtime::parse_tensor_storage_option(
         options,
-        "moonshine_stt.conv_weight_type",
+        "moonshine_asr.conv_weight_type",
         engine::assets::TensorStorageType::Native,
         {
             engine::assets::TensorStorageType::Native,
             engine::assets::TensorStorageType::F32,
             engine::assets::TensorStorageType::F16,
         });
-    const auto cpu_blas_scheduler = runtime::find_option(options, {"moonshine_stt.cpu_blas_scheduler"});
+    const auto cpu_blas_scheduler = runtime::find_option(options, {"moonshine_asr.cpu_blas_scheduler"});
     runtime_config.cpu_blas_scheduler = !cpu_blas_scheduler.has_value() ||
-        runtime::parse_bool_option(*cpu_blas_scheduler, "moonshine_stt.cpu_blas_scheduler");
+        runtime::parse_bool_option(*cpu_blas_scheduler, "moonshine_asr.cpu_blas_scheduler");
     return runtime_config;
 }
 
-runtime::TaskResult transcribe_moonshine_stt(
+runtime::TaskResult transcribe_moonshine_asr(
     const MoonshineAssets & assets,
     const MoonshineWeights & weights,
     const engine::core::ExecutionContext & execution_context,
@@ -1031,7 +1031,7 @@ runtime::TaskResult transcribe_moonshine_stt(
         audio.sample_rate,
         audio.channels,
         static_cast<int>(assets.config.encoder.sample_rate));
-    debug::timing_log_scalar("moonshine_stt.resample_ms", engine::debug::elapsed_ms(resample_start));
+    debug::timing_log_scalar("moonshine_asr.resample_ms", engine::debug::elapsed_ms(resample_start));
 
     const auto frontend_start = Clock::now();
     const auto frames = prepare_compressed_frames(
@@ -1044,9 +1044,9 @@ runtime::TaskResult transcribe_moonshine_stt(
         return result;
     }
     const int64_t frame_count = static_cast<int64_t>(frames.size()) / assets.config.encoder.frame_length;
-    debug::timing_log_scalar("moonshine_stt.frontend_cpu_ms", engine::debug::elapsed_ms(frontend_start));
-    debug::trace_log_scalar("moonshine_stt.input_samples", mono.size());
-    debug::trace_log_scalar("moonshine_stt.input_frames", frame_count);
+    debug::timing_log_scalar("moonshine_asr.frontend_cpu_ms", engine::debug::elapsed_ms(frontend_start));
+    debug::trace_log_scalar("moonshine_asr.input_samples", mono.size());
+    debug::trace_log_scalar("moonshine_asr.input_frames", frame_count);
 
     EncoderGraph encoder_graph(
         assets,
@@ -1058,7 +1058,7 @@ runtime::TaskResult transcribe_moonshine_stt(
         config.graph_arena_bytes);
     const auto memory = encoder_graph.run(frames, execution_context);
     const int64_t memory_frames = encoder_graph.memory_frames();
-    debug::trace_log_scalar("moonshine_stt.memory_frames", memory_frames);
+    debug::trace_log_scalar("moonshine_asr.memory_frames", memory_frames);
 
     const int64_t audio_max_tokens = static_cast<int64_t>(
         std::ceil(static_cast<double>(memory_frames) * 0.020 * static_cast<double>(assets.config.max_tokens_per_second)));
@@ -1090,12 +1090,12 @@ runtime::TaskResult transcribe_moonshine_stt(
         const auto logits = decoder_graph.run_step(prefix.back(), static_cast<int32_t>(step), execution_context);
         const auto select_start = Clock::now();
         if (logits.size() != static_cast<size_t>(decoder_graph.vocab_size())) {
-            throw std::runtime_error("Moonshine STT logits shape mismatch");
+            throw std::runtime_error("Moonshine ASR logits shape mismatch");
         }
         const int32_t next = sampling::HfLogitsProcessor::argmax(
             logits.data(),
             logits.size(),
-            "Moonshine STT greedy decode");
+            "Moonshine ASR greedy decode");
         decode_step_select_ms += engine::debug::elapsed_ms(select_start);
         if (next == assets.config.decoder.eos_token_id) {
             break;
@@ -1104,15 +1104,15 @@ runtime::TaskResult transcribe_moonshine_stt(
         prefix.push_back(next);
     }
     decoder_graph.log_step_timings();
-    debug::timing_log_scalar("moonshine_stt.decode_step_select_ms", decode_step_select_ms);
-    debug::timing_log_scalar("moonshine_stt.decode_ms", engine::debug::elapsed_ms(decode_start));
-    debug::trace_log_scalar("moonshine_stt.output_tokens", decoded.size());
+    debug::timing_log_scalar("moonshine_asr.decode_step_select_ms", decode_step_select_ms);
+    debug::timing_log_scalar("moonshine_asr.decode_ms", engine::debug::elapsed_ms(decode_start));
+    debug::trace_log_scalar("moonshine_asr.output_tokens", decoded.size());
 
     runtime::TaskResult result;
     result.text_output = runtime::Transcript{decode_moonshine_tokens(assets, decoded), "en"};
-    debug::timing_log_scalar("moonshine_stt.run_ms", engine::debug::elapsed_ms(start, Clock::now()));
+    debug::timing_log_scalar("moonshine_asr.run_ms", engine::debug::elapsed_ms(start, Clock::now()));
     return result;
 }
 
 
-}  // namespace engine::models::moonshine_stt
+}  // namespace engine::models::moonshine_asr

--- a/src/models/moonshine_asr/session.cpp
+++ b/src/models/moonshine_asr/session.cpp
@@ -1,21 +1,21 @@
-#include "engine/models/moonshine_stt/session.h"
+#include "engine/models/moonshine_asr/session.h"
 
-#include "engine/models/moonshine_stt/runtime.h"
-#include "engine/models/moonshine_stt/assets.h"
-#include "engine/models/moonshine_stt/weights.h"
+#include "engine/models/moonshine_asr/runtime.h"
+#include "engine/models/moonshine_asr/assets.h"
+#include "engine/models/moonshine_asr/weights.h"
 #include "engine/framework/runtime/spec_backed_model.h"
 
 #include <stdexcept>
 #include <utility>
 
-namespace engine::models::moonshine_stt {
+namespace engine::models::moonshine_asr {
 namespace {
 
-constexpr const char * kFamily = "moonshine_stt";
+constexpr const char * kFamily = "moonshine_asr";
 
 std::shared_ptr<const MoonshineAssets> require_assets(std::shared_ptr<const MoonshineAssets> assets) {
     if (assets == nullptr) {
-        throw std::runtime_error("Moonshine STT session requires assets");
+        throw std::runtime_error("Moonshine ASR session requires assets");
     }
     return assets;
 }
@@ -23,12 +23,12 @@ std::shared_ptr<const MoonshineAssets> require_assets(std::shared_ptr<const Moon
 std::shared_ptr<const engine::model_spec::ModelContract> require_contract(
     std::shared_ptr<const engine::model_spec::ModelContract> contract) {
     if (contract == nullptr) {
-        throw std::runtime_error("Moonshine STT session requires a model contract");
+        throw std::runtime_error("Moonshine ASR session requires a model contract");
     }
     return contract;
 }
 
-std::unique_ptr<runtime::IVoiceTaskSession> create_moonshine_stt_session(
+std::unique_ptr<runtime::IVoiceTaskSession> create_moonshine_asr_session(
     const runtime::TaskSpec & task,
     const runtime::SessionOptions & options,
     std::shared_ptr<const MoonshineAssets> assets,
@@ -51,15 +51,15 @@ MoonshineSTTSession::MoonshineSTTSession(
       task_(task),
       assets_(require_assets(std::move(assets))),
       contract_(require_contract(std::move(contract))) {
-    runtime::validate_spec_backed_session_options(RuntimeSessionBase::options(), *contract_, kFamily, "Moonshine STT");
+    runtime::validate_spec_backed_session_options(RuntimeSessionBase::options(), *contract_, kFamily, "Moonshine ASR");
     if (task_.task != runtime::VoiceTaskKind::Asr) {
-        throw std::runtime_error("Moonshine STT only supports VoiceTaskKind::Asr");
+        throw std::runtime_error("Moonshine ASR only supports VoiceTaskKind::Asr");
     }
     if (task_.mode != runtime::RunMode::Offline && task_.mode != runtime::RunMode::Streaming) {
-        throw std::runtime_error("Moonshine STT supports offline and streaming sessions");
+        throw std::runtime_error("Moonshine ASR supports offline and streaming sessions");
     }
     runtime_config_ = make_moonshine_runtime_config(assets_->config, execution_context().backend_type(), options.options);
-    weights_ = load_moonshine_stt_weights(
+    weights_ = load_moonshine_asr_weights(
         *assets_,
         execution_context().backend(),
         execution_context().backend_type(),
@@ -84,20 +84,20 @@ runtime::RunMode MoonshineSTTSession::run_mode() const {
 }
 
 void MoonshineSTTSession::prepare(const runtime::SessionPreparationRequest & request) {
-    runtime::validate_spec_backed_request_options(request.options, *contract_, "Moonshine STT");
+    runtime::validate_spec_backed_request_options(request.options, *contract_, "Moonshine ASR");
     mark_prepared();
 }
 
 runtime::TaskResult MoonshineSTTSession::run(const runtime::TaskRequest & request) {
     require_prepared("run()");
     if (task_.mode != runtime::RunMode::Offline) {
-        throw std::runtime_error("Moonshine STT run() requires an offline session");
+        throw std::runtime_error("Moonshine ASR run() requires an offline session");
     }
     if (!request.audio_input.has_value()) {
-        throw std::runtime_error("Moonshine STT requires audio input");
+        throw std::runtime_error("Moonshine ASR requires audio input");
     }
-    runtime::validate_spec_backed_request_options(request.options, *contract_, "Moonshine STT");
-    return transcribe_moonshine_stt(
+    runtime::validate_spec_backed_request_options(request.options, *contract_, "Moonshine ASR");
+    return transcribe_moonshine_asr(
         *assets_,
         *weights_,
         execution_context(),
@@ -116,11 +116,11 @@ runtime::StreamingPolicy MoonshineSTTSession::streaming_policy() const {
 }
 
 void MoonshineSTTSession::start_stream(const runtime::TaskRequest & request) {
-    require_prepared("Moonshine STT start_stream()");
+    require_prepared("Moonshine ASR start_stream()");
     if (task_.mode != runtime::RunMode::Streaming) {
-        throw std::runtime_error("Moonshine STT start_stream() requires a streaming session");
+        throw std::runtime_error("Moonshine ASR start_stream() requires a streaming session");
     }
-    runtime::validate_spec_backed_request_options(request.options, *contract_, "Moonshine STT");
+    runtime::validate_spec_backed_request_options(request.options, *contract_, "Moonshine ASR");
     reset();
     streaming_request_ = request;
     streaming_request_.audio_input = std::nullopt;
@@ -141,19 +141,19 @@ void MoonshineSTTSession::reset() {
 
 runtime::StreamEvent MoonshineSTTSession::process_audio_chunk(const runtime::AudioChunk & chunk) {
     if (task_.mode != runtime::RunMode::Streaming) {
-        throw std::runtime_error("Moonshine STT process_audio_chunk() requires a streaming session");
+        throw std::runtime_error("Moonshine ASR process_audio_chunk() requires a streaming session");
     }
     if (!stream_started_) {
-        throw std::runtime_error("Moonshine STT process_audio_chunk() requires start_stream()");
+        throw std::runtime_error("Moonshine ASR process_audio_chunk() requires start_stream()");
     }
     if (chunk.sample_rate <= 0 || chunk.channels <= 0) {
-        throw std::runtime_error("Moonshine STT streaming chunk has invalid audio metadata");
+        throw std::runtime_error("Moonshine ASR streaming chunk has invalid audio metadata");
     }
     if (streaming_audio_.samples.empty()) {
         streaming_audio_.sample_rate = chunk.sample_rate;
         streaming_audio_.channels = chunk.channels;
     } else if (streaming_audio_.sample_rate != chunk.sample_rate || streaming_audio_.channels != chunk.channels) {
-        throw std::runtime_error("Moonshine STT streaming chunks must use one sample rate and channel count");
+        throw std::runtime_error("Moonshine ASR streaming chunks must use one sample rate and channel count");
     }
     streaming_audio_.samples.insert(streaming_audio_.samples.end(), chunk.samples.begin(), chunk.samples.end());
 
@@ -167,13 +167,13 @@ runtime::StreamEvent MoonshineSTTSession::process_audio_chunk(const runtime::Aud
 
 runtime::TaskResult MoonshineSTTSession::finalize() {
     if (task_.mode != runtime::RunMode::Streaming) {
-        throw std::runtime_error("Moonshine STT finalize() requires a streaming session");
+        throw std::runtime_error("Moonshine ASR finalize() requires a streaming session");
     }
     if (!stream_started_) {
-        throw std::runtime_error("Moonshine STT finalize() requires start_stream()");
+        throw std::runtime_error("Moonshine ASR finalize() requires start_stream()");
     }
-    runtime::validate_spec_backed_request_options(streaming_request_.options, *contract_, "Moonshine STT");
-    auto result = transcribe_moonshine_stt(
+    runtime::validate_spec_backed_request_options(streaming_request_.options, *contract_, "Moonshine ASR");
+    auto result = transcribe_moonshine_asr(
         *assets_,
         *weights_,
         execution_context(),
@@ -188,12 +188,12 @@ runtime::TaskResult MoonshineSTTSession::finish_stream() {
     return finalize();
 }
 
-std::shared_ptr<runtime::IVoiceModelLoader> make_moonshine_stt_loader() {
+std::shared_ptr<runtime::IVoiceModelLoader> make_moonshine_asr_loader() {
     runtime::SpecBackedVoiceModelConfig<MoonshineAssets> config;
     config.family = kFamily;
-    config.load_assets = load_moonshine_stt_assets;
-    config.create_session = create_moonshine_stt_session;
+    config.load_assets = load_moonshine_asr_assets;
+    config.create_session = create_moonshine_asr_session;
     return runtime::make_spec_backed_voice_loader(std::move(config));
 }
 
-}  // namespace engine::models::moonshine_stt
+}  // namespace engine::models::moonshine_asr

--- a/src/models/moonshine_asr/weights.cpp
+++ b/src/models/moonshine_asr/weights.cpp
@@ -1,4 +1,4 @@
-#include "engine/models/moonshine_stt/weights.h"
+#include "engine/models/moonshine_asr/weights.h"
 
 #include "engine/framework/debug/profiler.h"
 #include "engine/framework/modules/packed_linear_weights.h"
@@ -10,7 +10,7 @@
 #include <string>
 #include <utility>
 
-namespace engine::models::moonshine_stt {
+namespace engine::models::moonshine_asr {
 namespace {
 
 using Clock = std::chrono::steady_clock;
@@ -196,7 +196,7 @@ MoonshineDecoderLayerWeights load_decoder_layer(
 
 }  // namespace
 
-std::shared_ptr<const MoonshineWeights> load_moonshine_stt_weights(
+std::shared_ptr<const MoonshineWeights> load_moonshine_asr_weights(
     const MoonshineAssets & assets,
     ggml_backend_t backend,
     engine::core::BackendType backend_type,
@@ -209,7 +209,7 @@ std::shared_ptr<const MoonshineWeights> load_moonshine_stt_weights(
     weights->store = std::make_shared<engine::core::BackendWeightStore>(
         backend,
         backend_type,
-        "Moonshine STT",
+        "Moonshine ASR",
         weight_context_bytes);
     const auto & source = *assets.source;
     const auto & enc = assets.config.encoder;
@@ -217,7 +217,7 @@ std::shared_ptr<const MoonshineWeights> load_moonshine_stt_weights(
 
     const auto log_k = source.require_f32("model.encoder.embedder.comp.log_k");
     if (log_k.size() != 1) {
-        throw std::runtime_error("Moonshine STT log_k must contain one scalar");
+        throw std::runtime_error("Moonshine ASR log_k must contain one scalar");
     }
     weights->encoder.frontend.log_k = log_k.front();
     weights->encoder.frontend.linear = binding::linear_from_source(
@@ -285,8 +285,8 @@ std::shared_ptr<const MoonshineWeights> load_moonshine_stt_weights(
             dec.hidden_size,
             false);
     weights->store->upload();
-    debug::timing_log_scalar("moonshine_stt.weights_load_ms", engine::debug::elapsed_ms(start, Clock::now()));
+    debug::timing_log_scalar("moonshine_asr.weights_load_ms", engine::debug::elapsed_ms(start, Clock::now()));
     return weights;
 }
 
-}  // namespace engine::models::moonshine_stt
+}  // namespace engine::models::moonshine_asr

--- a/tools/community_models/convert_moonshine_asr.py
+++ b/tools/community_models/convert_moonshine_asr.py
@@ -10,7 +10,7 @@ import tempfile
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-SPEC = REPO_ROOT / "model_specs" / "moonshine_stt.json"
+SPEC = REPO_ROOT / "model_specs" / "moonshine_asr.json"
 SCALAR_TENSORS = {"model.encoder.embedder.comp.log_k"}
 
 
@@ -54,7 +54,7 @@ def convert(converter: Path, checkpoint: Path, output: Path, quant_type: str, ov
         ckpt = candidates[-1]
 
     output.parent.mkdir(parents=True, exist_ok=True)
-    with tempfile.TemporaryDirectory(prefix="moonshine-stt-convert-") as tmp_dir:
+    with tempfile.TemporaryDirectory(prefix="moonshine-asr-convert-") as tmp_dir:
         converted_input = Path(tmp_dir) / ckpt.name
         rank1_scalar_safetensors(ckpt, converted_input)
         command = [
@@ -64,7 +64,7 @@ def convert(converter: Path, checkpoint: Path, output: Path, quant_type: str, ov
             "--root",
             str(checkpoint),
             "--family",
-            "moonshine_stt",
+            "moonshine_asr",
             "--model-spec",
             str(SPEC),
             "--type",


### PR DESCRIPTION
Renames the Moonshine model family from `moonshine_stt` to `moonshine_asr`.

Updates model paths, CMake registration, spec family, converter name, runtime namespace, and option prefixes.