### PR TITLE
Add an opt-in C ABI for in-process embedding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,9 @@ option(ENGINE_BUILD_TESTS "Build framework unit tests" OFF)
 option(ENGINE_BUILD_EXTENDED_TESTS "Build extended non-model tests and probes" OFF)
 option(ENGINE_BUILD_MODEL_TESTS "Build model-specific tests and probes" OFF)
 option(ENGINE_BUILD_WARMBENCH "Build warmbench helper binaries" OFF)
+option(AUDIOCPP_BUILD_C_API "Build the C ABI (include/audiocpp.h) as a shared library" OFF)
+set(AUDIOCPP_C_API_MODEL_ROOT "" CACHE PATH
+    "Models root for the C API model test. Unset leaves the test registered but skipping.")
 set(AUDIOCPP_GGML_SOURCE_DIR
     "${CMAKE_CURRENT_SOURCE_DIR}/external/ggml"
     CACHE PATH "ggml source tree to build with AudioCPP")
@@ -282,6 +285,12 @@ if (ENGINE_ENABLE_CUDA AND NOT ENGINE_ENABLE_HIP)
 endif()
 if (ENGINE_ENABLE_OPENMP)
     find_package(OpenMP REQUIRED COMPONENTS CXX)
+endif()
+
+if (AUDIOCPP_BUILD_C_API)
+    # engine_runtime and ggml are static/object libraries here; linking them into
+    # a shared libaudiocpp requires position-independent code throughout.
+    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 endif()
 
 if (ENGINE_ENABLE_CPU_ALL_VARIANTS)
@@ -1883,6 +1892,20 @@ add_library(cjson_vendor STATIC
     external/cJSON/cJSON.c
 )
 
+# cJSON annotates every CJSON_PUBLIC function with __declspec(dllexport) on
+# Windows unless told otherwise (external/cJSON/cJSON.h:59-66 defaults
+# CJSON_EXPORT_SYMBOLS on). Those annotations live in the object files, so any
+# DLL that absorbs this static library re-exports all 78 of them -- dllexport is
+# additive, it says "also export this", never "export only this". Measured: a
+# shared build exported 147 symbols where 69 were intended.
+#
+# No DLL is built from this tree by default, so this is latent rather than
+# broken today; AUDIOCPP_BUILD_C_API is the first target to expose it.
+# CJSON_HIDE_SYMBOLS is cJSON's own mechanism for exactly this case and selects
+# a plain declaration with no storage class. PUBLIC rather than PRIVATE so every
+# translation unit that includes cJSON.h agrees on the linkage.
+target_compile_definitions(cjson_vendor PUBLIC CJSON_HIDE_SYMBOLS)
+
 target_include_directories(cjson_vendor PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/external/cJSON
 )
@@ -2023,6 +2046,152 @@ if (MINGW)
 endif()
 if (ENGINE_ENABLE_OPENMP)
     target_link_libraries(audiocpp_cli PRIVATE OpenMP::OpenMP_CXX)
