### PR TITLE
perf(vibevoice_asr_streaming): flash suffix attention and bounded history window

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2699,6 +2699,9 @@ if (ENGINE_BUILD_TESTS OR ENGINE_BUILD_EXTENDED_TESTS OR ENGINE_BUILD_MODEL_TEST
             tests/personaplex/personaplex_ring_kv_cache_parity.cpp
         )
         target_link_libraries(personaplex_ring_kv_cache_parity PRIVATE engine_runtime ggml)
+
+        add_engine_unittest(transformer_kv_ring_test tests/unittests/test_transformer_kv_ring.cpp)
+        add_test(NAME transformer_kv_ring_test COMMAND transformer_kv_ring_test)
         if (ENGINE_ENABLE_OPENMP)
             target_link_libraries(personaplex_ring_kv_cache_parity PRIVATE OpenMP::OpenMP_CXX)
         endif()

--- a/docs/models/vibevoice_asr.md
+++ b/docs/models/vibevoice_asr.md
@@ -219,3 +219,36 @@ Common request options:
 | `--repetition-penalty` | float | `1` | Generation repetition penalty. |
 | `--audio-chunk-mode` | `auto`, `fixed`, `vad`, `none` | `auto` | Offline audio chunking mode. |
 | `--audio-chunk-seconds` | float seconds | `1200` | Offline chunk duration for fixed and VAD chunking. |
+| `--session-option vibevoice_asr_streaming.max_history_steps=<n>` | integer | `0` (uncapped) | Rolling window for decoder history, in steps. Refer to [Long streams](#long-streams-and-the-history-window). |
+
+### Long streams and the history window
+
+By default, the decoder stores the full conversation history. Memory use
+increases with stream length (approximately 0.4 MiB per step on Q8/CUDA).
+On very long streams, the GPU memory becomes full and transcription stops.
+
+Set `max_history_steps` to prevent this. The model then stores only the
+most recent steps. Memory use remains constant for streams of any length.
+
+```bash
+audiocpp_cli --task asr --family vibevoice_asr_streaming \
+  --model models/VibeVoice-ASR-Streaming-7B-GGUF/vibevoice-asr-streaming-7b-q8_0.gguf \
+  --backend cuda --mode streaming --audio - --input-format s16le \
+  --session-option vibevoice_asr_streaming.max_history_steps=4096
+```
+
+The model always stores the streaming prompt. It never removes the prompt.
+New steps replace the oldest stored steps, but not the prompt.
+
+Each step is approximately one audio frame or one generated word part.
+Speech contains approximately ten steps per second. Thus `4096` stores
+approximately ten minutes of speech. At `4096` on Q8/CUDA, total memory
+use is stable at approximately 10.0 GB. Larger windows use more memory.
+The value must not exceed the model position capacity (131072 for the 7B
+model). The program rejects larger values at startup.
+
+Note: A window changes the transcription when compared to full history
+because removed context is not available. The window size also causes very
+small differences in results because the model calculates in a different
+sequence. For reproducible results, do not change the binary or the window
+size.

--- a/include/engine/framework/runtime/kv_cache.h
+++ b/include/engine/framework/runtime/kv_cache.h
@@ -19,9 +19,24 @@ struct TransformerKVState {
     std::vector<KVLayerState> layers;
 };
 
+// Absolute position of the i-th stored row in a pinned-prefix ring:
+// pinned prefix first, then oldest-to-newest tail.
+inline int64_t ring_stored_position(
+    int64_t row,
+    int64_t valid_steps,
+    int64_t current_end,
+    int64_t pinned_prefix_steps) {
+    return row < pinned_prefix_steps ? row : current_end - valid_steps + row;
+}
+
 struct TransformerKVCacheOptions {
     bool allow_f16_storage = false;
     bool allow_bf16_storage = false;
+    // In-place ring: once full, appends overwrite the oldest unpinned
+    // entries instead of failing. The first ring_pinned_steps slots are
+    // reserved (e.g. prompt / attention sinks); positions stay absolute.
+    bool ring_mode = false;
+    int64_t ring_pinned_steps = 0;
 };
 
 class TransformerKVCache {
@@ -44,6 +59,8 @@ public:
 
     void advance_after_direct_append(int64_t steps);
     void retain_prefix(int64_t prefix_steps);
+
+    int64_t slot_for_position(int64_t position) const;
 
     int64_t valid_steps() const noexcept;
     int64_t current_end() const noexcept;

--- a/include/engine/models/vibevoice_asr/session.h
+++ b/include/engine/models/vibevoice_asr/session.h
@@ -104,6 +104,7 @@ private:
     size_t tokenizer_weight_context_bytes_ = 512ull * 1024ull * 1024ull;
     size_t connector_weight_context_bytes_ = 128ull * 1024ull * 1024ull;
     size_t decoder_weight_context_bytes_ = 4096ull * 1024ull * 1024ull;
+    int64_t max_history_steps_ = 0;
     assets::TensorStorageType tokenizer_weight_storage_type_ = assets::TensorStorageType::Native;
     assets::TensorStorageType connector_weight_storage_type_ = assets::TensorStorageType::Native;
     assets::TensorStorageType decoder_weight_storage_type_ = assets::TensorStorageType::Native;

--- a/include/engine/models/vibevoice_asr/text_decoder.h
+++ b/include/engine/models/vibevoice_asr/text_decoder.h
@@ -113,7 +113,8 @@ public:
         int threads,
         size_t weight_context_bytes = 256ull * 1024ull * 1024ull,
         size_t constant_context_bytes = 128ull * 1024ull * 1024ull,
-        assets::TensorStorageType weight_storage_type = assets::TensorStorageType::Native);
+        assets::TensorStorageType weight_storage_type = assets::TensorStorageType::Native,
+        int64_t max_history_steps = 0);
 
     ~VibeVoiceDecoderWeightsRuntime();
 
@@ -125,6 +126,9 @@ public:
     ggml_backend_t backend() const noexcept;
     core::ConstantTensorCache & constants() const noexcept;
     int threads() const noexcept;
