### PR TITLE
parakeet_tdt: size the encoder graph for the path run() will take

### DIFF
--- a/src/community_models/parakeet_tdt/session.cpp
+++ b/src/community_models/parakeet_tdt/session.cpp
@@ -345,14 +345,47 @@ void ParakeetTDTOfflineSession::prepare(const runtime::SessionPreparationRequest
     int64_t capacity_samples = request.audio->max_input_samples;
     int capacity_channels = request.audio->channels;
     int capacity_sample_rate = request.audio->sample_rate;
-    if (offline_mode_ == "long_form" ||
-        (offline_mode_ == "auto" &&
-         request.audio->max_input_samples / std::max(request.audio->channels, 1) >
-             auto_full_context_max_samples_)) {
+
+    // Mirror the dispatch in run(). vad and fixed take a bounded-window path
+    // whatever offline_mode says, so sizing the graph from offline_mode alone
+    // leaves prepare() and run() disagreeing: a long clip with
+    // audio_chunk_mode=vad gets a graph built for the whole recording and
+    // fails the encoder's relative-position ceiling before a chunk is cut.
+    const auto chunk_mode = engine::audio::parse_audio_chunk_mode(request.options);
+    const bool bounded_windows =
+        chunk_mode == engine::audio::AudioChunkMode::Vad ||
+        chunk_mode == engine::audio::AudioChunkMode::Fixed ||
+        // run() rejects quiet_energy outright. Size it bounded so prepare() does
+        // not pre-empt that with a ceiling error about input run() never encodes.
+        chunk_mode == engine::audio::AudioChunkMode::QuietEnergy ||
+        (chunk_mode == engine::audio::AudioChunkMode::Auto &&
+         (offline_mode_ == "long_form" ||
+          (offline_mode_ == "auto" &&
+           request.audio->max_input_samples / std::max(request.audio->channels, 1) >
+               auto_full_context_max_samples_)));
+
+    if (bounded_windows) {
         capacity_samples =
             left_context_samples_ + center_samples_ + right_context_samples_;
         capacity_channels = 1;
         capacity_sample_rate = assets_->config.frontend.sample_rate;
+
+        // A vad window is capped at audio_chunk_duration_sec, which is free to
+        // exceed the long-form window: the contexts default to 14s in total and
+        // the chunk duration is settable well past that.
+        if (chunk_mode == engine::audio::AudioChunkMode::Vad) {
+            auto chunk_seconds =
+                engine::audio::parse_audio_chunk_seconds_override(request.options);
+            if (!chunk_seconds.has_value()) {
+                chunk_seconds =
+                    engine::audio::parse_audio_chunk_seconds_override(this->options().options);
+            }
+            if (chunk_seconds.has_value() && *chunk_seconds > 0.0F) {
+                capacity_samples = std::max(
+                    capacity_samples,
+                    seconds_to_samples(*chunk_seconds, capacity_sample_rate));
+            }
+        }
     }
     const int64_t frames = frontend_frames_for_samples(
         capacity_samples,


### PR DESCRIPTION
## Problem

`prepare()` chooses between full-context and bounded-window capacity from `offline_mode` alone, but `run()` also takes a bounded path whenever `audio_chunk_mode` is `vad` or `fixed`. The two disagree, so a recording long enough to need chunking gets a graph sized for the whole thing and throws `Parakeet TDT encoder relative position frames exceed maximum`.

The throw originates inside `prepare()` — `prepare_capacity()` builds the relative positional encoding eagerly — so over-sizing fails immediately, while under-sizing is harmless because the graph grows at run time. Only the one direction is a defect.

The effect is that `audio_chunk_mode=vad` and `=fixed` do not work on the inputs they exist for, unless the caller also sets `offline_mode=long_form`. That combination happens to make `prepare()` agree, but it is not discoverable and not what the option means.

## Fix

`prepare()` mirrors the dispatch in `run()`.

Two details the mirror has to get right:

- A `vad` window is capped at `audio_chunk_duration_sec`, which can exceed the long-form window — the contexts total 14s by default and the duration is settable past that — so `vad` capacity takes the larger of the two, resolving the duration with the same request-then-session precedence `run_vad_chunks()` uses.
- `quiet_energy` is sized bounded even though `run()` rejects it, so `prepare()` does not pre-empt that rejection with a ceiling error about input `run()` will never encode.

## Measurements

One tree, one binary swapped between stock and patched. 10-minute conversational recording, q8_0 Parakeet GGUF, CUDA, `offline_mode` left at its default:

| `audio_chunk_mode` | before | after |
|---|---|---|
| `vad` | throws | 4885 ms, 1483 words |
| `fixed` | throws | 6881 ms, 1372 words |
| `none` | throws | throws — correct |
| `quiet_energy` | rejected with the mode error | rejected with the mode error |
| `vad` + `offline_mode=long_form` | 4852 ms, 1483 words | 4959 ms, 1483 words |

`none` still throwing is the intended outcome: chunking is off and the clip genuinely exceeds the encoder's ceiling.

Unchanged where it should be. A 90s clip that already fit gives the same 226 words (`vad`) and 236 (`none`) either way, and `vad` with `offline_mode=long_form` gives the same 1483 words.

## Reproducing

Load a Parakeet GGUF, create an offline `asr` session leaving `parakeet_tdt.offline_mode` at its default, and run a clip longer than the encoder ceiling — 5000 frames of `max_position_embeddings` at 80ms per frame after the 8x subsampling, so about 400s — with `audio_chunk_mode=vad` and `audio_chunk_duration_sec=10` on the request. Before this change that throws; after it, it transcribes.

No test is included: the suite here is weight-dependent warm benches rather than unit tests of `prepare()`, so there is no cheap place for a regression test that does not pull a checkpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EkxqpYvUbjCpRDnFiNiVfx