+endif()
+
+# ---------------------------------------------------------------------------
+# C ABI (opt-in)
+#
+# A thin facade over engine::runtime for embedding audio.cpp in-process from
+# languages that can call C. Purely additive: nothing above this point changes
+# when AUDIOCPP_BUILD_C_API is OFF, which is the default.
+# ---------------------------------------------------------------------------
+if (AUDIOCPP_BUILD_C_API)
+    add_library(audiocpp SHARED src/capi/audiocpp.cpp)
+    target_link_libraries(audiocpp PRIVATE engine_runtime ggml)
+    target_include_directories(audiocpp PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    )
+    target_compile_definitions(audiocpp
+        PRIVATE
+            AUDIOCPP_BUILD_DLL
+            AUDIOCPP_VERSION_STRING="${AUDIOCPP_VERSION}"
+        # Anything linking this gets __declspec(dllimport) on Windows without
+        # having to know to ask for it. No effect elsewhere.
+        INTERFACE
+            AUDIOCPP_USE_DLL
+    )
+    set_target_properties(audiocpp PROPERTIES
+        VERSION 0.1.0
+        SOVERSION 0
+        C_VISIBILITY_PRESET hidden
+        CXX_VISIBILITY_PRESET hidden
+        VISIBILITY_INLINES_HIDDEN ON
+    )
+    # The visibility presets above only reach this target's own sources. The
+    # static libraries linked in (ggml, cJSON, sentencepiece, ...) are built
+    # without -fvisibility=hidden, so without an explicit export list they are
+    # re-exported from libaudiocpp -- measured at 2767 dynamic symbols where the
+    # header declares 69 -- and can collide with whatever the host application
+    # has already loaded. Restrict the surface to audiocpp_*.
+    #
+    # Windows has no equivalent of these allowlists: __declspec(dllexport) is
+    # additive, so a DLL's surface is whatever its own annotations plus its
+    # dependencies' annotations add up to. Exclusivity there comes from making
+    # sure no dependency annotates its symbols, which is why cjson_vendor is
+    # built with CJSON_HIDE_SYMBOLS above.
+    if (APPLE)
+        target_link_options(audiocpp PRIVATE
+            "-Wl,-exported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/src/capi/audiocpp.symbols")
+        set_property(TARGET audiocpp APPEND PROPERTY
+            LINK_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/capi/audiocpp.symbols")
+    elseif (NOT WIN32)
+        target_link_options(audiocpp PRIVATE
+            "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/src/capi/audiocpp.map"
+            "-Wl,--exclude-libs,ALL")
+        set_property(TARGET audiocpp APPEND PROPERTY
+            LINK_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/capi/audiocpp.map")
+    endif()
+    if (ENGINE_ENABLE_OPENMP)
+        target_link_libraries(audiocpp PRIVATE OpenMP::OpenMP_CXX)
+    endif()
+    if(AUDIOCPP_STATIC_ESPEAK)
+        audiocpp_stage_espeak(audiocpp)
+    endif()
+
+    # enable_testing() is called again further down for the framework test
+    # suites; repeating it here is harmless, and it is what lets this test
+    # register without depending on ENGINE_BUILD_TESTS.
+    enable_testing()
+
+    # Compiled as C, not C++: the point of the test is that the header is
+    # consumable by a C compiler with no C++ runtime on the caller's side.
+    add_executable(audiocpp_c_api_path_test tests/capi/path_test.c)
+    target_link_libraries(audiocpp_c_api_path_test PRIVATE audiocpp)
+    set_target_properties(audiocpp_c_api_path_test PROPERTIES C_STANDARD 99)
+    add_test(NAME audiocpp_c_api_path
+        COMMAND audiocpp_c_api_path_test
+            "${CMAKE_CURRENT_SOURCE_DIR}/assets/framework/models/silero_vad"
+            "${CMAKE_CURRENT_SOURCE_DIR}/assets/resources/sample_16k.wav")
+
+    # Real families across task types. Needs downloaded models, so it reports
+    # SKIP rather than failure when AUDIOCPP_C_API_MODEL_ROOT is unset or a
+    # package is absent -- a checkout with no downloads still goes green.
+    add_executable(audiocpp_c_api_model_test tests/capi/model_test.c)
+    target_link_libraries(audiocpp_c_api_model_test PRIVATE audiocpp)
+    set_target_properties(audiocpp_c_api_model_test PROPERTIES C_STANDARD 99)
+    # Source separation dominates this test's wall time and scales with threads
+    # (measured 191s at 4, 113s at 16), and thread count does not change results
+    # -- verified bit-identical stems at both. So use the host's cores.
+    include(ProcessorCount)
+    ProcessorCount(AUDIOCPP_C_API_TEST_THREADS)
+    if (AUDIOCPP_C_API_TEST_THREADS EQUAL 0)
+        set(AUDIOCPP_C_API_TEST_THREADS 4)
+    endif()
+    add_test(NAME audiocpp_c_api_model
+        COMMAND audiocpp_c_api_model_test
+            "${AUDIOCPP_C_API_MODEL_ROOT}"
+            "${CMAKE_CURRENT_SOURCE_DIR}/assets/resources/sample_16k.wav"
+            "cpu"
+            "${CMAKE_CURRENT_SOURCE_DIR}/tests/ace_step/assets/complete_source_demucs_8s.wav"
+            "${AUDIOCPP_C_API_TEST_THREADS}")
+    set_tests_properties(audiocpp_c_api_model PROPERTIES SKIP_RETURN_CODE 77)
+
+    find_package(Python3 COMPONENTS Interpreter QUIET)
+
+    # The export surface is a property three platforms reach three different
+    # ways, and on Windows nothing enforces it at all -- a newly vendored
+    # library that annotates its own symbols would silently widen the DLL.
+    # cJSON did exactly that. So it is asserted rather than left to a comment.
+    if (Python3_Interpreter_FOUND)
+        # dumpbin ships beside the cl.exe that built the library, so its location
+        # is already known here -- no searching, no version guessing, and it is
+        # guaranteed to match the toolset that produced the binary. It is not on
+        # PATH outside a Developer Command Prompt, so without this the check
+        # silently skips on the one platform that has no export allowlist.
+        set(AUDIOCPP_EXPORT_TOOL_ARGS "")
+        if (MSVC)
+            get_filename_component(AUDIOCPP_MSVC_BIN "${CMAKE_CXX_COMPILER}" DIRECTORY)
+            find_program(AUDIOCPP_DUMPBIN dumpbin HINTS "${AUDIOCPP_MSVC_BIN}" NO_DEFAULT_PATH)
+            if (AUDIOCPP_DUMPBIN)
+                list(APPEND AUDIOCPP_EXPORT_TOOL_ARGS --symbol-tool "${AUDIOCPP_DUMPBIN}")
+            endif()
+            # The tool ships with the compiler, so on MSVC its absence is a real
+            # problem rather than an unsupported platform. Fail loudly instead of
+            # reporting a green run with the invariant unchecked.
+            list(APPEND AUDIOCPP_EXPORT_TOOL_ARGS --require-tool)
+        endif()
+        add_test(NAME audiocpp_c_api_exports
+            COMMAND "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/tests/capi/export_surface.py"
+                --build-dir "${CMAKE_BINARY_DIR}"
+                --header "${CMAKE_CURRENT_SOURCE_DIR}/include/audiocpp.h"
+                ${AUDIOCPP_EXPORT_TOOL_ARGS})
+        set_tests_properties(audiocpp_c_api_exports PROPERTIES SKIP_RETURN_CODE 77)
+    endif()
+
+    # The C API drives the same runtime audiocpp_cli does, so for identical
+    # inputs the two must produce identical output. That is the property worth
+    # testing -- not that the facade is plausible, but that it agrees. Skips
+    # when the CLI or the models are absent.
+    if (Python3_Interpreter_FOUND)
+        add_test(NAME audiocpp_c_api_parity
+            COMMAND "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/tests/capi/parity.py"
+                --build-dir "${CMAKE_BINARY_DIR}"
+                --models-root "${AUDIOCPP_C_API_MODEL_ROOT}"
+                --audio "${CMAKE_CURRENT_SOURCE_DIR}/assets/resources/sample_16k.wav"
+                --alt-audio "${CMAKE_CURRENT_SOURCE_DIR}/tests/ace_step/assets/complete_source_demucs_8s.wav"
+                --threads "${AUDIOCPP_C_API_TEST_THREADS}")
+        set_tests_properties(audiocpp_c_api_parity PROPERTIES SKIP_RETURN_CODE 77)
+    endif()
 endif()
 
 set(AUDIOCPP_UI_DIST "${CMAKE_CURRENT_SOURCE_DIR}/webui/native/dist/index.html")

--- a/docs/c_api.md
+++ b/docs/c_api.md
@@ -1,0 +1,292 @@
+# C API
+
+`include/audiocpp.h` is a C ABI for embedding audio.cpp **in-process**. It is a
+facade over `engine::runtime` and adds no behaviour of its own: every call maps
+onto `ModelRegistry` → `ILoadedVoiceModel` → `IVoiceTaskSession`, the same
+surfaces `audiocpp_cli` uses.
+
+It is off by default.
+
+```bash
+cmake -S . -B build -DAUDIOCPP_BUILD_C_API=ON
+cmake --build build --target audiocpp
+```
+
+This produces `libaudiocpp.so` / `libaudiocpp.dylib` / `audiocpp.dll` with
+`SOVERSION 0`. Nothing changes in a build that leaves the option off.
+
+## When to use it
+
+| | best for | cost |
+|---|---|---|
+| `audiocpp_cli` | scripting, batch jobs | a process per request; weights reload every time |
+| `audiocpp_server` | multi-client, remote, OpenAI-compatible clients | a port, a supervised process, audio serialization per call |
+| C API | embedding in an application | you manage the handles yourself |
+
+The C API is the only one of the three that keeps a session warm inside your own
+process, so it is the one that benefits from graph and cache reuse across
+requests.
+
+## Contract
+
+- **Opaque handles only.** No C++ type crosses the boundary.
+- **No exception escapes.** Every entry point returns `audiocpp_status`.
+  `audiocpp_last_error()` gives the detail for the last failing call *on the
+  calling thread*.
+- **Returned `const char *` and `const float *` are borrowed.** They are valid
+  until the handle that produced them is freed or mutated. Copy anything you
+  intend to keep.
+- **Strings are never NULL.** A field the model did not populate reads as `""`,
+  so callers need no null checks on returned strings.
+- **Freeing NULL is a no-op**, so cleanup paths need no null checks either.
+- **Out parameters are optional.** Pass NULL for anything you do not want.
+- **Handles are not individually thread-safe.** Separate handles may be used
+  concurrently from separate threads.
+
+### Lifetime
+
+Handles hold their parents alive internally: a session holds its model, and a
+model holds its registry. **Freeing out of order is therefore safe.**
+
+```c
+audiocpp_model_free(model);        /* the session keeps working */
+audiocpp_registry_free(registry);
+audiocpp_session_run(session, request, &result);   /* still valid */
+audiocpp_session_free(session);
+```
+
+This is deliberate. Callers from garbage-collected runtimes cannot control the
+order finalizers run in, and requiring them to would make the ABI a trap. The
+path test asserts it.
+
+### Versioning
+
+`audiocpp_abi_version()` returns `(major << 16) | (minor << 8) | patch`. A
+caller built against a different **major** must not use the library. Check it
+once at load time:
+
+```c
+if ((audiocpp_abi_version() >> 16) != AUDIOCPP_ABI_VERSION_MAJOR) {
+    /* refuse to proceed */
+}
+```
+
+## Usage
+
+```c
+#include "audiocpp.h"
+
+audiocpp_registry * registry = NULL;
+audiocpp_model    * model    = NULL;
+audiocpp_session  * session  = NULL;
+audiocpp_request  * request  = NULL;
+audiocpp_result   * result   = NULL;
+
+audiocpp_model_config config = { "kokoro_tts", NULL, NULL, NULL };
+
+audiocpp_registry_create(NULL, &registry);
+audiocpp_model_load(registry, "models/Kokoro-82M-GGUF/kokoro-82m-q8_0.gguf",
+                    &config, NULL, &model);
+
+audiocpp_backend_config backend = { "cuda", 0, 4 };
+audiocpp_session_create(model, "tts", "offline", &backend, NULL, &session);
+
+request = audiocpp_request_create();
+audiocpp_request_set_text(request, "Hello from audio.cpp.", "en-us");
+audiocpp_request_set_option(request, "voice-id", "af_heart");
+
+if (audiocpp_session_run(session, request, &result) == AUDIOCPP_OK) {
+    const float * samples; size_t frames; int rate, channels;
+    audiocpp_result_audio(result, &samples, &frames, &rate, &channels);
+    /* samples is interleaved and borrowed: frames * channels floats. */
+}
+
+audiocpp_result_free(result);
+audiocpp_request_free(request);
+audiocpp_session_free(session);
+audiocpp_model_free(model);
+audiocpp_registry_free(registry);
+```
+
+`task` and `mode` take the same spellings as `--task` and `--mode`; `backend`
+takes the same spellings as `--backend`. Options map 1:1 onto `--load-option`,
+`--session-option`, and `--request-option`, and the fields of
+`audiocpp_model_config` map onto `--family`, `--config`, `--weight` and
+`--model-spec-override`.
+
+Beyond text and audio, a request carries everything `TaskRequest` does: a
+speaker reference (`audiocpp_request_set_voice_id` /
+`..._set_voice_audio`), style conditioning (`..._set_speaking_rate`,
+`..._set_pitch_shift`, `..._set_emotion`, `..._set_style_language`,
+`..._set_energy_scale`, `..._set_style_tag`), and input artifacts
+(`audiocpp_request_add_artifact`). Results expose the matching outputs,
+including artifacts, so a speaker embedding can be read out of one result and
+fed back into a later request instead of being re-derived.
+
+## Discovering what a model accepts
+
+`ModelInspection::cli` is exposed, so a binding can enumerate a family's options
+at runtime instead of hardcoding per-family knowledge:
+
+```c
+size_t count = audiocpp_model_option_count(model, AUDIOCPP_OPTION_SCOPE_REQUEST);
+for (size_t i = 0; i < count; ++i) {
+    const char *name, *value_name, *description, *fallback, *min_value, *max_value;
+    int required;
+    audiocpp_model_option(model, AUDIOCPP_OPTION_SCOPE_REQUEST, i,
+                          &name, &value_name, &description, &fallback,
+                          &min_value, &max_value, &required);
+}
+```
+
+Bounds come through too, so generated wrappers can validate rather than just
+pass values along — Sortformer's `speaker_threshold` reports `[0, 1]`, Kokoro's
+`text_chunk_size` reports a minimum of 32.
+
+This is what keeps the ABI independent of the model surface: the option maps are
+`string -> string` in the framework already, so **adding a model family never
+changes this header**.
+
+## Streaming
+
+Pull-based, mirroring `IStreamingVoiceTaskSession`. No callback crosses the FFI
+boundary.
+
+```c
+audiocpp_session_create(model, "vad", "streaming", &backend, NULL, &session);
+
+int64_t chunk = 0;
+audiocpp_stream_policy(session, NULL, NULL, &chunk, NULL);   /* frames per push */
+audiocpp_stream_start(session, NULL);
+
+for (...) {
+    audiocpp_event * event = NULL;
+    audiocpp_stream_push(session, block, (size_t)chunk, 16000, 1, offset, &event);
+    if (event) {
+        const audiocpp_result * view = audiocpp_event_as_result(event);
+        /* read via the result accessors */
+        audiocpp_event_free(event);
+    }
+}
+
+audiocpp_stream_finish(session, &result);
+```
+
+A `StreamEvent` carries the same shapes a `TaskResult` does under different
+names, so it is read through the result accessors: `partial_text` appears as
+the result's text, and any voice-activity event carrying a segment appears as a
+speech segment. `audiocpp_stream_next_event()` sets `*out_event` to NULL when
+the queue is empty — that is `AUDIOCPP_OK`, not an error.
+
+## Symbol surface
+
+`libaudiocpp.so` exports exactly the 55 entry points in `audiocpp.h` and nothing
+else. This needs a linker export list, not just `CXX_VISIBILITY_PRESET hidden`:
+the visibility preset reaches only this target's own sources, while the static
+libraries linked in (ggml, cJSON, sentencepiece, ...) are compiled without
+`-fvisibility=hidden` and would otherwise be re-exported — 2767 dynamic symbols
+instead of 55, any of which could collide with something the host application
+has already loaded.
+
+`src/capi/audiocpp.map` (ELF) and `src/capi/audiocpp.symbols` (Mach-O) hold that
+list.
+
+Windows works differently and is worth understanding, because the obvious
+assumption is wrong. `__declspec(dllexport)` is **additive** — it says "also
+export this", never "export only this" — so a DLL's surface is its own
+annotations plus every annotation in the static libraries it absorbs. There is
+no PE equivalent of an allowlist short of a `.def` file. Vendored cJSON defaults
+to annotating all 78 of its public functions, which put the first Windows build
+at 147 exports instead of 69; `cjson_vendor` is therefore compiled with
+`CJSON_HIDE_SYMBOLS`. If a future dependency starts annotating its symbols, the
+Windows surface will grow again and neither of the two allowlists will stop it —
+which is why `audiocpp_c_api_exports` asserts the surface on every platform
+rather than leaving it to this paragraph.
+
+To check:
+
+```bash
+# ELF
+nm -D --defined-only build/bin/libaudiocpp.so | awk '$2=="T"{print $3}' | grep -cv '^audiocpp_'
+# Mach-O
+nm -gU build/bin/libaudiocpp.dylib | awk '{print $NF}' | grep -cv '^_audiocpp_'
+# PE
+dumpbin /EXPORTS build\bin\Release\audiocpp.dll
+# all three: 0 non-matching, 69 total
+```
+
+## Notes
+
+- The library does **not** call `omp_set_num_threads()`. `audiocpp_cli` does,
+  but that is process-global state and a library embedded in a host application
+  has no business changing it. Set `threads` in `audiocpp_backend_config`.
+- `audiocpp_session_run()` prepares the session implicitly. Call
+  `audiocpp_session_prepare()` directly only to pay that cost ahead of a
+  latency-sensitive run; the next run will then skip it.
+- The facade depends only on framework headers, never on `app/`, so the CLI and
+  the C API stay independent of each other. The one consequence is that the
+  backend-name mapping is duplicated from `app/cli/args.cpp`.
+
+## Test
+
+`tests/capi/path_test.c` is compiled **as C**, which is the point: the header
+must be consumable by a C compiler with no C++ runtime on the caller's side. It
+runs against Silero VAD, which ships in-repo, so it needs no model download.
+
+```bash
+cmake -S . -B build -DAUDIOCPP_BUILD_C_API=ON
+cmake --build build --target audiocpp_c_api_path_test
+ctest --test-dir build -R audiocpp_c_api_path --output-on-failure
+```
+
+Note the `-R audiocpp_c_api_path` there rather than the wider `-R audiocpp_c_api`.
+CTest treats a registered test whose executable has not been built as a hard
+failure rather than a skip, so running the full selector after building only one
+test binary reports red for a reason that is not a real failure. Either name the
+binaries you want, as below, or just `cmake --build build` and let everything
+build.
+
+The registered test runs on CPU so it needs no GPU. A fourth argument selects
+another backend through the ABI:
+
+```bash
+./build/bin/audiocpp_c_api_path_test \
+    assets/framework/models/silero_vad assets/resources/sample_16k.wav cuda
+```
+
+### Tests
+
+| test | needs | covers |
+|---|---|---|
+| `audiocpp_c_api_exports` | nothing | that the library exports exactly this header |
+| `audiocpp_c_api_path` | nothing (in-repo model) | the ABI contract, offline + streaming |
+| `audiocpp_c_api_model` | downloaded models | real families across TTS / ASR / diarization |
+| `audiocpp_c_api_parity` | models + `audiocpp_cli` | that the C API and the CLI agree |
+
+The last two **skip** (CTest exit 77) rather than fail when models are absent, so
+a checkout with no downloads still reports green. Point them at a models root:
+
+```bash
+cmake -S . -B build -DAUDIOCPP_BUILD_C_API=ON \
+    -DAUDIOCPP_C_API_MODEL_ROOT=/path/to/models
+cmake --build build --target audiocpp_c_api_path_test audiocpp_c_api_model_test audiocpp_cli
+ctest --test-dir build -R audiocpp_c_api --output-on-failure
+```
+
+`audiocpp_c_api_parity` is the one that answers "is this actually working": the
+C API drives the same runtime the CLI does, so for identical inputs the two must
+produce identical output.
+
+Note that generative families draw noise per run — two unseeded `audiocpp_cli`
+Kokoro runs over the same text produce different audio — so the parity check
+seeds both sides. Without that the comparison would be meaningless.
+
+### The path test
+
+It covers both the offline and the streaming surface -- Silero advertises
+`vad/streaming`, so no extra model is needed -- and asserts the ABI contract
+rather than the model's judgement: status codes, borrowed-string rules,
+out-of-range handling, out-of-order frees, each mode refusing the other's entry
+point, and that a reused session gives the same answer twice. It deliberately does not assert that
+synthetic audio is detected as speech, which would pin the test to Silero's
+thresholds instead of to the ABI.

--- a/include/audiocpp.h
+++ b/include/audiocpp.h
@@ -1,0 +1,457 @@
+/*
+ * audiocpp.h — C ABI for embedding audio.cpp in-process.
+ *
+ * This is a thin facade over engine::runtime. It adds no behaviour of its own:
+ * every call maps onto ModelRegistry -> ILoadedVoiceModel -> IVoiceTaskSession,
+ * the same surfaces audiocpp_cli uses.
+ *
+ * Contract:
+ *   - Opaque handles only. No C++ type crosses this boundary.
+ *   - No exception escapes. Every entry point returns audiocpp_status; the
+ *     detail for the last failing call on THIS thread is audiocpp_last_error().
+ *   - `const char *` and `const float *` outputs are BORROWED. They stay valid
+ *     until the handle that produced them is freed or mutated. Copy anything
+ *     you intend to keep.
+ *   - Handles are not thread-safe individually. Separate handles may be used
+ *     concurrently from separate threads.
+ *   - Freeing NULL is a no-op, so cleanup paths need no null checks.
+ *
+ * Lifetime note: handles keep their parents alive internally (a session holds
+ * its model, a model holds its registry). Freeing out of order is therefore
+ * safe, which matters for garbage-collected callers where finalizer order is
+ * not deterministic.
+ */
+
+#ifndef AUDIOCPP_H
+#define AUDIOCPP_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(_WIN32)
+#  if defined(AUDIOCPP_BUILD_DLL)
+#    define AUDIOCPP_API __declspec(dllexport)
+#  elif defined(AUDIOCPP_USE_DLL)
+#    define AUDIOCPP_API __declspec(dllimport)
+#  else
+#    define AUDIOCPP_API
+#  endif
+#elif defined(__GNUC__)
+#  define AUDIOCPP_API __attribute__((visibility("default")))
+#else
+#  define AUDIOCPP_API
+#endif
+
+/* ------------------------------------------------------------------ */
+/* Versioning                                                          */
+/* ------------------------------------------------------------------ */
+
+#define AUDIOCPP_ABI_VERSION_MAJOR 0
+#define AUDIOCPP_ABI_VERSION_MINOR 1
+#define AUDIOCPP_ABI_VERSION_PATCH 0
+
+/* Packed as (major << 16) | (minor << 8) | patch. A caller built against a
+ * different MAJOR must not use the library. */
+AUDIOCPP_API uint32_t audiocpp_abi_version(void);
+
+/* audio.cpp's own build version, e.g. "0.2.1". Borrowed, static lifetime. */
+AUDIOCPP_API const char * audiocpp_build_version(void);
+
+/* ------------------------------------------------------------------ */
+/* Status and errors                                                   */
+/* ------------------------------------------------------------------ */
+
+typedef enum audiocpp_status {
+    AUDIOCPP_OK = 0,
+    AUDIOCPP_ERR_INVALID_ARGUMENT = 1,
+    AUDIOCPP_ERR_UNSUPPORTED_FAMILY = 2,
+    AUDIOCPP_ERR_LOAD_FAILED = 3,
+    AUDIOCPP_ERR_RUNTIME = 4,
+    AUDIOCPP_ERR_OUT_OF_MEMORY = 5,
+    AUDIOCPP_ERR_OUT_OF_RANGE = 6,
+    AUDIOCPP_ERR_NOT_AVAILABLE = 7
+} audiocpp_status;
+
+/* Detail for the most recent failure on this thread. Read it immediately after
+ * a call returns non-OK; a later successful call may clear it. Never NULL, and
+ * borrowed until this thread's next call. */
+AUDIOCPP_API const char * audiocpp_last_error(void);
+
+/* Human-readable name for a status code. Borrowed, static lifetime. */
+AUDIOCPP_API const char * audiocpp_status_string(audiocpp_status status);
+
+/* ------------------------------------------------------------------ */
+/* Handles                                                             */
+/* ------------------------------------------------------------------ */
+
+typedef struct audiocpp_registry audiocpp_registry;
+typedef struct audiocpp_model    audiocpp_model;
+typedef struct audiocpp_session  audiocpp_session;
+typedef struct audiocpp_options  audiocpp_options;
+typedef struct audiocpp_request  audiocpp_request;
+typedef struct audiocpp_result   audiocpp_result;
+typedef struct audiocpp_event    audiocpp_event;
+
+/* ------------------------------------------------------------------ */
+/* Options — mirrors the framework's string->string option maps 1:1.   */
+/* ------------------------------------------------------------------ */
+
+AUDIOCPP_API audiocpp_options * audiocpp_options_create(void);
+AUDIOCPP_API audiocpp_status    audiocpp_options_set(audiocpp_options * options,
+                                                     const char * key,
+                                                     const char * value);
+AUDIOCPP_API void               audiocpp_options_free(audiocpp_options * options);
+
+/* ------------------------------------------------------------------ */
+/* Registry                                                            */
+/* ------------------------------------------------------------------ */
+
+/* config_path may be NULL for the default loader set. */
+AUDIOCPP_API audiocpp_status audiocpp_registry_create(const char * config_path,
+                                                      audiocpp_registry ** out_registry);
+AUDIOCPP_API void            audiocpp_registry_free(audiocpp_registry * registry);
+
+AUDIOCPP_API size_t          audiocpp_registry_family_count(const audiocpp_registry * registry);
+AUDIOCPP_API audiocpp_status audiocpp_registry_family(const audiocpp_registry * registry,
+                                                      size_t index,
+                                                      const char ** out_family);
+
+/* ------------------------------------------------------------------ */
+/* Model                                                               */
+/* ------------------------------------------------------------------ */
+
+/* Model selection. Every field may be NULL:
+ *   family_hint          --family, or NULL to identify the model from its path
+ *   config_id            --config, for packages that ship several configs
+ *   weight_id            --weight, for packages that ship several weight sets
+ *   model_spec_override  --model-spec-override */
+typedef struct audiocpp_model_config {
+    const char * family_hint;
+    const char * config_id;
+    const char * weight_id;
+    const char * model_spec_override;
+} audiocpp_model_config;
+
+/* config and options may both be NULL. options corresponds to --load-option. */
+AUDIOCPP_API audiocpp_status audiocpp_model_load(audiocpp_registry * registry,
+                                                  const char * model_path,
+                                                  const audiocpp_model_config * config,
+                                                  const audiocpp_options * options,
+                                                  audiocpp_model ** out_model);
+AUDIOCPP_API void            audiocpp_model_free(audiocpp_model * model);
+
+AUDIOCPP_API const char * audiocpp_model_family(const audiocpp_model * model);
+AUDIOCPP_API const char * audiocpp_model_description(const audiocpp_model * model);
+
+/* Capability queries. task/mode are the same spellings the CLI accepts,
+ * e.g. "tts", "asr", "vad", "diarization", "alignment" / "offline",
+ * "streaming". Returns 1 when supported, 0 when not or when unrecognised. */
+AUDIOCPP_API int audiocpp_model_supports(const audiocpp_model * model,
+                                         const char * task,
+                                         const char * mode);
+AUDIOCPP_API int audiocpp_model_supports_timestamps(const audiocpp_model * model);
+AUDIOCPP_API int audiocpp_model_supports_speaker_reference(const audiocpp_model * model);
+AUDIOCPP_API int audiocpp_model_supports_style_condition(const audiocpp_model * model);
+
+AUDIOCPP_API size_t          audiocpp_model_language_count(const audiocpp_model * model);
+AUDIOCPP_API audiocpp_status audiocpp_model_language(const audiocpp_model * model,
+                                                     size_t index,
+                                                     const char ** out_language);
+
+/* Which option map a CliOptionInfo belongs to. */
+typedef enum audiocpp_option_scope {
+    AUDIOCPP_OPTION_SCOPE_REQUEST = 0,
+    AUDIOCPP_OPTION_SCOPE_SESSION = 1,
+    AUDIOCPP_OPTION_SCOPE_LOAD    = 2
+} audiocpp_option_scope;
+
+/* Runtime introspection of a model's declared options, straight off
+ * ModelInspection::cli. This is what lets a binding enumerate what a family
+ * accepts instead of hardcoding per-family knowledge.
+ *
+ * Every out parameter is optional — pass NULL for anything you don't want.
+ * Strings that the model did not declare come back as "" rather than NULL, so
+ * callers never need a null check on them. out_required is 1 or 0. */
+AUDIOCPP_API size_t          audiocpp_model_option_count(const audiocpp_model * model,
+                                                         audiocpp_option_scope scope);
+AUDIOCPP_API audiocpp_status audiocpp_model_option(const audiocpp_model * model,
+                                                   audiocpp_option_scope scope,
+                                                   size_t index,
+                                                   const char ** out_name,
+                                                   const char ** out_value_name,
+                                                   const char ** out_description,
+                                                   const char ** out_default_value,
+                                                   const char ** out_min_value,
+                                                   const char ** out_max_value,
+                                                   int * out_required);
+
+/* ------------------------------------------------------------------ */
+/* Session                                                             */
+/* ------------------------------------------------------------------ */
+
+/* backend is "cpu", "cuda", "hip"/"rocm", "vulkan", "metal" or "best";
+ * NULL means "cpu". device and threads mirror --device / --threads. */
+typedef struct audiocpp_backend_config {
+    const char * backend;
+    int          device;
+    int          threads;
+} audiocpp_backend_config;
+
+/* backend_config may be NULL for CPU / device 0 / 1 thread.
+ * options may be NULL. Corresponds to --session-option. */
+AUDIOCPP_API audiocpp_status audiocpp_session_create(const audiocpp_model * model,
+                                                      const char * task,
+                                                      const char * mode,
+                                                      const audiocpp_backend_config * backend_config,
+                                                      const audiocpp_options * options,
+                                                      audiocpp_session ** out_session);
+AUDIOCPP_API void            audiocpp_session_free(audiocpp_session * session);
+
+AUDIOCPP_API const char * audiocpp_session_family(const audiocpp_session * session);
+
+/* Optional. audiocpp_session_run() and audiocpp_stream_start() always prepare
+ * with the request they are about to run -- preparation carries the input
+ * length, so a session prepared for one request must not run another. Call this
+ * only to force allocation early, with a request representative of what will
+ * follow; the run still prepares. */
+AUDIOCPP_API audiocpp_status audiocpp_session_prepare(audiocpp_session * session,
+                                                      const audiocpp_request * request);
+
+AUDIOCPP_API audiocpp_status audiocpp_session_run(audiocpp_session * session,
+                                                  const audiocpp_request * request,
+                                                  audiocpp_result ** out_result);
+
+/* ------------------------------------------------------------------ */
+/* Request                                                             */
+/* ------------------------------------------------------------------ */
+
+AUDIOCPP_API audiocpp_request * audiocpp_request_create(void);
+AUDIOCPP_API void               audiocpp_request_free(audiocpp_request * request);
+
+/* language may be NULL. A non-empty language is ALSO written to the request's
+ * "language" option, because that is what audiocpp_cli's --language does and
+ * some families read only the option. A later audiocpp_request_set_option with
+ * the same key overrides it. */
+AUDIOCPP_API audiocpp_status audiocpp_request_set_text(audiocpp_request * request,
+                                                       const char * text,
+                                                       const char * language);
+
+/* Interleaved float PCM. Copied into the request, so `samples` need not
+ * outlive the call. `frames` is per-channel. */
+AUDIOCPP_API audiocpp_status audiocpp_request_set_audio(audiocpp_request * request,
+                                                        const float * samples,
+                                                        size_t frames,
+                                                        int sample_rate,
+                                                        int channels);
+
+/* Speaker reference for cloning/conversion families. */
+AUDIOCPP_API audiocpp_status audiocpp_request_set_voice_audio(audiocpp_request * request,
+                                                              const float * samples,
+                                                              size_t frames,
+                                                              int sample_rate,
+                                                              int channels);
+AUDIOCPP_API audiocpp_status audiocpp_request_set_voice_id(audiocpp_request * request,
+                                                           const char * cached_voice_id);
+
+/* Style conditioning, for families that advertise it
+ * (audiocpp_model_supports_style_condition). These mirror --style-language,
+ * --emotion, --speaking-rate, --pitch-shift, --energy-scale and --style-tag.
+ * Each is independent; set only the ones you need. */
+AUDIOCPP_API audiocpp_status audiocpp_request_set_style_language(audiocpp_request * request,
+                                                                 const char * language);
+AUDIOCPP_API audiocpp_status audiocpp_request_set_emotion(audiocpp_request * request,
+                                                          const char * emotion);
+AUDIOCPP_API audiocpp_status audiocpp_request_set_speaking_rate(audiocpp_request * request,
+                                                                float speaking_rate);
+AUDIOCPP_API audiocpp_status audiocpp_request_set_pitch_shift(audiocpp_request * request,
+                                                              float pitch_shift);
+AUDIOCPP_API audiocpp_status audiocpp_request_set_energy_scale(audiocpp_request * request,
+                                                               float energy_scale);
+AUDIOCPP_API audiocpp_status audiocpp_request_set_style_tag(audiocpp_request * request,
+                                                            const char * key,
+                                                            const char * value);
+
+/* Artifacts: opaque payloads a family produces or consumes -- speaker
+ * embeddings, acoustic tokens, MIDI, diarization state. Persisting one from a
+ * result and feeding it back into a later request is how voice state is reused
+ * without re-deriving it. */
+typedef enum audiocpp_artifact_kind {
+    AUDIOCPP_ARTIFACT_SPEAKER_EMBEDDING = 0,
+    AUDIOCPP_ARTIFACT_STYLE_EMBEDDING = 1,
+    AUDIOCPP_ARTIFACT_PROMPT_EMBEDDING = 2,
+    AUDIOCPP_ARTIFACT_ACOUSTIC_TOKENS = 3,
+    AUDIOCPP_ARTIFACT_MIDI = 4,
+    AUDIOCPP_ARTIFACT_TRANSCRIPT_ALIGNMENT = 5,
+    AUDIOCPP_ARTIFACT_DIARIZATION_STATE = 6,
+    AUDIOCPP_ARTIFACT_VAD_STATE = 7,
+    AUDIOCPP_ARTIFACT_CUSTOM = 8
+} audiocpp_artifact_kind;
+
+/* The payload is copied, so it need not outlive the call. out_index (optional)
+ * receives the artifact's position, for use with set_artifact_meta. */
+AUDIOCPP_API audiocpp_status audiocpp_request_add_artifact(audiocpp_request * request,
+                                                           audiocpp_artifact_kind kind,
+                                                           const char * id,
+                                                           const void * payload,
+                                                           size_t payload_bytes,
+                                                           size_t * out_index);
+AUDIOCPP_API audiocpp_status audiocpp_request_set_artifact_meta(audiocpp_request * request,
+                                                                size_t index,
+                                                                const char * key,
+                                                                const char * value);
+
+/* Corresponds to --request-option. */
+AUDIOCPP_API audiocpp_status audiocpp_request_set_option(audiocpp_request * request,
+                                                         const char * key,
+                                                         const char * value);
+
+/* ------------------------------------------------------------------ */
+/* Result                                                              */
+/* ------------------------------------------------------------------ */
+/* Accessors rather than a struct copy, so TaskResult can gain fields without
+ * breaking the ABI. Every out parameter is optional. */
+
+AUDIOCPP_API void audiocpp_result_free(audiocpp_result * result);
+
+/* AUDIOCPP_ERR_NOT_AVAILABLE when the task produced no audio. */
+AUDIOCPP_API audiocpp_status audiocpp_result_audio(const audiocpp_result * result,
+                                                   const float ** out_samples,
+                                                   size_t * out_frames,
+                                                   int * out_sample_rate,
+                                                   int * out_channels);
+
+/* AUDIOCPP_ERR_NOT_AVAILABLE when the task produced no text. */
+AUDIOCPP_API audiocpp_status audiocpp_result_text(const audiocpp_result * result,
+                                                  const char ** out_text,
+                                                  const char ** out_language);
+
+AUDIOCPP_API size_t          audiocpp_result_segment_count(const audiocpp_result * result);
+AUDIOCPP_API audiocpp_status audiocpp_result_segment(const audiocpp_result * result,
+                                                     size_t index,
+                                                     int64_t * out_start_sample,
+                                                     int64_t * out_end_sample,
+                                                     float * out_confidence,
+                                                     const char ** out_text);
+
+AUDIOCPP_API size_t          audiocpp_result_speaker_turn_count(const audiocpp_result * result);
+AUDIOCPP_API audiocpp_status audiocpp_result_speaker_turn(const audiocpp_result * result,
+                                                          size_t index,
+                                                          int64_t * out_start_sample,
+                                                          int64_t * out_end_sample,
+                                                          const char ** out_speaker_id,
+                                                          float * out_confidence,
+                                                          const char ** out_text);
+
+AUDIOCPP_API size_t          audiocpp_result_word_count(const audiocpp_result * result);
+AUDIOCPP_API audiocpp_status audiocpp_result_word(const audiocpp_result * result,
+                                                  size_t index,
+                                                  const char ** out_word,
+                                                  int64_t * out_start_sample,
+                                                  int64_t * out_end_sample,
+                                                  float * out_confidence);
+
+/* Named audio outputs, for families that emit more than one stream
+ * (source separation, multi-speaker TTS). */
+AUDIOCPP_API size_t          audiocpp_result_named_audio_count(const audiocpp_result * result);
+AUDIOCPP_API audiocpp_status audiocpp_result_named_audio(const audiocpp_result * result,
+                                                         size_t index,
+                                                         const char ** out_id,
+                                                         const float ** out_samples,
+                                                         size_t * out_frames,
+                                                         int * out_sample_rate,
+                                                         int * out_channels);
+
+/* Artifacts the task produced. TaskResult carries a single artifact_output and
+ * a list of output_artifacts; both are presented here as one flat list, the
+ * single one first when present. The payload is borrowed. */
+AUDIOCPP_API size_t          audiocpp_result_artifact_count(const audiocpp_result * result);
+AUDIOCPP_API audiocpp_status audiocpp_result_artifact(const audiocpp_result * result,
+                                                      size_t index,
+                                                      audiocpp_artifact_kind * out_kind,
+                                                      const char ** out_id,
+                                                      const void ** out_payload,
+                                                      size_t * out_payload_bytes);
+AUDIOCPP_API size_t          audiocpp_result_artifact_meta_count(const audiocpp_result * result,
+                                                                 size_t index);
+AUDIOCPP_API audiocpp_status audiocpp_result_artifact_meta(const audiocpp_result * result,
+                                                           size_t index,
+                                                           size_t meta_index,
+                                                           const char ** out_key,
+                                                           const char ** out_value);
+
+/* ------------------------------------------------------------------ */
+/* Streaming                                                           */
+/* ------------------------------------------------------------------ */
+/* Pull-based, mirroring IStreamingVoiceTaskSession. No callback crosses the
+ * FFI boundary. Requires a session created with mode "streaming". */
+
+typedef enum audiocpp_stream_input_kind {
+    AUDIOCPP_STREAM_INPUT_NONE = 0,
+    AUDIOCPP_STREAM_INPUT_AUDIO_CHUNKS = 1
+} audiocpp_stream_input_kind;
+
+typedef enum audiocpp_stream_output_kind {
+    AUDIOCPP_STREAM_OUTPUT_FINAL_RESULT = 0,
+    AUDIOCPP_STREAM_OUTPUT_PULL_EVENTS = 1
+} audiocpp_stream_output_kind;
+
+/* The chunk size the family wants; push that many frames per call where you
+ * can. Every out parameter is optional. */
+AUDIOCPP_API audiocpp_status audiocpp_stream_policy(const audiocpp_session * session,
+                                                    audiocpp_stream_input_kind * out_input,
+                                                    audiocpp_stream_output_kind * out_output,
+                                                    int64_t * out_preferred_chunk_samples,
+                                                    double * out_preferred_chunk_seconds);
+
+/* request may be NULL. Resets any stream already in flight. */
+AUDIOCPP_API audiocpp_status audiocpp_stream_start(audiocpp_session * session,
+                                                   const audiocpp_request * request);
+
+/* Feeds one chunk and returns the event it produced. out_event may be NULL if
+ * the caller only wants the final result. */
+AUDIOCPP_API audiocpp_status audiocpp_stream_push(audiocpp_session * session,
+                                                  const float * samples,
+                                                  size_t frames,
+                                                  int sample_rate,
+                                                  int channels,
+                                                  int64_t start_sample,
+                                                  audiocpp_event ** out_event);
+
+/* Drains events the family queued itself. Sets *out_event to NULL when the
+ * queue is empty; that is AUDIOCPP_OK, not an error. */
+AUDIOCPP_API audiocpp_status audiocpp_stream_next_event(audiocpp_session * session,
+                                                        audiocpp_event ** out_event);
+
+AUDIOCPP_API audiocpp_status audiocpp_stream_finish(audiocpp_session * session,
+                                                    audiocpp_result ** out_result);
+AUDIOCPP_API audiocpp_status audiocpp_stream_reset(audiocpp_session * session);
+
+AUDIOCPP_API void audiocpp_event_free(audiocpp_event * event);
+AUDIOCPP_API int  audiocpp_event_is_final(const audiocpp_event * event);
+
+/* An event carries the same shapes a result does, so it is read through the
+ * result accessors. Borrowed — valid until the event is freed. */
+AUDIOCPP_API const audiocpp_result * audiocpp_event_as_result(const audiocpp_event * event);
+
+typedef enum audiocpp_voice_activity_kind {
+    AUDIOCPP_VOICE_ACTIVITY_SPEECH_START = 0,
+    AUDIOCPP_VOICE_ACTIVITY_SPEECH_END = 1,
+    AUDIOCPP_VOICE_ACTIVITY_SPEECH_SEGMENT = 2
+} audiocpp_voice_activity_kind;
+
+AUDIOCPP_API size_t          audiocpp_event_voice_activity_count(const audiocpp_event * event);
+AUDIOCPP_API audiocpp_status audiocpp_event_voice_activity(const audiocpp_event * event,
+                                                           size_t index,
+                                                           audiocpp_voice_activity_kind * out_kind,
+                                                           int64_t * out_sample,
+                                                           float * out_probability);
+
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif
+
+#endif /* AUDIOCPP_H */

--- a/src/capi/audiocpp.cpp
+++ b/src/capi/audiocpp.cpp
@@ -1,0 +1,1158 @@
+/*
+ * C ABI facade over engine::runtime.
+ *
+ * This file adds no behaviour. It owns three things and nothing else:
+ *   1. translating C types to and from the framework's own types,
+ *   2. stopping every exception at the boundary,
+ *   3. keeping parent handles alive so callers can free in any order.
+ *
+ * It deliberately depends only on the framework (the same headers
+ * audiocpp_cli uses) and never on app/, so the CLI and the C API stay
+ * independent of each other.
+ */
+
+#include "audiocpp.h"
+
+#include "engine/framework/core/backend.h"
+#include "engine/framework/core/module.h"
+#include "engine/framework/runtime/model.h"
+#include "engine/framework/runtime/registry.h"
+#include "engine/framework/runtime/session.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <filesystem>
+#include <iterator>
+#include <memory>
+#include <new>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace rt = engine::runtime;
+
+namespace {
+
+thread_local std::string g_last_error;
+
+const char * const kEmptyString = "";
+
+/* Every entry point funnels through here: the framework throws, the ABI
+ * returns codes. `runtime_status` lets a caller classify its own failures
+ * (a load failure is not a generic runtime failure) without parsing the
+ * exception message. */
+template <typename Fn>
+audiocpp_status guard(Fn && fn, audiocpp_status runtime_status = AUDIOCPP_ERR_RUNTIME) noexcept {
+    try {
+        g_last_error.clear();
+        return fn();
+    } catch (const std::bad_alloc & e) {
+        g_last_error = e.what();
+        return AUDIOCPP_ERR_OUT_OF_MEMORY;
+    } catch (const std::invalid_argument & e) {
+        g_last_error = e.what();
+        return AUDIOCPP_ERR_INVALID_ARGUMENT;
+    } catch (const std::exception & e) {
+        g_last_error = e.what();
+        return runtime_status;
+    } catch (...) {
+        g_last_error = "unknown error";
+        return runtime_status;
+    }
+}
+
+audiocpp_status fail(audiocpp_status status, const char * message) noexcept {
+    g_last_error = message;
+    return status;
+}
+
+engine::core::BackendType parse_backend_type(const std::string & value) {
+    /* Intentionally duplicated from app/cli/args.cpp rather than shared: the
+     * C API must not depend on the CLI app. The spellings are the CLI's. */
+    if (value == "cpu") return engine::core::BackendType::Cpu;
+    if (value == "cuda") return engine::core::BackendType::Cuda;
+    if (value == "hip" || value == "rocm") return engine::core::BackendType::Hip;
+    if (value == "vulkan") return engine::core::BackendType::Vulkan;
+    if (value == "metal") return engine::core::BackendType::Metal;
+    if (value == "best") return engine::core::BackendType::BestAvailable;
+    throw std::invalid_argument("unsupported backend: " + value);
+}
+
+std::unordered_map<std::string, std::string> option_map(const audiocpp_options * options);
+
+void assign_out(const char ** out, const std::string & value) {
+    if (out != nullptr) *out = value.c_str();
+}
+
+void assign_out(const char ** out, const std::optional<std::string> & value) {
+    if (out != nullptr) *out = value.has_value() ? value->c_str() : kEmptyString;
+}
+
+rt::AudioBuffer make_audio_buffer(const float * samples, size_t frames, int sample_rate, int channels) {
+    if (sample_rate <= 0) throw std::invalid_argument("sample_rate must be positive");
+    if (channels <= 0) throw std::invalid_argument("channels must be positive");
+    if (frames > 0 && samples == nullptr) throw std::invalid_argument("samples is null but frames > 0");
+    if (frames > SIZE_MAX / static_cast<size_t>(channels)) {
+        throw std::invalid_argument("frames * channels overflows");
+    }
+
+    rt::AudioBuffer buffer;
+    buffer.sample_rate = sample_rate;
+    buffer.channels = channels;
+    if (frames > 0) {
+        /* Interleaved, matching what the framework hands to the WAV sink.
+         * Guarded because [null, null) is not a valid range to assign from,
+         * even though an empty buffer is a legitimate request. */
+        buffer.samples.assign(samples, samples + (frames * static_cast<size_t>(channels)));
+    }
+    return buffer;
+}
+
+size_t frame_count(const rt::AudioBuffer & audio) noexcept {
+    const int channels = audio.channels > 0 ? audio.channels : 1;
+    return audio.samples.size() / static_cast<size_t>(channels);
+}
+
+}  // namespace
+
+/* ------------------------------------------------------------------ */
+/* Handles                                                             */
+/* ------------------------------------------------------------------ */
+
+struct audiocpp_options {
+    std::unordered_map<std::string, std::string> map;
+};
+
+struct audiocpp_registry {
+    std::shared_ptr<rt::ModelRegistry> registry;
+    std::vector<std::string> families;
+};
+
+struct audiocpp_model {
+    /* Held so the registry cannot outlive its loaded models regardless of the
+     * order the caller frees handles in. */
+    std::shared_ptr<rt::ModelRegistry> registry;
+    std::shared_ptr<rt::ILoadedVoiceModel> model;
+    rt::ModelLoadRequest load_request;
+
+    /* Inspection rescans the model directory, so it is deferred until a
+     * caller actually asks about options. */
+    mutable std::optional<rt::ModelInspection> inspection;
+
+    const rt::ModelInspection & inspect() const {
+        if (!inspection.has_value()) {
+            inspection = registry->inspect(load_request);
+        }
+        return *inspection;
+    }
+
+    const std::vector<rt::CliOptionInfo> & options_for(audiocpp_option_scope scope) const {
+        const auto & cli = inspect().cli;
+        switch (scope) {
+            case AUDIOCPP_OPTION_SCOPE_REQUEST: return cli.request_options;
+            case AUDIOCPP_OPTION_SCOPE_SESSION: return cli.session_options;
+            case AUDIOCPP_OPTION_SCOPE_LOAD:    return cli.load_options;
+        }
+        throw std::invalid_argument("unknown option scope");
+    }
+};
+
+struct audiocpp_session {
+    std::shared_ptr<rt::ModelRegistry> registry;
+    std::shared_ptr<rt::ILoadedVoiceModel> model;
+    std::unique_ptr<rt::IVoiceTaskSession> session;
+    rt::RunMode mode = rt::RunMode::Offline;
+    std::string family;
+
+    rt::IOfflineVoiceTaskSession & offline() const {
+        auto * offline = dynamic_cast<rt::IOfflineVoiceTaskSession *>(session.get());
+        if (offline == nullptr) {
+            throw std::runtime_error("session does not support offline execution");
+        }
+        return *offline;
+    }
+
+    rt::IStreamingVoiceTaskSession & streaming() const {
+        auto * streaming = dynamic_cast<rt::IStreamingVoiceTaskSession *>(session.get());
+        if (streaming == nullptr) {
+            throw std::runtime_error("session does not support streaming execution");
+        }
+        return *streaming;
+    }
+};
+
+struct audiocpp_request {
+    rt::TaskRequest request;
+};
+
+struct audiocpp_result {
+    rt::TaskResult result;
+    /* An event exposes its contents through a result view that it owns. The
+     * view has the same type as an owned result and there is a public free for
+     * that type, so freeing one has to be a no-op rather than a double free. */
+    bool owned = true;
+};
+
+struct audiocpp_event {
+    audiocpp_result view;
+    std::vector<rt::VoiceActivityEvent> voice_activity;
+    bool is_final = false;
+};
+
+namespace {
+
+std::unordered_map<std::string, std::string> option_map(const audiocpp_options * options) {
+    return options != nullptr ? options->map : std::unordered_map<std::string, std::string>{};
+}
+
+/* A StreamEvent carries the same shapes a TaskResult does under different
+ * names, so it is presented through the result accessors. partial_text maps
+ * to text_output, and any voice-activity event that carries a segment is
+ * surfaced as a speech segment. */
+std::unique_ptr<audiocpp_event> wrap_event(rt::StreamEvent && event) {
+    auto wrapped = std::make_unique<audiocpp_event>();
+    wrapped->view.owned = false;
+    wrapped->is_final = event.is_final;
+    wrapped->voice_activity = event.voice_activity;
+
+    auto & result = wrapped->view.result;
+    result.audio_output = std::move(event.audio_output);
+    result.named_audio_outputs = std::move(event.named_audio_outputs);
+    result.text_output = std::move(event.partial_text);
+    result.speaker_turns = std::move(event.speaker_turns);
+    result.word_timestamps = std::move(event.word_timestamps);
+    result.output_artifacts = std::move(event.output_artifacts);
+    for (const auto & activity : wrapped->voice_activity) {
+        if (activity.segment.has_value()) {
+            result.speech_segments.push_back(*activity.segment);
+        }
+    }
+    return wrapped;
+}
+
+}  // namespace
+
+/* ------------------------------------------------------------------ */
+/* Versioning                                                          */
+/* ------------------------------------------------------------------ */
+
+uint32_t audiocpp_abi_version(void) {
+    return (static_cast<uint32_t>(AUDIOCPP_ABI_VERSION_MAJOR) << 16) |
+           (static_cast<uint32_t>(AUDIOCPP_ABI_VERSION_MINOR) << 8) |
+           static_cast<uint32_t>(AUDIOCPP_ABI_VERSION_PATCH);
+}
+
+const char * audiocpp_build_version(void) {
+#ifdef AUDIOCPP_VERSION_STRING
+    return AUDIOCPP_VERSION_STRING;
+#else
+    return "unknown";
+#endif
+}
+
+const char * audiocpp_last_error(void) {
+    return g_last_error.c_str();
+}
+
+const char * audiocpp_status_string(audiocpp_status status) {
+    switch (status) {
+        case AUDIOCPP_OK: return "ok";
+        case AUDIOCPP_ERR_INVALID_ARGUMENT: return "invalid argument";
+        case AUDIOCPP_ERR_UNSUPPORTED_FAMILY: return "unsupported family";
+        case AUDIOCPP_ERR_LOAD_FAILED: return "load failed";
+        case AUDIOCPP_ERR_RUNTIME: return "runtime error";
+        case AUDIOCPP_ERR_OUT_OF_MEMORY: return "out of memory";
+        case AUDIOCPP_ERR_OUT_OF_RANGE: return "index out of range";
+        case AUDIOCPP_ERR_NOT_AVAILABLE: return "not available";
+    }
+    return "unknown status";
+}
+
+/* ------------------------------------------------------------------ */
+/* Options                                                             */
+/* ------------------------------------------------------------------ */
+
+audiocpp_options * audiocpp_options_create(void) {
+    try {
+        return new audiocpp_options();
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+audiocpp_status audiocpp_options_set(audiocpp_options * options, const char * key, const char * value) {
+    if (options == nullptr || key == nullptr || value == nullptr) {
+        return fail(AUDIOCPP_ERR_INVALID_ARGUMENT, "options, key and value must be non-null");
+    }
+    return guard([&] {
+        options->map[key] = value;
+        return AUDIOCPP_OK;
+    });
+}
+
+void audiocpp_options_free(audiocpp_options * options) {
+    delete options;
+}
+
+/* ------------------------------------------------------------------ */
+/* Registry                                                            */
+/* ------------------------------------------------------------------ */
+
+audiocpp_status audiocpp_registry_create(const char * config_path, audiocpp_registry ** out_registry) {
+    if (out_registry == nullptr) {
+        return fail(AUDIOCPP_ERR_INVALID_ARGUMENT, "out_registry must be non-null");
+    }
+    *out_registry = nullptr;
+    return guard([&] {
+        auto handle = std::make_unique<audiocpp_registry>();
+        auto config = config_path != nullptr
+            ? std::optional<std::filesystem::path>(std::filesystem::path(config_path))
+            : std::nullopt;
+        handle->registry = std::make_shared<rt::ModelRegistry>(rt::make_default_registry(config));
+        handle->families = handle->registry->families();
+        *out_registry = handle.release();
+        return AUDIOCPP_OK;
+    });
+}
+
+void audiocpp_registry_free(audiocpp_registry * registry) {
+    delete registry;
+}
+
+size_t audiocpp_registry_family_count(const audiocpp_registry * registry) {
+    return registry != nullptr ? registry->families.size() : 0;
+}
+
+audiocpp_status audiocpp_registry_family(const audiocpp_registry * registry, size_t index, const char ** out_family) {
+    if (registry == nullptr || out_family == nullptr) {
+        return fail(AUDIOCPP_ERR_INVALID_ARGUMENT, "registry and out_family must be non-null");
+    }
+    if (index >= registry->families.size()) {
+        return fail(AUDIOCPP_ERR_OUT_OF_RANGE, "family index out of range");
+    }
+    *out_family = registry->families[index].c_str();
+    return AUDIOCPP_OK;
+}
+
+/* ------------------------------------------------------------------ */
+/* Model                                                               */
+/* ------------------------------------------------------------------ */
+
+audiocpp_status audiocpp_model_load(audiocpp_registry * registry,
+                                    const char * model_path,
+                                    const audiocpp_model_config * config,
+                                    const audiocpp_options * options,
+                                    audiocpp_model ** out_model) {
+    if (registry == nullptr || model_path == nullptr || out_model == nullptr) {
+        return fail(AUDIOCPP_ERR_INVALID_ARGUMENT, "registry, model_path and out_model must be non-null");
+    }
+    *out_model = nullptr;
+    const char * family_hint = config != nullptr ? config->family_hint : nullptr;
+    /* Checked up front so an unknown family is reported as such instead of
+     * arriving as a generic load failure. */
+    if (family_hint != nullptr && !registry->registry->supports_family(family_hint)) {
+        return fail(AUDIOCPP_ERR_UNSUPPORTED_FAMILY, std::string("unsupported family: ").append(family_hint).c_str());
+    }
+    return guard([&] {
+        auto handle = std::make_unique<audiocpp_model>();
+        handle->registry = registry->registry;
+        handle->load_request.model_path = std::filesystem::path(model_path);
+        if (family_hint != nullptr) {
+            handle->load_request.family_hint = std::string(family_hint);
+        }
+        if (config != nullptr) {
+            if (config->config_id != nullptr) handle->load_request.config_id = std::string(config->config_id);
+            if (config->weight_id != nullptr) handle->load_request.weight_id = std::string(config->weight_id);
+            if (config->model_spec_override != nullptr) {
+                handle->load_request.model_spec_override =
+                    std::filesystem::path(config->model_spec_override);
+            }
+        }
+        handle->load_request.options = option_map(options);
+        handle->model = std::shared_ptr<rt::ILoadedVoiceModel>(
+            handle->registry->load(handle->load_request).release());
+        *out_model = handle.release();
+        return AUDIOCPP_OK;
+    }, AUDIOCPP_ERR_LOAD_FAILED);
+}
+
+void audiocpp_model_free(audiocpp_model * model) {
+    delete model;
+}
+
+const char * audiocpp_model_family(const audiocpp_model * model) {
+    if (model == nullptr) return kEmptyString;
+    return model->model->metadata().family.c_str();
+}
+
+const char * audiocpp_model_description(const audiocpp_model * model) {
+    if (model == nullptr) return kEmptyString;
+    return model->model->metadata().description.c_str();
+}
+
+int audiocpp_model_supports(const audiocpp_model * model, const char * task, const char * mode) {
+    if (model == nullptr || task == nullptr || mode == nullptr) return 0;
+    try {
+        const auto wanted_task = rt::parse_voice_task_kind(task);
+        const auto wanted_mode = rt::parse_run_mode(mode);
+        for (const auto & capability : model->model->capabilities().supported_tasks) {
+            if (capability.task != wanted_task) continue;
+            for (const auto & supported : capability.modes) {
+                if (supported == wanted_mode) return 1;
+            }
+        }
+    } catch (...) {
+        /* An unrecognised task or mode is "not supported", not an error. */
+        return 0;
+    }
+    return 0;
+}
+
+int audiocpp_model_supports_timestamps(const audiocpp_model * model) {
+    if (model == nullptr) return 0;
+    return model->model->capabilities().supports_timestamps ? 1 : 0;
+}
+
+int audiocpp_model_supports_speaker_reference(const audiocpp_model * model) {
+    if (model == nullptr) return 0;
+    return model->model->capabilities().supports_speaker_reference ? 1 : 0;
+}
+
+int audiocpp_model_supports_style_condition(const audiocpp_model * model) {
+    if (model == nullptr) return 0;
+    return model->model->capabilities().supports_style_condition ? 1 : 0;
+}
+
+size_t audiocpp_model_language_count(const audiocpp_model * model) {
+    if (model == nullptr) return 0;
+    return model->model->capabilities().languages.size();
+}
+
+audiocpp_status audiocpp_model_language(const audiocpp_model * model, size_t index, const char ** out_language) {
+    if (model == nullptr || out_language == nullptr) {
+        return fail(AUDIOCPP_ERR_INVALID_ARGUMENT, "model and out_language must be non-null");
+    }
+    const auto & languages = model->model->capabilities().languages;
+    if (index >= languages.size()) {
+        return fail(AUDIOCPP_ERR_OUT_OF_RANGE, "language index out of range");
+    }
+    *out_language = languages[index].c_str();
+    return AUDIOCPP_OK;
+}
+
+size_t audiocpp_model_option_count(const audiocpp_model * model, audiocpp_option_scope scope) {
+    if (model == nullptr) return 0;
+    try {
+        return model->options_for(scope).size();
+    } catch (...) {
+        return 0;
+    }
+}
+
+audiocpp_status audiocpp_model_option(const audiocpp_model * model,
+                                      audiocpp_option_scope scope,
+                                      size_t index,
+                                      const char ** out_name,
+                                      const char ** out_value_name,
+                                      const char ** out_description,
+                                      const char ** out_default_value,
+                                      const char ** out_min_value,
+                                      const char ** out_max_value,
+                                      int * out_required) {
+    if (model == nullptr) {
+        return fail(AUDIOCPP_ERR_INVALID_ARGUMENT, "model must be non-null");
+    }
+    return guard([&] {
+        const auto & options = model->options_for(scope);
+        if (index >= options.size()) {
+            return fail(AUDIOCPP_ERR_OUT_OF_RANGE, "option index out of range");
+        }
+        const auto & option = options[index];
+        assign_out(out_name, option.name);
+        assign_out(out_value_name, option.value_name);
+        assign_out(out_description, option.description);
+        assign_out(out_default_value, option.default_value);
+        assign_out(out_min_value, option.min_value);
+        assign_out(out_max_value, option.max_value);
+        if (out_required != nullptr) *out_required = option.required ? 1 : 0;
+        return AUDIOCPP_OK;
+    });
+}
+
+/* ------------------------------------------------------------------ */
+/* Session                                                             */
+/* ------------------------------------------------------------------ */
+
+audiocpp_status audiocpp_session_create(const audiocpp_model * model,
+                                        const char * task,
+                                        const char * mode,
+                                        const audiocpp_backend_config * backend_config,
+                                        const audiocpp_options * options,
+                                        audiocpp_session ** out_session) {
+    if (model == nullptr || task == nullptr || mode == nullptr || out_session == nullptr) {
+        return fail(AUDIOCPP_ERR_INVALID_ARGUMENT, "model, task, mode and out_session must be non-null");
+    }
+    *out_session = nullptr;
+    return guard([&] {
+        const rt::TaskSpec spec{rt::parse_voice_task_kind(task), rt::parse_run_mode(mode)};
+
+        rt::SessionOptions session_options;
+        if (backend_config != nullptr) {
+            if (backend_config->backend != nullptr) {
+                session_options.backend.type = parse_backend_type(backend_config->backend);
+            }
+            if (backend_config->threads <= 0) {
+                throw std::invalid_argument("threads must be positive");
+            }
+            session_options.backend.device = backend_config->device;
+            session_options.backend.threads = backend_config->threads;
+        }
+        session_options.options = option_map(options);
+
+        auto handle = std::make_unique<audiocpp_session>();
+        handle->registry = model->registry;
+        handle->model = model->model;
+        handle->mode = spec.mode;
+        handle->session = model->model->create_task_session(spec, session_options);
+        handle->family = handle->session->family();
+        *out_session = handle.release();
+        return AUDIOCPP_OK;
+    });
+}
+
+void audiocpp_session_free(audiocpp_session * session) {
+    delete session;
+}
+
+const char * audiocpp_session_family(const audiocpp_session * session) {
+    if (session == nullptr) return kEmptyString;
+    return session->family.c_str();
+}
+
+audiocpp_status audiocpp_session_prepare(audiocpp_session * session, const audiocpp_request * request) {
+    if (session == nullptr) {
+        return fail(AUDIOCPP_ERR_INVALID_ARGUMENT, "session must be non-null");
+    }
+    return guard([&] {
+        const rt::TaskRequest empty;
+        const auto & task_request = request != nullptr ? request->request : empty;
+        session->session->prepare(rt::build_preparation_request(task_request));
+        return AUDIOCPP_OK;
+    });
+}
+
+audiocpp_status audiocpp_session_run(audiocpp_session * session,
+                                     const audiocpp_request * request,
+                                     audiocpp_result ** out_result) {
+    if (session == nullptr || out_result == nullptr) {
+        return fail(AUDIOCPP_ERR_INVALID_ARGUMENT, "session and out_result must be non-null");
+    }
+    *out_result = nullptr;
+    if (session->mode != rt::RunMode::Offline) {
+        return fail(AUDIOCPP_ERR_NOT_AVAILABLE, "session was created in streaming mode");
+    }
+    return guard([&] {
+        const rt::TaskRequest empty;
+        const auto & task_request = request != nullptr ? request->request : empty;
+        /* Always prepared with the request that is about to run, exactly as
+         * audiocpp_cli does. build_preparation_request carries the input
+         * length, so preparing once and then running a different request would
+         * leave the session sized for the wrong input. */
+        session->session->prepare(rt::build_preparation_request(task_request));
+
+        auto handle = std::make_unique<audiocpp_result>();
+        handle->result = session->offline().run(task_request);
+        *out_result = handle.release();
+        return AUDIOCPP_OK;
+    });
+}
+
+/* ------------------------------------------------------------------ */
+/* Request                                                             */
+/* ------------------------------------------------------------------ */
+
+audiocpp_request * audiocpp_request_create(void) {
+    try {
+        return new audiocpp_request();
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+void audiocpp_request_free(audiocpp_request * request) {
+    delete request;
+}
+
+audiocpp_status audiocpp_request_set_text(audiocpp_request * request, const char * text, const char * language) {
+    if (request == nullptr || text == nullptr) {
+        return fail(AUDIOCPP_ERR_INVALID_ARGUMENT, "request and text must be non-null");
+    }
+    return guard([&] {
+        rt::Transcript transcript;
+        transcript.text = text;
+        if (language != nullptr) transcript.language = language;
+        request->request.text_input = std::move(transcript);
+        /* audiocpp_cli's --language sets BOTH the transcript language and
+         * options["language"] (app/cli/request.cpp:336), and some families read
+         * only the latter. Mirroring that is what keeps this API's answers
+         * identical to the CLI's. A later audiocpp_request_set_option wins. */
+        if (language != nullptr && *language != '\0') {
+            request->request.options["language"] = language;
+        }
+        return AUDIOCPP_OK;
+    });
+}
+
+audiocpp_status audiocpp_request_set_audio(audiocpp_request * request,
+                                           const float * samples,
+                                           size_t frames,
+                                           int sample_rate,
+                                           int channels) {
+    if (request == nullptr) {
+        return fail(AUDIOCPP_ERR_INVALID_ARGUMENT, "request must be non-null");
+    }
+    return guard([&] {
+        request->request.audio_input = make_audio_buffer(samples, frames, sample_rate, channels);
+        return AUDIOCPP_OK;
+    });
+}
+
+audiocpp_status audiocpp_request_set_voice_audio(audiocpp_request * request,
+                                                 const float * samples,
+                                                 size_t frames,
+                                                 int sample_rate,
+                                                 int channels) {
+    if (request == nullptr) {
+        return fail(AUDIOCPP_ERR_INVALID_ARGUMENT, "request must be non-null");
+    }
+    return guard([&] {
+        if (!request->request.voice.has_value()) request->request.voice = rt::VoiceCondition{};
+        if (!request->request.voice->speaker.has_value()) request->request.voice->speaker = rt::VoiceReference{};
+        request->request.voice->speaker->audio = make_audio_buffer(samples, frames, sample_rate, channels);
+        return AUDIOCPP_OK;
+    });
+}
+
+audiocpp_status audiocpp_request_set_voice_id(audiocpp_request * request, const char * cached_voice_id) {
+    if (request == nullptr || cached_voice_id == nullptr) {
+        return fail(AUDIOCPP_ERR_INVALID_ARGUMENT, "request and cached_voice_id must be non-null");
+    }
+    return guard([&] {
+        if (!request->request.voice.has_value()) request->request.voice = rt::VoiceCondition{};
+        if (!request->request.voice->speaker.has_value()) request->request.voice->speaker = rt::VoiceReference{};
+        request->request.voice->speaker->cached_voice_id = std::string(cached_voice_id);
+        return AUDIOCPP_OK;
+    });
+}
+
+namespace {
+
+rt::StyleCondition & mutable_style(audiocpp_request * request) {
+    if (!request->request.voice.has_value()) request->request.voice = rt::VoiceCondition{};
+    if (!request->request.voice->style.has_value()) request->request.voice->style = rt::StyleCondition{};
+    return *request->request.voice->style;
+}
+
+rt::ArtifactKind to_artifact_kind(audiocpp_artifact_kind kind) {
+    switch (kind) {
+        case AUDIOCPP_ARTIFACT_SPEAKER_EMBEDDING:    return rt::ArtifactKind::SpeakerEmbedding;
+        case AUDIOCPP_ARTIFACT_STYLE_EMBEDDING:      return rt::ArtifactKind::StyleEmbedding;
+        case AUDIOCPP_ARTIFACT_PROMPT_EMBEDDING:     return rt::ArtifactKind::PromptEmbedding;
+        case AUDIOCPP_ARTIFACT_ACOUSTIC_TOKENS:      return rt::ArtifactKind::AcousticTokens;
+        case AUDIOCPP_ARTIFACT_MIDI:                 return rt::ArtifactKind::Midi;
+        case AUDIOCPP_ARTIFACT_TRANSCRIPT_ALIGNMENT: return rt::ArtifactKind::TranscriptAlignment;
+        case AUDIOCPP_ARTIFACT_DIARIZATION_STATE:    return rt::ArtifactKind::DiarizationState;
+        case AUDIOCPP_ARTIFACT_VAD_STATE:            return rt::ArtifactKind::VadState;
+        case AUDIOCPP_ARTIFACT_CUSTOM:               return rt::ArtifactKind::Custom;
+    }
+    throw std::invalid_argument("unknown artifact kind");
+}
+
+audiocpp_artifact_kind from_artifact_kind(rt::ArtifactKind kind) noexcept {
+    switch (kind) {
+        case rt::ArtifactKind::SpeakerEmbedding:    return AUDIOCPP_ARTIFACT_SPEAKER_EMBEDDING;
+        case rt::ArtifactKind::StyleEmbedding:      return AUDIOCPP_ARTIFACT_STYLE_EMBEDDING;
+        case rt::ArtifactKind::PromptEmbedding:     return AUDIOCPP_ARTIFACT_PROMPT_EMBEDDING;
+        case rt::ArtifactKind::AcousticTokens:      return AUDIOCPP_ARTIFACT_ACOUSTIC_TOKENS;
+        case rt::ArtifactKind::Midi:                return AUDIOCPP_ARTIFACT_MIDI;
+        case rt::ArtifactKind::TranscriptAlignment: return AUDIOCPP_ARTIFACT_TRANSCRIPT_ALIGNMENT;
+        case rt::ArtifactKind::DiarizationState:    return AUDIOCPP_ARTIFACT_DIARIZATION_STATE;
+        case rt::ArtifactKind::VadState:            return AUDIOCPP_ARTIFACT_VAD_STATE;
+        case rt::ArtifactKind::Custom:              break;
+    }
+    return AUDIOCPP_ARTIFACT_CUSTOM;
+}
+
+/* TaskResult keeps a single artifact_output alongside a list. Callers see one
+ * flat list, the single one first. */
+const rt::VoiceArtifact * result_artifact_at(const audiocpp_result * result, size_t index) noexcept {
+    const auto & task = result->result;
+    if (task.artifact_output.has_value()) {
+        if (index == 0) return &*task.artifact_output;
+        index -= 1;
+    }
+    if (index >= task.output_artifacts.size()) return nullptr;
+    return &task.output_artifacts[index];
+}
+
+}  // namespace
+
+audiocpp_status audiocpp_request_set_style_language(audiocpp_request * request, const char * language) {
+    if (request == nullptr || language == nullptr) {
+        return fail(AUDIOCPP_ERR_INVALID_ARGUMENT, "request and language must be non-null");
+    }
+    return guard([&] { mutable_style(request).language = std::string(language); return AUDIOCPP_OK; });
+}
+
+audiocpp_status audiocpp_request_set_emotion(audiocpp_request * request, const char * emotion) {
+    if (request == nullptr || emotion == nullptr) {
+        return fail(AUDIOCPP_ERR_INVALID_ARGUMENT, "request and emotion must be non-null");
+    }
+    return guard([&] { mutable_style(request).emotion = std::string(emotion); return AUDIOCPP_OK; });
+}
+
+audiocpp_status audiocpp_request_set_speaking_rate(audiocpp_request * request, float speaking_rate) {
+    if (request == nullptr) return fail(AUDIOCPP_ERR_INVALID_ARGUMENT, "request must be non-null");
+    return guard([&] { mutable_style(request).speaking_rate = speaking_rate; return AUDIOCPP_OK; });
+}
+
+audiocpp_status audiocpp_request_set_pitch_shift(audiocpp_request * request, float pitch_shift) {
+    if (request == nullptr) return fail(AUDIOCPP_ERR_INVALID_ARGUMENT, "request must be non-null");
+    return guard([&] { mutable_style(request).pitch_shift = pitch_shift; return AUDIOCPP_OK; });
+}
+
+audiocpp_status audiocpp_request_set_energy_scale(audiocpp_request * request, float energy_scale) {
+    if (request == nullptr) return fail(AUDIOCPP_ERR_INVALID_ARGUMENT, "request must be non-null");
+    return guard([&] { mutable_style(request).energy_scale = energy_scale; return AUDIOCPP_OK; });
+}
+
+audiocpp_status audiocpp_request_set_style_tag(audiocpp_request * request, const char * key, const char * value) {
+    if (request == nullptr || key == nullptr || value == nullptr) {
+        return fail(AUDIOCPP_ERR_INVALID_ARGUMENT, "request, key and value must be non-null");
+    }
+    return guard([&] { mutable_style(request).tags[key] = value; return AUDIOCPP_OK; });
+}
+
+audiocpp_status audiocpp_request_add_artifact(audiocpp_request * request,
+                                              audiocpp_artifact_kind kind,
+                                              const char * id,
+                                              const void * payload,
+                                              size_t payload_bytes,
+                                              size_t * out_index) {
+    if (request == nullptr || id == nullptr) {
+        return fail(AUDIOCPP_ERR_INVALID_ARGUMENT, "request and id must be non-null");
+    }
+    if (payload_bytes > 0 && payload == nullptr) {
+        return fail(AUDIOCPP_ERR_INVALID_ARGUMENT, "payload is null but payload_bytes > 0");
+    }
+    return guard([&] {
+        rt::VoiceArtifact artifact;
+        artifact.kind = to_artifact_kind(kind);
+        artifact.id = id;
+        if (payload_bytes > 0) {
+            const auto * bytes = static_cast<const std::byte *>(payload);
+            artifact.payload.assign(bytes, bytes + payload_bytes);
+        }
+        request->request.input_artifacts.push_back(std::move(artifact));
+        if (out_index != nullptr) *out_index = request->request.input_artifacts.size() - 1;
+        return AUDIOCPP_OK;
+    });
+}
+
+audiocpp_status audiocpp_request_set_artifact_meta(audiocpp_request * request,
+                                                   size_t index,
+                                                   const char * key,
+                                                   const char * value) {
+    if (request == nullptr || key == nullptr || value == nullptr) {
+        return fail(AUDIOCPP_ERR_INVALID_ARGUMENT, "request, key and value must be non-null");
+    }
+    if (index >= request->request.input_artifacts.size()) {
+        return fail(AUDIOCPP_ERR_OUT_OF_RANGE, "artifact index out of range");
+    }
+    return guard([&] {
+        request->request.input_artifacts[index].meta[key] = value;
+        return AUDIOCPP_OK;
+    });
+}
+
+audiocpp_status audiocpp_request_set_option(audiocpp_request * request, const char * key, const char * value) {
+    if (request == nullptr || key == nullptr || value == nullptr) {
+        return fail(AUDIOCPP_ERR_INVALID_ARGUMENT, "request, key and value must be non-null");
+    }
+    return guard([&] {
+        request->request.options[key] = value;
+        return AUDIOCPP_OK;
+    });
+}
+
+/* ------------------------------------------------------------------ */
+/* Result                                                              */
+/* ------------------------------------------------------------------ */
+
+void audiocpp_result_free(audiocpp_result * result) {
+    if (result != nullptr && !result->owned) return;
+    delete result;
+}
+
+audiocpp_status audiocpp_result_audio(const audiocpp_result * result,
+                                      const float ** out_samples,
+                                      size_t * out_frames,
+                                      int * out_sample_rate,
+                                      int * out_channels) {
+    if (result == nullptr) {
+        return fail(AUDIOCPP_ERR_INVALID_ARGUMENT, "result must be non-null");
+    }
+    if (!result->result.audio_output.has_value()) {
+        return fail(AUDIOCPP_ERR_NOT_AVAILABLE, "result carries no audio output");
+    }
+    const auto & audio = *result->result.audio_output;
+    if (out_samples != nullptr) *out_samples = audio.samples.data();
+    if (out_frames != nullptr) *out_frames = frame_count(audio);
+    if (out_sample_rate != nullptr) *out_sample_rate = audio.sample_rate;
+    if (out_channels != nullptr) *out_channels = audio.channels;
+    return AUDIOCPP_OK;
+}
+
+audiocpp_status audiocpp_result_text(const audiocpp_result * result,
+                                     const char ** out_text,
+                                     const char ** out_language) {
+    if (result == nullptr) {
+        return fail(AUDIOCPP_ERR_INVALID_ARGUMENT, "result must be non-null");
+    }
+    if (!result->result.text_output.has_value()) {
+        return fail(AUDIOCPP_ERR_NOT_AVAILABLE, "result carries no text output");
+    }
+    assign_out(out_text, result->result.text_output->text);
+    assign_out(out_language, result->result.text_output->language);
+    return AUDIOCPP_OK;
+}
+
+size_t audiocpp_result_segment_count(const audiocpp_result * result) {
+    return result != nullptr ? result->result.speech_segments.size() : 0;
+}
+
+audiocpp_status audiocpp_result_segment(const audiocpp_result * result,
+                                        size_t index,
+                                        int64_t * out_start_sample,
+                                        int64_t * out_end_sample,
+                                        float * out_confidence,
+                                        const char ** out_text) {
+    if (result == nullptr) {
+        return fail(AUDIOCPP_ERR_INVALID_ARGUMENT, "result must be non-null");
+    }
+    if (index >= result->result.speech_segments.size()) {
+        return fail(AUDIOCPP_ERR_OUT_OF_RANGE, "segment index out of range");
+    }
+    const auto & segment = result->result.speech_segments[index];
+    if (out_start_sample != nullptr) *out_start_sample = segment.span.start_sample;
+    if (out_end_sample != nullptr) *out_end_sample = segment.span.end_sample;
+    if (out_confidence != nullptr) *out_confidence = segment.confidence;
+    assign_out(out_text, segment.text);
+    return AUDIOCPP_OK;
+}
+
+size_t audiocpp_result_speaker_turn_count(const audiocpp_result * result) {
+    return result != nullptr ? result->result.speaker_turns.size() : 0;
+}
+
+audiocpp_status audiocpp_result_speaker_turn(const audiocpp_result * result,
+                                             size_t index,
+                                             int64_t * out_start_sample,
+                                             int64_t * out_end_sample,
+                                             const char ** out_speaker_id,
+                                             float * out_confidence,
+                                             const char ** out_text) {
+    if (result == nullptr) {
+        return fail(AUDIOCPP_ERR_INVALID_ARGUMENT, "result must be non-null");
+    }
+    if (index >= result->result.speaker_turns.size()) {
+        return fail(AUDIOCPP_ERR_OUT_OF_RANGE, "speaker turn index out of range");
+    }
+    const auto & turn = result->result.speaker_turns[index];
+    if (out_start_sample != nullptr) *out_start_sample = turn.span.start_sample;
+    if (out_end_sample != nullptr) *out_end_sample = turn.span.end_sample;
+    assign_out(out_speaker_id, turn.speaker_id);
+    if (out_confidence != nullptr) *out_confidence = turn.confidence;
+    assign_out(out_text, turn.text);
+    return AUDIOCPP_OK;
+}
+
+size_t audiocpp_result_word_count(const audiocpp_result * result) {
+    return result != nullptr ? result->result.word_timestamps.size() : 0;
+}
+
+audiocpp_status audiocpp_result_word(const audiocpp_result * result,
+                                     size_t index,
+                                     const char ** out_word,
+                                     int64_t * out_start_sample,
+                                     int64_t * out_end_sample,
+                                     float * out_confidence) {
+    if (result == nullptr) {
+        return fail(AUDIOCPP_ERR_INVALID_ARGUMENT, "result must be non-null");
+    }
+    if (index >= result->result.word_timestamps.size()) {
+        return fail(AUDIOCPP_ERR_OUT_OF_RANGE, "word index out of range");
+    }
+    const auto & word = result->result.word_timestamps[index];
+    assign_out(out_word, word.word);
+    if (out_start_sample != nullptr) *out_start_sample = word.span.start_sample;
+    if (out_end_sample != nullptr) *out_end_sample = word.span.end_sample;
+    if (out_confidence != nullptr) *out_confidence = word.confidence;
+    return AUDIOCPP_OK;
+}
+
+size_t audiocpp_result_named_audio_count(const audiocpp_result * result) {
+    return result != nullptr ? result->result.named_audio_outputs.size() : 0;
+}
+
+audiocpp_status audiocpp_result_named_audio(const audiocpp_result * result,
+                                            size_t index,
+                                            const char ** out_id,
+                                            const float ** out_samples,
+                                            size_t * out_frames,
+                                            int * out_sample_rate,
+                                            int * out_channels) {
+    if (result == nullptr) {
+        return fail(AUDIOCPP_ERR_INVALID_ARGUMENT, "result must be non-null");
+    }
+    if (index >= result->result.named_audio_outputs.size()) {
+        return fail(AUDIOCPP_ERR_OUT_OF_RANGE, "named audio index out of range");
+    }
+    const auto & named = result->result.named_audio_outputs[index];
+    assign_out(out_id, named.id);
+    if (out_samples != nullptr) *out_samples = named.audio.samples.data();
+    if (out_frames != nullptr) *out_frames = frame_count(named.audio);
+    if (out_sample_rate != nullptr) *out_sample_rate = named.audio.sample_rate;
+    if (out_channels != nullptr) *out_channels = named.audio.channels;
+    return AUDIOCPP_OK;
+}
+
+size_t audiocpp_result_artifact_count(const audiocpp_result * result) {
+    if (result == nullptr) return 0;
+    return result->result.output_artifacts.size() +
+           (result->result.artifact_output.has_value() ? 1u : 0u);
+}
+
+audiocpp_status audiocpp_result_artifact(const audiocpp_result * result,
+                                         size_t index,
+                                         audiocpp_artifact_kind * out_kind,
+                                         const char ** out_id,
+                                         const void ** out_payload,
+                                         size_t * out_payload_bytes) {
+    if (result == nullptr) return fail(AUDIOCPP_ERR_INVALID_ARGUMENT, "result must be non-null");
+    const auto * artifact = result_artifact_at(result, index);
+    if (artifact == nullptr) return fail(AUDIOCPP_ERR_OUT_OF_RANGE, "artifact index out of range");
+    if (out_kind != nullptr) *out_kind = from_artifact_kind(artifact->kind);
+    assign_out(out_id, artifact->id);
+    if (out_payload != nullptr) *out_payload = artifact->payload.data();
+    if (out_payload_bytes != nullptr) *out_payload_bytes = artifact->payload.size();
+    return AUDIOCPP_OK;
+}
+
+size_t audiocpp_result_artifact_meta_count(const audiocpp_result * result, size_t index) {
+    if (result == nullptr) return 0;
+    const auto * artifact = result_artifact_at(result, index);
+    return artifact != nullptr ? artifact->meta.size() : 0;
+}
+
+audiocpp_status audiocpp_result_artifact_meta(const audiocpp_result * result,
+                                              size_t index,
+                                              size_t meta_index,
+                                              const char ** out_key,
+                                              const char ** out_value) {
+    if (result == nullptr) return fail(AUDIOCPP_ERR_INVALID_ARGUMENT, "result must be non-null");
+    const auto * artifact = result_artifact_at(result, index);
+    if (artifact == nullptr) return fail(AUDIOCPP_ERR_OUT_OF_RANGE, "artifact index out of range");
+    if (meta_index >= artifact->meta.size()) {
+        return fail(AUDIOCPP_ERR_OUT_OF_RANGE, "artifact meta index out of range");
+    }
+    /* unordered_map has no index; step to the requested position. Meta maps are
+     * a handful of entries, so this stays cheap. */
+    auto it = artifact->meta.begin();
+    std::advance(it, static_cast<std::ptrdiff_t>(meta_index));
+    assign_out(out_key, it->first);
+    assign_out(out_value, it->second);
+    return AUDIOCPP_OK;
+}
+
+/* ------------------------------------------------------------------ */
+/* Streaming                                                           */
+/* ------------------------------------------------------------------ */
+
+
+namespace {
+
+/* Mode is checked before the call rather than inferring it from a thrown
+ * exception, so a real failure inside a family is reported as a runtime error
+ * instead of being flattened into "not available". */
+audiocpp_status require_streaming(const audiocpp_session * session) noexcept {
+    if (session->mode != rt::RunMode::Streaming) {
+        return fail(AUDIOCPP_ERR_NOT_AVAILABLE, "session was not created in streaming mode");
+    }
+    return AUDIOCPP_OK;
+}
+
+}  // namespace
+
+audiocpp_status audiocpp_stream_policy(const audiocpp_session * session,
+                                       audiocpp_stream_input_kind * out_input,
+                                       audiocpp_stream_output_kind * out_output,
+                                       int64_t * out_preferred_chunk_samples,
+                                       double * out_preferred_chunk_seconds) {
+    if (session == nullptr) {
+        return fail(AUDIOCPP_ERR_INVALID_ARGUMENT, "session must be non-null");
+    }
+    { const audiocpp_status s = require_streaming(session); if (s != AUDIOCPP_OK) return s; }
+    return guard([&] {
+        const auto policy = session->streaming().streaming_policy();
+        if (out_input != nullptr) {
+            *out_input = policy.input == rt::StreamingInputKind::AudioChunks
+                ? AUDIOCPP_STREAM_INPUT_AUDIO_CHUNKS
+                : AUDIOCPP_STREAM_INPUT_NONE;
+        }
+        if (out_output != nullptr) {
+            *out_output = policy.output == rt::StreamingOutputKind::PullEvents
+                ? AUDIOCPP_STREAM_OUTPUT_PULL_EVENTS
+                : AUDIOCPP_STREAM_OUTPUT_FINAL_RESULT;
+        }
+        if (out_preferred_chunk_samples != nullptr) {
+            *out_preferred_chunk_samples = policy.preferred_audio_chunk_samples;
+        }
+        if (out_preferred_chunk_seconds != nullptr) {
+            *out_preferred_chunk_seconds = policy.preferred_audio_chunk_seconds;
+        }
+        return AUDIOCPP_OK;
+    });
+}
+
+audiocpp_status audiocpp_stream_start(audiocpp_session * session, const audiocpp_request * request) {
+    if (session == nullptr) {
+        return fail(AUDIOCPP_ERR_INVALID_ARGUMENT, "session must be non-null");
+    }
+    { const audiocpp_status s = require_streaming(session); if (s != AUDIOCPP_OK) return s; }
+    return guard([&] {
+        const rt::TaskRequest empty;
+        const auto & task_request = request != nullptr ? request->request : empty;
+        session->session->prepare(rt::build_preparation_request(task_request));
+        session->streaming().start_stream(task_request);
+        return AUDIOCPP_OK;
+    });
+}
+
+audiocpp_status audiocpp_stream_push(audiocpp_session * session,
+                                     const float * samples,
+                                     size_t frames,
+                                     int sample_rate,
+                                     int channels,
+                                     int64_t start_sample,
+                                     audiocpp_event ** out_event) {
+    if (session == nullptr) {
+        return fail(AUDIOCPP_ERR_INVALID_ARGUMENT, "session must be non-null");
+    }
+    if (out_event != nullptr) *out_event = nullptr;
+    { const audiocpp_status s = require_streaming(session); if (s != AUDIOCPP_OK) return s; }
+    return guard([&] {
+        auto buffer = make_audio_buffer(samples, frames, sample_rate, channels);
+        rt::AudioChunk chunk;
+        chunk.sample_rate = buffer.sample_rate;
+        chunk.channels = buffer.channels;
+        chunk.start_sample = start_sample;
+        chunk.samples = std::move(buffer.samples);
+
+        auto event = session->streaming().process_audio_chunk(chunk);
+        if (out_event != nullptr) {
+            *out_event = wrap_event(std::move(event)).release();
+        }
+        return AUDIOCPP_OK;
+    });
+}
+
+audiocpp_status audiocpp_stream_next_event(audiocpp_session * session, audiocpp_event ** out_event) {
+    if (session == nullptr || out_event == nullptr) {
+        return fail(AUDIOCPP_ERR_INVALID_ARGUMENT, "session and out_event must be non-null");
+    }
+    *out_event = nullptr;
+    { const audiocpp_status s = require_streaming(session); if (s != AUDIOCPP_OK) return s; }
+    return guard([&] {
+        auto event = session->streaming().next_stream_event();
+        /* An empty queue is a normal outcome, not a failure. */
+        if (event.has_value()) {
+            *out_event = wrap_event(std::move(*event)).release();
+        }
+        return AUDIOCPP_OK;
+    });
+}
+
+audiocpp_status audiocpp_stream_finish(audiocpp_session * session, audiocpp_result ** out_result) {
+    if (session == nullptr || out_result == nullptr) {
+        return fail(AUDIOCPP_ERR_INVALID_ARGUMENT, "session and out_result must be non-null");
+    }
+    *out_result = nullptr;
+    { const audiocpp_status s = require_streaming(session); if (s != AUDIOCPP_OK) return s; }
+    return guard([&] {
+        auto handle = std::make_unique<audiocpp_result>();
+        handle->result = session->streaming().finish_stream();
+        *out_result = handle.release();
+        return AUDIOCPP_OK;
+    });
+}
+
+audiocpp_status audiocpp_stream_reset(audiocpp_session * session) {
+    if (session == nullptr) {
+        return fail(AUDIOCPP_ERR_INVALID_ARGUMENT, "session must be non-null");
+    }
+    { const audiocpp_status s = require_streaming(session); if (s != AUDIOCPP_OK) return s; }
+    return guard([&] {
+        session->streaming().reset();
+        return AUDIOCPP_OK;
+    });
+}
+
+void audiocpp_event_free(audiocpp_event * event) {
+    delete event;
+}
+
+int audiocpp_event_is_final(const audiocpp_event * event) {
+    return event != nullptr && event->is_final ? 1 : 0;
+}
+
+const audiocpp_result * audiocpp_event_as_result(const audiocpp_event * event) {
+    return event != nullptr ? &event->view : nullptr;
+}
+
+size_t audiocpp_event_voice_activity_count(const audiocpp_event * event) {
+    return event != nullptr ? event->voice_activity.size() : 0;
+}
+
+audiocpp_status audiocpp_event_voice_activity(const audiocpp_event * event,
+                                              size_t index,
+                                              audiocpp_voice_activity_kind * out_kind,
+                                              int64_t * out_sample,
+                                              float * out_probability) {
+    if (event == nullptr) {
+        return fail(AUDIOCPP_ERR_INVALID_ARGUMENT, "event must be non-null");
+    }
+    if (index >= event->voice_activity.size()) {
+        return fail(AUDIOCPP_ERR_OUT_OF_RANGE, "voice activity index out of range");
+    }
+    const auto & activity = event->voice_activity[index];
+    if (out_kind != nullptr) {
+        switch (activity.kind) {
+            case rt::VoiceActivityEvent::Kind::SpeechStart:
+                *out_kind = AUDIOCPP_VOICE_ACTIVITY_SPEECH_START;
+                break;
+            case rt::VoiceActivityEvent::Kind::SpeechEnd:
+                *out_kind = AUDIOCPP_VOICE_ACTIVITY_SPEECH_END;
+                break;
+            case rt::VoiceActivityEvent::Kind::SpeechSegment:
+                *out_kind = AUDIOCPP_VOICE_ACTIVITY_SPEECH_SEGMENT;
+                break;
+        }
+    }
+    if (out_sample != nullptr) *out_sample = activity.sample;
+    if (out_probability != nullptr) *out_probability = activity.probability;
+    return AUDIOCPP_OK;
+}

--- a/src/capi/audiocpp.map
+++ b/src/capi/audiocpp.map
@@ -1,0 +1,14 @@
+/* Restricts the ELF dynamic symbol table to the C ABI.
+ *
+ * C_VISIBILITY_PRESET/CXX_VISIBILITY_PRESET only reach this target's own
+ * sources; the static libraries linked in (ggml, cJSON, sentencepiece, ...)
+ * were compiled without -fvisibility=hidden, so without this their symbols
+ * are re-exported from libaudiocpp and can collide with whatever the host
+ * application has already loaded.
+ */
+AUDIOCPP_0 {
+    global:
+        audiocpp_*;
+    local:
+        *;
+};

--- a/src/capi/audiocpp.symbols
+++ b/src/capi/audiocpp.symbols
@@ -1,0 +1,1 @@
+_audiocpp_*

--- a/tests/capi/export_surface.py
+++ b/tests/capi/export_surface.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Assert the shared library exports exactly the C ABI and nothing else.
+
+Three platforms reach this guarantee three different ways -- a version script on
+ELF, an exported-symbols list on Mach-O, and on Windows merely the absence of
+any dependency that annotates its own symbols, because __declspec(dllexport) is
+additive and there is no allowlist equivalent. The Windows case has no mechanism
+enforcing it at all: a newly vendored library that exports its own symbols would
+silently widen the surface. That happened once already -- cJSON put the first
+Windows build at 147 exports against the 69 intended.
+
+So the invariant is checked here rather than left to a comment.
+
+Exits 0 when the surface matches, 1 when it does not, and 77 (the CTest skip
+code) when the library or the platform's symbol tool is unavailable.
+"""
+
+import argparse
+import glob
+import os
+import re
+import shutil
+import subprocess
+import sys
+
+SKIP = 77
+
+
+def find_dumpbin(library, explicit=None):
+    """Locate dumpbin, which is not on PATH outside a Developer Command Prompt.
+
+    Three layers, most reliable first:
+
+    1. Whatever CMake passed in. dumpbin ships beside the cl.exe that built the
+       library, so CMake already knows exactly where the right one is -- no
+       searching, no version guessing, and guaranteed to match the toolset that
+       produced the binary being inspected.
+    2. PATH, for a Developer Command Prompt.
+    3. vswhere, for running this script standalone. Deliberately WITHOUT
+       -latest: that returns a single install, which would leave nothing to fall
+       back to when the newest one is registered but incomplete -- a real Windows
+       state, and one this project hit during testing.
+
+    Candidates are probed with the operation actually needed rather than with
+    help text. `dumpbin /?` exits 1100, not 0, so a returncode==0 check against
+    it rejects every candidate on every machine.
+    """
+    if explicit and os.path.exists(explicit):
+        return explicit
+
+    found = shutil.which("dumpbin")
+    if found:
+        return found
+    if os.name != "nt":
+        return None
+
+    program_files = os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)")
+    vswhere = os.path.join(program_files, "Microsoft Visual Studio", "Installer", "vswhere.exe")
+    if not os.path.exists(vswhere):
+        return None
+
+    try:
+        completed = subprocess.run(
+            [vswhere, "-products", "*", "-property", "installationPath"],
+            capture_output=True, text=True, timeout=30)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if completed.returncode != 0:
+        return None
+
+    def toolset_version(path):
+        # .../VC/Tools/MSVC/14.44.35207/bin/... -> (14, 44, 35207) for ordering.
+        match = re.search(r"MSVC[\\/]+([0-9.]+)[\\/]+", path)
+        if not match:
+            return ()
+        return tuple(int(part) for part in match.group(1).split(".") if part.isdigit())
+
+    candidates = []
+    for install in completed.stdout.splitlines():
+        install = install.strip()
+        if not install:
+            continue
+        for host in ("Hostx64", "Hostx86"):
+            for arch in ("x64", "x86"):
+                candidates.extend(glob.glob(os.path.join(
+                    install, "VC", "Tools", "MSVC", "*", "bin", host, arch, "dumpbin.exe")))
+
+    for candidate in sorted(candidates, key=toolset_version, reverse=True):
+        try:
+            probe = subprocess.run([candidate, "/EXPORTS", library],
+                                   capture_output=True, text=True, timeout=60)
+        except (OSError, subprocess.SubprocessError):
+            continue
+        if probe.returncode == 0:
+            return candidate
+
+    if candidates:
+        print(f"vswhere found {len(candidates)} dumpbin candidate(s), none of which ran:")
+        for candidate in sorted(candidates, key=toolset_version, reverse=True)[:5]:
+            print(f"  {candidate}")
+    return None
+
+
+def find_library(build_dir):
+    """Locate the built shared library, whatever this platform calls it.
+
+    Multi-config generators -- Visual Studio, Xcode, Ninja Multi-Config -- put
+    outputs in a per-configuration subdirectory, so bin/ alone is not enough on
+    any platform. Getting this wrong means skipping on a tree where the library
+    is sitting right there, which reads as "not applicable" and passes.
+
+    Returns (kind, path, searched) so a skip can say where it looked.
+    """
+    names = (
+        ("elf", "libaudiocpp.so"),
+        ("macho", "libaudiocpp.dylib"),
+        ("pe", "audiocpp.dll"),
+    )
+    configs = ("", "Release", "RelWithDebInfo", "MinSizeRel", "Debug")
+
+    searched = []
+    for config in configs:
+        for kind, name in names:
+            path = os.path.join(build_dir, "bin", config, name)
+            searched.append(path)
+            if os.path.exists(path):
+                return kind, os.path.realpath(path), searched
+    return None, None, searched
+
+
+def declared_symbols(header_path):
+    """Every audiocpp_* entry point the header declares."""
+    with open(header_path, encoding="utf-8") as handle:
+        source = handle.read()
+    # Strip comments so a name mentioned in prose is not mistaken for an entry point.
+    source = re.sub(r"/\*.*?\*/", "", source, flags=re.S)
+    return set(re.findall(r"AUDIOCPP_API[^;]*?\b(audiocpp_[a-z0-9_]+)\s*\(", source, flags=re.S))
+
+
+def exported_symbols(kind, library, symbol_tool=None):
+    """Every symbol the built library actually exports."""
+    if kind == "elf":
+        if not shutil.which("nm"):
+            return None
+        out = subprocess.run(["nm", "-D", "--defined-only", library],
+                             capture_output=True, text=True, check=True).stdout
+        names = set()
+        for line in out.splitlines():
+            parts = line.split()
+            if len(parts) >= 3 and parts[1] in ("T", "W"):
+                names.add(parts[2].split("@@")[0])
+        return names
+
+    if kind == "macho":
+        if not shutil.which("nm"):
+            return None
+        out = subprocess.run(["nm", "-gU", library],
+                             capture_output=True, text=True, check=True).stdout
+        # Mach-O prefixes C symbols with exactly one underscore. Stripping only
+        # that one, rather than all leading underscores, so a name that legitimately
+        # begins with one survives intact.
+        def unprefix(name):
+            return name[1:] if name.startswith("_") else name
+
+        return {unprefix(line.split()[-1]) for line in out.splitlines() if line.split()}
+
+    if kind == "pe":
+        dumpbin = find_dumpbin(library, symbol_tool)
+        if not dumpbin:
+            return None
+        environment = dict(os.environ)
+        environment["PATH"] = os.path.dirname(dumpbin) + os.pathsep + environment.get("PATH", "")
+        out = subprocess.run([dumpbin, "/EXPORTS", library], env=environment,
+                             capture_output=True, text=True, check=True).stdout
+        names = set()
+        # Rows are: ordinal hint RVA name
+        for line in out.splitlines():
+            match = re.match(r"\s*\d+\s+[0-9A-Fa-f]+\s+[0-9A-Fa-f]+\s+(\S+)", line)
+            if match:
+                names.add(match.group(1))
+        return names
+
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--build-dir", required=True)
+    parser.add_argument("--header", required=True)
+    parser.add_argument("--symbol-tool", default=None,
+                        help="Path to the platform's symbol tool. CMake passes dumpbin's "
+                             "location on MSVC, since it sits beside the compiler.")
+    parser.add_argument("--require-tool", action="store_true",
+                        help="Fail instead of skipping when no symbol tool is found. Set on "
+                             "MSVC builds: the tool ships with the compiler, so its absence "
+                             "means the invariant goes unchecked on the one platform with no "
+                             "allowlist to fall back on.")
+    args = parser.parse_args()
+
+    # Checked here rather than inside the PE branch so it is reported on every
+    # platform. Falling through to discovery is right -- a working tool beats no
+    # tool -- but doing it silently would mean reporting results from a tool the
+    # caller did not choose, which is the same reads-right-but-isn't shape this
+    # test exists to catch.
+    if args.symbol_tool and not os.path.exists(args.symbol_tool):
+        print(f"warning: --symbol-tool {args.symbol_tool} does not exist; "
+              "falling back to discovery")
+
+    kind, library, searched = find_library(args.build_dir)
+    if library is None:
+        print(f"no shared library under {args.build_dir}; build the audiocpp target first.")
+        print("Looked for:")
+        for path in searched:
+            print(f"  {path}")
+        print("Skipping.")
+        return SKIP
+
+    exported = exported_symbols(kind, library, args.symbol_tool)
+    if exported is None:
+        hint = (" (not on PATH, and vswhere offered nothing usable)" if kind == "pe" else "")
+        if args.require_tool:
+            print(f"no symbol tool for {kind}{hint}, and --require-tool was set.")
+            print("Skipping here would report a green run with the export surface")
+            print("unchecked, which is the gap this test exists to close.")
+            if kind == "pe":
+                print("Windows has no export allowlist to fall back on, so this is the")
+                print("platform where that matters most. Run from a Developer Command")
+                print("Prompt, or pass --symbol-tool with dumpbin's path.")
+            else:
+                print("Install the platform's symbol tool, or pass --symbol-tool.")
+            return 1
+        print(f"no symbol tool available for {kind} on this platform{hint}; skipping")
+        return SKIP
+
+    declared = declared_symbols(args.header)
+    if not declared:
+        print(f"parsed no declarations out of {args.header}; refusing to pass vacuously")
+        return 1
+
+    foreign = {name for name in exported if not name.startswith("audiocpp_")}
+    missing = declared - exported
+    extra = {name for name in exported if name.startswith("audiocpp_")} - declared
+
+    print(f"library:  {library} ({kind})")
+    print(f"declared: {len(declared)}   exported: {len(exported)}")
+
+    if not foreign and not missing and not extra:
+        print(f"export surface matches the header exactly ({len(declared)} symbols)")
+        return 0
+
+    if foreign:
+        print(f"\n{len(foreign)} symbol(s) leaked from a dependency:")
+        for name in sorted(foreign)[:40]:
+            print(f"  {name}")
+        if len(foreign) > 40:
+            print(f"  ... and {len(foreign) - 40} more")
+        print("\nOn ELF and Mach-O, add them to src/capi/audiocpp.map or audiocpp.symbols.")
+        print("On Windows there is no allowlist: find the dependency annotating its")
+        print("own symbols and build it with its equivalent of CJSON_HIDE_SYMBOLS.")
+    if missing:
+        print(f"\n{len(missing)} declared but not exported: {sorted(missing)}")
+    if extra:
+        print(f"\n{len(extra)} exported but not declared: {sorted(extra)}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/capi/model_test.c
+++ b/tests/capi/model_test.c
@@ -1,0 +1,500 @@
+/*
+ * C ABI model test -- opt-in, because it needs downloaded models.
+ *
+ * path_test.c proves the ABI contract against a model that ships in-repo. This
+ * one proves the ABI carries real work for real families across task types, and
+ * that the answers match what audiocpp_cli produces from the same inputs.
+ *
+ * It is registered unconditionally but SKIPS (exit 77) when no model is found,
+ * so a checkout with no downloads still reports green. Point it at a models
+ * root:
+ *
+ *   cmake -S . -B build -DAUDIOCPP_BUILD_C_API=ON \
+ *       -DAUDIOCPP_C_API_MODEL_ROOT=/path/to/models
+ *   ctest --test-dir build -R audiocpp_c_api_model --output-on-failure
+ *
+ * Transcripts and audio summaries are printed as `parity:<family>:<field>=...`
+ * lines so they can be diffed against the CLI's output for the same input.
+ */
+
+#include "audiocpp.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#if defined(_WIN32)
+#  include <windows.h>
+#else
+#  include <unistd.h>
+#endif
+
+#define CTEST_SKIP 77
+
+static int g_failures = 0;
+static int g_ran = 0;
+static int g_skipped = 0;
+
+#define CHECK(cond, ...)                                         \
+    do {                                                         \
+        if (!(cond)) {                                           \
+            fprintf(stderr, "FAIL %s:%d: ", __FILE__, __LINE__);  \
+            fprintf(stderr, __VA_ARGS__);                        \
+            fprintf(stderr, "\n");                               \
+            g_failures++;                                        \
+        }                                                        \
+    } while (0)
+
+#define CHECK_OK(expr)                                                    \
+    do {                                                                  \
+        audiocpp_status _s = (expr);                                      \
+        CHECK(_s == AUDIOCPP_OK, "%s -> %s (%s)", #expr,                  \
+              audiocpp_status_string(_s), audiocpp_last_error());         \
+    } while (0)
+
+typedef struct {
+    const char * family;
+    const char * task;
+    const char * mode;
+    /* Default package layout as documented per family. A case whose file is
+     * missing is skipped, so a renamed package degrades to a skip rather than
+     * a failure. */
+    const char * relative_model;
+    const char * text;       /* non-NULL => text-driven (TTS) */
+    const char * language;
+    const char * voice_id;
+    /* Generative families draw noise per run (Kokoro's harmonic-plus-noise
+     * excitation, for one), so a fixed seed is what makes a run comparable to
+     * anything -- including to audiocpp_cli's output for the same input. */
+    const char * seed;
+    int expect_audio;
+    int expect_text;
+    int expect_turns;
+    int expect_named_audio;
+    /* Some families fix their input rate (BS-RoFormer wants 44.1 kHz), so a
+     * case can ask for the alternate clip instead of the default one. */
+    int use_alt_audio;
+} model_case;
+
+static const model_case CASES[] = {
+    { "kokoro_tts", "tts", "offline",
+      "Kokoro-82M-GGUF/kokoro-82m-q8_0.gguf",
+      "The quick brown fox jumps over the lazy dog.", "en-us", "af_heart", "1234",
+      1, 0, 0, 0, 0 },
+    { "citrinet_asr", "asr", "offline",
+      "Citrinet-ASR-GGUF/citrinet-asr-q8_0.gguf",
+      NULL, NULL, NULL, NULL, 0, 1, 0, 0, 0 },
+    { "parakeet_tdt", "asr", "offline",
+      "Parakeet-TDT-0.6B-v3-GGUF/parakeet-tdt-0.6b-v3-q8_0.gguf",
+      NULL, NULL, NULL, NULL, 0, 1, 0, 0, 0 },
+    { "sortformer_diar", "diar", "offline",
+      "Sortformer-Diar-4spk-v1-GGUF/sortformer-diar-4spk-v1-q8_0.gguf",
+      NULL, NULL, NULL, NULL, 0, 0, 1, 0, 0 },
+    { "bs_roformer", "sep", "offline",
+      "BS-RoFormer-ep368-GGUF/bs-roformer-ep368-q8_0.gguf",
+      NULL, NULL, NULL, NULL, 0, 0, 0, 1, 1 },
+};
+
+#define CASE_COUNT (sizeof(CASES) / sizeof(CASES[0]))
+
+typedef struct {
+    float * samples;
+    size_t  frames;
+    int     sample_rate;
+    int     channels;
+} audio_clip;
+
+static uint16_t read_u16(const unsigned char * p) {
+    return (uint16_t)((uint32_t)p[0] | ((uint32_t)p[1] << 8));
+}
+
+static uint32_t read_u32(const unsigned char * p) {
+    return (uint32_t)p[0] | ((uint32_t)p[1] << 8) | ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+}
+
+static int load_wav(const char * path, audio_clip * clip) {
+    unsigned char header[12], chunk[8];
+    unsigned char * data = NULL;
+    uint32_t data_size = 0;
+    int channels = 0, sample_rate = 0, bits = 0;
+    size_t i;
+    FILE * file = fopen(path, "rb");
+
+    if (file == NULL) return 0;
+    if (fread(header, 1, sizeof(header), file) != sizeof(header) ||
+        memcmp(header, "RIFF", 4) != 0 || memcmp(header + 8, "WAVE", 4) != 0) {
+        fclose(file);
+        return 0;
+    }
+    while (fread(chunk, 1, sizeof(chunk), file) == sizeof(chunk)) {
+        const uint32_t size = read_u32(chunk + 4);
+        if (memcmp(chunk, "fmt ", 4) == 0) {
+            unsigned char fmt[16];
+            if (size < sizeof(fmt) || fread(fmt, 1, sizeof(fmt), file) != sizeof(fmt)) break;
+            channels = read_u16(fmt + 2);
+            sample_rate = (int)read_u32(fmt + 4);
+            bits = read_u16(fmt + 14);
+            if (size > sizeof(fmt)) fseek(file, (long)(size - sizeof(fmt)), SEEK_CUR);
+        } else if (memcmp(chunk, "data", 4) == 0) {
+            data = (unsigned char *)malloc(size);
+            if (data == NULL || fread(data, 1, size, file) != size) { free(data); data = NULL; break; }
+            data_size = size;
+            break;
+        } else {
+            fseek(file, (long)(size + (size & 1u)), SEEK_CUR);
+        }
+    }
+    fclose(file);
+    if (data == NULL || bits != 16 || channels < 1 || sample_rate <= 0) { free(data); return 0; }
+
+    clip->frames = data_size / (size_t)(2 * channels);
+    clip->channels = channels;
+    clip->sample_rate = sample_rate;
+    clip->samples = (float *)malloc(sizeof(float) * clip->frames * (size_t)channels);
+    if (clip->samples == NULL) { free(data); return 0; }
+    for (i = 0; i < clip->frames * (size_t)channels; ++i) {
+        clip->samples[i] = (float)(int16_t)read_u16(data + (i * 2)) / 32768.0f;
+    }
+    free(data);
+    return 1;
+}
+
+/* Online processor count, or 4 where it cannot be determined. */
+static int host_cpu_count(void) {
+#if defined(_WIN32)
+    SYSTEM_INFO info;
+    GetSystemInfo(&info);
+    return info.dwNumberOfProcessors > 0 ? (int)info.dwNumberOfProcessors : 4;
+#else
+    const long count = sysconf(_SC_NPROCESSORS_ONLN);
+    return count > 0 ? (int)count : 4;
+#endif
+}
+
+static int file_exists(const char * path) {
+    FILE * f = fopen(path, "rb");
+    if (f == NULL) return 0;
+    fclose(f);
+    return 1;
+}
+
+/* Prints every option a family declares. This is the part of the ABI that
+ * lets a binding generate typed wrappers without hardcoding families, and it
+ * is the part path_test.c cannot cover, because the in-repo VAD models declare
+ * no options at all. */
+static size_t dump_options(const audiocpp_model * model, const char * family) {
+    static const char * const SCOPES[] = { "request", "session", "load" };
+    size_t total = 0;
+    size_t scope;
+    for (scope = 0; scope < 3; ++scope) {
+        const size_t count = audiocpp_model_option_count(model, (audiocpp_option_scope)scope);
+        size_t i;
+        for (i = 0; i < count; ++i) {
+            const char * name = NULL;
+            const char * value_name = NULL;
+            const char * description = NULL;
+            const char * fallback = NULL;
+            const char * min_value = NULL;
+            const char * max_value = NULL;
+            int required = -1;
+            CHECK_OK(audiocpp_model_option(model, (audiocpp_option_scope)scope, i,
+                                           &name, &value_name, &description, &fallback,
+                                           &min_value, &max_value, &required));
+            CHECK(min_value != NULL && max_value != NULL,
+                  "%s option '%s' bounds are NULL; absent should read as \"\"",
+                  family, name ? name : "?");
+            CHECK(name != NULL && strlen(name) > 0, "%s %s option %zu has no name", family, SCOPES[scope], i);
+            CHECK(value_name != NULL && description != NULL && fallback != NULL,
+                  "%s option '%s' returned a NULL string; absent should read as \"\"",
+                  family, name ? name : "?");
+            CHECK(required == 0 || required == 1,
+                  "%s option '%s' required flag is %d", family, name ? name : "?", required);
+            printf("  %-8s %-28s value=%-14s required=%d default='%s' range=[%s,%s]\n",
+                   SCOPES[scope], name, value_name, required, fallback, min_value, max_value);
+        }
+        total += count;
+    }
+    return total;
+}
+
+static void run_case(const model_case * c, const char * models_root,
+                     const audio_clip * clip, const audio_clip * alt_clip,
+                     const char * backend_name, int threads) {
+    char model_path[4096];
+    audiocpp_registry * registry = NULL;
+    audiocpp_model * model = NULL;
+    audiocpp_session * session = NULL;
+    audiocpp_request * request = NULL;
+    audiocpp_result * result = NULL;
+    audiocpp_backend_config backend;
+    audiocpp_model_config load_config;
+    size_t options;
+
+    if (c->use_alt_audio) {
+        if (alt_clip->samples == NULL) {
+            printf("skip %-16s (needs the alternate audio clip)\n", c->family);
+            g_skipped++;
+            return;
+        }
+        clip = alt_clip;
+    }
+
+    snprintf(model_path, sizeof(model_path), "%s/%s", models_root, c->relative_model);
+    if (!file_exists(model_path)) {
+        printf("skip %-16s (no %s)\n", c->family, c->relative_model);
+        g_skipped++;
+        return;
+    }
+
+    printf("\n=== %s (%s/%s) ===\n", c->family, c->task, c->mode);
+    if (audiocpp_registry_create(NULL, &registry) != AUDIOCPP_OK) {
+        CHECK(0, "registry: %s", audiocpp_last_error());
+        return;
+    }
+    if (!audiocpp_registry_family_count(registry)) {
+        CHECK(0, "empty registry");
+        audiocpp_registry_free(registry);
+        return;
+    }
+    memset(&load_config, 0, sizeof(load_config));
+    load_config.family_hint = c->family;
+    if (audiocpp_model_load(registry, model_path, &load_config, NULL, &model) != AUDIOCPP_OK) {
+        /* A family not linked into this build is a skip, not a failure -- the
+         * model composite is a build-time choice. */
+        printf("skip %-16s (load: %s)\n", c->family, audiocpp_last_error());
+        g_skipped++;
+        audiocpp_registry_free(registry);
+        return;
+    }
+
+    CHECK(strcmp(audiocpp_model_family(model), c->family) == 0,
+          "loaded '%s' but asked for '%s'", audiocpp_model_family(model), c->family);
+    CHECK(audiocpp_model_supports(model, c->task, c->mode),
+          "%s does not advertise %s/%s", c->family, c->task, c->mode);
+
+    options = dump_options(model, c->family);
+    printf("declared_options=%zu speaker_ref=%d style=%d timestamps=%d\n", options,
+           audiocpp_model_supports_speaker_reference(model),
+           audiocpp_model_supports_style_condition(model),
+           audiocpp_model_supports_timestamps(model));
+
+    backend.backend = backend_name;
+    backend.device = 0;
+    backend.threads = threads;
+    if (audiocpp_session_create(model, c->task, c->mode, &backend, NULL, &session) != AUDIOCPP_OK) {
+        CHECK(0, "%s session: %s", c->family, audiocpp_last_error());
+        audiocpp_model_free(model);
+        audiocpp_registry_free(registry);
+        return;
+    }
+
+    request = audiocpp_request_create();
+    CHECK(request != NULL, "request alloc");
+    if (c->text != NULL) {
+        CHECK_OK(audiocpp_request_set_text(request, c->text, c->language));
+        if (c->voice_id != NULL) CHECK_OK(audiocpp_request_set_voice_id(request, c->voice_id));
+    } else {
+        CHECK_OK(audiocpp_request_set_audio(request, clip->samples, clip->frames,
+                                            clip->sample_rate, clip->channels));
+    }
+
+    if (c->seed != NULL) CHECK_OK(audiocpp_request_set_option(request, "seed", c->seed));
+
+    if (audiocpp_session_run(session, request, &result) != AUDIOCPP_OK) {
+        CHECK(0, "%s run: %s", c->family, audiocpp_last_error());
+    } else {
+        g_ran++;
+
+        if (c->expect_audio) {
+            const float * samples = NULL;
+            size_t frames = 0;
+            int rate = 0, channels = 0;
+            CHECK_OK(audiocpp_result_audio(result, &samples, &frames, &rate, &channels));
+            CHECK(frames > 0, "%s produced no audio frames", c->family);
+            CHECK(rate > 0 && channels > 0, "%s audio has rate=%d channels=%d",
+                  c->family, rate, channels);
+            if (frames > 0 && samples != NULL) {
+                double peak = 0.0;
+                size_t i;
+                for (i = 0; i < frames * (size_t)channels; ++i) {
+                    const double a = samples[i] < 0.0f ? -(double)samples[i] : (double)samples[i];
+                    if (a > peak) peak = a;
+                }
+                CHECK(peak > 0.001, "%s audio is silent (peak %.6f)", c->family, peak);
+                printf("parity:%s:audio_frames=%zu\n", c->family, frames);
+                printf("parity:%s:audio_rate=%d\n", c->family, rate);
+                printf("parity:%s:audio_seconds=%.3f\n", c->family, (double)frames / (double)rate);
+                printf("parity:%s:audio_peak=%.4f\n", c->family, peak);
+            }
+        }
+
+        if (c->expect_text) {
+            const char * text = NULL;
+            const char * language = NULL;
+            CHECK_OK(audiocpp_result_text(result, &text, &language));
+            CHECK(text != NULL && strlen(text) > 0, "%s produced no transcript", c->family);
+            if (text != NULL) printf("parity:%s:text=%s\n", c->family, text);
+        }
+
+        if (c->expect_turns) {
+            const size_t turns = audiocpp_result_speaker_turn_count(result);
+            size_t i;
+            CHECK(turns > 0, "%s produced no speaker turns", c->family);
+            for (i = 0; i < turns; ++i) {
+                int64_t start = -1, end = -1;
+                const char * speaker = NULL;
+                float confidence = -1.0f;
+                const char * text = NULL;
+                CHECK_OK(audiocpp_result_speaker_turn(result, i, &start, &end,
+                                                      &speaker, &confidence, &text));
+                CHECK(start >= 0 && end >= start, "%s turn %zu span [%lld,%lld]",
+                      c->family, i, (long long)start, (long long)end);
+                CHECK(speaker != NULL, "%s turn %zu speaker id is NULL", c->family, i);
+            }
+            printf("parity:%s:speaker_turns=%zu\n", c->family, turns);
+        }
+
+        if (c->expect_named_audio) {
+            const size_t streams = audiocpp_result_named_audio_count(result);
+            size_t i;
+            CHECK(streams > 0, "%s produced no named audio streams", c->family);
+            for (i = 0; i < streams; ++i) {
+                const char * id = NULL;
+                const float * samples = NULL;
+                size_t frames = 0;
+                int rate = 0, channels = 0;
+                CHECK_OK(audiocpp_result_named_audio(result, i, &id, &samples,
+                                                     &frames, &rate, &channels));
+                CHECK(id != NULL && strlen(id) > 0, "%s stream %zu has no id", c->family, i);
+                CHECK(frames > 0 && rate > 0 && channels > 0,
+                      "%s stream '%s' is %zu frames at %d Hz x%d",
+                      c->family, id ? id : "?", frames, rate, channels);
+                printf("parity:%s:stream_%zu=%s:%zu@%d\n", c->family, i,
+                       id ? id : "?", frames, rate);
+            }
+            printf("parity:%s:named_audio=%zu\n", c->family, streams);
+            CHECK(audiocpp_result_named_audio(result, streams, NULL, NULL, NULL, NULL, NULL)
+                  == AUDIOCPP_ERR_OUT_OF_RANGE,
+                  "%s: out-of-range named audio not rejected", c->family);
+        }
+
+        /* Word timestamps are optional per family; report when present so the
+         * accessor gets exercised wherever a model does emit them. */
+        {
+            const size_t words = audiocpp_result_word_count(result);
+            if (words > 0) {
+                size_t i;
+                for (i = 0; i < words; ++i) {
+                    const char * word = NULL;
+                    int64_t start = -1, end = -1;
+                    float confidence = -1.0f;
+                    CHECK_OK(audiocpp_result_word(result, i, &word, &start, &end, &confidence));
+                    CHECK(word != NULL, "%s word %zu is NULL", c->family, i);
+                    CHECK(start >= 0 && end >= start, "%s word %zu span [%lld,%lld]",
+                          c->family, i, (long long)start, (long long)end);
+                }
+                printf("parity:%s:words=%zu\n", c->family, words);
+            }
+        }
+
+        /* Artifacts, for families that emit them (MIDI, speaker embeddings,
+         * diarization state). Reported when present so the accessor is
+         * exercised wherever a model does produce one. */
+        {
+            const size_t artifacts = audiocpp_result_artifact_count(result);
+            size_t i;
+            for (i = 0; i < artifacts; ++i) {
+                audiocpp_artifact_kind kind = AUDIOCPP_ARTIFACT_CUSTOM;
+                const char * id = NULL;
+                const void * payload = NULL;
+                size_t bytes = 0;
+                CHECK_OK(audiocpp_result_artifact(result, i, &kind, &id, &payload, &bytes));
+                CHECK(id != NULL, "%s artifact %zu id is NULL", c->family, i);
+                printf("parity:%s:artifact_%zu=%s:%d:%zu\n", c->family, i,
+                       id ? id : "?", (int)kind, bytes);
+            }
+            if (artifacts > 0) printf("parity:%s:artifacts=%zu\n", c->family, artifacts);
+            CHECK(audiocpp_result_artifact(result, artifacts, NULL, NULL, NULL, NULL)
+                  == AUDIOCPP_ERR_OUT_OF_RANGE,
+                  "%s: out-of-range artifact not rejected", c->family);
+        }
+
+        /* Every indexed accessor must reject one past the end. */
+        CHECK(audiocpp_result_segment(result, audiocpp_result_segment_count(result),
+                                      NULL, NULL, NULL, NULL) == AUDIOCPP_ERR_OUT_OF_RANGE,
+              "%s: out-of-range segment not rejected", c->family);
+        CHECK(audiocpp_result_word(result, audiocpp_result_word_count(result),
+                                   NULL, NULL, NULL, NULL) == AUDIOCPP_ERR_OUT_OF_RANGE,
+              "%s: out-of-range word not rejected", c->family);
+        CHECK(audiocpp_result_speaker_turn(result, audiocpp_result_speaker_turn_count(result),
+                                           NULL, NULL, NULL, NULL, NULL) == AUDIOCPP_ERR_OUT_OF_RANGE,
+              "%s: out-of-range speaker turn not rejected", c->family);
+    }
+
+    audiocpp_result_free(result);
+    audiocpp_request_free(request);
+    audiocpp_session_free(session);
+    audiocpp_model_free(model);
+    audiocpp_registry_free(registry);
+}
+
+int main(int argc, char ** argv) {
+    const char * models_root = (argc > 1) ? argv[1] : "";
+    const char * audio_path = (argc > 2) ? argv[2] : "assets/resources/sample_16k.wav";
+    const char * backend_name = (argc > 3) ? argv[3] : "cpu";
+    /* 44.1 kHz stereo, for families that fix their input rate. */
+    const char * alt_audio_path = (argc > 4) ? argv[4] : "tests/ace_step/assets/complete_source_demucs_8s.wav";
+    /* Separation dominates this test's wall time and scales with threads (191s
+     * at 4 against 113s at 16), and thread count does not change results --
+     * verified bit-identical stems at both. Detected rather than defaulted to a
+     * constant, so a bare invocation uses the machine it is on instead of
+     * relying on every caller to remember the argument. */
+    const int threads = (argc > 5) ? atoi(argv[5]) : host_cpu_count();
+    audio_clip clip;
+    audio_clip alt_clip;
+    size_t i;
+
+    memset(&clip, 0, sizeof(clip));
+    memset(&alt_clip, 0, sizeof(alt_clip));
+
+    if (models_root[0] == '\0') {
+        printf("no model root configured; set AUDIOCPP_C_API_MODEL_ROOT to run this test\n");
+        return CTEST_SKIP;
+    }
+    if (threads <= 0) {
+        fprintf(stderr, "threads must be positive\n");
+        return 1;
+    }
+    if (!load_wav(audio_path, &clip)) {
+        fprintf(stderr, "cannot read %s\n", audio_path);
+        return 1;
+    }
+
+    if (!load_wav(alt_audio_path, &alt_clip)) {
+        printf("note: no alternate clip at %s; rate-fixed families will skip\n", alt_audio_path);
+    }
+
+    printf("models_root=%s\naudio=%s frames=%zu rate=%d\nbackend=%s\n",
+           models_root, audio_path, clip.frames, clip.sample_rate, backend_name);
+    printf("threads=%d\n", threads);
+    if (alt_clip.samples != NULL) {
+        printf("alt_audio=%s frames=%zu rate=%d ch=%d\n",
+               alt_audio_path, alt_clip.frames, alt_clip.sample_rate, alt_clip.channels);
+    }
+
+    for (i = 0; i < CASE_COUNT; ++i) {
+        run_case(&CASES[i], models_root, &clip, &alt_clip, backend_name, threads);
+    }
+
+    free(clip.samples);
+    free(alt_clip.samples);
+
+    printf("\nran=%d skipped=%d failures=%d\n", g_ran, g_skipped, g_failures);
+    if (g_failures > 0) return 1;
+    if (g_ran == 0) {
+        printf("no model was available; skipping\n");
+        return CTEST_SKIP;
+    }
+    printf("c api model test OK\n");
+    return 0;
+}

--- a/tests/capi/parity.py
+++ b/tests/capi/parity.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Check that the C API returns what audiocpp_cli returns.
+
+The C API is a facade over the same runtime the CLI drives, so for identical
+inputs the two must agree. That is the property worth testing: not that the
+facade produces plausible output, but that it produces the *same* output.
+
+    python3 tests/capi/parity.py --build-dir build --models-root /path/to/models
+
+Exits 0 when every available family matches, 1 on a mismatch, and 77 (the CTest
+skip code) when no model is present.
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import wave
+
+SKIP = 77
+
+# family -> (relative model path, CLI args builder, comparison)
+CASES = {
+    "citrinet_asr": {
+        "model": "Citrinet-ASR-GGUF/citrinet-asr-q8_0.gguf",
+        "task": "asr",
+        "kind": "text",
+    },
+    "parakeet_tdt": {
+        "model": "Parakeet-TDT-0.6B-v3-GGUF/parakeet-tdt-0.6b-v3-q8_0.gguf",
+        "task": "asr",
+        "kind": "text",
+    },
+    "kokoro_tts": {
+        "model": "Kokoro-82M-GGUF/kokoro-82m-q8_0.gguf",
+        "task": "tts",
+        "kind": "audio",
+        "text": "The quick brown fox jumps over the lazy dog.",
+        "language": "en-us",
+        "voice_id": "af_heart",
+        "seed": "1234",
+    },
+    "bs_roformer": {
+        "model": "BS-RoFormer-ep368-GGUF/bs-roformer-ep368-q8_0.gguf",
+        "task": "sep",
+        "kind": "stems",
+        # Fixed 44.1 kHz input; the default 16 kHz clip is rejected outright.
+        "use_alt_audio": True,
+    },
+    "sortformer_diar": {
+        "model": "Sortformer-Diar-4spk-v1-GGUF/sortformer-diar-4spk-v1-q8_0.gguf",
+        "task": "diar",
+        "kind": "turns",
+    },
+}
+
+
+def run(cmd):
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(f"{cmd[0]} failed ({proc.returncode}):\n{proc.stderr[-2000:]}")
+    return proc.stdout
+
+
+def wav_summary(path):
+    with wave.open(path) as handle:
+        frames = handle.getnframes()
+        rate = handle.getframerate()
+        channels = handle.getnchannels()
+        width = handle.getsampwidth()
+        raw = handle.readframes(frames)
+    peak = 0
+    if width == 2:
+        import array
+
+        samples = array.array("h")
+        samples.frombytes(raw)
+        if sys.byteorder == "big":
+            samples.byteswap()
+        peak = max((abs(v) for v in samples), default=0) / 32768.0
+    return frames, rate, channels, peak
+
+
+def why_missing(family, capi_output):
+    """Say why a family produced no comparable value.
+
+    "Not linked" and "ran but produced nothing" look identical from the parity
+    values alone, and reporting the wrong one sends a reader hunting through
+    CMake for a build problem that is not there.
+    """
+    if f"=== {family} (" in capi_output:
+        return "the C API run reported no comparable value"
+    for line in capi_output.splitlines():
+        if line.startswith(f"skip {family}") or line.startswith(f"skip {family:16}"):
+            return line.split("(", 1)[-1].rstrip(")") if "(" in line else "skipped by the C API run"
+    return "family not linked into this build"
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--build-dir", default="build")
+    parser.add_argument("--models-root", required=True)
+    parser.add_argument("--audio", default="assets/resources/sample_16k.wav")
+    # Separation families fix their input rate, so they need their own clip.
+    parser.add_argument("--alt-audio", default="tests/ace_step/assets/complete_source_demucs_8s.wav")
+    parser.add_argument("--backend", default="cpu")
+    # Separation dominates the wall time and scales with threads, and thread
+    # count does not change results (verified bit-identical stems at 4 and 16).
+    parser.add_argument("--threads", default=str(os.cpu_count() or 4))
+    args = parser.parse_args()
+
+    # Resolved up front: this runs from the build directory under CTest, where
+    # the repo-relative defaults would not exist. Silently losing a fixture is
+    # how a case skips while the run still reports OK.
+    args.audio = os.path.abspath(args.audio)
+    args.alt_audio = os.path.abspath(args.alt_audio)
+    for path in (args.audio, args.alt_audio):
+        if not os.path.exists(path):
+            print(f"missing audio fixture {path}; skipping")
+            return SKIP
+
+    binaries = os.path.join(args.build_dir, "bin")
+    cli = os.path.join(binaries, "audiocpp_cli")
+    model_test = os.path.join(binaries, "audiocpp_c_api_model_test")
+    for path in (cli, model_test):
+        if not os.path.exists(path):
+            print(f"missing {path}; build audiocpp_cli and audiocpp_c_api_model_test first")
+            return SKIP
+
+    available = {
+        family: case
+        for family, case in CASES.items()
+        if os.path.exists(os.path.join(args.models_root, case["model"]))
+    }
+    if not available:
+        print(f"no models under {args.models_root}; skipping")
+        return SKIP
+
+    # One C API run covers every family; parse its parity: lines. The alternate
+    # clip and thread count are passed explicitly so this matches what the C
+    # test does when CTest runs it directly.
+    capi = run([model_test, args.models_root, args.audio, args.backend,
+                args.alt_audio, args.threads])
+    values = dict(re.findall(r"^parity:(\S+?)=(.*)$", capi, re.M))
+
+    failures = []
+    checked = 0
+
+    with tempfile.TemporaryDirectory() as tmp:
+        for family, case in sorted(available.items()):
+            model = os.path.join(args.models_root, case["model"])
+            base = [cli, "--task", case["task"], "--family", family, "--model", model,
+                    "--backend", args.backend, "--threads", args.threads]
+
+            if case["kind"] == "text":
+                key = f"{family}:text"
+                if key not in values:
+                    print(f"{family:16} SKIP ({why_missing(family, capi)})")
+                    continue
+                out = os.path.join(tmp, f"{family}.txt")
+                run(base + ["--audio", args.audio, "--text-out", out])
+                with open(out) as handle:
+                    cli_value = handle.read().strip()
+                api_value = values[key].strip()
+                same = cli_value == api_value
+                print(f"{family:16} transcript {'MATCH' if same else 'DIFFER'} "
+                      f"({len(api_value)} chars)")
+                if not same:
+                    failures.append(family)
+                    print(f"  cli: {cli_value[:160]}")
+                    print(f"  api: {api_value[:160]}")
+
+            elif case["kind"] == "audio":
+                key = f"{family}:audio_frames"
+                if key not in values:
+                    print(f"{family:16} SKIP ({why_missing(family, capi)})")
+                    continue
+                out = os.path.join(tmp, f"{family}.wav")
+                # Kokoro draws noise per run, so both sides must be seeded or
+                # the comparison is meaningless. Verified: two unseeded CLI runs
+                # over the same input differ.
+                run(base + ["--language", case["language"], "--voice-id", case["voice_id"],
+                            "--seed", case["seed"], "--text", case["text"], "--out", out])
+                frames, rate, _channels, peak = wav_summary(out)
+                api_frames = int(values[f"{family}:audio_frames"])
+                api_rate = int(values[f"{family}:audio_rate"])
+                api_peak = float(values[f"{family}:audio_peak"])
+                # Length and rate must agree exactly. Peak carries a small
+                # tolerance only because the CLI quantises to 16-bit PCM on the
+                # way out while the C API hands back the float buffer directly;
+                # that error is ~3e-5, so 1e-3 is still a tight check. With both
+                # sides seeded these agree to four decimals in practice.
+                same = (frames == api_frames and rate == api_rate
+                        and abs(peak - api_peak) < 0.001)
+                print(f"{family:16} audio      {'MATCH' if same else 'DIFFER'} "
+                      f"cli={frames}@{rate}Hz peak={peak:.4f} "
+                      f"api={api_frames}@{api_rate}Hz peak={api_peak:.4f}")
+                if not same:
+                    failures.append(family)
+
+            elif case["kind"] == "stems":
+                key = f"{family}:named_audio"
+                if key not in values:
+                    print(f"{family:16} SKIP ({why_missing(family, capi)})")
+                    continue
+                out_dir = os.path.join(tmp, family)
+                os.makedirs(out_dir, exist_ok=True)
+                run(base + ["--audio", args.alt_audio, "--out-dir", out_dir])
+                cli_stems = {}
+                for name in sorted(os.listdir(out_dir)):
+                    if not name.lower().endswith(".wav"):
+                        continue
+                    frames, rate, _c, _p = wav_summary(os.path.join(out_dir, name))
+                    cli_stems[os.path.splitext(name)[0]] = (frames, rate)
+                api_stems = {}
+                for match in re.finditer(rf"^parity:{family}:stream_\d+=(\S+?):(\d+)@(\d+)$",
+                                         capi, re.M):
+                    api_stems[match.group(1)] = (int(match.group(2)), int(match.group(3)))
+                # CLI stem filenames may carry a prefix; compare on the suffix.
+                normalise = lambda d: {k.split("_")[-1]: v for k, v in d.items()}
+                same = normalise(cli_stems) == normalise(api_stems)
+                print(f"{family:16} stems      {'MATCH' if same else 'DIFFER'} "
+                      f"cli={sorted(normalise(cli_stems))} api={sorted(normalise(api_stems))}")
+                if not same:
+                    failures.append(family)
+                    print(f"  cli: {cli_stems}")
+                    print(f"  api: {api_stems}")
+
+            elif case["kind"] == "turns":
+                key = f"{family}:speaker_turns"
+                if key not in values:
+                    print(f"{family:16} SKIP ({why_missing(family, capi)})")
+                    continue
+                out = os.path.join(tmp, f"{family}.json")
+                run(base + ["--audio", args.audio, "--turns-out", out])
+                with open(out) as handle:
+                    parsed = json.load(handle)
+                cli_turns = len(parsed if isinstance(parsed, list) else parsed.get("turns", []))
+                api_turns = int(values[key])
+                same = cli_turns == api_turns
+                print(f"{family:16} turns      {'MATCH' if same else 'DIFFER'} "
+                      f"cli={cli_turns} api={api_turns}")
+                if not same:
+                    failures.append(family)
+
+            checked += 1
+
+    print()
+    if not checked:
+        print("nothing comparable was available; skipping")
+        return SKIP
+    if failures:
+        print(f"PARITY FAILED for: {', '.join(failures)}")
+        return 1
+    print(f"PARITY OK across {checked} famil{'y' if checked == 1 else 'ies'}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/capi/path_test.c
+++ b/tests/capi/path_test.c
@@ -1,0 +1,459 @@
+/*
+ * C ABI path test.
+ *
+ * Deliberately compiled as C: the point is that audiocpp.h is consumable by a
+ * C compiler, with no C++ runtime and no framework headers on the caller side.
+ *
+ * Runs Silero VAD over assets/resources/sample_16k.wav. Both ship in-repo, so
+ * the test needs no model download and no network, and runs on CPU in well
+ * under a second.
+ *
+ * It asserts the ABI contract: status codes, borrowed-string rules,
+ * out-of-range handling, out-of-order frees, and that a session reused across
+ * requests returns identical results. It asserts that speech is found, because
+ * the input really is speech, but nothing about how much -- that would pin the
+ * test to Silero's thresholds rather than to the ABI.
+ */
+
+#include "audiocpp.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int g_failures = 0;
+
+#define CHECK(cond, ...)                                         \
+    do {                                                         \
+        if (!(cond)) {                                           \
+            fprintf(stderr, "FAIL %s:%d: ", __FILE__, __LINE__);  \
+            fprintf(stderr, __VA_ARGS__);                        \
+            fprintf(stderr, "\n");                               \
+            g_failures++;                                        \
+        }                                                        \
+    } while (0)
+
+#define CHECK_OK(expr)                                                    \
+    do {                                                                  \
+        audiocpp_status _s = (expr);                                      \
+        CHECK(_s == AUDIOCPP_OK, "%s -> %s (%s)", #expr,                  \
+              audiocpp_status_string(_s), audiocpp_last_error());         \
+    } while (0)
+
+#define MAX_SEGMENTS 256
+
+typedef struct {
+    float * samples;
+    size_t  frames;
+    int     sample_rate;
+    int     channels;
+} audio_clip;
+
+static uint32_t read_u32(const unsigned char * p) {
+    return (uint32_t)p[0] | ((uint32_t)p[1] << 8) | ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+}
+
+static uint16_t read_u16(const unsigned char * p) {
+    return (uint16_t)((uint32_t)p[0] | ((uint32_t)p[1] << 8));
+}
+
+/* Minimal 16-bit PCM WAV reader. Only enough to walk the chunk list of the
+ * in-repo fixture; the C API itself takes float PCM and has no opinion on
+ * containers. */
+static int load_wav(const char * path, audio_clip * clip) {
+    unsigned char header[12];
+    unsigned char chunk[8];
+    unsigned char * data = NULL;
+    uint32_t data_size = 0;
+    int channels = 0, sample_rate = 0, bits = 0;
+    size_t i;
+    FILE * file = fopen(path, "rb");
+
+    if (file == NULL) {
+        fprintf(stderr, "cannot open %s\n", path);
+        return 0;
+    }
+    if (fread(header, 1, sizeof(header), file) != sizeof(header) ||
+        memcmp(header, "RIFF", 4) != 0 || memcmp(header + 8, "WAVE", 4) != 0) {
+        fprintf(stderr, "%s is not a RIFF/WAVE file\n", path);
+        fclose(file);
+        return 0;
+    }
+
+    while (fread(chunk, 1, sizeof(chunk), file) == sizeof(chunk)) {
+        const uint32_t size = read_u32(chunk + 4);
+        if (memcmp(chunk, "fmt ", 4) == 0) {
+            unsigned char fmt[16];
+            if (size < sizeof(fmt) || fread(fmt, 1, sizeof(fmt), file) != sizeof(fmt)) break;
+            channels = read_u16(fmt + 2);
+            sample_rate = (int)read_u32(fmt + 4);
+            bits = read_u16(fmt + 14);
+            if (size > sizeof(fmt)) fseek(file, (long)(size - sizeof(fmt)), SEEK_CUR);
+        } else if (memcmp(chunk, "data", 4) == 0) {
+            data = (unsigned char *)malloc(size);
+            if (data == NULL || fread(data, 1, size, file) != size) {
+                free(data);
+                data = NULL;
+                break;
+            }
+            data_size = size;
+            break;
+        } else {
+            fseek(file, (long)(size + (size & 1u)), SEEK_CUR);
+        }
+    }
+    fclose(file);
+
+    if (data == NULL || bits != 16 || channels < 1 || sample_rate <= 0) {
+        fprintf(stderr, "%s: unsupported or truncated (bits=%d ch=%d rate=%d)\n",
+                path, bits, channels, sample_rate);
+        free(data);
+        return 0;
+    }
+
+    clip->frames = data_size / (size_t)(2 * channels);
+    clip->channels = channels;
+    clip->sample_rate = sample_rate;
+    clip->samples = (float *)malloc(sizeof(float) * clip->frames * (size_t)channels);
+    if (clip->samples == NULL) {
+        free(data);
+        return 0;
+    }
+    for (i = 0; i < clip->frames * (size_t)channels; ++i) {
+        const int16_t pcm = (int16_t)read_u16(data + (i * 2));
+        clip->samples[i] = (float)pcm / 32768.0f;
+    }
+    free(data);
+    return 1;
+}
+
+typedef struct {
+    size_t  count;
+    int64_t start[MAX_SEGMENTS];
+    int64_t end[MAX_SEGMENTS];
+} segment_set;
+
+static void run_once(audiocpp_session * session, const audio_clip * clip, segment_set * out) {
+    audiocpp_request * request = audiocpp_request_create();
+    audiocpp_result * result = NULL;
+    size_t i;
+
+    out->count = 0;
+    CHECK(request != NULL, "audiocpp_request_create returned NULL");
+    if (request == NULL) return;
+
+    CHECK_OK(audiocpp_request_set_audio(request, clip->samples, clip->frames,
+                                        clip->sample_rate, clip->channels));
+    CHECK_OK(audiocpp_session_run(session, request, &result));
+    CHECK(result != NULL, "run produced no result handle");
+
+    if (result != NULL) {
+        const size_t count = audiocpp_result_segment_count(result);
+        int64_t previous_end = -1;
+        for (i = 0; i < count && i < MAX_SEGMENTS; ++i) {
+            int64_t start = -1, end = -1;
+            float confidence = -1.0f;
+            const char * text = NULL;
+            CHECK_OK(audiocpp_result_segment(result, i, &start, &end, &confidence, &text));
+            CHECK(start >= 0 && end >= start, "segment %zu span is malformed [%lld,%lld]",
+                  i, (long long)start, (long long)end);
+            CHECK(end <= (int64_t)clip->frames,
+                  "segment %zu ends at %lld, past the %zu-frame input",
+                  i, (long long)end, clip->frames);
+            CHECK(start >= previous_end, "segment %zu starts at %lld, before the previous end %lld",
+                  i, (long long)start, (long long)previous_end);
+            CHECK(text != NULL, "segment %zu text is NULL; absent should read as \"\"", i);
+            previous_end = end;
+            out->start[i] = start;
+            out->end[i] = end;
+        }
+        out->count = count;
+        /* Out-of-range access must be reported, not crash. */
+        CHECK(audiocpp_result_segment(result, count, NULL, NULL, NULL, NULL)
+              == AUDIOCPP_ERR_OUT_OF_RANGE, "out-of-range segment was not rejected");
+        /* A VAD result carries no audio or text; NOT_AVAILABLE, not a crash. */
+        CHECK(audiocpp_result_audio(result, NULL, NULL, NULL, NULL)
+              == AUDIOCPP_ERR_NOT_AVAILABLE, "vad result claimed to have audio");
+    }
+
+    audiocpp_result_free(result);
+    audiocpp_request_free(request);
+}
+
+static int same_segments(const segment_set * a, const segment_set * b) {
+    size_t i;
+    if (a->count != b->count) return 0;
+    for (i = 0; i < a->count && i < MAX_SEGMENTS; ++i) {
+        if (a->start[i] != b->start[i] || a->end[i] != b->end[i]) return 0;
+    }
+    return 1;
+}
+
+int main(int argc, char ** argv) {
+    const char * model_path = (argc > 1) ? argv[1] : "assets/framework/models/silero_vad";
+    const char * audio_path = (argc > 2) ? argv[2] : "assets/resources/sample_16k.wav";
+    /* Defaults to cpu so the registered test is deterministic and needs no GPU;
+     * pass "cuda"/"vulkan"/"metal" to exercise another backend through the ABI. */
+    const char * backend_name = (argc > 3) ? argv[3] : "cpu";
+    audiocpp_registry * registry = NULL;
+    audiocpp_model * model = NULL;
+    audiocpp_session * session = NULL;
+    audio_clip clip;
+    segment_set first, second, after_free;
+    size_t families, options, i;
+    int found_family = 0;
+
+    memset(&clip, 0, sizeof(clip));
+
+    printf("abi=%u build=%s backend=%s\n",
+           audiocpp_abi_version(), audiocpp_build_version(), backend_name);
+    CHECK(audiocpp_abi_version() == (((uint32_t)AUDIOCPP_ABI_VERSION_MAJOR << 16) |
+                                     ((uint32_t)AUDIOCPP_ABI_VERSION_MINOR << 8) |
+                                     (uint32_t)AUDIOCPP_ABI_VERSION_PATCH),
+          "abi version mismatch between header and library");
+
+    /* Freeing NULL is documented as a no-op; cleanup paths rely on it. */
+    audiocpp_registry_free(NULL);
+    audiocpp_model_free(NULL);
+    audiocpp_session_free(NULL);
+    audiocpp_result_free(NULL);
+    audiocpp_request_free(NULL);
+    audiocpp_options_free(NULL);
+    audiocpp_event_free(NULL);
+
+    if (!load_wav(audio_path, &clip)) return 1;
+    printf("audio=%s frames=%zu rate=%d ch=%d\n",
+           audio_path, clip.frames, clip.sample_rate, clip.channels);
+
+    CHECK_OK(audiocpp_registry_create(NULL, &registry));
+    if (registry == NULL) { fprintf(stderr, "no registry; aborting\n"); return 1; }
+
+    families = audiocpp_registry_family_count(registry);
+    CHECK(families > 0, "registry advertises no families");
+    for (i = 0; i < families; ++i) {
+        const char * family = NULL;
+        CHECK_OK(audiocpp_registry_family(registry, i, &family));
+        if (family != NULL && strcmp(family, "silero_vad") == 0) found_family = 1;
+    }
+    CHECK(found_family, "silero_vad is not in the registry");
+    {
+        const char * overflow = NULL;
+        CHECK(audiocpp_registry_family(registry, families, &overflow) == AUDIOCPP_ERR_OUT_OF_RANGE,
+              "out-of-range family was not rejected");
+        CHECK(audiocpp_registry_family(registry, 0, NULL) == AUDIOCPP_ERR_INVALID_ARGUMENT,
+              "NULL out parameter was not rejected");
+    }
+
+    /* An unknown family must be reported as such, not as a generic failure,
+     * and must leave a message behind. */
+    {
+        audiocpp_model * bogus = NULL;
+        audiocpp_model_config bogus_config;
+        audiocpp_status status;
+        memset(&bogus_config, 0, sizeof(bogus_config));
+        bogus_config.family_hint = "no_such_family";
+        status =
+            audiocpp_model_load(registry, model_path, &bogus_config, NULL, &bogus);
+        CHECK(status == AUDIOCPP_ERR_UNSUPPORTED_FAMILY,
+              "unknown family gave %s, expected unsupported family",
+              audiocpp_status_string(status));
+        CHECK(strlen(audiocpp_last_error()) > 0, "failing call left no error detail");
+        CHECK(bogus == NULL, "failed load still wrote an out handle");
+    }
+
+    {
+        audiocpp_model_config config;
+        memset(&config, 0, sizeof(config));
+        config.family_hint = "silero_vad";
+        CHECK_OK(audiocpp_model_load(registry, model_path, &config, NULL, &model));
+    }
+    if (model == NULL) { fprintf(stderr, "no model; aborting\n"); return 1; }
+
+    printf("family=%s\n", audiocpp_model_family(model));
+    CHECK(strcmp(audiocpp_model_family(model), "silero_vad") == 0,
+          "unexpected family '%s'", audiocpp_model_family(model));
+    CHECK(audiocpp_model_description(model) != NULL, "description is NULL");
+    CHECK(audiocpp_model_supports(model, "vad", "offline"), "model does not advertise vad/offline");
+    CHECK(!audiocpp_model_supports(model, "tts", "offline"), "vad model claims to do tts");
+    CHECK(!audiocpp_model_supports(model, "nonsense", "offline"),
+          "an unrecognised task should read as unsupported, not fail");
+
+    /* Runtime introspection: a binding must be able to discover what a family
+     * accepts without knowing anything about the family. Silero declares no
+     * options, so what is asserted here is that the accessor is well behaved
+     * at a count of zero. */
+    for (i = 0; i < 3; ++i) {
+        const audiocpp_option_scope scope = (audiocpp_option_scope)i;
+        size_t j;
+        options = audiocpp_model_option_count(model, scope);
+        printf("options[scope=%zu]=%zu\n", i, options);
+        for (j = 0; j < options; ++j) {
+            const char * name = NULL;
+            const char * value_name = NULL;
+            const char * description = NULL;
+            const char * default_value = NULL;
+            int required = -1;
+            const char * min_value = NULL;
+            const char * max_value = NULL;
+            CHECK_OK(audiocpp_model_option(model, scope, j, &name, &value_name,
+                                           &description, &default_value,
+                                           &min_value, &max_value, &required));
+            CHECK(min_value != NULL && max_value != NULL,
+                  "option %zu bounds are NULL; absent should read as \"\"", j);
+            CHECK(name != NULL && strlen(name) > 0, "option %zu has no name", j);
+            CHECK(value_name != NULL && description != NULL && default_value != NULL,
+                  "option %zu returned a NULL string; absent should read as \"\"", j);
+            CHECK(required == 0 || required == 1, "option %zu required flag is %d", j, required);
+            printf("  %s (%s) default='%s' required=%d\n", name, value_name, default_value, required);
+        }
+        CHECK(audiocpp_model_option(model, scope, options, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+              == AUDIOCPP_ERR_OUT_OF_RANGE, "out-of-range option was not rejected");
+    }
+
+    {
+        audiocpp_backend_config backend;
+        backend.backend = backend_name;
+        backend.device = 0;
+        backend.threads = 2;
+        CHECK_OK(audiocpp_session_create(model, "vad", "offline", &backend, NULL, &session));
+    }
+    if (session == NULL) { fprintf(stderr, "no session; aborting\n"); return 1; }
+    CHECK(strlen(audiocpp_session_family(session)) > 0, "session reports no family");
+
+    run_once(session, &clip, &first);
+    run_once(session, &clip, &second);
+    printf("segments=%zu\n", first.count);
+    CHECK(first.count > 0, "no speech found in %s, which is a speech recording", audio_path);
+    CHECK(first.count <= MAX_SEGMENTS, "more segments than this test can record");
+    /* Session reuse is the whole reason to embed rather than shell out, and it
+     * is the one thing the CLI path can never exercise. */
+    CHECK(same_segments(&first, &second), "reusing the session changed the result");
+
+    /* An explicit prepare must not disturb a later, differently shaped run.
+     * Preparation carries the input length, which is why run() re-prepares
+     * rather than trusting an earlier prepare. Note this asserts the invariant
+     * rather than detecting the hazard: Silero windows its input at a fixed 512
+     * frames and is indifferent to the declared length, as is Parakeet, so
+     * neither discriminates between the two implementations. */
+    {
+        audiocpp_request * warm = audiocpp_request_create();
+        segment_set after_warm;
+        CHECK(warm != NULL, "request alloc");
+        if (warm != NULL) {
+            CHECK_OK(audiocpp_request_set_audio(warm, clip.samples, clip.frames / 8,
+                                                clip.sample_rate, clip.channels));
+            CHECK_OK(audiocpp_session_prepare(session, warm));
+            audiocpp_request_free(warm);
+        }
+        run_once(session, &clip, &after_warm);
+        CHECK(same_segments(&first, &after_warm),
+              "a prepare sized for a shorter request changed the full run's result");
+    }
+
+    /* An offline session must refuse streaming calls rather than misbehave. */
+    CHECK(audiocpp_stream_push(session, clip.samples, 512, clip.sample_rate, clip.channels, 0, NULL)
+          == AUDIOCPP_ERR_NOT_AVAILABLE, "offline session accepted a stream push");
+
+    /* Streaming, over the same audio. Silero advertises vad/streaming, so this
+     * needs no extra model. The streaming and offline algorithms differ, so the
+     * segments are not required to match the offline run -- what is asserted is
+     * that the pull-based surface behaves. */
+    if (audiocpp_model_supports(model, "vad", "streaming")) {
+        audiocpp_session * stream = NULL;
+        audiocpp_backend_config backend;
+        backend.backend = backend_name;
+        backend.device = 0;
+        backend.threads = 2;
+        CHECK_OK(audiocpp_session_create(model, "vad", "streaming", &backend, NULL, &stream));
+        if (stream != NULL) {
+            audiocpp_stream_input_kind input = AUDIOCPP_STREAM_INPUT_NONE;
+            int64_t chunk_frames = 0;
+            size_t offset = 0;
+            size_t activity_events = 0;
+            size_t stream_segments = 0;
+            audiocpp_result * stream_result = NULL;
+
+            CHECK_OK(audiocpp_stream_policy(stream, &input, NULL, &chunk_frames, NULL));
+            CHECK(input == AUDIOCPP_STREAM_INPUT_AUDIO_CHUNKS, "vad stream wants no audio chunks");
+            CHECK(chunk_frames > 0, "stream policy gave a chunk size of %lld",
+                  (long long)chunk_frames);
+            if (chunk_frames <= 0) chunk_frames = 512;
+
+            CHECK_OK(audiocpp_stream_start(stream, NULL));
+            while (offset + (size_t)chunk_frames <= clip.frames) {
+                audiocpp_event * event = NULL;
+                CHECK_OK(audiocpp_stream_push(stream, clip.samples + offset,
+                                              (size_t)chunk_frames, clip.sample_rate,
+                                              clip.channels, (int64_t)offset, &event));
+                if (event != NULL) {
+                    const size_t activity = audiocpp_event_voice_activity_count(event);
+                    size_t k;
+                    for (k = 0; k < activity; ++k) {
+                        audiocpp_voice_activity_kind kind = (audiocpp_voice_activity_kind)-1;
+                        int64_t sample = -1;
+                        float probability = -1.0f;
+                        CHECK_OK(audiocpp_event_voice_activity(event, k, &kind, &sample, &probability));
+                        CHECK(kind == AUDIOCPP_VOICE_ACTIVITY_SPEECH_START ||
+                              kind == AUDIOCPP_VOICE_ACTIVITY_SPEECH_END ||
+                              kind == AUDIOCPP_VOICE_ACTIVITY_SPEECH_SEGMENT,
+                              "unrecognised voice activity kind %d", (int)kind);
+                        CHECK(probability >= 0.0f && probability <= 1.0f,
+                              "probability %f is outside [0,1]", (double)probability);
+                    }
+                    activity_events += activity;
+                    CHECK(audiocpp_event_voice_activity(event, activity, NULL, NULL, NULL)
+                          == AUDIOCPP_ERR_OUT_OF_RANGE, "out-of-range activity was not rejected");
+                    /* An event reads through the result accessors. The view is
+                     * owned by the event, and has the same type as an owned
+                     * result, so freeing it must be a no-op rather than a
+                     * double free -- the event stays usable afterwards. */
+                    {
+                        const audiocpp_result * view = audiocpp_event_as_result(event);
+                        CHECK(view != NULL, "event exposed no result view");
+                        if (view != NULL) {
+                            const size_t before = audiocpp_result_segment_count(view);
+                            audiocpp_result_free((audiocpp_result *)view);
+                            CHECK(audiocpp_result_segment_count(view) == before,
+                                  "freeing a borrowed event view damaged it");
+                        }
+                    }
+                    audiocpp_event_free(event);
+                }
+                offset += (size_t)chunk_frames;
+            }
+            CHECK_OK(audiocpp_stream_finish(stream, &stream_result));
+            if (stream_result != NULL) {
+                stream_segments = audiocpp_result_segment_count(stream_result);
+                audiocpp_result_free(stream_result);
+            }
+            printf("stream: chunk=%lld events=%zu segments=%zu\n",
+                   (long long)chunk_frames, activity_events, stream_segments);
+            CHECK(activity_events > 0 || stream_segments > 0,
+                  "streaming produced neither events nor segments over speech audio");
+
+            /* A streaming session must refuse the offline entry point. */
+            CHECK(audiocpp_session_run(stream, NULL, &stream_result) == AUDIOCPP_ERR_NOT_AVAILABLE,
+                  "streaming session accepted an offline run");
+            CHECK_OK(audiocpp_stream_reset(stream));
+            audiocpp_session_free(stream);
+        }
+    }
+
+    /* Handles hold their parents alive, so freeing out of order is safe.
+     * Without that, this would dangle. */
+    audiocpp_model_free(model);
+    audiocpp_registry_free(registry);
+    run_once(session, &clip, &after_free);
+    CHECK(same_segments(&first, &after_free),
+          "session stopped agreeing with itself after its model and registry were freed");
+    audiocpp_session_free(session);
+
+    free(clip.samples);
+
+    if (g_failures > 0) {
+        fprintf(stderr, "%d check(s) failed\n", g_failures);
+        return 1;
+    }
+    printf("c api path test OK\n");
+    return 0;
+}


### PR DESCRIPTION
Implements the C ABI proposed in #525 — an in-process entry point for applications
that embed audio.cpp rather than shelling out to the CLI or running the server.

One commit, 10 files, +3565/-0. `AUDIOCPP_BUILD_C_API` defaults to OFF; with it off,
configure produces no new targets, no tests, and no changed flags.

| | |
|---|---|
| `include/audiocpp.h` | the C header — C99, 69 entry points |
| `src/capi/audiocpp.cpp` | the facade — one translation unit |
| `src/capi/audiocpp.map` / `.symbols` | ELF / Mach-O export lists |
| `tests/capi/` | four tests, the C ones compiled as C |
| `docs/c_api.md` | ownership and lifetime rules |

## Design

A translation layer over `ModelRegistry` → `ILoadedVoiceModel` → `IVoiceTaskSession`,
the same surfaces `audiocpp_cli` uses. It depends only on framework headers, never on
`app/`, so the CLI and the C API stay independent.

Three properties of the runtime keep it thin. Options are already
`unordered_map<string, string>` in `ModelLoadRequest`, `SessionOptions` and
`TaskRequest`, so the ABI carries no per-family knowledge and **adding a model family
never changes the header**. `TaskRequest` → `TaskResult` is already generic, so there
are two run paths to wrap. And `ModelInspection::cli` is already self-describing, so
it is exposed as-is: a binding enumerates a family's options at runtime — names,
types, defaults, bounds — instead of hardcoding them.

Opaque handles only; no exception escapes; accessors rather than struct copies so
`TaskResult` can gain fields without breaking the ABI; returned strings are never
NULL. Handles hold their parents alive, so freeing out of order is safe — callers
from garbage-collected runtimes cannot control finalizer order.

## Two notes against the proposal

**The surface is 69 functions, not the ~50 sketched in #525**, and includes streaming,
artifacts and style conditioning rather than deferring them. It now covers everything
`TaskRequest`, `TaskResult`, `ModelLoadRequest` and `CliOptionInfo` carry, so a caller
is never pushed back to the CLI mid-workflow. Happy to split the offline core out if
you would rather review that first.

**One line falls outside the new files**: `cjson_vendor` is now compiled with
`CJSON_HIDE_SYMBOLS`. cJSON annotates its public functions with
`__declspec(dllexport)` by default, and since `dllexport` is additive, any DLL
absorbing that static library re-exports all 78 — the first Windows build produced 147
exports against 69 intended. No DLL is built from this tree today, so this was latent;
this is simply the first target to expose it.

## Validation

| platform | |
|---|---|
| Linux x86_64 | CPU and CUDA (RTX 3090, CUDA 12.8); single- and multi-config generators |
| macOS arm64 | CMake 3.31.12 and 4.4.3, Metal on and off, Xcode/clang 21 |
| macOS x86_64 | links, exports verified |
| Windows x64 | MSVC 14.44.35207, SDK 10.0.26100, VS 2022 generator |

Every platform produces the same results for the same inputs.

- **`audiocpp_c_api_path`** — the ABI contract, offline and streaming, against the
  Silero VAD model and speech clip already in the repo. No download, no network.
- **`audiocpp_c_api_model`** — five families across five task types, covering every
  result accessor: Kokoro (audio, 12 declared options), Citrinet and Parakeet
  (transcript, 28 word timestamps), Sortformer (5 speaker turns), BS-RoFormer (2 named
  streams).
- **`audiocpp_c_api_parity`** — the same inputs through `audiocpp_cli`, compared. The
  C API drives the same runtime, so it must produce not merely plausible output but
  the *same* output. Passes across all five families. Kokoro draws noise per run, so
  both sides are seeded.
- **`audiocpp_c_api_exports`** — asserts the library exports exactly this header, on
  all three platforms. 69 declared, 69 exported, nothing else.

The last three report SKIP (exit 77) when models or tooling are absent, so a checkout
with no downloads stays green.

Session reuse is the reason to embed rather than shell out, so: one session, repeated
requests, RSS sampled after warm-up — 1072 kB delta at 200, 500 and 1000 iterations.
Flat, not linear. 40.5 ms per request on CPU (347× realtime, 14 s of audio per
request).

A C# binding over this header exists in my fork
(christopherthompson81/audio.cpp#2) and is **not** proposed here — #525 scopes
language bindings out. It is worth mentioning only as validation: an independent
consumer, in another language, exercising the out-of-order-free guarantee that
motivated the design, since .NET finalizer order is not deterministic. Its tests and
the C tests report identical values across all five families — 11 lines,
byte-identical — on Linux, macOS and Windows. It also confirms the cJSON change
removed nothing a real consumer needs: every `audiocpp_*` symbol resolves through
P/Invoke at runtime.

## Notes for review

- `CMAKE_POSITION_INDEPENDENT_CODE` is set inside `if (AUDIOCPP_BUILD_C_API)` only —
  `BUILD_SHARED_LIBS` is forced OFF at `CMakeLists.txt:297`, so the objects are
  otherwise non-PIC. Enabling the option forces a full ggml rebuild.
- `enable_testing()` is called in the C API block. The existing call is further down
  and gated behind `ENGINE_BUILD_*`, so an `add_test()` here would silently never
  register.
- The backend-name mapping is duplicated from `app/cli/args.cpp`, to keep the C API
  independent of `app/`. Glad to lift it into the framework instead.
- The library does not call `omp_set_num_threads()`, unlike the CLI — that is
  process-global state a library shouldn't touch. Threads come from
  `audiocpp_backend_config`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EkxqpYvUbjCpRDnFiNiVfx
