### PR TITLE
Expose built-in audio utilities as a model family

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1697,6 +1697,15 @@ audiocpp_add_model(audiosr
         engine::models::audiosr::make_audiosr_loader
 )
 
+audiocpp_add_model(builtin_audio_utils
+    SOURCES
+        src/models/builtin_audio_utils/session.cpp
+    INCLUDES
+        engine/models/builtin_audio_utils/session.h
+    LOADERS
+        engine::models::builtin_audio_utils::make_builtin_audio_utils_loader
+)
+
 audiocpp_add_model(controlfoley
     SOURCES
         src/models/controlfoley/assets.cpp

--- a/app/server/config.cpp
+++ b/app/server/config.cpp
@@ -278,11 +278,14 @@ ServerConfig load_server_config(const std::filesystem::path & path) {
     for (const auto & item : models->as_array()) {
         ServerModelConfig model;
         model.id = engine::io::json::require_string(item, "id");
-        model.path = resolve_path(base, engine::io::json::require_string(item, "path"));
+        model.family = engine::io::json::require_string(item, "family");
+        const auto raw_path = engine::io::json::require_string(item, "path");
+        model.path = model.family == "builtin_audio_utils"
+            ? std::filesystem::path(raw_path)
+            : resolve_path(base, raw_path);
         if (const auto * value = item.find("model_spec_override")) {
             model.model_spec_override = resolve_path(base, value->as_string());
         }
-        model.family = engine::io::json::require_string(item, "family");
         model.task = engine::io::json::optional_string(item, "task", model.task);
         model.mode = engine::io::json::optional_string(item, "mode", model.mode);
         model.lazy = engine::io::json::optional_bool(item, "lazy", config.lazy_load);

--- a/docs/audio_tools.md
+++ b/docs/audio_tools.md
@@ -2,9 +2,10 @@
 
 | Model | Family | Task(s) | Quick Start |
 |---|---|---|---|
+| Built-in audio utilities | `builtin_audio_utils` | `s2s` denoise/enhance/super-resolution | [Built-in audio utilities](#built-in-audio-utilities) |
 | AudioSR | `audiosr` | `s2s` audio super-resolution | [AudioSR](#audiosr) |
 | ControlFoley | `controlfoley` | `gen` Foley/SFX generation | [ControlFoley](#controlfoley) |
-| GTCRN | `gtcrn`, `gtcrn_dns3`, `gtcrn_vctk`, `gtcrn_streaming` | framework denoise utility | [GTCRN](#gtcrn) |
+| GTCRN | `gtcrn`, `gtcrn_dns3`, `gtcrn_vctk`, `gtcrn_streaming` | framework denoise utility API | [GTCRN](#gtcrn) |
 | MeanVC2 | `meanvc2` | `vc` | [MeanVC2](#meanvc2) |
 | MioCodec | `miocodec` | `vc`, `s2s` | [MioCodec](#miocodec) |
 | PersonaPlex | `personaplex` | `s2s` | [PersonaPlex](#personaplex) |
@@ -27,6 +28,56 @@ Common CLI shape:
 
 ```bash
 audiocpp_cli --task <task> --family <family> --model <model-dir> --backend cuda ...
+```
+
+## Built-in Audio Utilities
+
+The `builtin_audio_utils` family exposes the built-in framework audio utility
+models through the normal CLI and server model-loading path. These utilities do
+not use a GGUF or external model directory as `--model`; pass the utility id
+directly.
+
+| Utility id | Operation | Input rate | Output rate |
+|---|---|---:|---:|
+| `deepfilternet2` | Denoise/enhance | 48 kHz | 48 kHz |
+| `rnnoise` | Denoise/enhance | 48 kHz | 48 kHz |
+| `zipenhancer` | Denoise/enhance | 16 kHz | 16 kHz |
+| `gtcrn` | Denoise/enhance, alias for `gtcrn_streaming` | 16 kHz | 16 kHz |
+| `gtcrn_streaming` | Denoise/enhance | 16 kHz | 16 kHz |
+| `gtcrn_dns3` | Denoise/enhance | 16 kHz | 16 kHz |
+| `gtcrn_vctk` | Denoise/enhance | 16 kHz | 16 kHz |
+| `flashsr` | Audio super-resolution | 16 kHz | 48 kHz |
+
+CLI example:
+
+```bash
+audiocpp_cli --task s2s --family builtin_audio_utils \
+  --model rnnoise \
+  --backend cuda \
+  --audio input.wav \
+  --out enhanced.wav \
+  --log \
+  --log-file rnnoise.log
+```
+
+Server config example:
+
+```json
+{
+  "id": "builtin-rnnoise",
+  "family": "builtin_audio_utils",
+  "path": "rnnoise",
+  "task": "s2s",
+  "mode": "offline"
+}
+```
+
+Server request example:
+
+```bash
+curl http://127.0.0.1:8080/v1/tasks/run \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"builtin-rnnoise","request":{"audio":"input.wav"}}'
 ```
 
 ## AudioSR

--- a/include/engine/framework/audio/utility_api.h
+++ b/include/engine/framework/audio/utility_api.h
@@ -3,11 +3,24 @@
 #include "engine/framework/core/backend.h"
 
 #include <filesystem>
+#include <optional>
 #include <string_view>
 #include <utility>
 #include <vector>
 
 namespace engine::audio {
+
+enum class BuiltinAudioUtilityKind {
+    Denoise,
+    SuperResolve,
+};
+
+struct BuiltinAudioUtilityInfo {
+    std::string_view id;
+    BuiltinAudioUtilityKind kind = BuiltinAudioUtilityKind::Denoise;
+    int input_sample_rate = 0;
+    int output_sample_rate = 0;
+};
 
 struct AudioUtilityPaths {
     AudioUtilityPaths() = default;
@@ -24,6 +37,14 @@ struct AudioUtilityPaths {
 struct AudioUtilityBatchResult {
     std::vector<std::filesystem::path> outputs;
 };
+
+std::filesystem::path default_audio_utility_assets_root();
+std::vector<BuiltinAudioUtilityInfo> list_builtin_audio_utilities();
+std::optional<BuiltinAudioUtilityInfo> find_builtin_audio_utility(std::string_view model);
+BuiltinAudioUtilityInfo require_builtin_audio_utility(std::string_view model);
+std::filesystem::path resolve_builtin_audio_utility_asset(
+    const AudioUtilityPaths & paths,
+    std::string_view model);
 
 void denoise_file(
     const std::filesystem::path & input_wav,

--- a/include/engine/models/builtin_audio_utils/session.h
+++ b/include/engine/models/builtin_audio_utils/session.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "engine/framework/runtime/model.h"
+#include "engine/framework/runtime/session.h"
+#include "engine/framework/runtime/session_base.h"
+
+#include <memory>
+#include <string>
+
+namespace engine::models::builtin_audio_utils {
+
+class BuiltinAudioUtilsLoadedModel final : public runtime::ILoadedVoiceModel {
+public:
+    explicit BuiltinAudioUtilsLoadedModel(std::string model_id);
+
+    const runtime::ModelMetadata & metadata() const noexcept override;
+    const runtime::CapabilitySet & capabilities() const noexcept override;
+    std::unique_ptr<runtime::IVoiceTaskSession> create_task_session(
+        const runtime::TaskSpec & task,
+        const runtime::SessionOptions & options) const override;
+
+private:
+    std::string model_id_;
+    runtime::ModelMetadata metadata_;
+    runtime::CapabilitySet capabilities_;
+};
+
+std::shared_ptr<runtime::IVoiceModelLoader> make_builtin_audio_utils_loader();
+
+}  // namespace engine::models::builtin_audio_utils

--- a/model_specs/builtin_audio_utils.json
+++ b/model_specs/builtin_audio_utils.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": 1,
+  "family": "builtin_audio_utils",
+  "display_name": "Built-in Audio Utilities",
+  "description": "Built-in denoise, enhancement, and audio super-resolution utilities packaged with audio.cpp.",
+  "category": "audio_tools",
+  "status": "experimental",
+  "tasks": [
+    "s2s"
+  ],
+  "modes": [
+    "offline"
+  ],
+  "languages": [
+    "auto"
+  ],
+  "runtime": {
+    "tags": [
+      "cpu",
+      "cuda"
+    ]
+  },
+  "capabilities": {
+    "s2s": [
+      "audio_enhancement"
+    ]
+  },
+  "options": {
+    "request": [],
+    "session": [],
+    "load": []
+  },
+  "packages": [],
+  "dependencies": [],
+  "ui": {
+    "tags": [],
+    "docs": [
+      "docs/audio_tools.md"
+    ]
+  },
+  "sources": []
+}

--- a/src/framework/audio/utility_api.cpp
+++ b/src/framework/audio/utility_api.cpp
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <array>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -94,7 +95,71 @@ bool is_gtcrn_model(std::string_view model) {
     return model == "gtcrn" || model == "gtcrn_dns3" || model == "gtcrn_vctk" || model == "gtcrn_streaming";
 }
 
+constexpr std::array<BuiltinAudioUtilityInfo, 8> kBuiltinUtilities{{
+    {"deepfilternet2", BuiltinAudioUtilityKind::Denoise, 48000, 48000},
+    {"rnnoise", BuiltinAudioUtilityKind::Denoise, 48000, 48000},
+    {"zipenhancer", BuiltinAudioUtilityKind::Denoise, 16000, 16000},
+    {"gtcrn", BuiltinAudioUtilityKind::Denoise, 16000, 16000},
+    {"gtcrn_streaming", BuiltinAudioUtilityKind::Denoise, 16000, 16000},
+    {"gtcrn_dns3", BuiltinAudioUtilityKind::Denoise, 16000, 16000},
+    {"gtcrn_vctk", BuiltinAudioUtilityKind::Denoise, 16000, 16000},
+    {"flashsr", BuiltinAudioUtilityKind::SuperResolve, 16000, 48000},
+}};
+
 }  // namespace
+
+std::filesystem::path default_audio_utility_assets_root() {
+    return std::filesystem::path("assets/framework/audio_utilities");
+}
+
+std::vector<BuiltinAudioUtilityInfo> list_builtin_audio_utilities() {
+    return std::vector<BuiltinAudioUtilityInfo>(kBuiltinUtilities.begin(), kBuiltinUtilities.end());
+}
+
+std::optional<BuiltinAudioUtilityInfo> find_builtin_audio_utility(std::string_view model) {
+    const auto it = std::find_if(
+        kBuiltinUtilities.begin(),
+        kBuiltinUtilities.end(),
+        [&](const BuiltinAudioUtilityInfo & info) {
+            return info.id == model;
+        });
+    if (it == kBuiltinUtilities.end()) {
+        return std::nullopt;
+    }
+    return *it;
+}
+
+BuiltinAudioUtilityInfo require_builtin_audio_utility(std::string_view model) {
+    if (auto info = find_builtin_audio_utility(model)) {
+        return *info;
+    }
+    throw_unsupported_model(
+        "builtin_audio_utils",
+        model,
+        "deepfilternet2, rnnoise, zipenhancer, gtcrn, gtcrn_streaming, gtcrn_dns3, gtcrn_vctk, flashsr");
+}
+
+std::filesystem::path resolve_builtin_audio_utility_asset(
+    const AudioUtilityPaths & paths,
+    std::string_view model) {
+    (void) require_builtin_audio_utility(model);
+    if (model == "deepfilternet2") {
+        return require_model_dir(paths, "deepfilternet2");
+    }
+    if (model == "rnnoise") {
+        return require_model_dir(paths, "rnnoise") / "rnnoise10Gb_15.safetensors";
+    }
+    if (model == "zipenhancer") {
+        return require_model_dir(paths, "zipenhancer");
+    }
+    if (is_gtcrn_model(model)) {
+        return gtcrn_checkpoint_for(paths, model);
+    }
+    if (model == "flashsr") {
+        return require_model_dir(paths, "flashsr");
+    }
+    throw_unsupported_model("builtin_audio_utils", model, "");
+}
 
 void denoise_file(
     const std::filesystem::path & input_wav,

--- a/src/framework/runtime/registry.cpp
+++ b/src/framework/runtime/registry.cpp
@@ -1,6 +1,7 @@
 #include "engine/framework/runtime/registry.h"
 
 #include "engine/framework/debug/trace.h"
+#include "engine/framework/audio/utility_api.h"
 #include "engine/framework/model_spec/package.h"
 #include "engine/framework/io/config.h"
 #include "engine/framework/io/filesystem.h"
@@ -149,7 +150,13 @@ std::unique_ptr<ILoadedVoiceModel> ModelRegistry::load(const std::filesystem::pa
 }
 
 void ModelRegistry::validate_request(const ModelLoadRequest & request) const {
-    if (!engine::io::is_existing_file(request.model_path) && !engine::io::is_existing_directory(request.model_path)) {
+    const bool builtin_audio_utility_id =
+        request.family_hint.has_value() &&
+        *request.family_hint == "builtin_audio_utils" &&
+        engine::audio::find_builtin_audio_utility(request.model_path.generic_string()).has_value();
+    if (!builtin_audio_utility_id &&
+        !engine::io::is_existing_file(request.model_path) &&
+        !engine::io::is_existing_directory(request.model_path)) {
         throw std::runtime_error("model path does not exist: " + request.model_path.string());
     }
     if (request.family_hint.has_value() && !supports_family(*request.family_hint)) {

--- a/src/models/builtin_audio_utils/session.cpp
+++ b/src/models/builtin_audio_utils/session.cpp
@@ -1,0 +1,262 @@
+#include "engine/models/builtin_audio_utils/session.h"
+
+#include "engine/framework/audio/conversion.h"
+#include "engine/framework/audio/deepfilternet2.h"
+#include "engine/framework/audio/flashsr.h"
+#include "engine/framework/audio/gtcrn.h"
+#include "engine/framework/audio/rnnoise.h"
+#include "engine/framework/audio/utility_api.h"
+#include "engine/framework/audio/zipenhancer.h"
+#include "engine/framework/debug/profiler.h"
+
+#include <chrono>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <variant>
+
+namespace engine::models::builtin_audio_utils {
+namespace {
+
+using UtilityRuntime = std::variant<
+    engine::audio::DeepFilterNet2Model,
+    engine::audio::RnnoiseModel,
+    engine::audio::ZipEnhancerModel,
+    engine::audio::GTCRNModel,
+    engine::audio::FlashSrModel>;
+
+runtime::CapabilitySet builtin_audio_utils_capabilities() {
+    runtime::CapabilitySet out;
+    out.supported_tasks = {
+        {runtime::VoiceTaskKind::SpeechToSpeech, {runtime::RunMode::Offline}},
+    };
+    return out;
+}
+
+runtime::ModelMetadata builtin_audio_utils_metadata(const std::string & model_id) {
+    const auto info = engine::audio::require_builtin_audio_utility(model_id);
+    runtime::ModelMetadata out;
+    out.family = "builtin_audio_utils";
+    out.variant = model_id;
+    out.description = info.kind == engine::audio::BuiltinAudioUtilityKind::SuperResolve
+        ? "Built-in audio utility: super resolution."
+        : "Built-in audio utility: denoise/enhance.";
+    return out;
+}
+
+std::string operation_name(engine::audio::BuiltinAudioUtilityKind kind) {
+    switch (kind) {
+    case engine::audio::BuiltinAudioUtilityKind::Denoise:
+        return "denoise";
+    case engine::audio::BuiltinAudioUtilityKind::SuperResolve:
+        return "super_resolve";
+    }
+    return "unknown";
+}
+
+UtilityRuntime load_utility_runtime(
+    const std::string & model_id,
+    const engine::audio::AudioUtilityPaths & paths) {
+    const auto asset = engine::audio::resolve_builtin_audio_utility_asset(paths, model_id);
+    if (model_id == "deepfilternet2") {
+        return engine::audio::DeepFilterNet2Model::load_from_directory(asset, paths.backend);
+    }
+    if (model_id == "rnnoise") {
+        return engine::audio::RnnoiseModel::load_from_safetensors(asset, paths.backend);
+    }
+    if (model_id == "zipenhancer") {
+        return engine::audio::ZipEnhancerModel::load_from_directory(asset, paths.backend);
+    }
+    if (model_id == "gtcrn" || model_id == "gtcrn_streaming" ||
+        model_id == "gtcrn_dns3" || model_id == "gtcrn_vctk") {
+        return engine::audio::GTCRNModel::load_from_safetensors(asset, paths.backend);
+    }
+    if (model_id == "flashsr") {
+        return engine::audio::FlashSrModel::load_from_directory(asset, paths.backend);
+    }
+    (void) engine::audio::require_builtin_audio_utility(model_id);
+    throw std::runtime_error("unreachable builtin audio utility model: " + model_id);
+}
+
+runtime::AudioBuffer audio_buffer_from_mono(
+    int sample_rate,
+    std::vector<float> samples) {
+    runtime::AudioBuffer output;
+    output.sample_rate = sample_rate;
+    output.channels = 1;
+    output.samples = std::move(samples);
+    return output;
+}
+
+class BuiltinAudioUtilsSession final
+    : public runtime::RuntimeSessionBase,
+      public runtime::IOfflineVoiceTaskSession {
+public:
+    BuiltinAudioUtilsSession(
+        runtime::TaskSpec task,
+        const runtime::SessionOptions & options,
+        std::string model_id)
+        : runtime::RuntimeSessionBase(options),
+          task_(task),
+          model_id_(std::move(model_id)),
+          info_(engine::audio::require_builtin_audio_utility(model_id_)),
+          runtime_(load_utility_runtime(
+              model_id_,
+              engine::audio::AudioUtilityPaths{
+                  engine::audio::default_audio_utility_assets_root(),
+                  options.backend})) {
+        if (task_.task != runtime::VoiceTaskKind::SpeechToSpeech) {
+            throw std::runtime_error("builtin_audio_utils only supports --task s2s");
+        }
+        if (task_.mode != runtime::RunMode::Offline) {
+            throw std::runtime_error("builtin_audio_utils only supports offline mode");
+        }
+    }
+
+    std::string family() const override {
+        return "builtin_audio_utils";
+    }
+
+    runtime::VoiceTaskKind task_kind() const override {
+        return task_.task;
+    }
+
+    runtime::RunMode run_mode() const override {
+        return task_.mode;
+    }
+
+    void prepare(const runtime::SessionPreparationRequest &) override {
+        mark_prepared();
+    }
+
+    runtime::TaskResult run(const runtime::TaskRequest & request) override {
+        require_prepared("builtin_audio_utils run");
+        if (!request.audio_input.has_value()) {
+            throw std::runtime_error("builtin_audio_utils requires --audio");
+        }
+        const auto & input = *request.audio_input;
+        const auto prep_start = std::chrono::steady_clock::now();
+        const auto mono = engine::audio::convert_interleaved_audio_to_mono_linear_resampled(
+            input.samples,
+            input.sample_rate,
+            input.channels,
+            info_.input_sample_rate);
+        engine::debug::timing_log_scalar(
+            "builtin_audio_utils.audio_prepare_ms",
+            engine::debug::elapsed_ms(prep_start));
+
+        const auto compute_start = std::chrono::steady_clock::now();
+        runtime::TaskResult result;
+        if (model_id_ == "deepfilternet2") {
+            const auto output = std::get<engine::audio::DeepFilterNet2Model>(runtime_).run_mono_48k(mono);
+            result.audio_output = audio_buffer_from_mono(output.sample_rate, output.samples);
+        } else if (model_id_ == "rnnoise") {
+            const auto output = std::get<engine::audio::RnnoiseModel>(runtime_).process_mono_48k(mono);
+            result.audio_output = audio_buffer_from_mono(output.sample_rate, output.samples);
+        } else if (model_id_ == "zipenhancer") {
+            const auto output = std::get<engine::audio::ZipEnhancerModel>(runtime_).denoise_mono_16k(mono);
+            result.audio_output = audio_buffer_from_mono(output.sample_rate, output.samples);
+        } else if (model_id_ == "gtcrn" || model_id_ == "gtcrn_streaming" ||
+                   model_id_ == "gtcrn_dns3" || model_id_ == "gtcrn_vctk") {
+            const auto output = std::get<engine::audio::GTCRNModel>(runtime_).denoise_mono_16k(mono);
+            result.audio_output = audio_buffer_from_mono(output.sample_rate, output.samples);
+        } else if (model_id_ == "flashsr") {
+            const auto output = std::get<engine::audio::FlashSrModel>(runtime_).super_resolve_mono_16k(mono);
+            result.audio_output = audio_buffer_from_mono(output.sample_rate, output.samples);
+        } else {
+            (void) engine::audio::require_builtin_audio_utility(model_id_);
+        }
+        engine::debug::timing_log_scalar(
+            "builtin_audio_utils." + operation_name(info_.kind) + "_ms",
+            engine::debug::elapsed_ms(compute_start));
+        return result;
+    }
+
+private:
+    runtime::TaskSpec task_;
+    std::string model_id_;
+    engine::audio::BuiltinAudioUtilityInfo info_;
+    UtilityRuntime runtime_;
+};
+
+class BuiltinAudioUtilsLoader final : public runtime::IVoiceModelLoader {
+public:
+    std::string family() const override {
+        return "builtin_audio_utils";
+    }
+
+    runtime::CapabilitySet advertised_capabilities() const override {
+        return builtin_audio_utils_capabilities();
+    }
+
+    bool can_load(const runtime::ModelLoadRequest & request) const override {
+        if (!request.family_hint.has_value() || *request.family_hint != family()) {
+            return false;
+        }
+        return engine::audio::find_builtin_audio_utility(request.model_path.generic_string()).has_value();
+    }
+
+    runtime::ModelInspection inspect(const runtime::ModelLoadRequest & request) const override {
+        const auto model_id = request.model_path.generic_string();
+        const auto info = engine::audio::require_builtin_audio_utility(model_id);
+        runtime::ModelInspection inspection;
+        inspection.model_root = engine::audio::default_audio_utility_assets_root();
+        inspection.metadata = builtin_audio_utils_metadata(model_id);
+        inspection.capabilities = builtin_audio_utils_capabilities();
+        inspection.discovered_weights.push_back(runtime::NamedAsset{
+            model_id,
+            engine::audio::resolve_builtin_audio_utility_asset(
+                engine::audio::AudioUtilityPaths{engine::audio::default_audio_utility_assets_root()},
+                model_id)});
+        inspection.cli.request_options.push_back(runtime::CliOptionInfo{
+            "audio",
+            "wav",
+            "Input WAV audio to process.",
+            true});
+        inspection.cli.request_options.push_back(runtime::CliOptionInfo{
+            "out",
+            "wav",
+            "Output WAV path.",
+            true});
+        inspection.cli.load_options.push_back(runtime::CliOptionInfo{
+            "operation",
+            operation_name(info.kind),
+            "Selected built-in audio utility operation.",
+            false,
+            operation_name(info.kind)});
+        return inspection;
+    }
+
+    std::unique_ptr<runtime::ILoadedVoiceModel> load(const runtime::ModelLoadRequest & request) const override {
+        return std::make_unique<BuiltinAudioUtilsLoadedModel>(request.model_path.generic_string());
+    }
+};
+
+}  // namespace
+
+BuiltinAudioUtilsLoadedModel::BuiltinAudioUtilsLoadedModel(std::string model_id)
+    : model_id_(std::move(model_id)),
+      metadata_(builtin_audio_utils_metadata(model_id_)),
+      capabilities_(builtin_audio_utils_capabilities()) {
+    (void) engine::audio::require_builtin_audio_utility(model_id_);
+}
+
+const runtime::ModelMetadata & BuiltinAudioUtilsLoadedModel::metadata() const noexcept {
+    return metadata_;
+}
+
+const runtime::CapabilitySet & BuiltinAudioUtilsLoadedModel::capabilities() const noexcept {
+    return capabilities_;
+}
+
+std::unique_ptr<runtime::IVoiceTaskSession> BuiltinAudioUtilsLoadedModel::create_task_session(
+    const runtime::TaskSpec & task,
+    const runtime::SessionOptions & options) const {
+    return std::make_unique<BuiltinAudioUtilsSession>(task, options, model_id_);
+}
+
+std::shared_ptr<runtime::IVoiceModelLoader> make_builtin_audio_utils_loader() {
+    return std::make_shared<BuiltinAudioUtilsLoader>();
+}
+
+}  // namespace engine::models::builtin_audio_utils


### PR DESCRIPTION
## Summary
- Add a `builtin_audio_utils` model family for built-in framework audio utilities.
- Allow CLI/server users to pass utility IDs such as `rnnoise`, `gtcrn`, and `flashsr` instead of fixed asset paths.
- Document CLI and server usage in `docs/audio_tools.md`.

## Validation
Built debug CLI/server and validated CUDA CLI plus `/v1/tasks/run` server requests for:

| Utility | CLI | Server |
|---|---|---|
| `deepfilternet2` | passed | passed |
| `rnnoise` | passed | passed |
| `zipenhancer` | passed | passed |
| `gtcrn` | passed | passed |
| `flashsr` | passed | passed |

The server responses returned audio payloads, sample rate, channel count, and timing fields for all five utilities.