+    int64_t max_history_steps() const noexcept;
+    int64_t pinned_prefix_steps() const noexcept;
+    void set_pinned_prefix_steps(int64_t steps);
 
     VibeVoiceTokenEmbeddings embed_tokens(const std::vector<int32_t> & input_ids) const;
     VibeVoiceDecoderPrefillOutput prefill_prompt(
@@ -159,8 +163,13 @@ private:
     std::unique_ptr<core::ConstantTensorCache> constants_;
     mutable std::unique_ptr<VibeVoiceDecoderEmbeddingGraph> embedding_graph_;
     mutable std::unique_ptr<VibeVoiceDecoderPrefillGraph> prefill_graph_;
+    int64_t apply_history_window(int64_t unbounded_required) const;
+    static int64_t cached_state_end_plus(const VibeVoiceDecoderCachedState & state, int64_t incoming_steps);
+
     ggml_backend_t backend_ = nullptr;
     int threads_ = 1;
+    int64_t max_history_steps_ = 0;
+    int64_t pinned_prefix_steps_ = 0;
 };
 
 VibeVoiceDecoderWeights load_vibevoice_decoder_weights(

--- a/src/framework/runtime/kv_cache.cpp
+++ b/src/framework/runtime/kv_cache.cpp
@@ -47,6 +47,20 @@ void write_cache_tensor(
     throw std::runtime_error("TransformerKVCache requires f32 cache tensors");
 }
 
+void copy_cache_row(
+    const std::vector<float> & source,
+    int64_t source_row,
+    std::vector<float> & dest,
+    int64_t dest_row,
+    int64_t step_elems) {
+    const size_t src_begin = static_cast<size_t>(source_row * step_elems);
+    const size_t dst_begin = static_cast<size_t>(dest_row * step_elems);
+    const size_t count = static_cast<size_t>(step_elems);
+    std::copy(source.begin() + static_cast<std::ptrdiff_t>(src_begin),
+                source.begin() + static_cast<std::ptrdiff_t>(src_begin + count),
+                dest.begin() + static_cast<std::ptrdiff_t>(dst_begin));
+}
+
 std::vector<float> read_cache_tensor(const core::TensorValue & tensor, const TransformerKVCacheOptions & options) {
     validate_cache_tensor(tensor, options);
     if (tensor.type == GGML_TYPE_F32) {
@@ -81,6 +95,15 @@ TransformerKVCache::TransformerKVCache(
       options_(options) {
     if (step_elems_ <= 0) {
         throw std::runtime_error("TransformerKVCache requires positive step_elems");
+    }
+    if (options_.ring_mode) {
+        if (cache_steps_ <= 0) {
+            throw std::runtime_error("TransformerKVCache ring_mode requires positive cache_steps");
+        }
+        if (options_.ring_pinned_steps < 0 || options_.ring_pinned_steps >= cache_steps_) {
+            throw std::runtime_error(
+                "TransformerKVCache ring_pinned_steps must satisfy 0 <= pinned < cache_steps");
+        }
     }
     if (keys.size() != values.size()) {
         throw std::runtime_error("TransformerKVCache key/value layer counts must match");
@@ -130,8 +153,19 @@ void TransformerKVCache::import_state(const TransformerKVState & state) {
             std::fill(cache.import_key_scratch.begin(), cache.import_key_scratch.end(), 0.0F);
             std::fill(cache.import_value_scratch.begin(), cache.import_value_scratch.end(), 0.0F);
             if (keep_elems > 0) {
-                std::copy(source.key.begin(), source.key.end(), cache.import_key_scratch.begin());
-                std::copy(source.value.begin(), source.value.end(), cache.import_value_scratch.begin());
+                if (!options_.ring_mode) {
+                    std::copy(source.key.begin(), source.key.end(), cache.import_key_scratch.begin());
+                    std::copy(source.value.begin(), source.value.end(), cache.import_value_scratch.begin());
+                } else {
+                    for (int64_t row = 0; row < state_steps; ++row) {
+                        const int64_t position = ring_stored_position(
+                            row, state_steps, current_end_, options_.ring_pinned_steps);
+                        copy_cache_row(
+                            source.key, row, cache.import_key_scratch, slot_for_position(position), step_elems_);
+                        copy_cache_row(
+                            source.value, row, cache.import_value_scratch, slot_for_position(position), step_elems_);
+                    }
+                }
             }
             write_cache_tensor(cache.key_tensor, cache.import_key_scratch, options_);
             write_cache_tensor(cache.value_tensor, cache.import_value_scratch, options_);
@@ -152,14 +186,41 @@ TransformerKVState TransformerKVCache::export_state() const {
         }
         const auto key_values = read_cache_tensor(layers_[layer].key_tensor, options_);
         const auto value_values = read_cache_tensor(layers_[layer].value_tensor, options_);
-        out.key.assign(key_values.begin(), key_values.begin() + static_cast<ptrdiff_t>(keep_elems));
-        out.value.assign(value_values.begin(), value_values.begin() + static_cast<ptrdiff_t>(keep_elems));
+        if (!options_.ring_mode) {
+            out.key.assign(key_values.begin(), key_values.begin() + static_cast<ptrdiff_t>(keep_elems));
+            out.value.assign(value_values.begin(), value_values.begin() + static_cast<ptrdiff_t>(keep_elems));
+            continue;
+        }
+        out.key.resize(keep_elems);
+        out.value.resize(keep_elems);
+        for (int64_t row = 0; row < valid_steps_; ++row) {
+            const int64_t position =
+                ring_stored_position(row, valid_steps_, current_end_, options_.ring_pinned_steps);
+            copy_cache_row(key_values, slot_for_position(position), out.key, row, step_elems_);
+            copy_cache_row(value_values, slot_for_position(position), out.value, row, step_elems_);
+        }
     }
     return state;
 }
 
+int64_t TransformerKVCache::slot_for_position(int64_t position) const {
+    if (position < 0) {
+        throw std::runtime_error("TransformerKVCache slot_for_position requires a non-negative position");
+    }
+    if (!options_.ring_mode || position < options_.ring_pinned_steps) {
+        return position;
+    }
+    return options_.ring_pinned_steps +
+        ((position - options_.ring_pinned_steps) % (cache_steps_ - options_.ring_pinned_steps));
+}
+
 void TransformerKVCache::advance_after_direct_append(int64_t steps) {
     if (steps <= 0) {
+        return;
+    }
+    if (options_.ring_mode) {
+        valid_steps_ = std::min(cache_steps_, valid_steps_ + steps);
+        current_end_ += steps;
         return;
     }
     if (valid_steps_ + steps > cache_steps_) {

--- a/src/models/vibevoice_asr/session.cpp
+++ b/src/models/vibevoice_asr/session.cpp
@@ -99,6 +99,7 @@ bool is_allowed_session_option(const std::string & key) {
         ".tokenizer_weight_context_mb",
         ".connector_weight_context_mb",
         ".decoder_weight_context_mb",
+        ".max_history_steps",
         ".vad_model_path",
     };
     for (const char * prefix_value : {"vibevoice_asr", "vibevoice_asr_streaming"}) {
@@ -547,6 +548,7 @@ VibeVoiceASRSession::VibeVoiceASRSession(
       tokenizer_weight_context_bytes_(runtime::parse_size_mb_option(options.options, {"vibevoice_asr_streaming.tokenizer_weight_context_mb", "vibevoice_asr.tokenizer_weight_context_mb"}, kDefaultTokenizerWeightContextBytes)),
       connector_weight_context_bytes_(runtime::parse_size_mb_option(options.options, {"vibevoice_asr_streaming.connector_weight_context_mb", "vibevoice_asr.connector_weight_context_mb"}, kDefaultConnectorWeightContextBytes)),
       decoder_weight_context_bytes_(runtime::parse_size_mb_option(options.options, {"vibevoice_asr_streaming.decoder_weight_context_mb", "vibevoice_asr.decoder_weight_context_mb"}, kDefaultDecoderWeightContextBytes)),
+      max_history_steps_(runtime::parse_i64_option(options.options, {"vibevoice_asr_streaming.max_history_steps", "vibevoice_asr.max_history_steps"}).value_or(0)),
       tokenizer_weight_storage_type_(option_weight_type(
           options,
           {"vibevoice_asr_streaming.tokenizer_weight_type", "vibevoice_asr.tokenizer_weight_type"},
@@ -588,7 +590,8 @@ VibeVoiceASRSession::VibeVoiceASRSession(
           options.backend.threads,
           decoder_weight_context_bytes_,
           128ull * 1024ull * 1024ull,
-          decoder_weight_storage_type_),
+          decoder_weight_storage_type_,
+          max_history_steps_),
       postprocessor_(tokenizer_),
       vad_model_path_(runtime::find_option(options.options, {"vibevoice_asr_streaming.vad_model_path", "vibevoice_asr.vad_model_path"}).value_or(default_vad_model_path().string())) {
     if (task_.task != runtime::VoiceTaskKind::Asr) {
@@ -603,6 +606,10 @@ VibeVoiceASRSession::VibeVoiceASRSession(
     validate_weight_storage(tokenizer_weight_storage_type_, "vibevoice_asr.tokenizer_weight_type");
     validate_weight_storage(connector_weight_storage_type_, "vibevoice_asr.connector_weight_type");
     validate_weight_storage(decoder_weight_storage_type_, "vibevoice_asr.decoder_weight_type");
+    if (max_history_steps_ > assets_->config.decoder.max_position_embeddings) {
+        throw std::runtime_error(
+            "vibevoice_asr_streaming.max_history_steps exceeds the model position capacity");
+    }
     for (const auto & [key, value] : options.options) {
         (void)value;
         if (!is_allowed_session_option(key) &&
@@ -1094,6 +1101,7 @@ void VibeVoiceASRSession::ensure_streaming_decoder_state(const VibeVoiceASRReque
     const auto prompt_ids = tokenizer_.build_streaming_prompt(request.context);
     const auto prompt_embeddings = text_decoder_.embed_tokens(prompt_ids);
     streaming_history_steps_ = prompt_embeddings.steps;
+    text_decoder_.set_pinned_prefix_steps(prompt_embeddings.steps);
     auto prefill = text_decoder_.prefill_embeddings(prompt_embeddings.values, streaming_history_steps_);
     streaming_decoder_state_ = std::make_unique<VibeVoiceDecoderCachedState>();
     text_decoder_.reset_cached_state(*streaming_decoder_state_, std::move(prefill.state));
@@ -1276,6 +1284,8 @@ runtime::TaskResult VibeVoiceASRSession::run_single(const VibeVoiceASRRequest & 
     const auto prompt_end = Clock::now();
 
     const auto decoder_start = Clock::now();
+    // Single-shot prompts embed the whole input; nothing is pinned here.
+    text_decoder_.set_pinned_prefix_steps(0);
     auto prefill = text_decoder_.prefill_prompt(prompt.input_ids, speech.values, prompt.speech_positions);
     const uint64_t rng_call_offset = (speech.next_rng_index + 3ull) / 4ull;
     std::string emitted_text;

--- a/src/models/vibevoice_asr/text_decoder.cpp
+++ b/src/models/vibevoice_asr/text_decoder.cpp
@@ -70,6 +70,10 @@ modules::QwenCausalDecoderConfig make_qwen_decoder_config(const VibeVoiceDecoder
     out.stack.use_qk_norm = false;
     out.stack.runtime.attention.prefill_mode = modules::QwenDecoderAttentionMode::FlashGroupedViewKV;
     out.stack.runtime.attention.static_mode = modules::QwenDecoderAttentionMode::FlashGroupedViewKV;
+    // The suffix path appends onto the prefix KV cache; without this it
+    // takes the eager branch and materializes per-head F32 intermediates
+    // that scale with the cache size.
+    out.stack.runtime.attention.prefix_mode = modules::QwenDecoderPrefixAttentionMode::FlashWithPrefix;
     out.stack.runtime.static_cache.update_mode = modules::QwenDecoderStaticCacheUpdateMode::DirectSetRows;
     out.stack.runtime.static_cache.set_rows_mode = modules::QwenDecoderStaticCacheSetRowsMode::BackendViewOptimized;
     out.logits_size = config.vocab_size;
@@ -636,6 +640,10 @@ public:
         }
         runtime::TransformerKVCacheOptions cache_options;
         cache_options.allow_f16_storage = true;
+        if (runtime_->max_history_steps() > 0) {
+            cache_options.ring_mode = true;
+            cache_options.ring_pinned_steps = runtime_->pinned_prefix_steps();
+        }
         cache_ = runtime::TransformerKVCache(
             cache_steps_,
             step_elems,
@@ -668,6 +676,10 @@ public:
 
     int64_t current_end() const noexcept {
         return cache_.current_end();
+    }
+
+    int64_t slot_for_position(int64_t position) const {
+        return cache_.slot_for_position(position);
     }
 
     void import_state(const runtime::TransformerKVState & state) {
@@ -815,20 +827,33 @@ public:
         if (static_cast<int64_t>(embedding.size()) != config.hidden_size) {
             throw std::runtime_error("VibeVoice decoder cached step embedding size mismatch");
         }
-        if (cache_->valid_steps() >= cache_steps_) {
+        if (cache_->valid_steps() >= cache_steps_ && runtime_->max_history_steps() <= 0) {
             throw std::runtime_error("VibeVoice decoder cached step exceeds cache capacity");
         }
         ggml_backend_tensor_set(input_, embedding.data(), 0, embedding.size() * sizeof(float));
-        const int32_t position = static_cast<int32_t>(cache_->current_end());
-        ggml_backend_tensor_set(positions_, &position, 0, sizeof(position));
-        const int32_t cache_slot = static_cast<int32_t>(cache_->valid_steps());
+        const int64_t position = cache_->current_end();
+        const int32_t position_i32 = static_cast<int32_t>(position);
+        ggml_backend_tensor_set(positions_, &position_i32, 0, sizeof(position_i32));
+        const int32_t cache_slot = static_cast<int32_t>(cache_->slot_for_position(position));
         ggml_backend_tensor_set(cache_slot_, &cache_slot, 0, sizeof(cache_slot));
-        modules::write_qwen_cached_step_mask(
-            attention_mask_,
-            attention_mask_buffer_,
-            static_cast<int64_t>(attention_mask_buffer_.size()),
-            cache_->valid_steps(),
-            cache_->valid_steps());
+        {
+            const auto masked = ggml_fp32_to_fp16(-std::numeric_limits<float>::infinity());
+            const auto visible = ggml_fp32_to_fp16(0.0F);
+            std::fill(attention_mask_buffer_.begin(), attention_mask_buffer_.end(), masked);
+            const int64_t valid = cache_->valid_steps();
+            const int64_t pinned = runtime_->pinned_prefix_steps();
+            for (int64_t row = 0; row < valid; ++row) {
+                const int64_t stored =
+                    runtime::ring_stored_position(row, valid, cache_->current_end(), pinned);
+                attention_mask_buffer_[static_cast<size_t>(cache_->slot_for_position(stored))] = visible;
+            }
+            attention_mask_buffer_[static_cast<size_t>(cache_slot)] = visible;
+            ggml_backend_tensor_set(
+                attention_mask_,
+                attention_mask_buffer_.data(),
+                0,
+                attention_mask_buffer_.size() * sizeof(ggml_fp16_t));
+        }
 
         core::set_backend_threads(runtime_->backend(), runtime_->threads());
         const ggml_status status = engine::core::compute_backend_graph(runtime_->backend(), graph_);
@@ -1004,13 +1029,17 @@ public:
         if (static_cast<int64_t>(embeddings.size()) != suffix_steps_ * config.hidden_size) {
             throw std::runtime_error("VibeVoice decoder cached suffix embedding size mismatch");
         }
-        if (cache_->valid_steps() + suffix_steps_ > cache_steps_) {
+        if (cache_->valid_steps() + suffix_steps_ > cache_steps_ && runtime_->max_history_steps() <= 0) {
             throw std::runtime_error("VibeVoice decoder cached suffix exceeds cache capacity");
         }
         ggml_backend_tensor_set(input_, embeddings.data(), 0, embeddings.size() * sizeof(float));
+        const int64_t append_end = cache_->current_end();
+        const int64_t append_valid = cache_->valid_steps();
+        const int64_t pinned = runtime_->pinned_prefix_steps();
         for (int64_t step = 0; step < suffix_steps_; ++step) {
-            position_values_[static_cast<size_t>(step)] = static_cast<int32_t>(cache_->current_end() + step);
-            cache_slot_values_[static_cast<size_t>(step)] = static_cast<int32_t>(cache_->valid_steps() + step);
+            position_values_[static_cast<size_t>(step)] = static_cast<int32_t>(append_end + step);
+            cache_slot_values_[static_cast<size_t>(step)] =
+                static_cast<int32_t>(cache_->slot_for_position(append_end + step));
         }
         ggml_backend_tensor_set(positions_, position_values_.data(), 0, position_values_.size() * sizeof(int32_t));
         ggml_backend_tensor_set(cache_slot_, cache_slot_values_.data(), 0, cache_slot_values_.size() * sizeof(int32_t));
@@ -1018,16 +1047,19 @@ public:
         const auto masked = ggml_fp32_to_fp16(-std::numeric_limits<float>::infinity());
         const auto visible = ggml_fp32_to_fp16(0.0F);
         std::fill(attention_mask_buffer_.begin(), attention_mask_buffer_.end(), masked);
+        for (int64_t row = 0; row < append_valid; ++row) {
+            const int64_t stored = runtime::ring_stored_position(row, append_valid, append_end, pinned);
+            const size_t slot = static_cast<size_t>(cache_->slot_for_position(stored));
+            for (int64_t query = 0; query < suffix_steps_; ++query) {
+                attention_mask_buffer_[static_cast<size_t>(query * attention_key_steps_) + slot] = visible;
+            }
+        }
         for (int64_t row = 0; row < suffix_steps_; ++row) {
-            const size_t row_offset = static_cast<size_t>(row * attention_key_steps_);
-            std::fill_n(
-                attention_mask_buffer_.begin() + static_cast<std::ptrdiff_t>(row_offset),
-                static_cast<size_t>(cache_->valid_steps()),
-                visible);
-            std::fill_n(
-                attention_mask_buffer_.begin() + static_cast<std::ptrdiff_t>(row_offset + cache_steps_),
-                static_cast<size_t>(row + 1),
-                visible);
+            for (int64_t step = 0; step <= row; ++step) {
+                const size_t slot =
+                    static_cast<size_t>(cache_->slot_for_position(append_end + step));
+                attention_mask_buffer_[static_cast<size_t>(row * attention_key_steps_) + slot] = visible;
+            }
         }
         ggml_backend_tensor_set(
             attention_mask_,
@@ -1089,11 +1121,16 @@ VibeVoiceDecoderWeightsRuntime::VibeVoiceDecoderWeightsRuntime(
     int threads,
     size_t weight_context_bytes,
     size_t constant_context_bytes,
-    assets::TensorStorageType weight_storage_type)
+    assets::TensorStorageType weight_storage_type,
+    int64_t max_history_steps)
     : assets_(std::move(assets)),
-      threads_(threads) {
+      threads_(threads),
+      max_history_steps_(max_history_steps) {
     if (assets_ == nullptr) {
         throw std::runtime_error("VibeVoice decoder weights runtime requires assets");
+    }
+    if (max_history_steps_ < 0) {
+        throw std::runtime_error("VibeVoice decoder max_history_steps must be >= 0 (0 disables the history window)");
     }
     if (threads_ <= 0) {
         throw std::runtime_error("VibeVoice decoder weights runtime requires positive thread count");
@@ -1149,6 +1186,39 @@ core::ConstantTensorCache & VibeVoiceDecoderWeightsRuntime::constants() const no
 
 int VibeVoiceDecoderWeightsRuntime::threads() const noexcept {
     return threads_;
+}
+
+void VibeVoiceDecoderWeightsRuntime::set_pinned_prefix_steps(int64_t steps) {
+    if (steps < 0) {
+        throw std::runtime_error("VibeVoice decoder pinned prefix steps must be >= 0");
+    }
+    pinned_prefix_steps_ = steps;
+}
+
+int64_t VibeVoiceDecoderWeightsRuntime::pinned_prefix_steps() const noexcept {
+    return pinned_prefix_steps_;
+}
+
+int64_t VibeVoiceDecoderWeightsRuntime::max_history_steps() const noexcept {
+    return max_history_steps_;
+}
+
+int64_t VibeVoiceDecoderWeightsRuntime::cached_state_end_plus(
+    const VibeVoiceDecoderCachedState & state,
+    int64_t incoming_steps) {
+    const int64_t current_end = state.cache_has_state_ && state.cache_ != nullptr
+        ? state.cache_->current_end()
+        : state.pending_state_.current_end;
+    return current_end + incoming_steps;
+}
+
+int64_t VibeVoiceDecoderWeightsRuntime::apply_history_window(int64_t unbounded_required) const {
+    // Clamp before tiering: tiering throws past model capacity, which a long
+    // stream's absolute history can exceed while the window stays small.
+    if (max_history_steps_ <= 0) {
+        return cache_graph_capacity(unbounded_required, assets_->config.decoder.max_position_embeddings);
+    }
+    return cache_graph_capacity(max_history_steps_, assets_->config.decoder.max_position_embeddings);
 }
 
 VibeVoiceTokenEmbeddings VibeVoiceDecoderWeightsRuntime::embed_tokens(
@@ -1234,7 +1304,8 @@ void VibeVoiceDecoderWeightsRuntime::prepare_cached_state(
     if (cache_capacity <= 0) {
         throw std::runtime_error("VibeVoice decoder cached state prepare requires positive cache capacity");
     }
-    const int64_t required_capacity = cache_graph_capacity(cache_capacity, config.max_position_embeddings);
+    const int64_t required_capacity =
+        apply_history_window(cache_capacity);
     if (state.cache_ != nullptr && state.cache_has_state_ && !state.cache_->can_run(*this, required_capacity)) {
         state.pending_state_ = state.cache_->export_state();
         state.cache_has_state_ = false;
@@ -1278,9 +1349,8 @@ void VibeVoiceDecoderWeightsRuntime::clone_cached_state(
         throw std::runtime_error("VibeVoice decoder cached state clone requires live source graph state");
     }
     const auto source_state = source.cache_->export_state();
-    const int64_t required_capacity = cache_graph_capacity(
-        std::max<int64_t>(cache_capacity, source.cache_->current_end() + 1),
-        config.max_position_embeddings);
+    const int64_t required_capacity = apply_history_window(
+        std::max<int64_t>(cache_capacity, source.cache_->current_end() + 1));
     if (target.cache_ == nullptr || !target.cache_->can_run(*this, required_capacity)) {
         target.graph_.reset();
         target.suffix_graph_.reset();
@@ -1302,12 +1372,8 @@ VibeVoiceDecoderResult VibeVoiceDecoderWeightsRuntime::cached_step(
     if (cache_capacity <= 0) {
         throw std::runtime_error("VibeVoice decoder cached step requires positive cache capacity");
     }
-    const int64_t current_end = state.cache_has_state_ && state.cache_ != nullptr
-        ? state.cache_->current_end()
-        : state.pending_state_.current_end;
-    const int64_t required_capacity = cache_graph_capacity(
-        std::max<int64_t>(cache_capacity, current_end + 1),
-        config.max_position_embeddings);
+    const int64_t required_capacity =
+        apply_history_window(std::max<int64_t>(cache_capacity, cached_state_end_plus(state, 1)));
     if (state.cache_ != nullptr && state.cache_has_state_ && !state.cache_->can_run(*this, required_capacity)) {
         state.pending_state_ = state.cache_->export_state();
         state.cache_has_state_ = false;
@@ -1351,12 +1417,8 @@ void VibeVoiceDecoderWeightsRuntime::append_cached_step(
     if (cache_capacity <= 0) {
         throw std::runtime_error("VibeVoice decoder cached append requires positive cache capacity");
     }
-    const int64_t current_end = state.cache_has_state_ && state.cache_ != nullptr
-        ? state.cache_->current_end()
-        : state.pending_state_.current_end;
-    const int64_t required_capacity = cache_graph_capacity(
-        std::max<int64_t>(cache_capacity, current_end + 1),
-        config.max_position_embeddings);
+    const int64_t required_capacity =
+        apply_history_window(std::max<int64_t>(cache_capacity, cached_state_end_plus(state, 1)));
     if (state.cache_ != nullptr && state.cache_has_state_ && !state.cache_->can_run(*this, required_capacity)) {
         state.pending_state_ = state.cache_->export_state();
         state.cache_has_state_ = false;
@@ -1404,12 +1466,8 @@ VibeVoiceDecoderResult VibeVoiceDecoderWeightsRuntime::cached_suffix(
     if (cache_capacity <= 0) {
         throw std::runtime_error("VibeVoice decoder cached suffix requires positive cache capacity");
     }
-    const int64_t current_end = state.cache_has_state_ && state.cache_ != nullptr
-        ? state.cache_->current_end()
-        : state.pending_state_.current_end;
-    const int64_t required_capacity = cache_graph_capacity(
-        std::max<int64_t>(cache_capacity, current_end + steps),
-        config.max_position_embeddings);
+    const int64_t required_capacity =
+        apply_history_window(std::max<int64_t>(cache_capacity, cached_state_end_plus(state, steps)));
     if (state.cache_ != nullptr && state.cache_has_state_ && !state.cache_->can_run(*this, required_capacity)) {
         state.pending_state_ = state.cache_->export_state();
         state.cache_has_state_ = false;

--- a/tests/unittests/test_transformer_kv_ring.cpp
+++ b/tests/unittests/test_transformer_kv_ring.cpp
@@ -1,0 +1,287 @@
+// Unit tests for TransformerKVCache ring_mode: slot mapping, wrap advance,
+// chronological export, wrap-placement import, and non-ring regression.
+#include "engine/framework/runtime/kv_cache.h"
+
+#include "engine/framework/core/backend.h"
+
+#include "ggml-backend.h"
+#include "ggml.h"
+
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+namespace core = engine::core;
+namespace runtime = engine::runtime;
+
+int failures = 0;
+
+void check(bool condition, const std::string & message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << "\n";
+    }
+}
+
+struct GgmlContextDeleter {
+    void operator()(ggml_context * ctx) const noexcept {
+        if (ctx != nullptr) {
+            ggml_free(ctx);
+        }
+    }
+};
+
+struct BackendDeleter {
+    void operator()(ggml_backend_t backend) const noexcept {
+        if (backend != nullptr) {
+            ggml_backend_free(backend);
+        }
+    }
+};
+
+// 1 layer of F32 key/value tensors with room for (steps * elems) floats.
+struct TestTensors {
+    std::unique_ptr<ggml_context, GgmlContextDeleter> ctx;
+    std::unique_ptr<std::remove_pointer_t<ggml_backend_buffer_t>, void (*)(ggml_backend_buffer_t)> buffer{
+        nullptr, ggml_backend_buffer_free};
+    core::TensorValue keys;
+    core::TensorValue values;
+};
+
+ggml_backend_t cpu_backend() {
+    static std::unique_ptr<std::remove_pointer_t<ggml_backend_t>, BackendDeleter> backend(
+        ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, nullptr), BackendDeleter{});
+    if (backend == nullptr) {
+        throw std::runtime_error("test CPU backend init failed");
+    }
+    return backend.get();
+}
+
+TestTensors make_tensors(int64_t steps, int64_t elems) {
+    TestTensors out;
+    ggml_init_params params{1024ull * 1024ull, nullptr, true};
+    out.ctx.reset(ggml_init(params));
+    if (out.ctx == nullptr) {
+        throw std::runtime_error("test context init failed");
+    }
+    const int64_t count = steps * elems;
+    ggml_tensor * k = ggml_new_tensor_1d(out.ctx.get(), GGML_TYPE_F32, count);
+    ggml_tensor * v = ggml_new_tensor_1d(out.ctx.get(), GGML_TYPE_F32, count);
+    out.buffer.reset(ggml_backend_alloc_ctx_tensors(out.ctx.get(), cpu_backend()));
+    if (out.buffer == nullptr) {
+        throw std::runtime_error("test buffer alloc failed");
+    }
+    out.keys = core::TensorValue{k, core::TensorShape::from_dims({count}), GGML_TYPE_F32};
+    out.values = core::TensorValue{v, core::TensorShape::from_dims({count}), GGML_TYPE_F32};
+    return out;
+}
+
+runtime::TransformerKVCache make_cache(
+    TestTensors & tensors, int64_t steps, int64_t elems, runtime::TransformerKVCacheOptions options) {
+    return runtime::TransformerKVCache(
+        steps, elems, {tensors.keys}, {tensors.values}, options);
+}
+
+// Row r filled with float(position): positions are directly readable.
+std::vector<float> tagged_row(int64_t position, int64_t elems) {
+    return std::vector<float>(static_cast<size_t>(elems), static_cast<float>(position));
+}
+
+runtime::KVLayerState tagged_layer(const std::vector<int64_t> & positions, int64_t elems) {
+    runtime::KVLayerState layer;
+    layer.valid_steps = static_cast<int64_t>(positions.size());
+    for (const int64_t pos : positions) {
+        const auto row = tagged_row(pos, elems);
+        layer.key.insert(layer.key.end(), row.begin(), row.end());
+        layer.value.insert(layer.value.end(), row.begin(), row.end());
+    }
+    return layer;
+}
+
+int64_t row_position(const std::vector<float> & flat, int64_t row, int64_t elems) {
+    return static_cast<int64_t>(flat[static_cast<size_t>(row * elems)]);
+}
+
+void test_slot_mapping() {
+    runtime::TransformerKVCacheOptions off;
+    {
+        TestTensors t = make_tensors(8, 4);
+        runtime::TransformerKVCache cache = make_cache(t, 8, 4, off);
+        check(cache.slot_for_position(0) == 0, "identity slot 0 when ring off");
+        check(cache.slot_for_position(100) == 100, "identity slot 100 when ring off");
+    }
+    runtime::TransformerKVCacheOptions ring;
+    ring.ring_mode = true;
+    ring.ring_pinned_steps = 2;
+    {
+        TestTensors t = make_tensors(8, 4);
+        runtime::TransformerKVCache cache = make_cache(t, 8, 4, ring);
+        check(cache.slot_for_position(0) == 0, "pinned slot 0");
+        check(cache.slot_for_position(1) == 1, "pinned slot 1");
+        check(cache.slot_for_position(2) == 2, "first ring slot");
+        check(cache.slot_for_position(7) == 7, "last ring slot first lap");
+        check(cache.slot_for_position(8) == 2, "wrap to slot 2");
+        check(cache.slot_for_position(9) == 3, "wrap to slot 3");
+        check(cache.slot_for_position(14) == 2, "second wrap to slot 2");
+        bool threw = false;
+        try {
+            cache.slot_for_position(-1);
+        } catch (const std::runtime_error &) {
+            threw = true;
+        }
+        check(threw, "negative position throws");
+    }
+    std::cout << "slot mapping done\n";
+}
+
+void test_option_validation() {
+    auto expect_throw = [](runtime::TransformerKVCacheOptions options, const std::string & what) {
+        bool threw = false;
+        try {
+            TestTensors t = make_tensors(8, 4);
+            runtime::TransformerKVCache cache = make_cache(t, 8, 4, options);
+            (void)cache;
+        } catch (const std::runtime_error &) {
+            threw = true;
+        }
+        check(threw, what);
+    };
+    runtime::TransformerKVCacheOptions zero_cap;
+    zero_cap.ring_mode = true;
+    // NOTE: cache_steps is clamped to >= 0 in the ctor; ring requires positive.
+    {
+        bool threw = false;
+        try {
+            TestTensors t = make_tensors(0, 4);
+            runtime::TransformerKVCache cache = make_cache(t, 0, 4, zero_cap);
+            (void)cache;
+        } catch (const std::runtime_error &) {
+            threw = true;
+        }
+        check(threw, "ring with zero capacity throws");
+    }
+    runtime::TransformerKVCacheOptions bad_pin;
+    bad_pin.ring_mode = true;
+    bad_pin.ring_pinned_steps = 8;
+    expect_throw(bad_pin, "pinned == capacity throws");
+    bad_pin.ring_pinned_steps = -1;
+    expect_throw(bad_pin, "negative pinned throws");
+    std::cout << "option validation done\n";
+}
+
+void test_wrap_round_trip() {
+    constexpr int64_t steps = 8;
+    constexpr int64_t elems = 4;
+    runtime::TransformerKVCacheOptions ring;
+    ring.ring_mode = true;
+    ring.ring_pinned_steps = 2;
+    TestTensors t = make_tensors(steps, elems);
+    runtime::TransformerKVCache cache = make_cache(t, steps, elems, ring);
+    // Chronological rows for positions [0,1] + [6..11] (2,3,4,5 evicted).
+    runtime::TransformerKVState state;
+    state.current_end = 12;
+    state.layers.push_back(tagged_layer({0, 1, 6, 7, 8, 9, 10, 11}, elems));
+    cache.import_state(state);
+    check(cache.valid_steps() == 8, "import keeps valid count");
+    check(cache.current_end() == 12, "import keeps absolute end");
+    // Physical placement: prompt at 0,1; tail 6..11 wraps into 4,5,6,7,2,3.
+    const std::vector<float> raw = core::read_tensor_f32(t.keys.tensor);
+    const int64_t expected_slots[8] = {0, 1, 6, 7, 8, 9, 10, 11};
+    check(row_position(raw, 0, elems) == 0, "slot 0 holds pinned 0");
+    check(row_position(raw, 1, elems) == 1, "slot 1 holds pinned 1");
+    check(row_position(raw, 2, elems) == 8, "slot 2 holds wrapped 8");
+    check(row_position(raw, 3, elems) == 9, "slot 3 holds wrapped 9");
+    check(row_position(raw, 4, elems) == 10, "slot 4 holds wrapped 10");
+    check(row_position(raw, 5, elems) == 11, "slot 5 holds wrapped 11");
+    check(row_position(raw, 6, elems) == 6, "slot 6 holds 6");
+    check(row_position(raw, 7, elems) == 7, "slot 7 holds 7");
+    // Chronological export restores input order.
+    const runtime::TransformerKVState back = cache.export_state();
+    check(back.current_end == 12, "export keeps absolute end");
+    check(back.layers.front().valid_steps == 8, "export keeps valid count");
+    for (int row = 0; row < 8; ++row) {
+        check(row_position(back.layers.front().key, row, elems) == expected_slots[row],
+              "export row " + std::to_string(row) + " chronological");
+    }
+    std::cout << "wrap round-trip done\n";
+}
+
+void test_wrap_advance() {
+    constexpr int64_t steps = 8;
+    constexpr int64_t elems = 4;
+    runtime::TransformerKVCacheOptions ring;
+    ring.ring_mode = true;
+    ring.ring_pinned_steps = 2;
+    TestTensors t = make_tensors(steps, elems);
+    runtime::TransformerKVCache cache = make_cache(t, steps, elems, ring);
+    runtime::TransformerKVState state;
+    state.current_end = 2;
+    state.layers.push_back(tagged_layer({0, 1}, elems));
+    cache.import_state(state);
+    cache.advance_after_direct_append(6);
+    check(cache.valid_steps() == 8, "advance fills to capacity");
+    check(cache.current_end() == 8, "advance moves end");
+    cache.advance_after_direct_append(4);
+    check(cache.valid_steps() == 8, "advance past capacity stays capped");
+    check(cache.current_end() == 12, "advance past capacity moves end");
+    // Non-ring still throws on overflow.
+    runtime::TransformerKVCacheOptions off;
+    TestTensors t2 = make_tensors(steps, elems);
+    runtime::TransformerKVCache plain = make_cache(t2, steps, elems, off);
+    plain.import_state(state);
+    bool threw = false;
+    try {
+        plain.advance_after_direct_append(7);
+    } catch (const std::runtime_error &) {
+        threw = true;
+    }
+    check(threw, "non-ring advance overflow still throws");
+    std::cout << "wrap advance done\n";
+}
+
+void test_non_ring_regression() {
+    constexpr int64_t steps = 8;
+    constexpr int64_t elems = 4;
+    runtime::TransformerKVCacheOptions off;
+    TestTensors t = make_tensors(steps, elems);
+    runtime::TransformerKVCache cache = make_cache(t, steps, elems, off);
+    runtime::TransformerKVState state;
+    state.current_end = 5;
+    state.layers.push_back(tagged_layer({10, 11, 12, 13, 14}, elems));
+    cache.import_state(state);
+    const runtime::TransformerKVState back = cache.export_state();
+    check(back.current_end == 5, "dense export keeps end");
+    for (int row = 0; row < 5; ++row) {
+        check(row_position(back.layers.front().key, row, elems) == 10 + row, "dense export row order");
+    }
+    cache.retain_prefix(3);
+    check(cache.valid_steps() == 3, "retain_prefix keeps count");
+    check(cache.current_end() == 3, "retain_prefix rewinds end");
+    std::cout << "non-ring regression done\n";
+}
+
+}  // namespace
+
+int main() {
+    try {
+        test_slot_mapping();
+        test_option_validation();
+        test_wrap_round_trip();
+        test_wrap_advance();
+        test_non_ring_regression();
+    } catch (const std::exception & e) {
+        std::cerr << "ERROR: " << e.what() << "\n";
+        return 1;
+    }
+    if (failures != 0) {
+        std::cerr << failures << " check(s) failed\n";
+        return 1;
+    }
+    std::cout << "transformer_kv_ring: all checks passed\n";
+    return 0;
+}


### PR DESCRIPTION
Streaming `vibevoice_asr_streaming` (Q8, one 16 GB GPU) stops on long audio for two reasons. The suffix graph uses approximately 4.8 GiB of temporary data at 1024 cache steps in addition to approximately 9.9 GiB of weights (memory becomes full after approximately 35 s). Then the decoder history increases without limit toward the 131072-position limit. This PR removes both causes. It makes no engine changes for other families. All new functions are off by default.

## Change 1: suffix path uses prefix-flash attention

The suffix graph is the only path that adds data onto the prefix KV cache. `make_qwen_decoder_config` selects flash modes for prefill and cached-step graphs, but it leaves the default `prefix_mode=Exact`. As a result, the suffix graph uses the eager branch. `FlashWithPrefix` (same as higgs/personaplex) sends it through `flash_attention_from_grouped_heads_view_kv`. The suffix graph decreases from 4.8 GiB to 1.1 GiB at 1024 steps. The increase rate decreases from approximately 4.7 to approximately 0.4 MiB/step.

## Change 2: `max_history_steps` rolling window (default `0` = off)

New session option (`vibevoice_asr_streaming.max_history_steps`, `vibevoice_asr.` prefix also accepted). When the option has a value, the program allocates the cache and the graphs one time at the window size. It never increases them. New steps replace the oldest entries in their positions:

- General ring support in `TransformerKVCache` (`ring_mode` +
`ring_pinned_steps`, off by default): wrap on advance, chronological export, wrap placement on import, `slot_for_position` mapping, shared `ring_stored_position` rule. No existing method changes function unless `ring_mode` is true.
- The streaming prompt has a pin and the program never removes it.
Removal of the prompt first causes the output to collapse into repetition loops (measured). Positions continue to increase. The mask uses stored counts.
- `tests/unittests/test_transformer_kv_ring.cpp`: mapping, wrap
round-trip, advance, option validation, non-ring regression.
- Documentation, subsection "Long streams and the history window", with
use and size data.

This PR also corrects the suffix causal-triangle mask. The mask was at key columns `[cache_steps_, …]` (padding). The real suffix slots had no mask to each other. The new code puts the mask on the actual appended slots. This agrees with the reference (`modeling_vibevoice_asr.py`). Transcriptions show small changes versus #497 even with the window off.

## Outputs / performance / memory

- Memory: the suffix graph is smaller in all runs. With a window, memory
use is flat. A 2 h 40 m file uses approximately 9.9 GB for 24 min wall time on a 16 GB card. Without a window, memory use exhausts the card. With the window off, the program uses memory as before.
- Outputs: flash and eager calculations can show very small differences.
The mask correction causes small changes in transcriptions. The window changes outputs when removal of old steps starts (expected). Runs give the same results for a fixed binary and window (identical rerun verified). For reproducible runs, do not change the binary or the window size.
- Performance: no change (43 s with window versus 44 s without window on
a 300 s slice, approximately 7 times real time; chunk delay approximately 0.5 s against a 4.4 s chunk).

## Families / routes checked

- `vibevoice_asr_streaming`: full list below.
- `parakeet_tdt` (other family, same framework and CLI paths): golden
clip is identical to the golden transcription on the rebuilt tree.
- `transformer_kv_ring_test` has a pass in ctest (includes non-ring
regression).
- Full-tree Release build: `audiocpp_cli` and `audiocpp_server` build.

## Validation (RTX 4070 Ti SUPER, CUDA, Q8, `--device 1`)

| Run | Result |
|---|---|
| Golden clip (7.4 s EN) | Correct transcript with `Speaker 0:` labels |
| 6 s sine / 6 s silence | `[Music] [Music]` / `[Silence] [Silence]`, exit 0 |
| 60 s file, window 256 (wrap torture) | Exit 0, normal output |
| 300 s file, window 4096 vs uncapped | Same structure and labels, only local variants |
| Identical rerun | Identical result (deterministic) |
| **2 h 40 m file, window 4096** | **Exit 0, 4185 lines, 5 speaker labels, memory flat at ~9.9 GB** |
| `max_history_steps=-5` / `> 131072` | Clear startup errors |

Sizing: approximately ten steps per audio second. Thus `4096` stores approximately ten minutes of context. Stable state is approximately 10.0 GB on Q8/CUDA.

## Known limits (nothing pending release; model stays as merged in #497)

- No ground-truth WER exists for the long file. Structural checks and
the comparisons above are the quality evidence.
- Positions can increase past the trained 131 k cap on very long streams
(same as the reference). The window limits memory, not positions.
- `--turns-out` gives no output in CLI streaming mode (existing
function).
